### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,18 +37,15 @@ generate-rust-toolchain-%:
 build: build-charon-rust build-charon-ml
 
 .PHONY: build-charon-rust
-build-charon-rust: generate-rust-toolchain build-bin-dir
+build-charon-rust: generate-rust-toolchain
 	cd charon && $(MAKE)
+	mkdir -p bin
+	cp -f charon/target/release/charon bin
+	cp -f charon/target/release/charon-driver bin
 
 .PHONY: build-charon-ml
 build-charon-ml:
 	cd charon-ml && $(MAKE)
-
-.PHONY: build-bin-dir
-build-bin-dir:
-	mkdir -p bin
-	cp -f charon/target/release/charon bin
-	cp -f charon/target/release/charon-driver bin
 
 # Build the tests crate, and run the cargo tests
 .PHONY: build-tests

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,22 @@ generate-rust-toolchain-%:
 .PHONY: build
 build: build-charon-rust build-charon-ml
 
+.PHONY: build-debug
+build-debug: build-charon-rust-debug build-charon-ml
+
 .PHONY: build-charon-rust
 build-charon-rust: generate-rust-toolchain
 	cd charon && $(MAKE)
 	mkdir -p bin
 	cp -f charon/target/release/charon bin
 	cp -f charon/target/release/charon-driver bin
+
+.PHONY: build-charon-rust-debug
+build-charon-rust-debug: generate-rust-toolchain
+	cd charon && cargo build
+	mkdir -p bin
+	cp -f charon/target/debug/charon bin
+	cp -f charon/target/debug/charon-driver bin
 
 .PHONY: build-charon-ml
 build-charon-ml:

--- a/charon/src/assumed.rs
+++ b/charon/src/assumed.rs
@@ -41,6 +41,7 @@ pub static OPTION_SOME_VARIANT_ID: types::VariantId::Id = types::VariantId::ONE;
 //
 pub static PANIC_NAME: [&str; 3] = ["core", "panicking", "panic"];
 pub static BEGIN_PANIC_NAME: [&str; 3] = ["std", "panicking", "begin_panic"];
+pub static ASSERT_FAILED_NAME: [&str; 3] = ["core", "panicking", "assert_failed"];
 
 // Boxes
 pub static BOX_NEW_NAME: [&str; 4] = ["alloc", "boxed", "Box", "new"];

--- a/charon/src/gast_utils.rs
+++ b/charon/src/gast_utils.rs
@@ -360,8 +360,8 @@ impl<T> GFunDecl<T> {
             format!(" -> {}", ret_ty.fmt_with_ctx(ctx))
         };
 
-        // Clauses
-        let trait_clauses = fmt_where_clauses_with_ctx(
+        // Predicates
+        let preds = fmt_where_clauses_with_ctx(
             ctx,
             tab,
             &self.signature.parent_params_info,
@@ -373,7 +373,7 @@ impl<T> GFunDecl<T> {
         match &self.body {
             Option::None => {
                 // Put everything together
-                format!("{tab}{unsafe_kw}fn {name}{params}({args}){ret_ty}{trait_clauses}")
+                format!("{tab}{unsafe_kw}fn {name}{params}({args}){ret_ty}{preds}")
             }
             Option::Some(body) => {
                 // Body
@@ -382,7 +382,7 @@ impl<T> GFunDecl<T> {
 
                 // Put everything together
                 format!(
-                    "{tab}{unsafe_kw}fn {name}{params}({args}){ret_ty}{trait_clauses}\n{tab}{{\n{body}\n{tab}}}",
+                    "{tab}{unsafe_kw}fn {name}{params}({args}){ret_ty}{preds}\n{tab}{{\n{body}\n{tab}}}",
                 )
             }
         }

--- a/charon/src/meta_utils.rs
+++ b/charon/src/meta_utils.rs
@@ -45,19 +45,24 @@ impl Loc {
 /// meta-information of, say, a sequence).
 pub fn combine_meta(m0: &Meta, m1: &Meta) -> Meta {
     // Merge the spans
-    assert!(m0.span.file_id == m1.span.file_id);
-    let span = Span {
-        file_id: m0.span.file_id,
-        beg: Loc::min(&m0.span.beg, &m1.span.beg),
-        end: Loc::max(&m0.span.end, &m1.span.end),
-    };
+    if m0.span.file_id == m1.span.file_id {
+        let span = Span {
+            file_id: m0.span.file_id,
+            beg: Loc::min(&m0.span.beg, &m1.span.beg),
+            end: Loc::max(&m0.span.end, &m1.span.end),
+        };
 
-    // We don't attempt to merge the "generated from" spans: they might
-    // come from different files, and even if they come from the same files
-    // they might come from different macros, etc.
-    Meta {
-        span,
-        generated_from_span: None,
+        // We don't attempt to merge the "generated from" spans: they might
+        // come from different files, and even if they come from the same files
+        // they might come from different macros, etc.
+        Meta {
+            span,
+            generated_from_span: None,
+        }
+    } else {
+        // It happens that the spans don't come from the same file. In this
+        // situation, we just return the first span. TODO: improve this.
+        *m0
     }
 }
 

--- a/charon/src/translate_predicates.rs
+++ b/charon/src/translate_predicates.rs
@@ -144,21 +144,25 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // **IMPORTANT**:
         // There are two functions which allow to retrieve the predicates of
         // a definition:
-        // - [TyCtxt::predicates_of]
-        // - [TyCtxt::predicates_defined_on]
-        // If we use [TyCtxt::predicates_of] on a trait `Foo`, we get an
-        // additional predicate `Self : Foo` (i.e., the trait requires itself),
-        // which is not what we want.
-        let tcx = self.t_ctx.tcx;
-        let param_env = tcx.param_env(def_id);
-        // Remark: we don't convert the predicates yet because we need to
-        // normalize them before.
-        let predicates = tcx.predicates_defined_on(def_id);
-        let parent: Option<hax::DefId> = predicates.parent.sinto(&self.hax_state);
-        let predicates: Vec<_> = predicates.predicates.iter().collect();
-        trace!("Predicates of {:?}:\n{:?}", def_id, predicates);
-
-        // We reorder the predicates to make sure that the trait clauses come
+        // - [TyCtxt::predicates_defined_on]: returns exactly the list of predicates
+        //   that the user has written on the definition:
+        // - [TyCtxt::predicates_of]: returns the user defined predicates and also:
+        //   - if called on a trait `Foo`, we get an additional trait clause
+        //     `Self : Foo` (i.e., the trait requires itself), which is not what we want.
+        //   - for the type definitions, it also returns additional type/region outlives
+        //     information, which the user doesn't have to write by hand (but it doesn't
+        //     add those for functions). For instance, below:
+        //     ```
+        //     type MutMut<'a, 'b> {
+        //       x : &'a mut &'b mut u32,
+        //     }
+        //     ```
+        //     The rust compiler adds the predicate: `'b : 'a` ('b outlives 'a).
+        // For this reason we:
+        // - retrieve the trait predicates with [TyCtxt::predicates_defined_on]
+        // - retrieve the other predicates with [TyCtxt::predicates_of]
+        //
+        // Also, we reorder the predicates to make sure that the trait clauses come
         // *before* the other clauses. This way we are sure that, when translating,
         // all the trait clauses are in the context if we need them.
         //
@@ -166,58 +170,104 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // ```
         // f<T : Foo<S = U::S>, U : Foo>(...)
         //               ^^^^
-        //        must make sure we have U : Foo in the contextx
+        //        must make sure we have U : Foo in the context
         //                before translating this
         // ```
-        let (trait_clauses, non_trait_preds): (
-            Vec<&(rustc_middle::ty::Predicate<'_>, rustc_span::Span)>,
-            Vec<&(rustc_middle::ty::Predicate<'_>, rustc_span::Span)>,
-        ) = predicates.into_iter().partition(|x| {
-            matches!(
-                &x.0.kind().skip_binder(),
-                rustc_middle::ty::PredicateKind::Clause(rustc_middle::ty::Clause::Trait(_))
-            )
-        });
+        let tcx = self.t_ctx.tcx;
+        let param_env = tcx.param_env(def_id);
+        let parent: Option<hax::DefId>;
 
-        let trait_clauses: Vec<(rustc_middle::ty::TraitPredicate<'_>, rustc_span::Span)> =
-            trait_clauses
-                .into_iter()
-                .map(|(pred, span)| {
-                    if let rustc_middle::ty::PredicateKind::Clause(
-                        rustc_middle::ty::Clause::Trait(tr),
-                    ) = &pred.kind().no_bound_vars().unwrap()
-                    {
-                        // Normalize the trait clause
-                        let tr = tcx.normalize_erasing_regions(param_env, *tr);
-                        (tr, *span)
-                    } else {
-                        unreachable!();
-                    }
+        let trait_preds = {
+            // Remark: we don't convert the predicates yet because we need to
+            // normalize them before.
+            let predicates = tcx.predicates_defined_on(def_id);
+            parent = predicates.parent.sinto(&self.hax_state);
+            let predicates: Vec<_> = predicates.predicates.iter().collect();
+            trace!(
+                "TyCtxt::predicates_defined_on({:?}):\n{:?}",
+                def_id,
+                predicates
+            );
+
+            let trait_clauses: Vec<&(rustc_middle::ty::Predicate<'_>, rustc_span::Span)> =
+                predicates
+                    .into_iter()
+                    .filter(|x| {
+                        matches!(
+                            &x.0.kind().skip_binder(),
+                            rustc_middle::ty::PredicateKind::Clause(
+                                rustc_middle::ty::Clause::Trait(_)
+                            )
+                        )
+                    })
+                    .collect();
+
+            let trait_clauses: Vec<(rustc_middle::ty::TraitPredicate<'_>, rustc_span::Span)> =
+                trait_clauses
+                    .into_iter()
+                    .map(|(pred, span)| {
+                        if let rustc_middle::ty::PredicateKind::Clause(
+                            rustc_middle::ty::Clause::Trait(tr),
+                        ) = &pred.kind().no_bound_vars().unwrap()
+                        {
+                            // Normalize the trait clause
+                            let tr = tcx.normalize_erasing_regions(param_env, *tr);
+                            (tr, *span)
+                        } else {
+                            unreachable!();
+                        }
+                    })
+                    .collect();
+
+            let trait_preds: Vec<_> = trait_clauses
+                .iter()
+                .map(|(tr, span)| {
+                    let value =
+                        hax::PredicateKind::Clause(hax::Clause::Trait(tr.sinto(&self.hax_state)));
+                    let pred = hax::Binder {
+                        value,
+                        bound_vars: Vec::new(),
+                    };
+                    (pred, span.sinto(&self.hax_state))
                 })
                 .collect();
+            trait_preds
+        };
 
-        let trait_preds: Vec<_> = trait_clauses
-            .iter()
-            .map(|(tr, span)| {
-                let value =
-                    hax::PredicateKind::Clause(hax::Clause::Trait(tr.sinto(&self.hax_state)));
-                let pred = hax::Binder {
-                    value,
-                    bound_vars: Vec::new(),
-                };
-                (pred, span.sinto(&self.hax_state))
-            })
-            .collect();
+        let non_trait_preds = {
+            let predicates = tcx.predicates_of(def_id);
+            let predicates: Vec<_> = predicates.predicates.iter().collect();
+            trace!("TyCtxt::predicates_of({:?}):\n{:?}", def_id, predicates);
 
-        let non_trait_preds: Vec<_> = non_trait_preds
-            .iter()
-            .map(|(pred, span)| (pred.sinto(&self.hax_state), span.sinto(&self.hax_state)))
-            .collect();
+            let non_trait_preds: Vec<&(rustc_middle::ty::Predicate<'_>, rustc_span::Span)> =
+                predicates
+                    .into_iter()
+                    .filter(|x| {
+                        !(matches!(
+                            &x.0.kind().skip_binder(),
+                            rustc_middle::ty::PredicateKind::Clause(
+                                rustc_middle::ty::Clause::Trait(_)
+                            )
+                        ))
+                    })
+                    .collect();
+            trace!(
+                "TyCtxt::predicates_of({:?}) after filtering trait clauses:\n{:?}",
+                def_id,
+                non_trait_preds
+            );
+            let non_trait_preds: Vec<_> = non_trait_preds
+                .iter()
+                .map(|(pred, span)| (pred.sinto(&self.hax_state), span.sinto(&self.hax_state)))
+                .collect();
+            non_trait_preds
+        };
 
         let predicates: Vec<(hax::Predicate, hax::Span)> = trait_preds
             .into_iter()
             .chain(non_trait_preds.into_iter())
             .collect();
+        trace!("Predicates of {:?}\n{:?}", def_id, predicates);
         hax::GenericPredicates { parent, predicates }
     }
 

--- a/charon/src/translate_traits.rs
+++ b/charon/src/translate_traits.rs
@@ -233,7 +233,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         let name = names_utils::extended_def_id_to_name(&rust_id.sinto(&bt_ctx.hax_state));
 
         // Translate the generic
-        let _substs = bt_ctx.translate_generics(rust_id);
+        bt_ctx.translate_generic_params(rust_id);
 
         // Add the trait clauses
         bt_ctx.while_registering_trait_clauses(&mut |bt_ctx| {
@@ -413,7 +413,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         let name = names_utils::extended_def_id_to_name(&rust_id.sinto(&bt_ctx.hax_state));
 
         // Translate the generics
-        let _substs = bt_ctx.translate_generics(rust_id);
+        bt_ctx.translate_generic_params(rust_id);
 
         // Add the trait self clauses
         bt_ctx.while_registering_trait_clauses(&mut |bt_ctx| {

--- a/charon/src/translate_types.rs
+++ b/charon/src/translate_types.rs
@@ -682,6 +682,8 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
             regions_hierarchy: RegionGroups::new(),
         };
 
+        trace!("translate_type: preds: {:?}", &type_def.preds);
+
         trace!("{} -> {}", trans_id.to_string(), type_def.to_string());
 
         self.type_defs.insert(trans_id, type_def);

--- a/charon/src/types_utils.rs
+++ b/charon/src/types_utils.rs
@@ -646,7 +646,7 @@ impl TypeDecl {
         let (params, trait_clauses) = self.generics.fmt_with_ctx_with_trait_clauses(ctx);
         // Trait clauses
         let eq_space = if trait_clauses.is_empty() {
-            "".to_string()
+            " ".to_string()
         } else {
             format!("\n ")
         };


### PR DESCRIPTION
This PR performs minor modifications:
- it properly retrieves the types/lifetime constraints automatically introduced by rustc on the type definitions
- fixes the `build-bin-dir` rule in the Makefile, and adds a `build-debug` rule
- fixes an issue in `combine_meta`
- fixes an issue in `regions_hierarchy.rs`