### PR TITLE
Update the Names

### DIFF
--- a/charon-ml/name_matcher_parser/Ast.ml
+++ b/charon-ml/name_matcher_parser/Ast.ml
@@ -7,18 +7,27 @@ let pp_big_int (fmt : Format.formatter) (bi : big_int) : unit =
 let compare_big_int (bi0 : big_int) (bi1 : big_int) : int = Z.compare bi0 bi1
 let show_big_int (bi : big_int) : string = Z.to_string bi
 
-type var = VarName of string | VarIndex of int [@@deriving show, ord]
+(** Ancestor the pattern iter visitor *)
+class ['self] iter_pattern_base =
+  object (_self : 'self)
+    inherit [_] VisitorsRuntime.iter
+    method visit_big_int : 'env -> big_int -> unit = fun _ _ -> ()
+  end
 
-type literal = LInt of big_int | LBool of bool | LChar of char
-[@@deriving show, ord]
+(** Ancestor the pattern map visitor *)
+class ['self] map_pattern_base =
+  object (_self : 'self)
+    inherit [_] VisitorsRuntime.map
+    method visit_big_int : 'env -> big_int -> big_int = fun _ x -> x
+  end
 
-(*type const_generic = CgVar of const_generic_var option | CgValue of Z.t*)
-type ref_kind = RMut | RShared [@@deriving show, ord]
-type region = RVar of var option | RStatic [@@deriving show, ord]
-type primitive_adt = TTuple | TArray | TSlice [@@deriving show, ord]
-type mutability = Mut | Not [@@deriving show, ord]
-
-type pattern = pattern_elem list
+type var = VarName of string | VarIndex of int
+and literal = LInt of big_int | LBool of bool | LChar of char
+and ref_kind = RMut | RShared
+and region = RVar of var option | RStatic
+and primitive_adt = TTuple | TArray | TSlice
+and mutability = Mut | Not
+and pattern = pattern_elem list
 and pattern_elem = PIdent of string * generic_args | PImpl of expr
 
 (** An expression can be a type or a trait ref.
@@ -39,4 +48,26 @@ and expr =
   | ERawPtr of mutability * expr
 
 and generic_arg = GExpr of expr | GValue of literal | GRegion of region
-and generic_args = generic_arg list [@@deriving show, ord]
+
+and generic_args = generic_arg list
+[@@deriving
+  show,
+    ord,
+    visitors
+      {
+        name = "iter_pattern";
+        variety = "iter";
+        ancestors = [ "iter_pattern_base" ];
+        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
+        concrete = true;
+        polymorphic = false;
+      },
+    visitors
+      {
+        name = "map_pattern";
+        variety = "map";
+        ancestors = [ "map_pattern_base" ];
+        nude = true (* Don't inherit {!VisitorsRuntime.map} *);
+        concrete = false;
+        polymorphic = false;
+      }]

--- a/charon-ml/name_matcher_parser/dune
+++ b/charon-ml/name_matcher_parser/dune
@@ -6,7 +6,7 @@
 (library
  (name name_matcher_parser)
  (public_name name_matcher_parser)
- (preprocess (pps ppx_deriving.show ppx_deriving.ord))
+ (preprocess (pps ppx_deriving.show ppx_deriving.ord visitors.ppx))
  (libraries zarith menhirLib)
  (flags
   ; menhir generates instances of the "unused rec flag" warning

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -105,20 +105,22 @@ type fun_sig = {
 }
 [@@deriving show]
 
-type fun_kind =
-  | RegularKind  (** A "normal" function *)
-  | TraitMethodImpl of trait_impl_id * trait_decl_id * string * bool
-      (** Trait method implementation.
+type item_kind =
+  | RegularKind
+      (** A "normal" item (either defined at the top-level, or inside
+          a type impl block). *)
+  | TraitItemImpl of trait_impl_id * trait_decl_id * string * bool
+      (** Trait item implementation.
 
           Fields:
           - [trait impl id]
           - [trait_id]
-          - [method_name]
-          - [provided]: true if this function re-implements a provided method
+          - [item_name]
+          - [provided]: true if this item *re-implements* a provided item
         *)
-  | TraitMethodDecl of trait_decl_id * string  (** A trait method declaration *)
-  | TraitMethodProvided of trait_decl_id * string
-      (** Trait method provided function (trait method declaration which defines a
+  | TraitItemDecl of trait_decl_id * string  (** A trait item declaration *)
+  | TraitItemProvided of trait_decl_id * string
+      (** Provided trait item (trait item declaration which defines a
           default implementation at the same time *)
 [@@deriving show]
 
@@ -140,7 +142,7 @@ type 'body gfun_decl = {
   is_local : bool;
   name : name;
   signature : fun_sig;
-  kind : fun_kind;
+  kind : item_kind;
   body : 'body gexpr_body option;
   is_global_decl_body : bool;
 }
@@ -200,6 +202,7 @@ type 'body gglobal_decl = {
   is_local : bool;
   name : name;
   ty : ty;
+  kind : item_kind;
   body : 'body;
 }
 [@@deriving show]

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -134,7 +134,9 @@ let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
      let* global =
        gglobal_decl_of_json (statement_of_json id_to_file) id_to_file js
      in
-     let { def_id = global_id; meta; body; is_local; name; ty } = global in
+     let { def_id = global_id; meta; body; is_local; name; ty; kind } =
+       global
+     in
      (* Decompose into a global and a function *)
      let fun_id = global_to_fun_id gid_conv global.def_id in
      let signature : fun_sig =
@@ -151,7 +153,7 @@ let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
        }
      in
      let global_decl : global_decl =
-       { def_id = global_id; meta; body = fun_id; is_local; name; ty }
+       { def_id = global_id; meta; body = fun_id; is_local; name; ty; kind }
      in
      let fun_decl : fun_decl =
        {

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -240,6 +240,21 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       ^ ")"
   | UnknownTrait msg -> "UNKNOWN(" ^ msg ^ ")"
 
+and impl_elem_kind_to_string (env : ('a, 'b) fmt_env) (k : impl_elem_kind) :
+    string =
+  match k with
+  | ImplElemTy ty -> ty_to_string env ty
+  | ImplElemTrait tr ->
+      (* Put the first type argument aside (it gives the type for which we
+         implement the trait) *)
+      let { trait_decl_id; decl_generics } = tr in
+      let ty, types = Collections.List.pop decl_generics.types in
+      let decl_generics = { decl_generics with types } in
+      let ty = ty_to_string env ty in
+      let tr = { trait_decl_id; decl_generics } in
+      let tr = trait_decl_ref_to_string env tr in
+      "(" ^ tr ^ " for " ^ ty ^ ")"
+
 and impl_elem_to_string (env : ('a, 'b) fmt_env) (e : impl_elem) : string =
   (* Locally replace the generics and the predicates *)
   let env = fmt_env_update_generics_and_preds env e.generics e.preds in
@@ -247,8 +262,8 @@ and impl_elem_to_string (env : ('a, 'b) fmt_env) (e : impl_elem) : string =
     if e.disambiguator = Disambiguator.zero then ""
     else "#" ^ Disambiguator.to_string e.disambiguator
   in
-  let ty = ty_to_string env e.ty in
-  "{" ^ ty ^ d ^ "}"
+  let kind = impl_elem_kind_to_string env e.kind in
+  "{" ^ kind ^ d ^ "}"
 
 and path_elem_to_string (env : ('a, 'b) fmt_env) (e : path_elem) : string =
   match e with

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -483,12 +483,17 @@ and predicates = {
         polymorphic = false;
       }]
 
+(** In implementation path elements we distinguish inherent impls (impl blocks
+    for types) from trait impls *)
+type impl_elem_kind = ImplElemTy of ty | ImplElemTrait of trait_decl_ref
+[@@deriving show, ord]
+
 (** An impl path element for [name] *)
 type impl_elem = {
+  disambiguator : Disambiguator.id;
   generics : generic_params;
   preds : predicates;
-  ty : ty;
-  disambiguator : Disambiguator.id;
+  kind : impl_elem_kind;
 }
 [@@deriving show, ord]
 

--- a/charon/src/assumed.rs
+++ b/charon/src/assumed.rs
@@ -108,8 +108,8 @@ fn get_fun_id_from_name_full(name: &Name) -> Option<FunId> {
         match name.name.as_slice() {
             [Ident(alloc, _), Ident(boxed, _), Impl(impl_elem), Ident(new, _)] => {
                 if alloc == "alloc" && boxed == "boxed" && new == "new" {
-                    match &impl_elem.ty {
-                        Ty::Adt(TypeId::Assumed(AssumedTy::Box), generics) => {
+                    match &impl_elem.kind {
+                        ImplElemKind::Ty(Ty::Adt(TypeId::Assumed(AssumedTy::Box), generics)) => {
                             let GenericArgs {
                                 regions,
                                 types,

--- a/charon/src/driver.rs
+++ b/charon/src/driver.rs
@@ -156,7 +156,11 @@ pub fn translate(sess: &Session, tcx: TyCtxt, internal: &mut CharonCallbacks) ->
     // # Translate the declarations in the crate.
     // We translate the declarations in an ad-hoc order, and do not group
     // the mutually recursive groups - we do this in the next step.
-    let mut ctx = translate_crate_to_ullbc::translate(crate_info, options, sess, tcx, mir_level);
+    let mut ctx =
+        match translate_crate_to_ullbc::translate(crate_info, options, sess, tcx, mir_level) {
+            Ok(ctx) => ctx,
+            Err(_) => return Err(()),
+        };
 
     trace!("# After translation from MIR:\n\n{}\n", ctx);
 

--- a/charon/src/gast.rs
+++ b/charon/src/gast.rs
@@ -43,19 +43,19 @@ pub struct GExprBody<T> {
     pub body: T,
 }
 
-/// Function kind: "regular" function, trait method declaration, etc.
+/// Item kind kind: "regular" item (not linked to a trait), trait item declaration, etc.
 ///
 /// Example:
 /// ========
 /// ```text
 /// trait Foo {
-///   fn bar(x : u32) -> u32; // trait method: declaration
+///   fn bar(x : u32) -> u32; // trait item: declaration (required)
 ///
-///   fn baz(x : bool) -> bool { x } // trait method: provided
+///   fn baz(x : bool) -> bool { x } // trait item: provided
 /// }
 ///
 /// impl Foo for ... {
-///   fn bar(x : u32) -> u32 { x } // trait method: implementation
+///   fn bar(x : u32) -> u32 { x } // trait item: implementation
 /// }
 ///
 /// fn test(...) { ... } // regular
@@ -65,25 +65,25 @@ pub struct GExprBody<T> {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub enum FunKind {
+pub enum ItemKind {
     /// A "normal" function
     Regular,
-    /// Trait method implementation
-    TraitMethodImpl {
+    /// Trait item implementation
+    TraitItemImpl {
         /// The trait implementation block the method belongs to
         impl_id: TraitImplId::Id,
         /// The id of the trait decl the method belongs to
         trait_id: TraitDeclId::Id,
-        /// The name of the method
-        method_name: TraitItemName,
-        /// True if this function re-implements a provided method
+        /// The name of the item
+        item_name: TraitItemName,
+        /// True if this item *re-implements* a provided item
         provided: bool,
     },
-    /// Trait method declaration
-    TraitMethodDecl(TraitDeclId::Id, TraitItemName),
-    /// Trait method provided function (trait method declaration which defines
+    /// Trait item declaration
+    TraitItemDecl(TraitDeclId::Id, TraitItemName),
+    /// Provided trait item (trait item declaration which defines
     /// a default implementation at the same time)
-    TraitMethodProvided(TraitDeclId::Id, TraitItemName),
+    TraitItemProvided(TraitDeclId::Id, TraitItemName),
 }
 
 /// A function definition
@@ -102,7 +102,7 @@ pub struct GFunDecl<T> {
     /// It also contains the list of region and type parameters.
     pub signature: FunSig,
     /// The function kind: "regular" function, trait method declaration, etc.
-    pub kind: FunKind,
+    pub kind: ItemKind,
     /// The function body, in case the function is not opaque.
     /// Opaque functions are: external functions, or local functions tagged
     /// as opaque.
@@ -122,6 +122,8 @@ pub struct GGlobalDecl<T> {
     pub is_local: bool,
     pub name: Name,
     pub ty: Ty,
+    /// The global kind: "regular" function, trait const declaration, etc.
+    pub kind: ItemKind,
     pub body: Option<GExprBody<T>>,
 }
 

--- a/charon/src/names.rs
+++ b/charon/src/names.rs
@@ -16,10 +16,30 @@ pub enum PathElem {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ImplElem {
+    pub disambiguator: Disambiguator::Id,
     pub generics: GenericParams,
     pub preds: Predicates,
-    pub ty: Ty,
-    pub disambiguator: Disambiguator::Id,
+    pub kind: ImplElemKind,
+}
+
+/// There are two kinds of `impl` blocks:
+/// - impl blocks linked to a type ("inherent" impl blocks following Rust terminology):
+///   ```text
+///   impl<T> List<T> { ...}
+///   ```
+/// - trait impl blocks:
+///   ```text
+///   impl<T> PartialEq for List<T> { ...}
+///   ```
+/// We distinguish the two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum ImplElemKind {
+    Ty(Ty),
+    /// Remark: the first type argument in the trait ref gives the type for
+    /// which we implement the trait.
+    /// For instance: `PartialEq<List<T>>` means: the `PartialEq` instance
+    /// for `List<T>`.
+    Trait(TraitDeclRef),
 }
 
 /// An item name/path

--- a/charon/src/reorder_decls.rs
+++ b/charon/src/reorder_decls.rs
@@ -294,10 +294,10 @@ impl Deps {
                 //
                 // The declaration may not be present if we encountered errors.
                 if let Some(decl) = ctx.fun_decls.get(id) {
-                    if let FunKind::TraitMethodImpl {
+                    if let ItemKind::TraitItemImpl {
                         impl_id,
                         trait_id: _,
-                        method_name: _,
+                        item_name: _,
                         provided: _,
                     } = &decl.kind
                     {

--- a/charon/src/translate_functions_to_ullbc.rs
+++ b/charon/src/translate_functions_to_ullbc.rs
@@ -112,21 +112,21 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         }
     }
 
-    pub(crate) fn get_fun_kind(
+    pub(crate) fn get_item_kind(
         &mut self,
         src: &Option<DepSource>,
         rust_id: DefId,
-    ) -> Result<FunKind, Error> {
+    ) -> Result<ItemKind, Error> {
         trace!("rust_id: {:?}", rust_id);
         let tcx = self.tcx;
         if let Some(assoc) = tcx.opt_associated_item(rust_id) {
             let kind = match assoc.container {
                 ty::AssocItemContainer::ImplContainer => {
-                    // This method is defined in an impl block.
-                    // It can be a regular function in an impl block or a trait
-                    // method implementation.
+                    // This item is defined in an impl block.
+                    // It can be a regular item in an impl block or a trait
+                    // item implementation.
                     //
-                    // Ex.:
+                    // Ex.: (with methods)
                     // ====
                     // ```
                     // impl<T> List<T> {
@@ -138,8 +138,8 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                     // }
                     // ```
 
-                    // Check if there is a trait item (if yes, it is a trait method
-                    // implementation, if no it is a regular function).
+                    // Check if there is a trait item (if yes, it is a trait item
+                    // implementation, if no it is a regular item).
                     // Remark: this trait item is the id of the item associated
                     // in the trait. For instance:
                     // ```
@@ -152,9 +152,9 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                     //   fn bar() { ... } // trait_item_def_id: Some(Foo_bar)
                     // }
                     match assoc.trait_item_def_id {
-                        None => FunKind::Regular,
-                        Some(trait_method_id) => {
-                            let trait_id = tcx.trait_of_item(trait_method_id).unwrap();
+                        None => ItemKind::Regular,
+                        Some(trait_item_id) => {
+                            let trait_id = tcx.trait_of_item(trait_item_id).unwrap();
                             let trait_id = self.translate_trait_decl_id(src, trait_id)?;
                             // The trait id should be Some(...): trait markers (that we
                             // may eliminate) don't have methods.
@@ -168,30 +168,30 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                                 )?
                                 .unwrap();
 
-                            let method_name = self.translate_trait_item_name(trait_method_id)?;
+                            let item_name = self.translate_trait_item_name(trait_item_id)?;
 
                             // Check if the current function implements a provided method.
                             // We do so by retrieving the def id of the method which is
                             // implemented, and checking its kind.
-                            let provided = match self.get_fun_kind(src, trait_method_id)? {
-                                FunKind::TraitMethodDecl(..) => false,
-                                FunKind::TraitMethodProvided(..) => true,
-                                FunKind::Regular | FunKind::TraitMethodImpl { .. } => {
+                            let provided = match self.get_item_kind(src, trait_item_id)? {
+                                ItemKind::TraitItemDecl(..) => false,
+                                ItemKind::TraitItemProvided(..) => true,
+                                ItemKind::Regular | ItemKind::TraitItemImpl { .. } => {
                                     unreachable!()
                                 }
                             };
 
-                            FunKind::TraitMethodImpl {
+                            ItemKind::TraitItemImpl {
                                 impl_id,
                                 trait_id,
-                                method_name,
+                                item_name,
                                 provided,
                             }
                         }
                     }
                 }
                 ty::AssocItemContainer::TraitContainer => {
-                    // This method is the *declaration* of a trait method
+                    // This method is the *declaration* of a trait item
                     // Ex.:
                     // ====
                     // ```
@@ -200,31 +200,31 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                     // }
                     // ```
 
-                    // Yet, this could be a default method implementation, in which
+                    // Yet, this could be a default item implementation, in which
                     // case there is a body: we need to check that.
 
-                    // In order to check if this is a provided method, we check
-                    // the defaultness (i.e., whether the method has a default value):
+                    // In order to check if this is a provided item, we check
+                    // the defaultness (i.e., whether the item has a default value):
                     let is_provided = tcx.impl_defaultness(rust_id).has_value();
 
                     // Compute additional information
-                    let method_name = self.translate_trait_item_name(rust_id)?;
+                    let item_name = self.translate_trait_item_name(rust_id)?;
                     let trait_id = tcx.trait_of_item(rust_id).unwrap();
                     let trait_id = self.translate_trait_decl_id(src, trait_id)?;
                     // The trait id should be Some(...): trait markers (that we
-                    // may eliminate) don't have methods.
+                    // may eliminate) don't have associated items.
                     let trait_id = trait_id.unwrap();
 
                     if is_provided {
-                        FunKind::TraitMethodProvided(trait_id, method_name)
+                        ItemKind::TraitItemProvided(trait_id, item_name)
                     } else {
-                        FunKind::TraitMethodDecl(trait_id, method_name)
+                        ItemKind::TraitItemDecl(trait_id, item_name)
                     }
                 }
             };
             Ok(kind)
         } else {
-            Ok(FunKind::Regular)
+            Ok(ItemKind::Regular)
         }
     }
 }
@@ -1687,17 +1687,17 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         let signature = signature.value;
 
         self.set_first_bound_regions_group(bvar_names);
-        let fun_kind = &self.t_ctx.get_fun_kind(&dep_src, def_id)?;
+        let fun_kind = &self.t_ctx.get_item_kind(&dep_src, def_id)?;
 
         // Add the trait clauses
         self.while_registering_trait_clauses(move |ctx| {
             // Add the ctx trait clause if it is a trait decl item
             match fun_kind {
-                FunKind::Regular => (),
-                FunKind::TraitMethodImpl { impl_id, .. } => {
+                ItemKind::Regular => (),
+                ItemKind::TraitItemImpl { impl_id, .. } => {
                     ctx.add_trait_impl_self_trait_clause(*impl_id)?;
                 }
-                FunKind::TraitMethodProvided(..) | FunKind::TraitMethodDecl(..) => {
+                ItemKind::TraitItemProvided(..) | ItemKind::TraitItemDecl(..) => {
                     // This is a trait decl item
                     let trait_id = tcx.trait_of_item(def_id).unwrap();
                     ctx.add_self_trait_clause(trait_id)?;
@@ -1706,11 +1706,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
             // Translate the predicates (in particular, the trait clauses)
             match &fun_kind {
-                FunKind::Regular | FunKind::TraitMethodImpl { .. } => {
+                ItemKind::Regular | ItemKind::TraitItemImpl { .. } => {
                     ctx.translate_predicates_of(None, def_id)?;
                 }
-                FunKind::TraitMethodProvided(trait_decl_id, ..)
-                | FunKind::TraitMethodDecl(trait_decl_id, ..) => {
+                ItemKind::TraitItemProvided(trait_decl_id, ..)
+                | ItemKind::TraitItemDecl(trait_decl_id, ..) => {
                     ctx.translate_predicates_of(Some(*trait_decl_id), def_id)?;
                 }
             }
@@ -1756,7 +1756,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // If this is a trait decl method, we need to adjust the number of parent clauses
         if matches!(
             fun_kind,
-            FunKind::TraitMethodProvided(..) | FunKind::TraitMethodDecl(..)
+            ItemKind::TraitItemProvided(..) | ItemKind::TraitItemDecl(..)
         ) {
             if let Some(info) = &mut parent_params_info {
                 // All the trait clauses are registered as parent (of Self)
@@ -1782,12 +1782,12 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         src: &Option<DepSource>,
         def_id: DefId,
     ) -> Result<Option<ParamsInfo>, Error> {
-        let kind = self.t_ctx.get_fun_kind(src, def_id)?;
+        let kind = self.t_ctx.get_item_kind(src, def_id)?;
         let info = match kind {
-            FunKind::Regular => None,
-            FunKind::TraitMethodImpl { .. }
-            | FunKind::TraitMethodDecl { .. }
-            | FunKind::TraitMethodProvided { .. } => {
+            ItemKind::Regular => None,
+            ItemKind::TraitItemImpl { .. }
+            | ItemKind::TraitItemDecl { .. }
+            | ItemKind::TraitItemProvided { .. } => {
                 Some(self.get_parent_params_info(def_id)?.unwrap())
             }
         };
@@ -1836,12 +1836,12 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         // If this is the case, it shouldn't contain a body.
         let kind = bt_ctx
             .t_ctx
-            .get_fun_kind(&DepSource::make(rust_id, def_span), rust_id)?;
+            .get_item_kind(&DepSource::make(rust_id, def_span), rust_id)?;
         let is_trait_method_decl = match &kind {
-            FunKind::Regular
-            | FunKind::TraitMethodImpl { .. }
-            | FunKind::TraitMethodProvided(..) => false,
-            FunKind::TraitMethodDecl(..) => true,
+            ItemKind::Regular
+            | ItemKind::TraitItemImpl { .. }
+            | ItemKind::TraitItemProvided(..) => false,
+            ItemKind::TraitItemDecl(..) => true,
         };
 
         // Translate the function signature
@@ -1924,6 +1924,11 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         let erase_regions = false; // This doesn't matter: there shouldn't be any regions
         let ty = bt_ctx.translate_ty(span, erase_regions, &mir_ty.sinto(hax_state))?;
 
+        // Retrieve the kind
+        let kind = bt_ctx
+            .t_ctx
+            .get_item_kind(&DepSource::make(rust_id, span), rust_id)?;
+
         let body = if rust_id.is_local() && is_transparent {
             // It's a local and transparent global: we extract its body as for functions.
             match bt_ctx.translate_body(rust_id.expect_local(), 0) {
@@ -1948,6 +1953,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                 is_local: rust_id.is_local(),
                 name,
                 ty,
+                kind,
                 body,
             },
         );

--- a/charon/src/types_utils.rs
+++ b/charon/src/types_utils.rs
@@ -333,6 +333,31 @@ impl GenericArgs {
         }
     }
 
+    /// Return the same generics, but where we pop the first type arguments.
+    /// This is useful for trait references (for pretty printing for instance),
+    /// because the first type argument is the type for which the trait is
+    /// implemented.
+    pub fn pop_first_type_arg(&self) -> (Ty, Self) {
+        let GenericArgs {
+            regions,
+            types,
+            const_generics,
+            trait_refs,
+        } = self;
+        let mut it = types.iter();
+        let ty = it.next().unwrap().clone();
+        let types = it.cloned().collect();
+        (
+            ty,
+            GenericArgs {
+                regions: regions.clone(),
+                types,
+                const_generics: const_generics.clone(),
+                trait_refs: trait_refs.clone(),
+            },
+        )
+    }
+
     pub(crate) fn fmt_with_ctx_no_brackets<C>(&self, ctx: &C) -> String
     where
         C: AstFormatter,

--- a/charon/src/ullbc_to_llbc.rs
+++ b/charon/src/ullbc_to_llbc.rs
@@ -1988,6 +1988,7 @@ fn translate_global(ctx: &TransCtx, global_id: GlobalDeclId::Id) -> tgt::GlobalD
         is_local: src_def.is_local,
         name: src_def.name.clone(),
         ty: src_def.ty.clone(),
+        kind: src_def.kind.clone(),
         body: src_def
             .body
             .as_ref()


### PR DESCRIPTION
This PR introduces a distinction between the "regular" `impl` blocks (linked to types) and the trait `impl` blocks in the name elements. This is useful to generate proper names in Aeneas.