### PR TITLE
Implement a pass to reconstruct matches by removing discriminant reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Museo del Prado, Madrid.
 
 # Charon
 Charon acts as an interface between the rustc compiler and program verification projects. Its
-purpose is to process Rust .rs files and convert them into files easy to handle by program
+purpose is to process Rust crates and convert them into files easy to handle by program
 verifiers. It is implemented as a custom driver for the rustc compiler.
 
 Charon is, in Greek mythology, an old man carrying the souls of the deceased accross the
@@ -23,34 +23,59 @@ We are **open to contributions**! Please contact us so that we can coordinate ou
 if you are willing to contribute.
 
 ## LLBC
-Charon converts MIR code to LLBC (Low-Level Borrow Calculus), which is MIR
-but with the following differences:
-- control-flow has been reconstructed: LLBC uses a structured control-flow with loops,
-  if ... then ... else ..., etc. instead of gotos.
-- MIR statements and terminators are merged into a single statement type.
-  Followingly, we do not manipulate basic blocks, but only statements.
+Charon converts MIR code to ULLBC (Unstructured Low-Level Borrow Calculus) then
+to LLBC. Both ASTs can be output by Charon.
+
+ULLBC is MIR with the following differences:
+- we desugar a bit accesses to constants and globals. In MIR, constants and globals
+  can be accessed in operands, while in LLBC we introduce intermediate assignments
+  so that they are accessed only by means of a `Global` rvalue (which reads a
+  global). Our representation of constants is also simplified and higher level.
+- if you extract the built or promoted MIR, global declarations will have their
+  own declarations. If you extract the optimized MIR, their values will be
+  evaluated and inlined in the function bodies (in the first case, you would
+  get a declaration for `std::u32::MAX`, in the second case the generated code
+  would directly manipulate the value `4294967295`).
+
+LLBC is ULLBC where the control-flow has been restructured with loops, `if
+... then ... else ...`, etc. instead of gotos. Consequently, we merge MIR
+statements and terminators into a single LLBC statement type. We also perform
+some additional modifications, some of which are listed below:
+
 - calls to arithmetic operations are simplified: we remove the dynamic checks for
   divisions by zero and overflows. The rationale is that in theorem provers, those
   operations either have preconditions, or perform the checks themselves.
-- we desugar a bit accesses to constants and globals. In MIR, constants and globals
-  can be accessed in operands, while in LLBC we introduce intermediate assignments
-  so that they are accessed only by means of an `AssignGlobal` statement (which
-  reads a global and stores it in a local variable).
+- we remove the discriminant rvalue (see the MIR
+  [rvalues](https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.Rvalue.html)).
+  In MIR, matches are desugared to:
+  ```rust
+  d := discriminant(x);
+  switch move d {
+    ...
+  }
+  ```
+  
+  In LLBC, we change this to:
+  ```rust
+  match d {
+    ...
+  }
+  ```
 
-**Remark**: most of the transformations above are applied through micro-passes. Depending on
-the need, we could make them optional and control them with flags. If you want
-to know more about the details, see `translate` in `src/main.rs`, which applies
-the micro-passes one after the other.
+**Remark**: most of the transformations above are applied through
+micro-passes. Depending on the need, we could make them optional and control
+them with flags. If you want to know more about the details, see `translate` in
+`src/driver.rs`, which applies the micro-passes one after the other.
 
-**Remark**: if you want to know the full details of LLBC, have a look at: `types.rs`,
-`values.rs`, `expressions.rs` and `llbc_ast.rs`.
+**Remark**: if you want to know the full details of (U)LLBC, have a look at: `types.rs`,
+`values.rs`, `expressions.rs`, `ullbc_ast.rs` and `llbc_ast.rs`.
 
 We also reorder the function and type definitions, so that for instance if a
 function `f` calls a function `g`, `f` is defined after `g`, mutually recursive
 definitions are grouped, etc.
 
-The extracted AST is serialized in .llbc files (using the JSON format).
-We generate one file per extracted crate.
+The extracted AST is serialized in `.ullbc` and `.llbc` files (using the JSON format).
+We extract a whole crate in one file.
 
 ## Project Structure
 
@@ -58,7 +83,7 @@ We generate one file per extracted crate.
 - `charon-ml`: the ML library. Provides utilities to retrieve and manipulate
   the AST in OCaml (deserialization, printing, etc.).
 - `tests` and `tests-polonius`: test files directories. `tests-polonius` contains
-  code which requires non-lexical lifetimes (i.e., the Polonius borrow checker).
+  code which requires the Polonius borrow checker.
 
 ## Installation & Build
 
@@ -82,7 +107,7 @@ The dependencies can then be installed with the following command:
 opam install ppx_deriving visitors easy_logging zarith yojson core_unix odoc
 ```
 
-You can then run `make build-charon-ml` to build the ML library, or even simply
+You can finally run `make build-charon-ml` to build the ML library, or even simply
 `make` to build the whole project and run the tests.
 
 ## Documentation
@@ -93,18 +118,16 @@ If you run `make`, you will generate a documentation accessible from
 
 ## Usage
 
-To use Charon, you should first build the project you wish to extract in debug mode: `cargo build`.
-The reason is that Charon will look for already compiled external dependencies in the
-target directory (`/target/debug/deps/`, usually).
+To run Charon, you should run the Charon binary from *within* the crate that you
+want to compile (as if you wanted to build the crate with `cargo build`). The
+Charon executable is located in `charon/target/{debug,release}/`; you can for
+instance run `PATH_TO_CHARON/target/debug/charon` (running `make` in the
+repository will by default build Charon in debug mode).
 
-Then, the simplest is to do: `cd charon && cargo run -- [OPTIONS] FILE`,
-where `FILE` is the entry point of the crate to extract (`PROJECT_PATH/src/main.rs`,
-for instance).
+Charon will build the crate and its dependencies, then extract the AST. Charon
+provides various options and flags to tweak its behaviour: you can display a
+detailed documentation with `--help`.
 
-**Remark**: the crate to be extracted must be built with the same version of rustc
-as Charon (see the file `charon/rust-toolchain`). If it is not the case, the extraction
-will likely fail with an error saying that there is a mismatch in the metadata of the compiled
-files.
-
-Charon provides various options and flags to tweak its behaviour: you can display a detailed
-documentation with `--help`.
+**Remark**: because Charon is compiled with Rust nigthly (this is a requirement
+to implement a rustc driver), it will build your crate with Rust nightly. You
+can find the nightly version pinned for Charon in [`rust-toolchain.template`](rust-toolchain.template).

--- a/charon-ml/src/Collections.ml
+++ b/charon-ml/src/Collections.ml
@@ -24,6 +24,17 @@ module List = struct
           let ls1, ls2 = split_at ls' (i - 1) in
           (x :: ls1, ls2)
 
+  (** Take a slice of a list.
+
+      The slice includes [n] elements starting at [i].
+
+      Raise [Failure] if the list is too short..
+  *)
+  let subslice (ls : 'a list) (i : int) (n : int) =
+    let _, ls = split_at ls i in
+    let ls, _ = split_at ls n in
+    ls
+
   (** Pop the last element of a list
      
       Raise [Failure] if the list is empty.

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -22,7 +22,7 @@ let rec list_ancestor_region_groups (sg : fun_sig) (gid : T.RegionGroupId.id) :
   in
   parents
 
-(** Small utility: same as {!list_ancestors_region_groups}, but returns an ordered list.  *)
+(** Small utility: same as {!list_ancestor_region_groups}, but returns an ordered list.  *)
 let list_ordered_ancestor_region_groups (sg : fun_sig)
     (gid : T.RegionGroupId.id) : T.RegionGroupId.id list =
   let pset = list_ancestor_region_groups sg gid in

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -44,7 +44,7 @@ and switch =
           - the "otherwise" statement
           Also note that we precise the type of the integer (uint32, int64, etc.)
           which we switch on. *)
-  | Match of place * (variant_id list * statement) list
+  | Match of place * (variant_id list * statement) list * statement
       (** A match over an ADT.
 
           Similar comments as for {!SwitchInt}.

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -30,12 +30,13 @@ and raw_statement =
           the same way as for {!Break} *)
   | Nop
   | Sequence of statement * statement
-  | Switch of operand * switch_targets
+  | Switch of switch
   | Loop of statement
 
-and switch_targets =
-  | If of statement * statement  (** Gives the "if" and "else" blocks *)
-  | SwitchInt of integer_type * (scalar_value list * statement) list * statement
+and switch =
+  | If of operand * statement * statement
+  | SwitchInt of
+      operand * integer_type * (scalar_value list * statement) list * statement
       (** The targets for a switch over an integer are:
           - the list [(matched values, statement to execute)]
             We need a list for the matched values in case we do something like this:
@@ -43,6 +44,11 @@ and switch_targets =
           - the "otherwise" statement
           Also note that we precise the type of the integer (uint32, int64, etc.)
           which we switch on. *)
+  | Match of place * (variant_id list * statement) list
+      (** A match over an ADT.
+
+          Similar comments as for {!SwitchInt}.
+       *)
 [@@deriving
   show,
     visitors

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -65,8 +65,9 @@ and chain_statements_in_switch (switch : switch) (st : statement) : switch =
       in
       let otherwise = chain_statements otherwise st in
       SwitchInt (op, int_ty, branches, otherwise)
-  | Match (op, branches) ->
+  | Match (op, branches, otherwise) ->
       let branches =
         List.map (fun (svl, br) -> (svl, chain_statements br st)) branches
       in
-      Match (op, branches)
+      let otherwise = chain_statements otherwise st in
+      Match (op, branches, otherwise)

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -111,7 +111,7 @@ and switch_of_json (id_to_file : id_to_file_map) (js : json) :
         in
         let* otherwise = statement_of_json id_to_file otherwise in
         Ok (A.SwitchInt (op, int_ty, tgts, otherwise))
-    | `Assoc [ ("Match", `List [ p; tgts ]) ] ->
+    | `Assoc [ ("Match", `List [ p; tgts; otherwise ]) ] ->
         let* p = place_of_json p in
         let* tgts =
           list_of_json
@@ -120,7 +120,8 @@ and switch_of_json (id_to_file : id_to_file_map) (js : json) :
                (statement_of_json id_to_file))
             tgts
         in
-        Ok (A.Match (p, tgts))
+        let* otherwise = statement_of_json id_to_file otherwise in
+        Ok (A.Match (p, tgts, otherwise))
     | _ -> Error "")
 
 let fun_decl_of_json (id_to_file : id_to_file_map) (js : json) :

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -85,7 +85,7 @@ module Ast = struct
               ^ inner_to_string2 otherwise ^ "\n" ^ indent1 ^ "}"
             in
             indent ^ "switch (" ^ op ^ ") {\n" ^ branches ^ "\n" ^ indent ^ "}"
-        | A.Match (p, branches) ->
+        | A.Match (p, branches, otherwise) ->
             let p = PE.place_to_string fmt p in
             let indent1 = indent ^ indent_incr in
             let indent2 = indent1 ^ indent_incr in
@@ -104,6 +104,10 @@ module Ast = struct
                 branches
             in
             let branches = String.concat "\n" branches in
+            let branches =
+              branches ^ "\n" ^ indent1 ^ "_ => {\n"
+              ^ inner_to_string2 otherwise ^ "\n" ^ indent1 ^ "}"
+            in
             indent ^ "match (" ^ p ^ ") {\n" ^ branches ^ "\n" ^ indent ^ "}")
     | A.Loop loop_st ->
         indent ^ "loop {\n"

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -39,7 +39,7 @@ module Ast = struct
         indent ^ "storage_dead " ^ fmt.var_id_to_string var_id
     | A.Deinit p -> indent ^ "deinit " ^ PE.place_to_string fmt p
 
-  let switch_targets_to_string (indent : string) (tgt : A.switch_targets) :
+  let switch_to_string (indent : string) (tgt : A.switch) :
       string =
     match tgt with
     | A.If (b0, b1) ->
@@ -69,7 +69,7 @@ module Ast = struct
     | Switch (op, tgts) ->
         indent ^ "switch "
         ^ PE.operand_to_string fmt op
-        ^ switch_targets_to_string indent tgts
+        ^ switch_to_string indent tgts
     | A.Panic -> indent ^ "panic"
     | A.Return -> indent ^ "return"
     | A.Unreachable -> indent ^ "unreachable"

--- a/charon-ml/src/Scalars.ml
+++ b/charon-ml/src/Scalars.ml
@@ -26,7 +26,12 @@ let u128_max = Z.of_string "340282366920938463463374607431768211455"
 
 (** Being a bit conservative about isize/usize: depending on the system,
     the values are encoded as 32-bit values or 64-bit values - we may
-    want to take that into account in the future *)
+    want to take that into account in the future
+
+    Note that we use those bounds only to check that the values are *in range*:
+    when evaluating operations like addition, negation, etc. It is thus ok to
+    not use the precise bounds.
+ *)
 
 let isize_min = i32_min
 let isize_max = i32_max

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -8,7 +8,7 @@ open Names
 module BlockId = IdGen ()
 
 (** We define this type to control the name of the visitor functions
-    (see e.g., {!UllbcAst.iter_statement_base} and {!switch_targets}).
+    (see e.g., {!UllbcAst.iter_statement_base} and {!switch}).
   *)
 type block_id = BlockId.id [@@deriving show, ord]
 
@@ -58,14 +58,14 @@ and raw_statement =
         concrete = true;
       }]
 
-type switch_targets =
+type switch =
   | If of block_id * block_id
   | SwitchInt of integer_type * (scalar_value * block_id) list * block_id
 [@@deriving
   show,
     visitors
       {
-        name = "iter_switch_targets";
+        name = "iter_switch";
         variety = "iter";
         ancestors = [ "iter_statement" ];
         nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
@@ -73,7 +73,7 @@ type switch_targets =
       },
     visitors
       {
-        name = "map_switch_targets";
+        name = "map_switch";
         variety = "map";
         ancestors = [ "map_statement" ];
         nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
@@ -87,7 +87,7 @@ type terminator = {
 
 and raw_terminator =
   | Goto of block_id
-  | Switch of operand * switch_targets
+  | Switch of operand * switch
   | Panic
   | Return
   | Unreachable
@@ -100,7 +100,7 @@ and raw_terminator =
       {
         name = "iter_terminator";
         variety = "iter";
-        ancestors = [ "iter_switch_targets" ];
+        ancestors = [ "iter_switch" ];
         nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
         concrete = true;
       },
@@ -108,7 +108,7 @@ and raw_terminator =
       {
         name = "map_terminator";
         variety = "map";
-        ancestors = [ "map_switch_targets" ];
+        ancestors = [ "map_switch" ];
         nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
         concrete = true;
       }]

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -39,7 +39,7 @@ and raw_statement_of_json (js : json) : (A.raw_statement, string) result =
         Ok (A.Deinit place)
     | _ -> Error "")
 
-let switch_targets_of_json (js : json) : (A.switch_targets, string) result =
+let switch_of_json (js : json) : (A.switch, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("If", `List [ id0; id1 ]) ] ->
@@ -98,7 +98,7 @@ and raw_terminator_of_json (js : json) : (A.raw_terminator, string) result =
     | `Assoc [ ("Switch", `Assoc [ ("discr", discr); ("targets", targets) ]) ]
       ->
         let* discr = operand_of_json discr in
-        let* targets = switch_targets_of_json targets in
+        let* targets = switch_of_json targets in
         Ok (A.Switch (discr, targets))
     | `String "Panic" -> Ok A.Panic
     | `String "Return" -> Ok A.Return

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "charon"
+name = "charon_lib"
 path = "src/lib.rs"
 
 [[bin]]
-name = "cargo-charon"
+name = "charon"
 path = "src/main.rs"
 
 [[bin]]

--- a/charon/src/charon-driver.rs
+++ b/charon/src/charon-driver.rs
@@ -59,6 +59,7 @@ mod regions_hierarchy;
 mod register;
 mod regularize_constant_adts;
 mod remove_drop_never;
+mod remove_read_discriminant;
 mod remove_unused_locals;
 mod reorder_decls;
 mod rust_to_local_ids;

--- a/charon/src/divergent.rs
+++ b/charon/src/divergent.rs
@@ -36,8 +36,8 @@ fn statement_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, st: &llbc::
         RawStatement::Sequence(st1, st2) => {
             statement_diverges(divergent, &st1) || statement_diverges(divergent, &st2)
         }
-        RawStatement::Switch(_, tgts) => {
-            let tgts = tgts.get_targets();
+        RawStatement::Match(mtch) => {
+            let tgts = mtch.get_targets();
             tgts.iter().any(|st| statement_diverges(divergent, st))
         }
         RawStatement::Loop(_) => true,

--- a/charon/src/divergent.rs
+++ b/charon/src/divergent.rs
@@ -36,8 +36,8 @@ fn statement_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, st: &llbc::
         RawStatement::Sequence(st1, st2) => {
             statement_diverges(divergent, &st1) || statement_diverges(divergent, &st2)
         }
-        RawStatement::Match(mtch) => {
-            let tgts = mtch.get_targets();
+        RawStatement::Switch(switch) => {
+            let tgts = switch.get_targets();
             tgts.iter().any(|st| statement_diverges(divergent, st))
         }
         RawStatement::Loop(_) => true,

--- a/charon/src/expressions.rs
+++ b/charon/src/expressions.rs
@@ -5,7 +5,7 @@ use crate::types::*;
 use crate::values::*;
 use im::Vector; // TODO: im::Vector is not necessary anymore
 use macros::generate_index_type;
-use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
+use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::Serialize;
 use std::vec::Vec;
 
@@ -120,7 +120,9 @@ pub enum BinOp {
     // No Offset binary operation: this is an operation on raw pointers
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, EnumIsA, EnumToGetters, EnumAsGetters, VariantName, Serialize,
+)]
 pub enum Operand {
     Copy(Place),
     Move(Place),
@@ -165,7 +167,7 @@ pub enum OperandConstantValue {
     StaticId(GlobalDeclId::Id),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, EnumToGetters, EnumIsA)]
 pub enum Rvalue {
     Use(Operand),
     Ref(Place, BorrowKind),
@@ -174,7 +176,9 @@ pub enum Rvalue {
     /// Binary operations (note that we merge "checked" and "unchecked" binops)
     BinaryOp(BinOp, Operand, Operand),
     /// Discriminant (for enumerations).
-    /// Note that discriminant values have type isize
+    /// Note that discriminant values have type isize.
+    ///
+    /// This case is filtered in [crate::remove_read_discriminant]
     Discriminant(Place),
     /// Creates an aggregate value, like a tuple, a struct or an enum:
     /// ```text

--- a/charon/src/insert_assign_return_unit.rs
+++ b/charon/src/insert_assign_return_unit.rs
@@ -42,17 +42,18 @@ fn transform_st(mut st: Statement) -> Statement {
                 let st2 = Box::new(transform_st(*st2));
                 RawStatement::Switch(Switch::If(op, st1, st2))
             }
-            Switch::SwitchInt(op, int_ty, targets, otherwise) => {
+            Switch::SwitchInt(op, int_ty, targets, mut otherwise) => {
                 let targets =
                     Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
-                let otherwise = transform_st(*otherwise);
-                let switch = Switch::SwitchInt(op, int_ty, targets, Box::new(otherwise));
+                *otherwise = transform_st(*otherwise);
+                let switch = Switch::SwitchInt(op, int_ty, targets, otherwise);
                 RawStatement::Switch(switch)
             }
-            Switch::Match(op, targets) => {
+            Switch::Match(op, targets, mut otherwise) => {
                 let targets =
                     Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
-                let switch = Switch::Match(op, targets);
+                *otherwise = transform_st(*otherwise);
+                let switch = Switch::Match(op, targets, otherwise);
                 RawStatement::Switch(switch)
             }
         },

--- a/charon/src/insert_assign_return_unit.rs
+++ b/charon/src/insert_assign_return_unit.rs
@@ -7,7 +7,7 @@ use take_mut::take;
 
 use crate::expressions::*;
 use crate::llbc_ast::{
-    CtxNames, ExprBody, FunDecl, FunDecls, GlobalDecl, GlobalDecls, Match, RawStatement, Statement,
+    CtxNames, ExprBody, FunDecl, FunDecls, GlobalDecl, GlobalDecls, RawStatement, Statement, Switch,
 };
 use crate::names::Name;
 use crate::values::*;
@@ -36,24 +36,24 @@ fn transform_st(mut st: Statement) -> Statement {
         RawStatement::Break(i) => RawStatement::Break(i),
         RawStatement::Continue(i) => RawStatement::Continue(i),
         RawStatement::Nop => RawStatement::Nop,
-        RawStatement::Match(mtch) => match mtch {
-            Match::If(op, st1, st2) => {
+        RawStatement::Switch(switch) => match switch {
+            Switch::If(op, st1, st2) => {
                 let st1 = Box::new(transform_st(*st1));
                 let st2 = Box::new(transform_st(*st2));
-                RawStatement::Match(Match::If(op, st1, st2))
+                RawStatement::Switch(Switch::If(op, st1, st2))
             }
-            Match::SwitchInt(op, int_ty, targets, otherwise) => {
+            Switch::SwitchInt(op, int_ty, targets, otherwise) => {
                 let targets =
                     Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
                 let otherwise = transform_st(*otherwise);
-                let mtch = Match::SwitchInt(op, int_ty, targets, Box::new(otherwise));
-                RawStatement::Match(mtch)
+                let switch = Switch::SwitchInt(op, int_ty, targets, Box::new(otherwise));
+                RawStatement::Switch(switch)
             }
-            Match::Match(op, targets) => {
+            Switch::Match(op, targets) => {
                 let targets =
                     Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
-                let mtch = Match::Match(op, targets);
-                RawStatement::Match(mtch)
+                let switch = Switch::Match(op, targets);
+                RawStatement::Switch(switch)
             }
         },
         RawStatement::Loop(loop_body) => RawStatement::Loop(Box::new(transform_st(*loop_body))),

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -69,6 +69,7 @@ pub mod regions_hierarchy;
 pub mod register;
 pub mod regularize_constant_adts;
 pub mod remove_drop_never;
+pub mod remove_read_discriminant;
 pub mod remove_unused_locals;
 pub mod reorder_decls;
 pub mod rust_to_local_ids;

--- a/charon/src/llbc_ast.rs
+++ b/charon/src/llbc_ast.rs
@@ -67,7 +67,7 @@ pub enum RawStatement {
     /// to the semantically equivalent statement `s0; (s1; s2)`
     /// To ensure that, use [crate::llbc_ast_utils::new_sequence] to build sequences.
     Sequence(Box<Statement>, Box<Statement>),
-    Match(Match),
+    Switch(Switch),
     Loop(Box<Statement>),
 }
 
@@ -78,7 +78,7 @@ pub struct Statement {
 }
 
 #[derive(Debug, Clone, EnumIsA, EnumToGetters, EnumAsGetters, VariantName, VariantIndexArity)]
-pub enum Match {
+pub enum Switch {
     /// Gives the `if` block and the `else` block
     If(Operand, Box<Statement>, Box<Statement>),
     /// Gives the integer type, a map linking values to switch branches, and the

--- a/charon/src/llbc_ast.rs
+++ b/charon/src/llbc_ast.rs
@@ -106,7 +106,7 @@ pub enum Switch {
     /// The match statement is introduced in [crate::remove_read_discriminant]
     /// (whenever we find a discriminant read, we merge it with the subsequent
     /// switch into a match)
-    Match(Place, Vec<(Vec<VariantId::Id>, Statement)>),
+    Match(Place, Vec<(Vec<VariantId::Id>, Statement)>, Box<Statement>),
 }
 
 pub type ExprBody = GExprBody<Statement>;

--- a/charon/src/reconstruct_asserts.rs
+++ b/charon/src/reconstruct_asserts.rs
@@ -47,14 +47,14 @@ fn transform_st(mut st: Statement) -> Statement {
                         RawStatement::Switch(switch)
                     }
                 }
-                Switch::SwitchInt(op, int_ty, targets, otherwise) => {
+                Switch::SwitchInt(op, int_ty, targets, mut otherwise) => {
                     let targets =
                         Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
-                    let otherwise = transform_st(*otherwise);
-                    let switch = Switch::SwitchInt(op, int_ty, targets, Box::new(otherwise));
+                    *otherwise = transform_st(*otherwise);
+                    let switch = Switch::SwitchInt(op, int_ty, targets, otherwise);
                     RawStatement::Switch(switch)
                 }
-                Switch::Match(_, _) => {
+                Switch::Match(_, _, _) => {
                     // This variant is introduced in a subsequent pass
                     unreachable!();
                 }

--- a/charon/src/reconstruct_asserts.rs
+++ b/charon/src/reconstruct_asserts.rs
@@ -6,7 +6,7 @@
 use take_mut::take;
 
 use crate::{
-    llbc_ast::{Assert, CtxNames, FunDecls, GlobalDecls, RawStatement, Statement, SwitchTargets},
+    llbc_ast::{Assert, CtxNames, FunDecls, GlobalDecls, Match, RawStatement, Statement},
     ullbc_ast::{iter_function_bodies, iter_global_bodies},
 };
 use std::iter::FromIterator;
@@ -24,9 +24,9 @@ fn transform_st(mut st: Statement) -> Statement {
         RawStatement::Break(i) => RawStatement::Break(i),
         RawStatement::Continue(i) => RawStatement::Continue(i),
         RawStatement::Nop => RawStatement::Nop,
-        RawStatement::Switch(op, targets) => {
-            match targets {
-                SwitchTargets::If(st1, st2) => {
+        RawStatement::Match(mtch) => {
+            match mtch {
+                Match::If(op, st1, st2) => {
                     let st2 = Box::new(transform_st(*st2));
 
                     // Check if the first statement is a panic: if yes, replace
@@ -43,16 +43,20 @@ fn transform_st(mut st: Statement) -> Statement {
 
                         RawStatement::Sequence(st1, st2)
                     } else {
-                        let targets = SwitchTargets::If(Box::new(transform_st(*st1)), st2);
-                        RawStatement::Switch(op, targets)
+                        let mtch = Match::If(op, Box::new(transform_st(*st1)), st2);
+                        RawStatement::Match(mtch)
                     }
                 }
-                SwitchTargets::SwitchInt(int_ty, targets, otherwise) => {
+                Match::SwitchInt(op, int_ty, targets, otherwise) => {
                     let targets =
                         Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
                     let otherwise = transform_st(*otherwise);
-                    let targets = SwitchTargets::SwitchInt(int_ty, targets, Box::new(otherwise));
-                    RawStatement::Switch(op, targets)
+                    let mtch = Match::SwitchInt(op, int_ty, targets, Box::new(otherwise));
+                    RawStatement::Match(mtch)
+                }
+                Match::Match(_, _) => {
+                    // This variant is introduced in a subsequent pass
+                    unreachable!();
                 }
             }
         }

--- a/charon/src/remove_read_discriminant.rs
+++ b/charon/src/remove_read_discriminant.rs
@@ -1,0 +1,134 @@
+//! The MIR code often contains variables with type `Never`, and we want to get
+//! rid of those. We proceed in two steps. First, we remove the instructions
+//! `drop(v)` where `v` has type `Never` (it can happen - this module does the
+//! filtering). Then, we filter the unused variables ([crate::remove_unused_locals]).
+
+use take_mut::take;
+
+use crate::expressions::*;
+use crate::llbc_ast::{
+    new_sequence, CtxNames, FunDecls, GlobalDecls, Match, RawStatement, Statement,
+};
+use crate::meta::combine_meta;
+use crate::types::*;
+use crate::ullbc_ast::{iter_function_bodies, iter_global_bodies};
+use std::iter::FromIterator;
+
+// TODO: don't consume `st`, use mutable borrows
+fn transform_st(st: Statement) -> Statement {
+    let content = match st.content {
+        RawStatement::Assign(p, rv) => {
+            // Check that we never failed to remove a [Discriminant]
+            if let Rvalue::Discriminant(_) = &rv {
+                // Should have been filtered
+                unreachable!();
+            }
+            RawStatement::Assign(p, rv)
+        }
+        RawStatement::FakeRead(p) => RawStatement::FakeRead(p),
+        RawStatement::SetDiscriminant(p, vid) => RawStatement::SetDiscriminant(p, vid),
+        RawStatement::Drop(p) => RawStatement::Drop(p),
+        RawStatement::Assert(assert) => RawStatement::Assert(assert),
+        RawStatement::Call(call) => RawStatement::Call(call),
+        RawStatement::Panic => RawStatement::Panic,
+        RawStatement::Return => RawStatement::Return,
+        RawStatement::Break(i) => RawStatement::Break(i),
+        RawStatement::Continue(i) => RawStatement::Continue(i),
+        RawStatement::Nop => RawStatement::Nop,
+        RawStatement::Match(mtch) => {
+            let mtch = match mtch {
+                Match::If(op, st1, st2) => Match::If(
+                    op,
+                    Box::new(transform_st(*st1)),
+                    Box::new(transform_st(*st2)),
+                ),
+                Match::SwitchInt(op, int_ty, targets, otherwise) => {
+                    let targets =
+                        Vec::from_iter(targets.into_iter().map(|(v, e)| (v, transform_st(e))));
+                    let otherwise = transform_st(*otherwise);
+                    Match::SwitchInt(op, int_ty, targets, Box::new(otherwise))
+                }
+                Match::Match(_, _) => {
+                    // We shouldn't get there: this variant is introduced *during*
+                    // this traversal
+                    unreachable!();
+                }
+            };
+            RawStatement::Match(mtch)
+        }
+        RawStatement::Loop(loop_body) => RawStatement::Loop(Box::new(transform_st(*loop_body))),
+        RawStatement::Sequence(st1, st2) => {
+            if st1.content.is_assign() {
+                let (_, rv) = st1.content.as_assign();
+                if rv.is_discriminant() {
+                    let (dest, rv) = st1.content.to_assign();
+                    let p = rv.to_discriminant();
+
+                    // The destination should be a variable
+                    assert!(dest.projection.is_empty());
+
+                    // A discriminant read must be immediately followed by a switch int.
+                    // Note that it may be contained in a sequence, of course.
+                    let (meta, mtch, st3_opt) = match st2.content {
+                        RawStatement::Sequence(st2, st3) => {
+                            (st2.meta, st2.content.to_match(), Some(*st3))
+                        }
+                        RawStatement::Match(mtch) => (st2.meta, mtch, None),
+                        _ => unreachable!(),
+                    };
+                    let (op, int_ty, targets, _) = mtch.to_switch_int();
+                    assert!(int_ty.is_isize());
+                    // The operand should be a [Move] applied to the variable `dest`
+                    let op_p = op.to_move();
+                    assert!(op_p.projection.is_empty() && op_p.var_id == dest.var_id);
+
+                    let targets = Vec::from_iter(targets.into_iter().map(|(v, e)| {
+                        (
+                            Vec::from_iter(
+                                v.into_iter()
+                                    .map(|x| VariantId::Id::new(*x.as_isize() as usize)),
+                            ),
+                            transform_st(e),
+                        )
+                    }));
+                    let mtch = RawStatement::Match(Match::Match(p, targets));
+
+                    // Add the next statement if there is one
+                    if let Some(st3) = st3_opt {
+                        let meta = combine_meta(&st1.meta, &meta);
+                        let mtch = Statement {
+                            meta,
+                            content: mtch,
+                        };
+                        new_sequence(mtch, st3).content
+                    } else {
+                        mtch
+                    }
+                } else {
+                    let st1 = Box::new(transform_st(*st1));
+                    let st2 = Box::new(transform_st(*st2));
+                    RawStatement::Sequence(st1, st2)
+                }
+            } else {
+                let st1 = Box::new(transform_st(*st1));
+                let st2 = Box::new(transform_st(*st2));
+                RawStatement::Sequence(st1, st2)
+            }
+        }
+    };
+
+    Statement::new(st.meta, content)
+}
+
+/// `fmt_ctx` is used for pretty-printing purposes.
+pub fn transform<'ctx>(fmt_ctx: &CtxNames<'ctx>, funs: &mut FunDecls, globals: &mut GlobalDecls) {
+    for (name, b) in iter_function_bodies(funs).chain(iter_global_bodies(globals)) {
+        trace!(
+            "# About to remove [ReadDiscriminant] occurrences in decl: {name}:\n{}",
+            b.fmt_with_ctx_names(fmt_ctx)
+        );
+
+        // Compute the set of local variables
+        take(&mut b.body, |b| transform_st(b));
+    }
+}

--- a/charon/src/remove_unused_locals.rs
+++ b/charon/src/remove_unused_locals.rs
@@ -5,7 +5,7 @@
 
 use crate::expressions::*;
 use crate::id_vector::ToUsize;
-use crate::llbc_ast::{CtxNames, FunDecls, GlobalDecls, RawStatement, Statement, SwitchTargets};
+use crate::llbc_ast::{CtxNames, FunDecls, GlobalDecls, Match, RawStatement, Statement};
 use crate::ullbc_ast::{iter_function_bodies, iter_global_bodies, Var};
 use crate::values::*;
 use std::collections::{HashMap, HashSet};
@@ -65,21 +65,26 @@ fn compute_used_locals_in_statement(locals: &mut HashSet<VarId::Id>, st: &Statem
         RawStatement::Break(_) => (),
         RawStatement::Continue(_) => (),
         RawStatement::Nop => (),
-        RawStatement::Switch(op, targets) => {
-            compute_used_locals_in_operand(locals, op);
-            match targets {
-                SwitchTargets::If(st1, st2) => {
-                    compute_used_locals_in_statement(locals, st1);
-                    compute_used_locals_in_statement(locals, st2);
-                }
-                SwitchTargets::SwitchInt(_, targets, otherwise) => {
-                    compute_used_locals_in_statement(locals, otherwise);
-                    for (_, tgt) in targets {
-                        compute_used_locals_in_statement(locals, tgt);
-                    }
+        RawStatement::Match(m) => match m {
+            Match::If(op, st1, st2) => {
+                compute_used_locals_in_operand(locals, op);
+                compute_used_locals_in_statement(locals, st1);
+                compute_used_locals_in_statement(locals, st2);
+            }
+            Match::SwitchInt(op, _, targets, otherwise) => {
+                compute_used_locals_in_operand(locals, op);
+                compute_used_locals_in_statement(locals, otherwise);
+                for (_, tgt) in targets {
+                    compute_used_locals_in_statement(locals, tgt);
                 }
             }
-        }
+            Match::Match(p, targets) => {
+                compute_used_locals_in_place(locals, p);
+                for (_, tgt) in targets {
+                    compute_used_locals_in_statement(locals, tgt);
+                }
+            }
+        },
         RawStatement::Loop(loop_body) => compute_used_locals_in_statement(locals, loop_body),
         RawStatement::Sequence(st1, st2) => {
             compute_used_locals_in_statement(locals, st1);
@@ -151,25 +156,35 @@ fn transform_st(vids_map: &HashMap<VarId::Id, VarId::Id>, st: Statement) -> Stat
         RawStatement::Break(i) => RawStatement::Break(i),
         RawStatement::Continue(i) => RawStatement::Continue(i),
         RawStatement::Nop => RawStatement::Nop,
-        RawStatement::Switch(op, targets) => {
-            let op = transform_operand(vids_map, op);
-            match targets {
-                SwitchTargets::If(st1, st2) => {
+        RawStatement::Match(mtch) => {
+            let mtch = match mtch {
+                Match::If(op, st1, st2) => {
+                    let op = transform_operand(vids_map, op);
                     let st1 = Box::new(transform_st(vids_map, *st1));
                     let st2 = Box::new(transform_st(vids_map, *st2));
-                    RawStatement::Switch(op, SwitchTargets::If(st1, st2))
+                    Match::If(op, st1, st2)
                 }
-                SwitchTargets::SwitchInt(int_ty, targets, otherwise) => {
+                Match::SwitchInt(op, int_ty, targets, otherwise) => {
+                    let op = transform_operand(vids_map, op);
                     let targets = Vec::from_iter(
                         targets
                             .into_iter()
                             .map(|(v, e)| (v, transform_st(vids_map, e))),
                     );
                     let otherwise = transform_st(vids_map, *otherwise);
-                    let targets = SwitchTargets::SwitchInt(int_ty, targets, Box::new(otherwise));
-                    RawStatement::Switch(op, targets)
+                    Match::SwitchInt(op, int_ty, targets, Box::new(otherwise))
                 }
-            }
+                Match::Match(p, targets) => {
+                    let p = transform_place(vids_map, p);
+                    let targets = Vec::from_iter(
+                        targets
+                            .into_iter()
+                            .map(|(v, e)| (v, transform_st(vids_map, e))),
+                    );
+                    Match::Match(p, targets)
+                }
+            };
+            RawStatement::Match(mtch)
         }
         RawStatement::Loop(loop_body) => {
             RawStatement::Loop(Box::new(transform_st(vids_map, *loop_body)))

--- a/charon/src/simplify_ops.rs
+++ b/charon/src/simplify_ops.rs
@@ -17,7 +17,7 @@ use take_mut::take;
 
 use crate::expressions::*;
 use crate::llbc_ast::{
-    new_sequence, Assert, CtxNames, FunDecls, GlobalDecls, RawStatement, Statement, SwitchTargets,
+    new_sequence, Assert, CtxNames, FunDecls, GlobalDecls, Match, RawStatement, Statement,
 };
 use crate::meta::combine_meta;
 use crate::types::*;
@@ -583,6 +583,7 @@ fn simplify_st_seq(
     }
 }
 
+// TODO: don't consume `st`, use mutable borrows
 fn simplify_st(release: bool, st: Statement) -> Statement {
     let content = match st.content {
         RawStatement::Assign(p, rv) => {
@@ -649,23 +650,28 @@ fn simplify_st(release: bool, st: Statement) -> Statement {
         RawStatement::Break(i) => RawStatement::Break(i),
         RawStatement::Continue(i) => RawStatement::Continue(i),
         RawStatement::Nop => RawStatement::Nop,
-        RawStatement::Switch(op, targets) => {
-            let targets = match targets {
-                SwitchTargets::If(st1, st2) => SwitchTargets::If(
+        RawStatement::Match(mtch) => {
+            let mtch = match mtch {
+                Match::If(op, st1, st2) => Match::If(
+                    op,
                     Box::new(simplify_st(release, *st1)),
                     Box::new(simplify_st(release, *st2)),
                 ),
-                SwitchTargets::SwitchInt(int_ty, targets, otherwise) => {
+                Match::SwitchInt(op, int_ty, targets, otherwise) => {
                     let targets = Vec::from_iter(
                         targets
                             .into_iter()
                             .map(|(v, e)| (v, simplify_st(release, e))),
                     );
                     let otherwise = simplify_st(release, *otherwise);
-                    SwitchTargets::SwitchInt(int_ty, targets, Box::new(otherwise))
+                    Match::SwitchInt(op, int_ty, targets, Box::new(otherwise))
+                }
+                Match::Match(_, _) => {
+                    // We shouldn't get there: those are introduced later, in [remove_read_discriminant]
+                    unreachable!();
                 }
             };
-            RawStatement::Switch(op, targets)
+            RawStatement::Match(mtch)
         }
         RawStatement::Loop(loop_body) => {
             RawStatement::Loop(Box::new(simplify_st(release, *loop_body)))

--- a/charon/src/simplify_ops.rs
+++ b/charon/src/simplify_ops.rs
@@ -657,16 +657,16 @@ fn simplify_st(release: bool, st: Statement) -> Statement {
                     Box::new(simplify_st(release, *st1)),
                     Box::new(simplify_st(release, *st2)),
                 ),
-                Switch::SwitchInt(op, int_ty, targets, otherwise) => {
+                Switch::SwitchInt(op, int_ty, targets, mut otherwise) => {
                     let targets = Vec::from_iter(
                         targets
                             .into_iter()
                             .map(|(v, e)| (v, simplify_st(release, e))),
                     );
-                    let otherwise = simplify_st(release, *otherwise);
-                    Switch::SwitchInt(op, int_ty, targets, Box::new(otherwise))
+                    *otherwise = simplify_st(release, *otherwise);
+                    Switch::SwitchInt(op, int_ty, targets, otherwise)
                 }
-                Switch::Match(_, _) => {
+                Switch::Match(_, _, _) => {
                     // We shouldn't get there: those are introduced later, in [remove_read_discriminant]
                     unreachable!();
                 }

--- a/charon/src/translate_functions_to_ullbc.rs
+++ b/charon/src/translate_functions_to_ullbc.rs
@@ -1405,7 +1405,7 @@ fn translate_statement<'tcx, 'ctx, 'ctx1>(
 ) -> Result<Option<ast::Statement>> {
     trace!("About to translate statement (MIR) {:?}", statement);
 
-    use ::std::ops::Deref;
+    use std::ops::Deref;
 
     let sess = bt_ctx.ft_ctx.sess;
     let tcx = bt_ctx.ft_ctx.tcx;

--- a/charon/src/ullbc_to_llbc.rs
+++ b/charon/src/ullbc_to_llbc.rs
@@ -1503,7 +1503,7 @@ fn translate_terminator(
         }
         src::RawTerminator::Switch { discr, targets } => {
             // Translate the target expressions
-            let targets = match &targets {
+            let mtch = match &targets {
                 src::SwitchTargets::If(then_tgt, else_tgt) => {
                     // Translate the children expressions
                     let then_exp = translate_child_block(
@@ -1534,7 +1534,7 @@ fn translate_terminator(
                     let else_exp = opt_statement_to_nop_if_none(terminator.meta, else_exp);
 
                     // Translate
-                    tgt::SwitchTargets::If(Box::new(then_exp), Box::new(else_exp))
+                    tgt::Match::If(discr.clone(), Box::new(then_exp), Box::new(else_exp))
                 }
                 src::SwitchTargets::SwitchInt(int_ty, targets, otherwise) => {
                     // Note that some branches can be grouped together, like
@@ -1609,14 +1609,19 @@ fn translate_terminator(
                         opt_statement_to_nop_if_none(terminator.meta, otherwise_exp);
 
                     // Translate
-                    tgt::SwitchTargets::SwitchInt(*int_ty, targets_exps, Box::new(otherwise_exp))
+                    tgt::Match::SwitchInt(
+                        discr.clone(),
+                        *int_ty,
+                        targets_exps,
+                        Box::new(otherwise_exp),
+                    )
                 }
             };
 
             // Return
-            let meta = tgt::combine_switch_targets_meta(&targets);
+            let meta = tgt::combine_switch_targets_meta(&mtch);
             let meta = combine_meta(&src_meta, &meta);
-            let st = tgt::RawStatement::Switch(discr.clone(), targets);
+            let st = tgt::RawStatement::Match(mtch);
             let st = tgt::Statement::new(meta, st);
             Some(st)
         }
@@ -1668,7 +1673,7 @@ fn is_terminal_explore(num_loops: usize, st: &tgt::Statement) -> bool {
                 return is_terminal_explore(num_loops, st2);
             }
         }
-        tgt::RawStatement::Switch(_, targets) => targets
+        tgt::RawStatement::Match(mtch) => mtch
             .get_targets()
             .iter()
             .all(|tgt_st| is_terminal_explore(num_loops, tgt_st)),

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           inherit cargoArtifacts;
           buildPhase = ''
             # Run the tests for Charon
-            DEST=$out CHARON="${charon}/bin/cargo-charon --cargo-no-rust-version" \
+            DEST=$out CHARON="${charon}/bin/charon --cargo-no-rust-version" \
             make charon-tests
           '';
           doCheck = false;
@@ -58,7 +58,7 @@
           doCheck = false;
           buildPhase = ''
             # Run the tests for Charon
-            DEST=$out CHARON="${charon}/bin/cargo-charon --cargo-no-rust-version" \
+            DEST=$out CHARON="${charon}/bin/charon --cargo-no-rust-version" \
             make charon-tests
 
             # Nix doesn't run the cargo tests, so run them by hand

--- a/tests-polonius/Makefile
+++ b/tests-polonius/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR = $(shell pwd)
-CHARON ?= $(CURRENT_DIR)/../charon/target/debug/cargo-charon
+CHARON ?= $(CURRENT_DIR)/../charon/target/debug/charon
 DEST ?= .
 OPTIONS = --polonius
 NOT_ALL_TESTS ?=

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR = $(shell pwd)
-CHARON ?= $(CURRENT_DIR)/../charon/target/debug/cargo-charon
+CHARON ?= $(CURRENT_DIR)/../charon/target/debug/charon
 DEST ?= .
 OPTIONS =
 CHARON_CMD :=

--- a/tests/src/hashmap.rs
+++ b/tests/src/hashmap.rs
@@ -63,7 +63,7 @@ impl<T> HashMap<T> {
         max_load_dividend: usize,
         max_load_divisor: usize,
     ) -> Self {
-        // TODO: better to use `Vec::with_capacity(32)` instead
+        // TODO: better to use `Vec::with_capacity(capacity)` instead
         // of `Vec::new()`
         let slots = HashMap::allocate_slots(Vec::new(), capacity);
         HashMap {
@@ -83,8 +83,6 @@ impl<T> HashMap<T> {
         if i < slots.len() {
             slots[i] = List::Nil;
             HashMap::clear_slots(slots, i + 1)
-        } else {
-            ()
         }
     }
 


### PR DESCRIPTION
In Rust, the following match:
```rust
match ls {
    Nil => ...,
    Cons(hd, tl) => ...,
}
```

gets desugared to the following MIR:
```rust
d := discriminant(ls);
switch (move d) {
    0 => ..., // Nil case
    1 => ..., // Cons case
    _ => panic,
}
```

This PR implements a pass which reconstructs the matches. We also leverage this PR to cleanup a bit the project.