### PR TITLE
Use rust edition 2021

### DIFF
--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "charon"
 version = "0.1.0"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "charon_lib"

--- a/charon/attributes/Cargo.toml
+++ b/charon/attributes/Cargo.toml
@@ -2,7 +2,7 @@
 name = "attributes"
 version = "0.1.0"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/charon/macros/Cargo.toml
+++ b/charon/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "macros"
 version = "0.1.0"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/charon/src/values_utils.rs
+++ b/charon/src/values_utils.rs
@@ -149,7 +149,6 @@ impl ScalarValue {
     }
 
     pub fn from_le_bytes(ty: IntegerTy, b: [u8; 16]) -> ScalarValue {
-        use std::convert::TryInto;
         match ty {
             IntegerTy::Isize => {
                 let b: [u8; 8] = b[0..8].try_into().unwrap();


### PR DESCRIPTION
One benefit is that this allows `panic!("Interpolated string with {values}")` instead of `panic!("Interpolated string with {}", values)`. There are [a few other minor changes](https://blog.rust-lang.org/2021/05/11/edition-2021.html).