### PR TITLE
Fix the Nix package

### DIFF
--- a/charon/rust-toolchain
+++ b/charon/rust-toolchain
@@ -1,1 +1,4 @@
-../rust-toolchain.template
+# update rust-toolchain.template in the top directory.
+[toolchain]
+channel = "nightly-2022-10-20"
+components = [ "rustc-dev", "llvm-tools-preview" ]

--- a/flake.lock
+++ b/flake.lock
@@ -8,14 +8,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1664412889,
-        "narHash": "sha256-gyVtTQf3CiXLe1cwNRFxqUqYl9BCmIDvK7hIpzR/oQU=",
+        "lastModified": 1666567222,
+        "narHash": "sha256-AVySilLW+eNM409GSIJYsF6wg5NsxK12Ht2DMSYAgO0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "755acd231a7de182fdc772bee1b2a1f21d4ec9ed",
+        "rev": "2ce1a3313e299b0db63b11f94c863af74b0b08ad",
         "type": "github"
       },
       "original": {
@@ -57,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664989420,
-        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37bd39839acf99c5b738319f42478296f827f274",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
         "type": "github"
       },
       "original": {
@@ -75,10 +76,35 @@
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay_2"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666494036,
+        "narHash": "sha256-4mmm+1MBPMD56LMLN9QcEwnfnu41NkA6lDeZGjSrxIw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "af2e939ba2c7cbb188d06d6650c6353b10b3f2be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "flake-utils": [
           "flake-utils"
@@ -88,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665111330,
-        "narHash": "sha256-bvL2xzSVOLBUlXQIklqHqn1M6z5aXrr3FKcqtSnGJ8I=",
+        "lastModified": 1666839029,
+        "narHash": "sha256-gmSmf3bDS9oR4OHsvKHEErqje228XXP22uKIQWZj4Jo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fb8f4fa9c5514dbbc7d2a7c310d8ba874c519779",
+        "rev": "c095030cf6c84e304f867ad066d8d5b051131af5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
-        rustToolchain = pkgs.rust-bin.nightly."2022-01-29".default.override {
+        rustToolchain = pkgs.rust-bin.nightly."2022-10-20".default.override {
           extensions = [ "rust-src" "rustc-dev" "llvm-tools-preview" ];
         };
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/tests-polonius/rust-toolchain
+++ b/tests-polonius/rust-toolchain
@@ -1,1 +1,4 @@
-../rust-toolchain.template
+# update rust-toolchain.template in the top directory.
+[toolchain]
+channel = "nightly-2022-10-20"
+components = [ "rustc-dev", "llvm-tools-preview" ]

--- a/tests/rust-toolchain
+++ b/tests/rust-toolchain
@@ -1,1 +1,4 @@
-../rust-toolchain.template
+# update rust-toolchain.template in the top directory.
+[toolchain]
+channel = "nightly-2022-10-20"
+components = [ "rustc-dev", "llvm-tools-preview" ]


### PR DESCRIPTION
Instead of using symbolic links to keep the various `rust-toolchain` files in sync with the `rust-toolchain.template` file located at the root (which is unaccessible when we build, say, the Nix derivation for Charon), we now rely on the `Makefile` to copy `rust-toolchain.template` to the various subdirectories.