### PR TITLE
Unconfuse variant indices and discriminants

### DIFF
--- a/charon/macros/src/lib.rs
+++ b/charon/macros/src/lib.rs
@@ -34,6 +34,7 @@ pub mod {} {{
              std::hash::Hash, std::cmp::PartialEq, std::cmp::Eq,
              std::cmp::PartialOrd, std::cmp::Ord)]
     pub struct Id {{
+        // Must fit in an u32 for serialization.
         index: usize,
     }}
 
@@ -47,6 +48,8 @@ pub mod {} {{
 
     impl Id {{
         pub fn new(init: usize) -> Id {{
+            // We need to fit in an u32 for serialization.
+            assert!(init <= std::u32::MAX as usize);
             Id {{ index: init }}
         }}
         
@@ -58,6 +61,7 @@ pub mod {} {{
             // Overflows are extremely unlikely, but we do want to make sure
             // we panick whenever there is one.
             self.index = self.index.checked_add(1).unwrap();
+            assert!(self.index <= std::u32::MAX as usize);
         }}
     }}
 

--- a/charon/src/remove_read_discriminant.rs
+++ b/charon/src/remove_read_discriminant.rs
@@ -8,8 +8,8 @@ use crate::llbc_ast::*;
 use crate::meta::combine_meta;
 use crate::translate_ctx::*;
 use crate::types::*;
-use std::collections::HashSet;
-use std::iter::FromIterator;
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet};
 
 struct Visitor<'a, 'tcx, 'ctx> {
     ctx: &'a mut TransCtx<'tcx, 'ctx>,
@@ -48,67 +48,74 @@ impl<'a, 'tcx, 'ctx> Visitor<'a, 'tcx, 'ctx> {
                         box st3,
                     ) => (meta2, switch, Some(st3)),
                     RawStatement::Switch(switch) => (st2.meta, switch, None),
-                    _ => unreachable!(),
+                    _ => unreachable!("A discriminant read must be followed by a `Switch`"),
                 };
 
                 let Switch::SwitchInt(Operand::Move(op_p), _int_ty, targets, otherwise) = switch
                 else { unreachable!() };
-                // Remark: the discriminant can be of any *signed* integer type
-                // (`isize` of course, but also `i8`, etc.).
                 assert!(op_p.projection.is_empty() && op_p.var_id == dest.var_id);
 
-                let targets = Vec::from_iter(targets.into_iter().map(|(v, e)| {
-                    (
-                        Vec::from_iter(
-                            v.into_iter()
-                                .map(|x| VariantId::Id::new(x.as_int().unwrap() as usize)),
-                        ),
-                        e,
-                    )
-                }));
-                // Filter the otherwise branch, if it is not necessary.
-                use crate::id_vector::ToUsize;
-                let covered_variants: HashSet<usize> =
-                    targets.iter().fold(HashSet::new(), |mut hs, (ids, _)| {
-                        ids.iter().for_each(|id| {
-                            let _ = hs.insert(id.to_usize());
-                        });
-                        hs
-                    });
-                let covers_all = {
-                    // Lookup the type of the scrutinee
-                    match self.ctx.type_decls.get(*adt_id) {
-                        None => {
-                            // This can happen if there was an error while
-                            // extracting the definitions
-                            assert!(self.ctx.error_count > 0);
-                            // For safety, we consider that not all the patterns
-                            // were covered
-                            false
-                        }
-                        Some(d) => {
-                            match &d.kind {
-                                TypeDeclKind::Struct(_) | TypeDeclKind::Opaque => {
-                                    // We shouldn't get there
-                                    register_error_or_panic!(
-                                        self.ctx,
-                                        st.meta.span.rust_span_data.span(),
-                                        "Unreachable case"
-                                    );
-                                    false
-                                }
-                                TypeDeclKind::Error(_) => false,
-                                TypeDeclKind::Enum(variants) => {
-                                    // Check that all the variants are covered
-                                    variants
-                                        .iter()
-                                        .enumerate()
-                                        .all(|(i, _)| covered_variants.contains(&i))
-                                }
+                // Lookup the type of the scrutinee
+                let variants = match self.ctx.type_decls.get(*adt_id) {
+                    // This can happen if there was an error while extracting the definitions
+                    None => None,
+                    Some(d) => {
+                        match &d.kind {
+                            TypeDeclKind::Struct(_) | TypeDeclKind::Opaque => {
+                                // We shouldn't get there
+                                register_error_or_panic!(
+                                    self.ctx,
+                                    st.meta.span.rust_span_data.span(),
+                                    "Unreachable case"
+                                );
+                                None
                             }
+                            TypeDeclKind::Error(_) => None,
+                            TypeDeclKind::Enum(variants) => Some(variants),
                         }
                     }
                 };
+                let Some(variants) = variants else {
+                    // An error occurred. We can't keep the `Rvalue::Discriminant` around so we
+                    // `Nop` the whole statement sequence.
+                    assert!(self.ctx.error_count > 0);
+                    *st = Statement {
+                        content: RawStatement::Nop,
+                        meta: st.meta,
+                    };
+                    return
+                };
+
+                // Convert between discriminants and variant indices. Remark: the discriminant can
+                // be of any *signed* integer type (`isize`, `i8`, etc.).
+                let discr_to_id: HashMap<u128, VariantId::Id> = variants
+                    .iter_indexed_values()
+                    .map(|(id, variant)| (variant.discriminant, id))
+                    .collect();
+                let mut covered_discriminants: HashSet<u128> = HashSet::default();
+                let targets = targets
+                    .into_iter()
+                    .map(|(v, e)| {
+                        (
+                            v.into_iter()
+                                .map(|x| {
+                                    let discr = x.to_bits();
+                                    covered_discriminants.insert(discr);
+                                    discr_to_id.get(&discr).unwrap_or_else(|| {
+                                        panic!(
+                                            "Found incorrect discriminant {discr} for enum {}",
+                                            adt_id
+                                        )
+                                    })
+                                })
+                                .copied()
+                                .collect_vec(),
+                            e,
+                        )
+                    })
+                    .collect_vec();
+                // Filter the otherwise branch if it is not necessary.
+                let covers_all = covered_discriminants.len() == discr_to_id.len();
                 let otherwise = if covers_all { None } else { Some(otherwise) };
 
                 let switch = RawStatement::Switch(Switch::Match(p.clone(), targets, otherwise));

--- a/charon/src/translate_types.rs
+++ b/charon/src/translate_types.rs
@@ -537,9 +537,16 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // The type is transparent: explore the variants
         let mut variants: Vec<Variant> = vec![];
         let erase_regions = false;
-        for (i, var_def) in adt.variants().iter().enumerate() {
+        for (i, (rust_var_id, var_def)) in adt.variants().iter_enumerated().enumerate() {
             let var_def: hax::VariantDef = var_def.sinto(&self.hax_state);
             trace!("variant {}: {:?}", i, var_def);
+
+            let discriminant: u128 = if adt.is_enum() {
+                adt.discriminant_for_variant(self.t_ctx.tcx, rust_var_id)
+                    .val
+            } else {
+                0
+            };
 
             let mut fields: Vec<Field> = vec![];
             /* This is for sanity: check that either all the fields have names, or
@@ -585,6 +592,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 meta,
                 name: variant_name,
                 fields: FieldId::Vector::from(fields),
+                discriminant,
             });
         }
 

--- a/charon/src/types.rs
+++ b/charon/src/types.rs
@@ -372,7 +372,8 @@ pub struct Variant {
     pub name: String,
     pub fields: FieldId::Vector<Field>,
     #[serde(skip)]
-    /// The discriminant used at runtime.
+    /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
+    /// `SwitchInt` targets with the corresponding `Variant`.
     pub discriminant: u128,
 }
 

--- a/charon/src/types.rs
+++ b/charon/src/types.rs
@@ -371,6 +371,9 @@ pub struct Variant {
     pub meta: Meta,
     pub name: String,
     pub fields: FieldId::Vector<Field>,
+    #[serde(skip)]
+    /// The discriminant used at runtime.
+    pub discriminant: u128,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/charon/src/values_utils.rs
+++ b/charon/src/values_utils.rs
@@ -201,6 +201,24 @@ impl ScalarValue {
         }
     }
 
+    /// Most integers are represented as `u128` by rustc. We must be careful not to sign-extend.
+    pub fn to_bits(&self) -> u128 {
+        match *self {
+            ScalarValue::Usize(v) => v as u128,
+            ScalarValue::U8(v) => v as u128,
+            ScalarValue::U16(v) => v as u128,
+            ScalarValue::U32(v) => v as u128,
+            ScalarValue::U64(v) => v as u128,
+            ScalarValue::U128(v) => v,
+            ScalarValue::Isize(v) => v as usize as u128,
+            ScalarValue::I8(v) => v as u8 as u128,
+            ScalarValue::I16(v) => v as u16 as u128,
+            ScalarValue::I32(v) => v as u32 as u128,
+            ScalarValue::I64(v) => v as u64 as u128,
+            ScalarValue::I128(v) => v as u128,
+        }
+    }
+
     /// **Warning**: most constants are stored as u128 by rustc. When converting
     /// to i128, it is not correct to do `v as i128`, we must reinterpret the
     /// bits (see [ScalarValue::from_le_bytes]).

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.out
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.out
@@ -1,7 +1,7 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
 enum issue_92_nonpositive_variant_indices::Ordering =
-|  Lesser()
+|  Less()
 |  Equal()
 |  Greater()
 
@@ -12,17 +12,25 @@ fn issue_92_nonpositive_variant_indices::main()
     let @1: issue_92_nonpositive_variant_indices::Ordering; // anonymous local
     let @2: (); // anonymous local
     let @3: (); // anonymous local
+    let @4: (); // anonymous local
 
-    @1 := issue_92_nonpositive_variant_indices::Ordering::Lesser {  }
+    @1 := issue_92_nonpositive_variant_indices::Ordering::Less {  }
     @fake_read(@1)
     match @1 {
         18446744073709551615 => {
             @3 := ()
             @0 := move (@3)
         },
-        _ => {
+        0 => {
+            @4 := ()
+            @0 := move (@4)
+        },
+        1 => {
             @2 := ()
             @0 := move (@2)
+        },
+        _ => {
+            panic
         }
     }
     drop @1

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.out
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.out
@@ -17,20 +17,17 @@ fn issue_92_nonpositive_variant_indices::main()
     @1 := issue_92_nonpositive_variant_indices::Ordering::Less {  }
     @fake_read(@1)
     match @1 {
-        18446744073709551615 => {
+        0 => {
             @3 := ()
             @0 := move (@3)
         },
-        0 => {
+        1 => {
             @4 := ()
             @0 := move (@4)
         },
-        1 => {
+        2 => {
             @2 := ()
             @0 := move (@2)
-        },
-        _ => {
-            panic
         }
     }
     drop @1

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.rs
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.rs
@@ -1,13 +1,14 @@
 //@ output=pretty-llbc
 enum Ordering {
-    Lesser = -1,
+    Less = -1,
     Equal = 0,
     Greater = 1,
 }
 
 fn main() {
-    match Ordering::Lesser {
-        Ordering::Lesser => {}
-        _ => {}
+    match Ordering::Less {
+        Ordering::Less => {}
+        Ordering::Equal => {}
+        Ordering::Greater => {}
     }
 }


### PR DESCRIPTION
They're conceptually different entities but happen to coincide for basic enums, hence the confusion.

Fixes https://github.com/AeneasVerif/charon/issues/92.