### PR TITLE
Add missing opam dependency and fix clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ charon-tests-polonius: build-tests-polonius
 
 .PHONY: clean
 clean:
-	cd attributes && cargo clean
+	cd charon/attributes && cargo clean
 	cd charon && cargo clean
 	cd charon/macros && cargo clean
 	cd tests && cargo clean

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For Charon-ML, we use **OCaml 4.13.1**: `opam switch create 4.13.1+options`
 The dependencies can be installed with the following command:
 
 ```
-opam install ppx_deriving visitors easy_logging zarith yojson core_unix odoc
+opam install ppx_deriving visitors easy_logging zarith yojson core_unix odoc menhir
 ```
 
 You can then run `make build-charon-ml` to build the ML library, or even simply


### PR DESCRIPTION
A couple of minor fixes:

1. Add missing OPAM dependency (`menhir`) to installation instructions. Apparently, this package was introduced in https://github.com/AeneasVerif/charon/commit/56c011f7a7ddd484f4db7349ddb6e648f92b153b and without it, building the `charon-ml` library fails
2. Fix the makfile's `clean` target which is referring to an `attributes` directory that was moved inside the `charon` directory in https://github.com/AeneasVerif/charon/pull/12/commits/a781da965c10bb09ec131539fc338b4caea276d1. Without it, `make clean` fails:
```
$ make clean
cd attributes && cargo clean
/bin/sh: 1: cd: can't cd to attributes
make: *** [Makefile:99: clean] Error 2
```