### PR TITLE
Retrieve the trait refs of the impl block for inherent methods

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
+source = "git+https://github.com/Nadrieril/hax?branch=fix-parent-item-clauses#fdccc197b51731b57beb628387ecc2e1879bacdf"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
+source = "git+https://github.com/Nadrieril/hax?branch=fix-parent-item-clauses#fdccc197b51731b57beb628387ecc2e1879bacdf"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hacspec-v2.git?branch=charon/globals#5d700e3d119995e1cf75695153f6e95bfd677537"
+source = "git+https://github.com/Nadrieril/hax?branch=fix-parent-item-clauses#fdccc197b51731b57beb628387ecc2e1879bacdf"
 dependencies = [
  "schemars",
  "serde",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -42,8 +42,8 @@ take_mut = "0.2.2"
 toml = "0.5.10"
 walkdir = "2.3.2"
 
-hax-frontend-exporter = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon/globals" }
-hax-frontend-exporter-options = { git = "https://github.com/hacspec/hacspec-v2.git", branch = "charon/globals" }
+hax-frontend-exporter = { git = "https://github.com/Nadrieril/hax", branch = "fix-parent-item-clauses" }
+hax-frontend-exporter-options = { git = "https://github.com/Nadrieril/hax", branch = "fix-parent-item-clauses" }
 #hax-frontend-exporter = { path = "../../hacspec-v2/frontend/exporter" }
 #hax-frontend-exporter-options = { path = "../../hacspec-v2/frontend/exporter/options" }
 macros = { path = "./macros" }

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -28,7 +28,7 @@ fn issue_97_missing_parent_item_clause::test(@1: issue_97_missing_parent_item_cl
     let @4: (); // anonymous local
 
     @3 := &two-phase-mut tree@1
-    @2 := issue_97_missing_parent_item_clause::{issue_97_missing_parent_item_clause::AVLTree<T>}::insert<u32>(move (@3))
+    @2 := issue_97_missing_parent_item_clause::{issue_97_missing_parent_item_clause::AVLTree<T>}::insert<u32>[issue_97_missing_parent_item_clause::{impl issue_97_missing_parent_item_clause::Ord for u32#1}](move (@3))
     drop @3
     drop @2
     @4 := ()


### PR DESCRIPTION
Uses [my own hax branch](https://github.com/Nadrieril/hax/tree/fix-parent-item-clauses) based on https://github.com/hacspec/hax/tree/charon/globals.

Fixes https://github.com/AeneasVerif/aeneas/issues/97.