### PR TITLE
Add support for array aggregates

### DIFF
--- a/charon/src/expressions.rs
+++ b/charon/src/expressions.rs
@@ -211,7 +211,7 @@ pub enum Rvalue {
     Global(GlobalDeclId::Id),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, VariantIndexArity)]
 pub enum AggregateKind {
     Tuple,
     // TODO: treat Option in a general manner (we should extract the definitions

--- a/charon/src/expressions.rs
+++ b/charon/src/expressions.rs
@@ -224,4 +224,5 @@ pub enum AggregateKind {
         Vec<ErasedRegion>,
         Vec<ETy>,
     ),
+    Array(ETy),
 }

--- a/charon/src/translate_functions_to_ullbc.rs
+++ b/charon/src/translate_functions_to_ullbc.rs
@@ -1276,8 +1276,9 @@ fn translate_rvalue<'tcx>(
                 .collect();
 
             match aggregate_kind.deref() {
-                mir::AggregateKind::Array(_ty) => {
-                    unimplemented!();
+                mir::AggregateKind::Array(ty) => {
+                    let t_ty = translate_ety(bt_ctx, &ty);
+                    e::Rvalue::Aggregate(e::AggregateKind::Array(t_ty.unwrap()), operands_t)
                 }
                 mir::AggregateKind::Tuple => {
                     e::Rvalue::Aggregate(e::AggregateKind::Tuple, operands_t)


### PR DESCRIPTION
This adds support for serializing array aggregates. Some notes:
- there seemed to be an issue in the serialization functions where the AggregateKind::Adt was using the same variant number as AggregateKind::Options... was this intentional? (reading the doc, I would say no)
- I pointed out one potential inefficiency as a TODO but I don't think it's a big deal.
