### PR TITLE
project(nix): development shell via Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ You can then run `make build-charon-ml` to build the ML library, or even simply
 `make` to build the whole project (Rust and OCaml). Finally, you can run the
 tests with `make test`.
 
+Alternatively, you can use Nix and do `nix develop` (or use https://direnv.net/ and `direnv allow`)
+and all dependencies should be made available.
+
 ## Documentation
 
 If you run `make`, you will generate a documentation accessible from

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -98,7 +98,7 @@ performs: `y := (x as E2).1`). Producing a better reconstruction is non-trivial.
     /// This is for Nix: outside of Nix, we use Rustup to call the proper version
     /// of Cargo (and thus need this argument), but within Nix we build and call a very
     /// specific version of Cargo.
-    #[structopt(long = "cargo-no-rust-version", env = "CARGO_NO_RUST_VERSION")]
+    #[structopt(long = "cargo-no-rust-version")]
     pub cargo_no_rust_version: bool,
     /// Panic on the first error. This is useful for debugging.
     #[structopt(long = "abort-on-error")]

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -98,7 +98,7 @@ performs: `y := (x as E2).1`). Producing a better reconstruction is non-trivial.
     /// This is for Nix: outside of Nix, we use Rustup to call the proper version
     /// of Cargo (and thus need this argument), but within Nix we build and call a very
     /// specific version of Cargo.
-    #[structopt(long = "cargo-no-rust-version")]
+    #[structopt(long = "cargo-no-rust-version", env = "CARGO_NO_RUST_VERSION")]
     pub cargo_no_rust_version: bool,
     /// Panic on the first error. This is useful for debugging.
     #[structopt(long = "abort-on-error")]

--- a/charon/src/main.rs
+++ b/charon/src/main.rs
@@ -98,7 +98,9 @@ fn process(options: &CliOpts) -> Result<(), i32> {
     cmd.env("RUSTC_WORKSPACE_WRAPPER", path());
     cmd.env(CHARON_ARGS, serde_json::to_string(&options).unwrap());
 
-    if !options.cargo_no_rust_version {
+    if !options.cargo_no_rust_version
+        && std::env::var("CARGO_NO_RUST_VERSION") != Ok("1".to_string())
+    {
         cmd.arg(rust_version);
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -152,8 +152,14 @@
           # which works only with `rustup`.
           CARGO_NO_RUST_VERSION = 1;
 
+          packages = [
+            pkgs.ocamlPackages.menhir
+            pkgs.ocamlPackages.odoc
+          ];
+
           inputsFrom = [
             self.packages.${system}.charon
+            self.packages.${system}.charon-ml
           ];
         };
         checks = { inherit tests tests-polonius charon-ml-tests; };

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,15 @@
           inherit charon charon-ml;
           default = charon;
         };
+        devShells.default = pkgs.mkShell {
+          # To prevent Charon to add the `+nightly` identifier
+          # which works only with `rustup`.
+          CARGO_NO_RUST_VERSION = 1;
+
+          inputsFrom = [
+            self.packages.${system}.charon
+          ];
+        };
         checks = { inherit tests tests-polonius charon-ml-tests; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,8 @@
           CARGO_NO_RUST_VERSION = 1;
 
           packages = [
+            pkgs.ocamlPackages.ocaml
+            pkgs.ocamlPackages.ocamlformat
             pkgs.ocamlPackages.menhir
             pkgs.ocamlPackages.odoc
           ];


### PR DESCRIPTION
This adds some niceties for people already using Nix to skip the installation process.
Tested successfully:

```console
make build-charon-rust
make build-charon-ml
make tests
```

with this PR without `rustup` or `ocaml` manually installed.