### PR TITLE
Add generics to constants/globals

### DIFF
--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -243,7 +243,7 @@ and rvalue =
   | BinaryOp of binop * operand * operand
   | Discriminant of place * type_decl_id
   | Aggregate of aggregate_kind * operand list
-  | Global of global_decl_id
+  | Global of global_decl_id * generic_args
 [@@deriving
   show,
     visitors

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -201,6 +201,8 @@ type 'body gglobal_decl = {
   def_id : GlobalDeclId.id;
   is_local : bool;
   name : name;
+  generics : generic_params;
+  preds : predicates;
   ty : ty;
   kind : item_kind;
   body : 'body;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1082,6 +1082,8 @@ let gglobal_decl_of_json (body_of_json : json -> ('body, string) result)
           ("meta", meta);
           ("is_local", is_local);
           ("name", name);
+          ("generics", generics);
+          ("preds", preds);
           ("ty", ty);
           ("kind", kind);
           ("body", body);
@@ -1090,13 +1092,25 @@ let gglobal_decl_of_json (body_of_json : json -> ('body, string) result)
         let* meta = meta_of_json id_to_file meta in
         let* is_local = bool_of_json is_local in
         let* name = name_of_json id_to_file name in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* preds = predicates_of_json preds in
         let* ty = ty_of_json ty in
         let* body =
           option_of_json (gexpr_body_of_json body_of_json id_to_file) body
         in
         let* kind = item_kind_of_json kind in
         let global =
-          { def_id = global_id; meta; body; is_local; name; ty; kind }
+          {
+            def_id = global_id;
+            meta;
+            body;
+            is_local;
+            name;
+            generics;
+            preds;
+            ty;
+            kind;
+          }
         in
         Ok global
     | _ -> Error "")

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -876,9 +876,10 @@ let rvalue_of_json (js : json) : (rvalue, string) result =
         let* place = place_of_json place in
         let* adt_id = TypeDeclId.id_of_json adt_id in
         Ok (Discriminant (place, adt_id))
-    | `Assoc [ ("Global", gid) ] ->
+    | `Assoc [ ("Global", `List [ gid; generics ]) ] ->
         let* gid = GlobalDeclId.id_of_json gid in
-        Ok (Global gid : rvalue)
+        let* generics = generic_args_of_json generics in
+        Ok (Global (gid, generics) : rvalue)
     | `Assoc [ ("Aggregate", `List [ aggregate_kind; ops ]) ] ->
         let* aggregate_kind = aggregate_kind_of_json aggregate_kind in
         let* ops = list_of_json operand_of_json ops in

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -134,7 +134,17 @@ let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
      let* global =
        gglobal_decl_of_json (statement_of_json id_to_file) id_to_file js
      in
-     let { def_id = global_id; meta; body; is_local; name; ty; kind } =
+     let {
+       def_id = global_id;
+       meta;
+       body;
+       is_local;
+       name;
+       generics;
+       preds;
+       ty;
+       kind;
+     } =
        global
      in
      (* Decompose into a global and a function *)
@@ -153,7 +163,17 @@ let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
        }
      in
      let global_decl : global_decl =
-       { def_id = global_id; meta; body = fun_id; is_local; name; ty; kind }
+       {
+         def_id = global_id;
+         meta;
+         body = fun_id;
+         is_local;
+         name;
+         generics;
+         preds;
+         ty;
+         kind;
+       }
      in
      let fun_decl : fun_decl =
        {

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -155,8 +155,8 @@ let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
          is_unsafe = false;
          is_closure = false;
          closure_info = None;
-         generics = TypesUtils.empty_generic_params;
-         preds = TypesUtils.empty_predicates;
+         generics;
+         preds;
          parent_params_info = None;
          inputs = [];
          output = ty;

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -146,7 +146,9 @@ let rvalue_to_string (env : ('a, 'b) fmt_env) (rv : rvalue) : string =
       operand_to_string env op1 ^ " " ^ binop_to_string binop ^ " "
       ^ operand_to_string env op2
   | Discriminant (p, _) -> "discriminant(" ^ place_to_string env p ^ ")"
-  | Global gid -> "global " ^ global_decl_id_to_string env gid
+  | Global (gid, generics) ->
+      let generics = generic_args_to_string env generics in
+      "global " ^ global_decl_id_to_string env gid ^ generics
   | Aggregate (akind, ops) -> (
       let ops = List.map (operand_to_string env) ops in
       match akind with

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -118,7 +118,17 @@ module Ast = struct
 
   let global_decl_to_string (env : fmt_env) (indent : string)
       (_indent_incr : string) (def : global_decl) : string =
-    (* No need to locally update the environment *)
+    (* Locally update the generics and the predicates *)
+    let env = fmt_env_update_generics_and_preds env def.generics def.preds in
+    let params, trait_clauses = generic_params_to_strings env def.generics in
+    let clauses =
+      predicates_and_trait_clauses_to_string env "" "  " None trait_clauses
+        def.preds
+    in
+    let params =
+      if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
+    in
+
     (* Global name *)
     let name = name_to_string env def.name in
 
@@ -126,7 +136,7 @@ module Ast = struct
     let ty = ty_to_string env def.ty in
 
     let body_id = fun_decl_id_to_string env def.body in
-    indent ^ "global " ^ name ^ " : " ^ ty ^ " = " ^ body_id
+    indent ^ "global " ^ name ^ params ^ clauses ^ " : " ^ ty ^ " = " ^ body_id
 end
 
 (** Pretty-printing for ASTs (functions based on a declaration context) *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon_traits_merge#b8c69e796642aada65164276c4cd3a72a104924b"
+source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon_traits_merge#b8c69e796642aada65164276c4cd3a72a104924b"
+source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon_traits_merge#b8c69e796642aada65164276c4cd3a72a104924b"
+source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
 dependencies = [
  "schemars",
  "serde",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -39,8 +39,8 @@ macros = { path = "./macros" }
 take_mut = "0.2.2"
 rustc_tools_util = "0.2.1"
 bumpalo = "3.11.1" # We constrain the version of [bumpalo] because of a vulnerability
-hax-frontend-exporter = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon_traits_merge" }
-hax-frontend-exporter-options = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon_traits_merge" }
+hax-frontend-exporter = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon/globals" }
+hax-frontend-exporter-options = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon/globals" }
 #hax-frontend-exporter = { path = "../../hacspec-v2/frontend/exporter" }
 #hax-frontend-exporter-options = { path = "../../hacspec-v2/frontend/exporter/options" }
 colored = "2.0.4"

--- a/charon/src/expressions_utils.rs
+++ b/charon/src/expressions_utils.rs
@@ -161,17 +161,13 @@ impl RawConstantExpr {
                     generics.fmt_with_ctx_split_trait_refs(ctx)
                 )
             }
-            RawConstantExpr::TraitConst(trait_ref, generics, name) => {
-                format!(
-                    "{}{}::{name}",
-                    trait_ref.fmt_with_ctx(ctx),
-                    generics.fmt_with_ctx_split_trait_refs(ctx)
-                )
+            RawConstantExpr::TraitConst(trait_ref, name) => {
+                format!("{}::{name}", trait_ref.fmt_with_ctx(ctx),)
             }
             RawConstantExpr::Ref(cv) => {
                 format!("&{}", cv.fmt_with_ctx(ctx))
             }
-            RawConstantExpr::Var(id) => format!("const {}", ctx.format_object(*id)),
+            RawConstantExpr::Var(id) => format!("{}", ctx.format_object(*id)),
             RawConstantExpr::FnPtr(f) => {
                 format!("{}", f.fmt_with_ctx(ctx),)
             }
@@ -396,7 +392,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
                 self.visit_global_decl_id(id);
                 self.visit_generic_args(generics);
             }
-            TraitConst(trait_ref, generics, _name) => {
+            TraitConst(trait_ref, _name) => {
                 self.visit_trait_ref(trait_ref);
             }
             Ref(cv) => self.visit_constant_expr(cv),

--- a/charon/src/gast.rs
+++ b/charon/src/gast.rs
@@ -121,6 +121,8 @@ pub struct GGlobalDecl<T> {
     /// an external crate.
     pub is_local: bool,
     pub name: Name,
+    pub generics: GenericParams,
+    pub preds: Predicates,
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
     pub kind: ItemKind,

--- a/charon/src/simplify_constants.rs
+++ b/charon/src/simplify_constants.rs
@@ -47,12 +47,12 @@ fn transform_constant_expr<F: FnMut(Ty) -> VarId::Id>(
             // it as a function call, like for globals.
             Operand::Const(val)
         }
-        RawConstantExpr::Global(global_id) => {
+        RawConstantExpr::Global(global_id, substs) => {
             // Introduce an intermediate statement
             let var_id = make_new_var(val.ty.clone());
             nst.push(Statement::new(
                 *meta,
-                RawStatement::Assign(Place::new(var_id), Rvalue::Global(global_id)),
+                RawStatement::Assign(Place::new(var_id), Rvalue::Global(global_id, substs)),
             ));
             Operand::Move(Place::new(var_id))
         }

--- a/charon/src/translate_constants.rs
+++ b/charon/src/translate_constants.rs
@@ -51,22 +51,29 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         Ok(RawConstantExpr::Literal(lit))
     }
 
-    pub(crate) fn translate_constant_expr_kind_to_constant_expr(
+    /// Remark: [hax::ConstantExpr] contains span information, but it is often
+    /// the default span (i.e., it is useless), hence the additional span argument.
+    /// TODO: the user_ty might be None because hax doesn't extract it (because
+    /// we are translating a [ConstantExpr] instead of a [Constant]. We need to
+    /// update hax.
+    pub(crate) fn translate_constant_expr_to_constant_expr(
         &mut self,
         span: rustc_span::Span,
-        ty: &hax::Ty,
-        v: &hax::ConstantExprKind,
+        user_ty: &Option<hax::UserTypeAnnotationIndex>,
+        v: &hax::ConstantExpr,
     ) -> Result<ConstantExpr, Error> {
         use hax::ConstantExprKind;
+        let ty = &v.ty;
         let erase_regions = true;
-        let value = match v {
+        let value = match &(*v.contents) {
             ConstantExprKind::Literal(lit) => {
                 self.translate_constant_literal_to_raw_constant_expr(span, lit)?
             }
             ConstantExprKind::Adt { info, fields } => {
                 let fields: Vec<ConstantExpr> = fields
                     .iter()
-                    .map(|f| self.translate_constant_expr_to_constant_expr(span, &f.value))
+                    // TODO: the user_ty is not always None
+                    .map(|f| self.translate_constant_expr_to_constant_expr(span, &None, &f.value))
                     .try_collect()?;
                 let vid = if info.typ_is_struct {
                     None
@@ -81,7 +88,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             ConstantExprKind::Tuple { fields } => {
                 let fields: Vec<ConstantExpr> = fields
                     .iter()
-                    .map(|f| self.translate_constant_expr_to_constant_expr(span, f))
+                    // TODO: the user_ty is not always None
+                    .map(|f| self.translate_constant_expr_to_constant_expr(span, &None, f))
                     .try_collect()?;
                 RawConstantExpr::Adt(Option::None, fields)
             }
@@ -96,8 +104,162 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             ConstantExprKind::GlobalName { id } => {
                 RawConstantExpr::Global(self.translate_global_decl_id(span, DefId::from(id)))
             }
+            ConstantExprKind::GlobalName { id } => {
+                // The constant might have generics, in which case they are
+                // provided by the user-provided annotations
+                println!("constant.user_ty: {:?}", user_ty);
+                let substs = if let Some(id) = user_ty {
+                    use crate::rustc_index::Idx;
+                    let id = rustc_middle::ty::UserTypeAnnotationIndex::from_usize(id.index());
+                    let annots = &self.user_type_annotations.as_ref();
+                    let annots = if let Option::Some(annots) = annots {
+                        annots
+                    } else {
+                        error_or_panic!(
+                            self,
+                            span,
+                            "No user type annotations available in the context"
+                        )
+                    };
+
+                    let annot = annots.get(id).unwrap();
+                    match &annot.user_ty.value {
+                        rustc_middle::ty::UserType::Ty(_) => {
+                            error_or_panic!(self, span, "Unexpected user type annotation")
+                        }
+                        rustc_middle::ty::UserType::TypeOf(def_id, user_substs) => {
+                            use hax_frontend_exporter::SInto;
+                            let tcx = self.t_ctx.tcx;
+                            // The def id is the def id of the constant: we need
+                            // to retrieve the def id of the parent impl block,
+                            // then the type of this impl block.
+                            let def_id = tcx.parent(*def_id);
+                            println!("parent: {:?}", def_id);
+                            let ty = tcx.type_of(def_id).subst(tcx, user_substs.substs);
+
+                            println!("parent ty: {:?}", ty);
+
+                            // We need to retrieve the trait information, because
+                            // it is not provided by hax
+                            println!("def_id: {:?}", def_id);
+                            println!("self.def_id: {:?}", self.def_id);
+                            println!("user_substs.substs: {:?}", user_substs.substs);
+                            // For some reason we have to update the substitutions
+                            // to refer to parameters instead of bound variables
+                            /*let substs : Vec<_> = user_substs.substs.iter().cloned().map(|b| {
+                                use rustc_middle::ty::GenericArgKind;
+                                match b.unpack() {
+                                    GenericArgKind::Lifetime(_) => {
+                                        b
+                                    }
+                                    GenericArgKind::Type(ty) => {
+                                        match ty.kind () {
+                                            rustc_middle::ty::TyKind::Bound(id, )
+                                            _ => b,
+                                        }
+                                    }
+                                    GenericArgKind::Const(_) => {
+                                        b
+                                    }
+                                }
+                            }).collect();*/
+
+                            let param_env = self.t_ctx.tcx.param_env(self.def_id);
+                            println!("param_env: {:?}", param_env);
+                            let trait_refs = hax::solve_item_traits(
+                                &self.hax_state,
+                                param_env,
+                                def_id,
+                                user_substs.substs,
+                                None,
+                            );
+                            println!("trait_refs: {:?}", trait_refs);
+                            panic!();
+
+                            /*// Retrieve the trait references (there can be
+                            // trait obligations, as well as a non-empty
+                            // substitution, if the item was defined in a block).
+                            if let Some(assoc) = tcx.opt_associated_item(def_id) {
+                                if let rustc_middle::ty::AssocItemContainer::ImplContainer =
+                                    assoc.container
+                                {
+                                    // The constant comes from an impl block.
+                                    // Retrieve the type, instantiate it and solve the trait
+                                    // obligations.
+                                    println!("assoc.def_id: {:?}", assoc.def_id);
+                                    let ty =
+                                        tcx.type_of(assoc.def_id).subst(tcx, user_substs.substs);
+                                    println!("type_of(assoc.def_id): {:?}", ty);
+
+                                    panic!();
+                                } else {
+                                    error_or_panic!(
+                                        self,
+                                        span,
+                                        format!("Unexpected case: {:?}", assoc.container)
+                                    )
+                                }
+                            } else {
+                                // The generic arguments should be empty
+                                error_assert!(self, span, user_substs.substs.is_empty());
+                                GenericArgs::empty()
+                            }*/
+                            /*println!("substs: {:?}", user_substs.substs);
+                            println!("def_id: {:?}", def_id);
+                            let ty = self.t_ctx.tcx.type_of(def_id);
+                            println!("ty: {:?}", ty);
+                            let ty = ty.subst(self.t_ctx.tcx, user_substs.substs);
+                            println!("ty (after subst): {:?}", ty);
+                            println!("\n\n");
+                            panic!();
+
+                            let erase_regions = true;
+                            // Retrieve the list of used arguments
+                            let used_params = if def_id.is_local() {
+                                Option::None
+                            } else {
+                                println!("def_id: {:?}", def_id);
+                                let def_id = def_id.sinto(&self.hax_state);
+                                let name = self.t_ctx.def_id_to_name(&def_id)?;
+                                crate::assumed::type_to_used_params(&name)
+                            };
+
+                            GenericArgs::empty()*/
+
+                            /*
+                            // We need to retrieve the trait information, because
+                            // it is not provided by hax
+                            println!("def_id: {:?}", def_id);
+                            let param_env = self.t_ctx.tcx.param_env(self.def_id);
+                            let trait_refs = hax::solve_item_traits(
+                                &self.hax_state,
+                                param_env,
+                                *def_id,
+                                user_substs.substs,
+                                None,
+                            );
+
+                            let substs = user_substs.substs.sinto(&self.hax_state);
+                            self.translate_substs_and_trait_refs(
+                                span,
+                                erase_regions,
+                                used_params,
+                                &substs,
+                                &trait_refs,
+                            )?*/
+                        }
+                    }
+                } else {
+                    GenericArgs::empty()
+                };
+
+                RawConstantExpr::Global(
+                    self.translate_global_decl_id(span, id.rust_def_id.unwrap()),
+                    substs,
+                )
+            }
             ConstantExprKind::Borrow(be) => {
-                let be = self.translate_constant_expr_to_constant_expr(span, be)?;
+                let be = self.translate_constant_expr_to_constant_expr(span, user_ty, be)?;
                 RawConstantExpr::Ref(Box::new(be))
             }
             ConstantExprKind::ConstRef { id } => {
@@ -142,27 +304,22 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     /// Remark: [hax::ConstantExpr] contains span information, but it is often
     /// the default span (i.e., it is useless), hence the additional span argument.
-    pub(crate) fn translate_constant_expr_to_constant_expr(
-        &mut self,
-        span: rustc_span::Span,
-        v: &hax::ConstantExpr,
-    ) -> Result<ConstantExpr, Error> {
-        self.translate_constant_expr_kind_to_constant_expr(span, &v.ty, &v.contents)
-    }
-
-    /// Remark: [hax::ConstantExpr] contains span information, but it is often
-    /// the default span (i.e., it is useless), hence the additional span argument.
     pub(crate) fn translate_constant_expr_to_const_generic(
         &mut self,
         span: rustc_span::Span,
         v: &hax::ConstantExpr,
     ) -> Result<ConstGeneric, Error> {
+        // Remark: we can't user globals as constant generics (meaning
+        // the user provided type annotation should always be none).
         let value = self
-            .translate_constant_expr_to_constant_expr(span, v)?
+            .translate_constant_expr_to_constant_expr(span, &None, v)?
             .value;
         match value {
             RawConstantExpr::Literal(v) => Ok(ConstGeneric::Value(v)),
-            RawConstantExpr::Global(v) => Ok(ConstGeneric::Global(v)),
+            RawConstantExpr::Global(id, substs) => {
+                error_assert!(self, span, substs.is_empty());
+                Ok(ConstGeneric::Global(id))
+            }
             RawConstantExpr::Adt(..)
             | RawConstantExpr::TraitConst { .. }
             | RawConstantExpr::Ref(_)
@@ -184,6 +341,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         span: rustc_span::Span,
         v: &hax::Constant,
     ) -> Result<ConstantExpr, Error> {
-        self.translate_constant_expr_to_constant_expr(span, &v.literal.constant_kind)
+        self.translate_constant_expr_to_constant_expr(span, &v.user_ty, &v.literal.constant_kind)
     }
 }

--- a/charon/src/translate_constants.rs
+++ b/charon/src/translate_constants.rs
@@ -116,8 +116,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     span,
                     erase_regions,
                     used_params,
-                    &generics,
-                    &trait_refs,
+                    generics,
+                    trait_refs,
                 )?;
 
                 let global_decl_id = self.translate_global_decl_id(span, DefId::from(id));

--- a/charon/src/translate_constants.rs
+++ b/charon/src/translate_constants.rs
@@ -101,10 +101,24 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let name = TraitItemName(name.clone());
                 RawConstantExpr::TraitConst(trait_ref, name)
             }
-            ConstantExprKind::GlobalName { id } => {
-                RawConstantExpr::Global(self.translate_global_decl_id(span, DefId::from(id)))
-            }
-            ConstantExprKind::GlobalName { id } => {
+            ConstantExprKind::GlobalName {
+                id,
+                generics,
+                trait_refs,
+            } => {
+                println!("generics: {:?}", generics);
+                println!("trait_refs: {:?}", trait_refs);
+                let erase_regions = true;
+                let used_params = None;
+                let generics = self.translate_substs_and_trait_refs(
+                    span,
+                    erase_regions,
+                    used_params,
+                    &generics,
+                    &trait_refs,
+                )?;
+
+                /*
                 // The constant might have generics, in which case they are
                 // provided by the user-provided annotations
                 println!("constant.user_ty: {:?}", user_ty);
@@ -251,12 +265,10 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     }
                 } else {
                     GenericArgs::empty()
-                };
+                };*/
 
-                RawConstantExpr::Global(
-                    self.translate_global_decl_id(span, id.rust_def_id.unwrap()),
-                    substs,
-                )
+                let global_decl_id = self.translate_global_decl_id(span, DefId::from(id));
+                RawConstantExpr::Global(global_decl_id, generics)
             }
             ConstantExprKind::Borrow(be) => {
                 let be = self.translate_constant_expr_to_constant_expr(span, user_ty, be)?;

--- a/charon/src/translate_ctx.rs
+++ b/charon/src/translate_ctx.rs
@@ -279,24 +279,6 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     pub t_ctx: &'ctx mut TransCtx<'tcx, 'ctx1>,
     /// A hax state with an owner id
     pub hax_state: hax::State<hax::Base<'tcx>, (), (), rustc_hir::def_id::DefId>,
-    /// The user type annotations (this fields comes from [rustc_middle::mir::Body]).
-    /// Those are used for constants: some constants may have generics, and as
-    /// a consequence may require type annotations to disambiguate where they
-    /// come from. For instance:
-    /// ```text
-    /// struct V<const N: usize, T> {
-    ///   x: [T; N],
-    /// }
-    ///
-    /// impl<const N: usize, T> V<N, T> {
-    ///   const LEN: usize = N;
-    /// }
-    ///
-    /// fn use_v<const N: usize, T>(v: V<N, T>) {
-    ///   let l = V::<N, T>::LEN; // HERE
-    /// }
-    /// ```
-    pub user_type_annotations: Option<rustc_middle::ty::CanonicalUserTypeAnnotations<'tcx>>,
     /// The regions.
     /// We use DeBruijn indices, so we have a stack of regions.
     /// See the comments for [Region::BVar].
@@ -723,7 +705,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             def_id,
             t_ctx,
             hax_state,
-            user_type_annotations: None,
             region_vars: im::vector![RegionId::Vector::new()],
             free_region_vars: std::collections::BTreeMap::new(),
             bound_region_var_id_generator: RegionId::Generator::new(),

--- a/charon/src/translate_functions_to_ullbc.rs
+++ b/charon/src/translate_functions_to_ullbc.rs
@@ -1453,9 +1453,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // Retrive the body
         let body = get_mir_for_def_id_and_level(tcx, local_id, self.t_ctx.mir_level);
 
-        // Retrieve the user type annotations
-        self.user_type_annotations = Some(body.user_type_annotations.clone());
-
         // Here, we have to create a MIR state, which contains the body
         let state = hax::state::State::new_from_mir(
             tcx,

--- a/charon/src/translate_functions_to_ullbc.rs
+++ b/charon/src/translate_functions_to_ullbc.rs
@@ -1453,6 +1453,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // Retrive the body
         let body = get_mir_for_def_id_and_level(tcx, local_id, self.t_ctx.mir_level);
 
+        // Retrieve the user type annotations
+        self.user_type_annotations = Some(body.user_type_annotations.clone());
+
         // Here, we have to create a MIR state, which contains the body
         let state = hax::state::State::new_from_mir(
             tcx,
@@ -1859,6 +1862,17 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
 
         // Initialize the body translation context
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
+
+        // Check and translate the generics - globals *can* have generics
+        // Ex.:
+        // ```
+        // impl<const N : usize> Foo<N> {
+        //   const LEN : usize = N;
+        // }
+        // ```
+        bt_ctx.translate_generic_params(rust_id)?;
+        bt_ctx.translate_predicates_solve_trait_obligations_of(None, rust_id)?;
+
         let hax_state = &bt_ctx.hax_state;
 
         // Translate the global name
@@ -1873,6 +1887,9 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         let kind = bt_ctx
             .t_ctx
             .get_item_kind(&DepSource::make(rust_id, span), rust_id)?;
+
+        let generics = bt_ctx.get_generics();
+        let preds = bt_ctx.get_predicates();
 
         let body = if rust_id.is_local() && is_transparent {
             // It's a local and transparent global: we extract its body as for functions.
@@ -1897,6 +1914,8 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                 meta,
                 is_local: rust_id.is_local(),
                 name,
+                generics,
+                preds,
                 ty,
                 kind,
                 body,

--- a/charon/src/ullbc_ast_utils.rs
+++ b/charon/src/ullbc_ast_utils.rs
@@ -203,7 +203,7 @@ impl BlockData {
             Rvalue::Repeat(op, _, _) => {
                 f(meta, nst, op);
             }
-            Rvalue::Global(_) | Rvalue::Discriminant(..) | Rvalue::Ref(_, _) | Rvalue::Len(..) => {
+            Rvalue::Global(..) | Rvalue::Discriminant(..) | Rvalue::Ref(_, _) | Rvalue::Len(..) => {
                 // No operands: nothing to do
             }
         }

--- a/charon/src/ullbc_to_llbc.rs
+++ b/charon/src/ullbc_to_llbc.rs
@@ -1987,6 +1987,8 @@ fn translate_global(ctx: &TransCtx, global_id: GlobalDeclId::Id) -> tgt::GlobalD
         meta: src_def.meta,
         is_local: src_def.is_local,
         name: src_def.name.clone(),
+        generics: src_def.generics.clone(),
+        preds: src_def.preds.clone(),
         ty: src_def.ty.clone(),
         kind: src_def.kind.clone(),
         body: src_def

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -81,3 +81,16 @@ pub static S1: u32 = 6;
 pub static S2: u32 = incr(S1);
 pub static S3: Pair<u32, u32> = P3;
 pub static S4: Pair<u32, u32> = mk_pair1(7, 8);
+
+// Constants with generics
+pub struct V<const N: usize, T> {
+    pub x: [T; N],
+}
+
+impl<const N: usize, T> V<N, T> {
+    pub const LEN: usize = N;
+}
+
+pub fn use_v<const N: usize, T>() -> usize {
+    V::<N, T>::LEN
+}

--- a/tests/src/traits.rs
+++ b/tests/src/traits.rs
@@ -323,10 +323,19 @@ pub fn use_wrapper_len<T: Trait>() -> usize {
     Wrapper::<T>::LEN
 }
 
-impl<T: Trait> Wrapper<T> {
-    const FOO: Result<T, i32> = Err(0);
+pub struct Foo<T, U> {
+    pub x: T,
+    pub y: U,
 }
 
-pub fn use_wrapper_foo<T: Trait, U>() -> Result<T, i32> {
-    Wrapper::<T>::FOO
+impl<T: Trait, U> Foo<T, U> {
+    pub const FOO: Result<T, i32> = Err(0);
+}
+
+pub fn use_foo1<T: Trait, U>() -> Result<T, i32> {
+    Foo::<T, U>::FOO
+}
+
+pub fn use_foo2<T, U: Trait>() -> Result<U, i32> {
+    Foo::<U, T>::FOO
 }

--- a/tests/src/traits.rs
+++ b/tests/src/traits.rs
@@ -305,3 +305,28 @@ pub trait GetTrait {
 pub fn test_get_trait<T: GetTrait>(x: &T) -> T::W {
     x.get_w()
 }
+
+// Constants with generics
+pub trait Trait {
+    const LEN: usize;
+}
+
+impl<const N: usize, T> Trait for [T; N] {
+    const LEN: usize = N;
+}
+
+impl<T: Trait> Trait for Wrapper<T> {
+    const LEN: usize = 0;
+}
+
+pub fn use_wrapper_len<T: Trait>() -> usize {
+    Wrapper::<T>::LEN
+}
+
+impl<T: Trait> Wrapper<T> {
+    const FOO: Result<T, i32> = Err(0);
+}
+
+pub fn use_wrapper_foo<T: Trait, U>() -> Result<T, i32> {
+    Wrapper::<T>::FOO
+}


### PR DESCRIPTION
This PR adds generics to constants/globals to account for situations like the following one:
```rust
struct V<const N: usize, T> {
  x: [T; N],
}

impl<const N: usize, T> V<N, T> {
  const LEN: usize = N; // This has generics <N, T>
}

fn use_v<const N: usize, T>(v: V<N, T>) {
  let l = V::<N, T>::LEN; // We need to provided a substitution here
}
```

This also fixes https://github.com/AeneasVerif/charon/issues/85