### PR TITLE
Make the otherwise branch in the LLBC match statements optional

### DIFF
--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -246,7 +246,7 @@ and rvalue =
   | RvRef of place * borrow_kind
   | UnaryOp of unop * operand
   | BinaryOp of binop * operand * operand
-  | Discriminant of place
+  | Discriminant of place * type_decl_id
   | Aggregate of aggregate_kind * operand list
   | Global of global_decl_id
 [@@deriving

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -877,9 +877,10 @@ let rvalue_of_json (js : json) : (rvalue, string) result =
         let* op1 = operand_of_json op1 in
         let* op2 = operand_of_json op2 in
         Ok (BinaryOp (binop, op1, op2))
-    | `Assoc [ ("Discriminant", place) ] ->
+    | `Assoc [ ("Discriminant", `List [ place; adt_id ]) ] ->
         let* place = place_of_json place in
-        Ok (Discriminant place)
+        let* adt_id = TypeDeclId.id_of_json adt_id in
+        Ok (Discriminant (place, adt_id))
     | `Assoc [ ("Global", gid) ] ->
         let* gid = GlobalDeclId.id_of_json gid in
         Ok (Global gid : rvalue)

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -43,10 +43,11 @@ and switch =
           - the "otherwise" statement
           Also note that we precise the type of the integer (uint32, int64, etc.)
           which we switch on. *)
-  | Match of place * (variant_id list * statement) list * statement
+  | Match of place * (variant_id list * statement) list * statement option
       (** A match over an ADT.
 
-          Similar comments as for {!SwitchInt}.
+          Similar comments as for {!SwitchInt}. Note that the "otherwise" branch
+          is optional.
        *)
 [@@deriving
   show,

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -62,7 +62,11 @@ and chain_statements_in_switch (switch : switch) (st : statement) : switch =
       let branches =
         List.map (fun (svl, br) -> (svl, chain_statements br st)) branches
       in
-      let otherwise = chain_statements otherwise st in
+      let otherwise =
+        match otherwise with
+        | None -> None
+        | Some otherwise -> Some (chain_statements otherwise st)
+      in
       Match (op, branches, otherwise)
 
 (** Compute a map from function declaration ids to declaration groups. *)

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -102,7 +102,9 @@ and switch_of_json (id_to_file : id_to_file_map) (js : json) :
                (statement_of_json id_to_file))
             tgts
         in
-        let* otherwise = statement_of_json id_to_file otherwise in
+        let* otherwise =
+          option_of_json (statement_of_json id_to_file) otherwise
+        in
         Ok (Match (p, tgts, otherwise))
     | _ -> Error "")
 

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -146,7 +146,7 @@ let rvalue_to_string (env : ('a, 'b) fmt_env) (rv : rvalue) : string =
   | BinaryOp (binop, op1, op2) ->
       operand_to_string env op1 ^ " " ^ binop_to_string binop ^ " "
       ^ operand_to_string env op2
-  | Discriminant p -> "discriminant(" ^ place_to_string env p ^ ")"
+  | Discriminant (p, _) -> "discriminant(" ^ place_to_string env p ^ ")"
   | Global gid -> "global " ^ global_decl_id_to_string env gid
   | Aggregate (akind, ops) -> (
       let ops = List.map (operand_to_string env) ops in

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -94,10 +94,14 @@ module Ast = struct
                 branches
             in
             let branches = String.concat "\n" branches in
-            let branches =
-              branches ^ "\n" ^ indent1 ^ "_ => {\n"
-              ^ inner_to_string2 otherwise ^ "\n" ^ indent1 ^ "}"
+            let otherwise =
+              match otherwise with
+              | None -> ""
+              | Some otherwise ->
+                  "\n" ^ indent1 ^ "_ => {\n" ^ inner_to_string2 otherwise
+                  ^ "\n" ^ indent1 ^ "}"
             in
+            let branches = branches ^ otherwise in
             indent ^ "match (" ^ p ^ ") {\n" ^ branches ^ "\n" ^ indent ^ "}")
     | Loop loop_st ->
         indent ^ "loop {\n"

--- a/charon/src/driver.rs
+++ b/charon/src/driver.rs
@@ -249,7 +249,7 @@ pub fn translate(sess: &Session, tcx: TyCtxt, internal: &mut CharonCallbacks) ->
         index_to_function_calls::transform(&ctx, &mut llbc_funs, &mut llbc_globals);
 
         // # Micro-pass: Remove the discriminant reads (merge them with the switches)
-        remove_read_discriminant::transform(&ctx, &mut llbc_funs, &mut llbc_globals);
+        remove_read_discriminant::transform(&mut ctx, &mut llbc_funs, &mut llbc_globals);
 
         // # Micro-pass: add the missing assignments to the return value.
         // When the function return type is unit, the generated MIR doesn't

--- a/charon/src/expressions.rs
+++ b/charon/src/expressions.rs
@@ -328,10 +328,11 @@ pub enum Rvalue {
     /// Binary operations (note that we merge "checked" and "unchecked" binops)
     BinaryOp(BinOp, Operand, Operand),
     /// Discriminant (for enumerations).
-    /// Note that discriminant values have type isize.
+    /// Note that discriminant values have type isize. We also store the identifier
+    /// of the type from which we read the discriminant.
     ///
     /// This case is filtered in [crate::remove_read_discriminant]
-    Discriminant(Place),
+    Discriminant(Place, TypeDeclId::Id),
     /// Creates an aggregate value, like a tuple, a struct or an enum:
     /// ```text
     /// l = List::Cons { value:x, tail:tl };

--- a/charon/src/expressions_utils.rs
+++ b/charon/src/expressions_utils.rs
@@ -241,7 +241,7 @@ impl Rvalue {
             Rvalue::BinaryOp(binop, x, y) => {
                 format!("{} {} {}", x.fmt_with_ctx(ctx), binop, y.fmt_with_ctx(ctx))
             }
-            Rvalue::Discriminant(p) => {
+            Rvalue::Discriminant(p, _) => {
                 format!("@discriminant({})", p.fmt_with_ctx(ctx),)
             }
             Rvalue::Aggregate(kind, ops) => {
@@ -405,7 +405,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
             Rvalue::Ref(p, bkind) => self.visit_ref(p, bkind),
             Rvalue::UnaryOp(op, o1) => self.visit_unary_op(op, o1),
             Rvalue::BinaryOp(op, o1, o2) => self.visit_binary_op(op, o1, o2),
-            Rvalue::Discriminant(p) => self.visit_discriminant(p),
+            Rvalue::Discriminant(p, adt_id) => self.visit_discriminant(p, adt_id),
             Rvalue::Aggregate(kind, ops) => self.visit_aggregate(kind, ops),
             Rvalue::Global(gid) => self.visit_global(gid),
             Rvalue::Len(p, ty, cg) => self.visit_len(p, ty, cg),
@@ -445,8 +445,9 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
         self.visit_operand(o2);
     }
 
-    fn visit_discriminant(&mut self, p: &Place) {
-        self.visit_place(p)
+    fn visit_discriminant(&mut self, p: &Place, adt_id: &TypeDeclId::Id) {
+        self.visit_place(p);
+        self.visit_type_decl_id(adt_id);
     }
 
     fn visit_aggregate(&mut self, ak: &AggregateKind, ops: &Vec<Operand>) {

--- a/charon/src/index_to_function_calls.rs
+++ b/charon/src/index_to_function_calls.rs
@@ -162,7 +162,7 @@ impl<'a> MutExprVisitor for Transform<'a> {
                     }
                 }
             }
-            Discriminant(p) | Len(p, _, _) => {
+            Discriminant(p, _) | Len(p, _, _) => {
                 // We access places, but those places are used to access
                 // elements without mutating them
                 self.visit_transform_place(false, p);

--- a/charon/src/llbc_ast.rs
+++ b/charon/src/llbc_ast.rs
@@ -96,8 +96,12 @@ pub enum Switch {
     ///
     /// The match statement is introduced in [crate::remove_read_discriminant]
     /// (whenever we find a discriminant read, we merge it with the subsequent
-    /// switch into a match)
-    Match(Place, Vec<(Vec<VariantId::Id>, Statement)>, Box<Statement>),
+    /// switch into a match).
+    Match(
+        Place,
+        Vec<(Vec<VariantId::Id>, Statement)>,
+        Option<Box<Statement>>,
+    ),
 }
 
 pub type ExprBody = GExprBody<Statement>;

--- a/charon/src/translate_ctx.rs
+++ b/charon/src/translate_ctx.rs
@@ -100,6 +100,19 @@ macro_rules! error_assert_then {
 }
 pub(crate) use error_assert_then;
 
+macro_rules! register_error_or_panic {
+    ($ctx:expr, $span: expr, $msg: expr) => {{
+        $ctx.span_err($span, &$msg);
+        if $ctx.continue_on_failure() {
+            // Nothing to do
+            ();
+        } else {
+            panic!("{}", $msg);
+        }
+    }};
+}
+pub(crate) use register_error_or_panic;
+
 pub struct CrateInfo {
     pub crate_name: String,
     pub opaque_mods: HashSet<String>,

--- a/charon/src/ullbc_ast_utils.rs
+++ b/charon/src/ullbc_ast_utils.rs
@@ -203,7 +203,7 @@ impl BlockData {
             Rvalue::Repeat(op, _, _) => {
                 f(meta, nst, op);
             }
-            Rvalue::Global(_) | Rvalue::Discriminant(_) | Rvalue::Ref(_, _) | Rvalue::Len(..) => {
+            Rvalue::Global(_) | Rvalue::Discriminant(..) | Rvalue::Ref(_, _) | Rvalue::Len(..) => {
                 // No operands: nothing to do
             }
         }


### PR DESCRIPTION
Upon reconstructing the matches, we check if all the variants are covered in the "regular" branches, in which case we remove the "otherwise" branch.