### PR TITLE
Run `charon-driver` in tests

### DIFF
--- a/charon/src/charon-driver.rs
+++ b/charon/src/charon-driver.rs
@@ -212,16 +212,14 @@ fn main() {
     // on Cargo, the charon-driver is only called on the target (and not its
     // dependencies).
     //
-    // Note that the first call to the driver is with "--crate-name ___" and no
-    // source file, for Cargo to retrieve some information about the crate.
-    // We don't need to check this case in order to use the default Rustc callbacks
-    // instead of the Charon callback: because there is nothing to build, Rustc will
-    // take care of everything and actually not call us back.
+    // Cargo calls the driver twice. The first call to the driver is with "--crate-name ___" and no
+    // source file, for Cargo to retrieve some information about the crate. The compiler
+    // infrastructure will give cargo what it needs without calling any of our callbacks. In that
+    // case `callback.crate_data` stays `None`.
     let errors_as_warnings = options.errors_as_warnings;
     let mut callback = CharonCallbacks::new(options);
     let mut res = callback.run_compiler(compiler_args);
     if let Some(crate_data) = &callback.crate_data {
-        // `crate_data` is `None` on the first call of the driver.
         if !callback.options.no_serialize {
             // # Final step: generate the files.
             res = res.and_then(|()| {

--- a/charon/src/charon-driver.rs
+++ b/charon/src/charon-driver.rs
@@ -223,13 +223,19 @@ fn main() {
         if !callback.options.no_serialize {
             // # Final step: generate the files.
             res = res.and_then(|()| {
-                let dest_file = callback.options.dest_file.clone().unwrap_or_else(|| {
-                    let (crate_name, extension) = match crate_data {
-                        CrateData::ULLBC(d) => (&d.name, "ullbc"),
-                        CrateData::LLBC(d) => (&d.name, "llbc"),
-                    };
-                    format!("{crate_name}.{extension}").into()
-                });
+                let dest_file = match callback.options.dest_file.clone() {
+                    Some(f) => f,
+                    None => {
+                        let mut target_filename =
+                            callback.options.dest_dir.clone().unwrap_or_default();
+                        let (crate_name, extension) = match crate_data {
+                            CrateData::ULLBC(d) => (&d.name, "ullbc"),
+                            CrateData::LLBC(d) => (&d.name, "llbc"),
+                        };
+                        target_filename.push(format!("{crate_name}.{extension}"));
+                        target_filename
+                    }
+                };
                 trace!("Target file: {:?}", dest_file);
                 crate_data
                     .serialize_to_file(&dest_file)

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -45,7 +45,13 @@ pub struct CliOpts {
     #[clap(long = "input", parse(from_os_str))]
     #[serde(default)]
     pub input_file: Option<PathBuf>,
-    /// The destination file. By default `<crate_name>.llbc`.
+    /// The destination directory. Files fill be generated as `<dest_dir>/<crate_name>.llbc`,
+    /// unless `dest_file` is set. `dest_dir` defaults to the current directory.
+    #[clap(long = "dest", parse(from_os_str))]
+    #[serde(default)]
+    pub dest_dir: Option<PathBuf>,
+    /// The destination file. By default `<dest_dir>/<crate_name>.llbc`. If this is set we gnore
+    /// `dest_dir`.
     #[clap(long = "dest-file", parse(from_os_str))]
     #[serde(default)]
     pub dest_file: Option<PathBuf>,

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -45,12 +45,12 @@ pub struct CliOpts {
     #[clap(long = "input", parse(from_os_str))]
     #[serde(default)]
     pub input_file: Option<PathBuf>,
-    /// The destination directory. Files fill be generated as `<dest_dir>/<crate_name>.llbc`,
+    /// The destination directory. Files will be generated as `<dest_dir>/<crate_name>.{u}llbc`,
     /// unless `dest_file` is set. `dest_dir` defaults to the current directory.
     #[clap(long = "dest", parse(from_os_str))]
     #[serde(default)]
     pub dest_dir: Option<PathBuf>,
-    /// The destination file. By default `<dest_dir>/<crate_name>.llbc`. If this is set we gnore
+    /// The destination file. By default `<dest_dir>/<crate_name>.llbc`. If this is set we ignore
     /// `dest_dir`.
     #[clap(long = "dest-file", parse(from_os_str))]
     #[serde(default)]

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -1,4 +1,4 @@
-use clap::StructOpt;
+use clap::Parser;
 /// The options received as input by cargo-charon
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -11,51 +11,51 @@ use std::path::PathBuf;
 // Note that because we need to transmit the options to the charon driver,
 // we store them in a file before calling this driver (hence the `Serialize`,
 // `Deserialize` options).
-#[derive(StructOpt, Default, Serialize, Deserialize)]
-#[structopt(name = "Charon")]
+#[derive(Parser, Default, Serialize, Deserialize)]
+#[clap(name = "Charon")]
 pub struct CliOpts {
     /// Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
-    #[structopt(long = "ullbc")]
+    #[clap(long = "ullbc")]
     #[serde(default)]
     pub ullbc: bool,
     /// Compile the package's library
-    #[structopt(long = "lib")]
+    #[clap(long = "lib")]
     #[serde(default)]
     pub lib: bool,
     /// Compile the specified binary
-    #[structopt(long = "bin")]
+    #[clap(long = "bin")]
     #[serde(default)]
     pub bin: Option<String>,
     /// Extract the promoted MIR instead of the built MIR
-    #[structopt(long = "mir_promoted")]
+    #[clap(long = "mir_promoted")]
     #[serde(default)]
     pub mir_promoted: bool,
     /// Extract the optimized MIR instead of the built MIR
-    #[structopt(long = "mir_optimized")]
+    #[clap(long = "mir_optimized")]
     #[serde(default)]
     pub mir_optimized: bool,
     /// Provide a custom name for the compiled crate (ignore the name computed
     /// by Cargo)
-    #[structopt(long = "crate")]
+    #[clap(long = "crate")]
     #[serde(default)]
     pub crate_name: Option<String>,
     /// The input file (the entry point of the crate to extract).
     /// This is needed if you want to define a custom entry point (to only
     /// extract part of a crate for instance).
-    #[structopt(long = "input", parse(from_os_str))]
+    #[clap(long = "input", parse(from_os_str))]
     #[serde(default)]
     pub input_file: Option<PathBuf>,
     /// The destination directory, if we don't want to generate the output
     /// .llbc files in the same directory as the input .rs files.
-    #[structopt(long = "dest", parse(from_os_str))]
+    #[clap(long = "dest", parse(from_os_str))]
     #[serde(default)]
     pub dest_dir: Option<PathBuf>,
     /// If activated, use Polonius' non-lexical lifetimes (NLL) analysis.
     /// Otherwise, use the standard borrow checker.
-    #[structopt(long = "polonius")]
+    #[clap(long = "polonius")]
     #[serde(default)]
     pub use_polonius: bool,
-    #[structopt(
+    #[clap(
         long = "no-code-duplication",
         help = "Check that no code duplication happens during control-flow reconstruction
 of the MIR code.
@@ -102,22 +102,22 @@ performs: `y := (x as E2).1`). Producing a better reconstruction is non-trivial.
     /// A list of modules of the extracted crate that we consider as opaque: we
     /// extract only the signature information, without the definition content
     /// (of the functions, types, etc.).
-    #[structopt(long = "opaque")]
+    #[clap(long = "opaque")]
     #[serde(default)]
     pub opaque_modules: Vec<String>,
     /// Do not provide a Rust version argument to Cargo (e.g., `+nightly-2022-01-29`).
     /// This is for Nix: outside of Nix, we use Rustup to call the proper version
     /// of Cargo (and thus need this argument), but within Nix we build and call a very
     /// specific version of Cargo.
-    #[structopt(long = "cargo-no-rust-version", env = "CARGO_NO_RUST_VERSION")]
+    #[clap(long = "cargo-no-rust-version", env = "CARGO_NO_RUST_VERSION")]
     #[serde(default)]
     pub cargo_no_rust_version: bool,
     /// Panic on the first error. This is useful for debugging.
-    #[structopt(long = "abort-on-error")]
+    #[clap(long = "abort-on-error")]
     #[serde(default)]
     pub abort_on_error: bool,
     /// Print the errors as warnings
-    #[structopt(
+    #[clap(
         long = "errors-as-warnings",
         help = "
 Report the errors as warnings
@@ -125,7 +125,7 @@ Report the errors as warnings
     )]
     #[serde(default)]
     pub errors_as_warnings: bool,
-    #[structopt(
+    #[clap(
         long = "no-serialize",
         help = "
 Don't serialize the final (U)LLBC to a file.
@@ -133,7 +133,7 @@ Don't serialize the final (U)LLBC to a file.
     )]
     #[serde(default)]
     pub no_serialize: bool,
-    #[structopt(
+    #[clap(
         long = "print-ullbc",
         help = "
 Print the ULLBC immediately after extraction from MIR.
@@ -141,7 +141,7 @@ Print the ULLBC immediately after extraction from MIR.
     )]
     #[serde(default)]
     pub print_ullbc: bool,
-    #[structopt(
+    #[clap(
         long = "print-built-llbc",
         help = "
 Print the LLBC just after we built it (i.e., immediately after loop reconstruction).
@@ -149,7 +149,7 @@ Print the LLBC just after we built it (i.e., immediately after loop reconstructi
     )]
     #[serde(default)]
     pub print_built_llbc: bool,
-    #[structopt(
+    #[clap(
         long = "print-llbc",
         help = "
 Print the final LLBC (after all the cleaning micro-passes).

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -45,11 +45,10 @@ pub struct CliOpts {
     #[clap(long = "input", parse(from_os_str))]
     #[serde(default)]
     pub input_file: Option<PathBuf>,
-    /// The destination directory, if we don't want to generate the output
-    /// .llbc files in the same directory as the input .rs files.
-    #[clap(long = "dest", parse(from_os_str))]
+    /// The destination file. By default `<crate_name>.llbc`.
+    #[clap(long = "dest-file", parse(from_os_str))]
     #[serde(default)]
-    pub dest_dir: Option<PathBuf>,
+    pub dest_file: Option<PathBuf>,
     /// If activated, use Polonius' non-lexical lifetimes (NLL) analysis.
     /// Otherwise, use the standard borrow checker.
     #[clap(long = "polonius")]

--- a/charon/src/main.rs
+++ b/charon/src/main.rs
@@ -37,7 +37,7 @@ extern crate rustc_tools_util;
 mod cli_options;
 mod logger;
 
-use clap::StructOpt;
+use clap::Parser;
 use cli_options::{CliOpts, CHARON_ARGS};
 use log::trace;
 use std::env;
@@ -51,7 +51,7 @@ pub fn main() {
     logger::initialize_logger();
 
     // Parse the command-line
-    let options = CliOpts::from_args();
+    let options = CliOpts::parse();
     trace!("Arguments: {:?}", std::env::args());
 
     // Check that the options are meaningful

--- a/charon/tests/ui.rs
+++ b/charon/tests/ui.rs
@@ -85,16 +85,20 @@ fn perform_test(test_case: &Case, action: Action) -> anyhow::Result<()> {
     if matches!(test_case.magic_comments.test_kind, TestKind::Unspecified) {
         bail!(HELP_STRING);
     }
+
     // Call the charon driver.
     let mut options = CliOpts::default();
     options.print_llbc = true;
     options.no_serialize = true;
+    options.crate_name = Some("test_crate".into());
+
     let output = Command::cargo_bin("charon-driver")?
         .arg("rustc")
         .arg(test_case.input_path.to_string_lossy().into_owned())
         .env(CHARON_ARGS, serde_json::to_string(&options).unwrap())
         .output()?;
     let stderr = String::from_utf8(output.stderr.clone())?;
+
     if matches!(test_case.magic_comments.test_kind, TestKind::KnownPanic) {
         if output.status.code() != Some(101) {
             let status = if output.status.success() {

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -1,6 +1,6 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-fn closures::incr_u32(@1: u32) -> u32
+fn test_crate::incr_u32(@1: u32) -> u32
 {
     let @0: u32; // return
     let x@1: u32; // arg #1
@@ -37,7 +37,7 @@ enum core::option::Option<T> =
 
 fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> (parents((parents((parents(Self)::[@TraitClause0]))::[@TraitClause3]))::[@TraitClause0])::Output
 
-fn closures::map_option<T, F>(@1: core::option::Option<T>, @2: F) -> core::option::Option<T>
+fn test_crate::map_option<T, F>(@1: core::option::Option<T>, @2: F) -> core::option::Option<T>
 where
     [@TraitClause0]: core::ops::function::Fn<F, (T)>,
     (parents((parents((parents((parents(@TraitClause0)::[@TraitClause3]))::[@TraitClause0]))::[@TraitClause3]))::[@TraitClause0])::Output = T,
@@ -78,7 +78,7 @@ where
     return
 }
 
-fn closures::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>), @2: fn<'_0>(&'_0 (T)) -> T) -> core::option::Option<T>
+fn test_crate::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>), @2: fn<'_0>(&'_0 (T)) -> T) -> core::option::Option<T>
 {
     let @0: core::option::Option<T>; // return
     let x@1: &'_ (core::option::Option<T>); // arg #1
@@ -109,19 +109,19 @@ fn closures::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>),
     return
 }
 
-fn closures::test_map_option1(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option1(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
     let @2: core::option::Option<u32>; // anonymous local
 
     @2 := copy (x@1)
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (closures::incr_u32))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (test_crate::incr_u32))
     drop @2
     return
 }
 
-fn closures::test_closure_u32::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_closure_u32::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -131,7 +131,7 @@ fn closures::test_closure_u32::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
     return
 }
 
-fn closures::test_closure_u32(@1: u32) -> u32
+fn test_crate::test_closure_u32(@1: u32) -> u32
 {
     let @0: u32; // return
     let x@1: u32; // arg #1
@@ -140,7 +140,7 @@ fn closures::test_closure_u32(@1: u32) -> u32
     let @4: fn(u32) -> u32; // anonymous local
     let @5: u32; // anonymous local
 
-    @3 := {closures::test_closure_u32::closure} {}
+    @3 := {test_crate::test_closure_u32::closure} {}
     f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
@@ -153,7 +153,7 @@ fn closures::test_closure_u32(@1: u32) -> u32
     return
 }
 
-fn closures::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (u32))) -> &'_0 (u32)
+fn test_crate::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (u32))) -> &'_0 (u32)
 {
     let @0: &'_ (u32); // return
     let state@1: &'_1 (()); // arg #1
@@ -163,7 +163,7 @@ fn closures::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (u
     return
 }
 
-fn closures::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
+fn test_crate::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
 {
     let @0: &'_ (u32); // return
     let x@1: &'_ (u32); // arg #1
@@ -173,7 +173,7 @@ fn closures::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
     let @5: fn<'_0>(&'_0 (u32)) -> &'_0 (u32); // anonymous local
     let @6: &'_ (u32); // anonymous local
 
-    @3 := {closures::test_closure_ref_u32::closure} {}
+    @3 := {test_crate::test_closure_ref_u32::closure} {}
     f@2 := cast<fn<'_0>(&'_0 (u32)) -> &'_0 (u32),fn<'_0>(&'_0 (u32)) -> &'_0 (u32)>(move (@3))
     drop @3
     @fake_read(f@2)
@@ -188,7 +188,7 @@ fn closures::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
     return
 }
 
-fn closures::test_closure_ref_param::closure<'_0, '_1, T>(@1: &'_1 (()), @2: (&'_0 (T))) -> &'_0 (T)
+fn test_crate::test_closure_ref_param::closure<'_0, '_1, T>(@1: &'_1 (()), @2: (&'_0 (T))) -> &'_0 (T)
 {
     let @0: &'_ (T); // return
     let state@1: &'_1 (()); // arg #1
@@ -198,7 +198,7 @@ fn closures::test_closure_ref_param::closure<'_0, '_1, T>(@1: &'_1 (()), @2: (&'
     return
 }
 
-fn closures::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
+fn test_crate::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
 {
     let @0: &'_ (T); // return
     let x@1: &'_ (T); // arg #1
@@ -208,7 +208,7 @@ fn closures::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
     let @5: fn<'_0>(&'_0 (T)) -> &'_0 (T); // anonymous local
     let @6: &'_ (T); // anonymous local
 
-    @3 := {closures::test_closure_ref_param::closure<T>} {}
+    @3 := {test_crate::test_closure_ref_param::closure<T>} {}
     f@2 := cast<fn<'_0>(&'_0 (T)) -> &'_0 (T),fn<'_0>(&'_0 (T)) -> &'_0 (T)>(move (@3))
     drop @3
     @fake_read(f@2)
@@ -223,7 +223,7 @@ fn closures::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
     return
 }
 
-fn closures::test_map_option2::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_map_option2::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -236,7 +236,7 @@ fn closures::test_map_option2::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
     return
 }
 
-fn closures::test_map_option2(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option2(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
@@ -245,20 +245,20 @@ fn closures::test_map_option2(@1: core::option::Option<u32>) -> core::option::Op
     let @4: core::option::Option<u32>; // anonymous local
     let @5: fn(u32) -> u32; // anonymous local
 
-    @3 := {closures::test_map_option2::closure} {}
+    @3 := {test_crate::test_map_option2::closure} {}
     f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
     @4 := copy (x@1)
     @5 := copy (f@2)
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@4), move (@5))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@4), move (@5))
     drop @5
     drop @4
     drop f@2
     return
 }
 
-fn closures::id<T>(@1: T) -> T
+fn test_crate::id<T>(@1: T) -> T
 {
     let @0: T; // return
     let x@1: T; // arg #1
@@ -268,19 +268,19 @@ fn closures::id<T>(@1: T) -> T
     return
 }
 
-fn closures::test_map_option_id1(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option_id1(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
     let @2: core::option::Option<u32>; // anonymous local
 
     @2 := copy (x@1)
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (closures::id<u32>))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (test_crate::id<u32>))
     drop @2
     return
 }
 
-fn closures::test_map_option_id2(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option_id2(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
@@ -288,11 +288,11 @@ fn closures::test_map_option_id2(@1: core::option::Option<u32>) -> core::option:
     let @3: core::option::Option<u32>; // anonymous local
     let @4: fn(u32) -> u32; // anonymous local
 
-    f@2 := const (closures::id<u32>)
+    f@2 := const (test_crate::id<u32>)
     @fake_read(f@2)
     @3 := copy (x@1)
     @4 := copy (f@2)
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@3), move (@4))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@3), move (@4))
     drop @4
     drop @3
     drop f@2
@@ -307,7 +307,7 @@ trait core::clone::Clone<Self>
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
-fn closures::id_clone<T>(@1: T) -> T
+fn test_crate::id_clone<T>(@1: T) -> T
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
@@ -329,7 +329,7 @@ impl core::clone::impls::{impl core::clone::Clone for u32#8} : core::clone::Clon
     fn clone = core::clone::impls::{impl core::clone::Clone for u32#8}::clone
 }
 
-fn closures::test_id_clone(@1: u32) -> u32
+fn test_crate::test_id_clone(@1: u32) -> u32
 {
     let @0: u32; // return
     let x@1: u32; // arg #1
@@ -337,7 +337,7 @@ fn closures::test_id_clone(@1: u32) -> u32
     let @3: fn(u32) -> u32; // anonymous local
     let @4: u32; // anonymous local
 
-    f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(const (closures::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
+    f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
     @fake_read(f@2)
     @3 := copy (f@2)
     @4 := copy (x@1)
@@ -348,7 +348,7 @@ fn closures::test_id_clone(@1: u32) -> u32
     return
 }
 
-fn closures::test_id_clone_param<T>(@1: T) -> T
+fn test_crate::test_id_clone_param<T>(@1: T) -> T
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
@@ -358,7 +358,7 @@ where
     let @3: fn(T) -> T; // anonymous local
     let @4: T; // anonymous local
 
-    f@2 := cast<fn(T) -> T,fn(T) -> T>(const (closures::id_clone<T>[@TraitClause0]))
+    f@2 := cast<fn(T) -> T,fn(T) -> T>(const (test_crate::id_clone<T>[@TraitClause0]))
     @fake_read(f@2)
     @3 := copy (f@2)
     @4 := move (x@1)
@@ -370,19 +370,19 @@ where
     return
 }
 
-fn closures::test_map_option_id_clone(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option_id_clone(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
     let @2: core::option::Option<u32>; // anonymous local
 
     @2 := copy (x@1)
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (closures::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(fn_ptr:fn(u32) -> u32)](move (@2), const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
     drop @2
     return
 }
 
-fn closures::test_map_option3::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_map_option3::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -395,7 +395,7 @@ fn closures::test_map_option3::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
     return
 }
 
-fn closures::test_map_option3(@1: core::option::Option<u32>) -> core::option::Option<u32>
+fn test_crate::test_map_option3(@1: core::option::Option<u32>) -> core::option::Option<u32>
 {
     let @0: core::option::Option<u32>; // return
     let x@1: core::option::Option<u32>; // arg #1
@@ -403,14 +403,14 @@ fn closures::test_map_option3(@1: core::option::Option<u32>) -> core::option::Op
     let @3: fn(u32) -> u32; // anonymous local
 
     @2 := copy (x@1)
-    @3 := {closures::test_map_option3::closure} {}
-    @0 := closures::map_option<u32, fn(u32) -> u32>[(closure:closures::test_map_option3::closure)](move (@2), move (@3))
+    @3 := {test_crate::test_map_option3::closure} {}
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[(closure:test_crate::test_map_option3::closure)](move (@2), move (@3))
     drop @3
     drop @2
     return
 }
 
-fn closures::test_regions::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (&'_ (u32)))) -> u32
+fn test_crate::test_regions::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (&'_ (u32)))) -> u32
 {
     let @0: u32; // return
     let state@1: &'_1 (()); // arg #1
@@ -420,7 +420,7 @@ fn closures::test_regions::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (&'_ (u32)
     return
 }
 
-fn closures::test_regions<'a>(@1: &'a (u32)) -> u32
+fn test_crate::test_regions<'a>(@1: &'a (u32)) -> u32
 {
     let @0: u32; // return
     let x@1: &'_ (u32); // arg #1
@@ -430,7 +430,7 @@ fn closures::test_regions<'a>(@1: &'a (u32)) -> u32
     let @5: &'_ (&'_ (u32)); // anonymous local
     let @6: &'_ (&'_ (u32)); // anonymous local
 
-    @3 := {closures::test_regions::closure} {}
+    @3 := {test_crate::test_regions::closure} {}
     f@2 := cast<fn<'_0>(&'_0 (&'_ (u32))) -> u32,fn<'_0>(&'_0 (&'_ (u32))) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
@@ -445,7 +445,7 @@ fn closures::test_regions<'a>(@1: &'a (u32)) -> u32
     return
 }
 
-fn closures::test_closure_capture::closure<'_0, '_1, '_2>(@1: &'_0 ((&'_1 (u32), &'_2 (u32))), @2: (u32)) -> u32
+fn test_crate::test_closure_capture::closure<'_0, '_1, '_2>(@1: &'_0 ((&'_1 (u32), &'_2 (u32))), @2: (u32)) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 ((&'_1 (u32), &'_2 (u32))); // arg #1
@@ -467,7 +467,7 @@ fn closures::test_closure_capture::closure<'_0, '_1, '_2>(@1: &'_0 ((&'_1 (u32),
     return
 }
 
-fn closures::test_closure_capture(@1: u32, @2: u32) -> u32
+fn test_crate::test_closure_capture(@1: u32, @2: u32) -> u32
 {
     let @0: u32; // return
     let x@1: u32; // arg #1
@@ -481,14 +481,14 @@ fn closures::test_closure_capture(@1: u32, @2: u32) -> u32
 
     @5 := &x@1
     @6 := &y@2
-    @4 := {closures::test_closure_capture::closure} {move (@5), move (@6)}
+    @4 := {test_crate::test_closure_capture::closure} {move (@5), move (@6)}
     drop @6
     drop @5
     f@3 := &@4
     @fake_read(f@3)
     @7 := &*(f@3)
     @8 := (const (0 : u32))
-    @0 := (closure:closures::test_closure_capture::closure)::call(move (@7), move (@8))
+    @0 := (closure:test_crate::test_closure_capture::closure)::call(move (@7), move (@8))
     drop @8
     drop @7
     drop @4
@@ -496,7 +496,7 @@ fn closures::test_closure_capture(@1: u32, @2: u32) -> u32
     return
 }
 
-fn closures::test_closure_clone::closure<'_0, T>(@1: &'_0 (()), @2: (T)) -> T
+fn test_crate::test_closure_clone::closure<'_0, T>(@1: &'_0 (()), @2: (T)) -> T
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
@@ -512,7 +512,7 @@ where
     return
 }
 
-fn closures::test_closure_clone<T>(@1: T) -> T
+fn test_crate::test_closure_clone<T>(@1: T) -> T
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
@@ -524,13 +524,13 @@ where
     let @5: (T); // anonymous local
     let @6: T; // anonymous local
 
-    @3 := {closures::test_closure_clone::closure<T>[@TraitClause0]} {}
+    @3 := {test_crate::test_closure_clone::closure<T>[@TraitClause0]} {}
     f@2 := &@3
     @fake_read(f@2)
     @4 := &*(f@2)
     @6 := move (x@1)
     @5 := (move (@6))
-    @0 := (closure:closures::test_closure_clone::closure<T>)::call(move (@4), move (@5))
+    @0 := (closure:test_crate::test_closure_clone::closure<T>)::call(move (@4), move (@5))
     drop @6
     drop @6
     drop @5
@@ -541,7 +541,7 @@ where
     return
 }
 
-fn closures::test_array_map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
+fn test_crate::test_array_map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
 {
     let @0: i32; // return
     let state@1: &'_0 mut (()); // arg #1
@@ -556,7 +556,7 @@ where
     [@TraitClause0]: core::ops::function::FnMut<F, (T)>,
     (parents((parents(@TraitClause0)::[@TraitClause3]))::[@TraitClause0])::Output = U,
 
-fn closures::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
+fn test_crate::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
 {
     let @0: Array<i32, 256 : usize>; // return
     let x@1: Array<i32, 256 : usize>; // arg #1
@@ -564,8 +564,8 @@ fn closures::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usi
     let @3: fn(i32) -> i32; // anonymous local
 
     @2 := copy (x@1)
-    @3 := {closures::test_array_map::closure} {}
-    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[(closure:closures::test_array_map::closure)](move (@2), move (@3))
+    @3 := {test_crate::test_array_map::closure} {}
+    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[(closure:test_crate::test_array_map::closure)](move (@2), move (@3))
     drop @3
     drop @2
     return

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -1,6 +1,6 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-struct issue_118_generic_copy::Foo = {}
+struct test_crate::Foo = {}
 
 trait core::clone::Clone<Self>
 {
@@ -8,18 +8,18 @@ trait core::clone::Clone<Self>
     fn clone_from
 }
 
-fn issue_118_generic_copy::{impl core::clone::Clone for issue_118_generic_copy::Foo}::clone<'_0>(@1: &'_0 (issue_118_generic_copy::Foo)) -> issue_118_generic_copy::Foo
+fn test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0>(@1: &'_0 (test_crate::Foo)) -> test_crate::Foo
 {
-    let @0: issue_118_generic_copy::Foo; // return
-    let self@1: &'_ (issue_118_generic_copy::Foo); // arg #1
+    let @0: test_crate::Foo; // return
+    let self@1: &'_ (test_crate::Foo); // arg #1
 
     @0 := copy (*(self@1))
     return
 }
 
-impl issue_118_generic_copy::{impl core::clone::Clone for issue_118_generic_copy::Foo} : core::clone::Clone<issue_118_generic_copy::Foo>
+impl test_crate::{impl core::clone::Clone for test_crate::Foo} : core::clone::Clone<test_crate::Foo>
 {
-    fn clone = issue_118_generic_copy::{impl core::clone::Clone for issue_118_generic_copy::Foo}::clone
+    fn clone = test_crate::{impl core::clone::Clone for test_crate::Foo}::clone
 }
 
 trait core::marker::Copy<Self>
@@ -27,17 +27,17 @@ trait core::marker::Copy<Self>
     parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-impl issue_118_generic_copy::{impl core::marker::Copy for issue_118_generic_copy::Foo#1} : core::marker::Copy<issue_118_generic_copy::Foo>
+impl test_crate::{impl core::marker::Copy for test_crate::Foo#1} : core::marker::Copy<test_crate::Foo>
 {
-    parent_clause0 = issue_118_generic_copy::{impl core::clone::Clone for issue_118_generic_copy::Foo}
+    parent_clause0 = test_crate::{impl core::clone::Clone for test_crate::Foo}
 }
 
-fn issue_118_generic_copy::copy_foo(@1: issue_118_generic_copy::Foo)
+fn test_crate::copy_foo(@1: test_crate::Foo)
 {
     let @0: (); // return
-    let x@1: issue_118_generic_copy::Foo; // arg #1
-    let y@2: issue_118_generic_copy::Foo; // local
-    let z@3: issue_118_generic_copy::Foo; // local
+    let x@1: test_crate::Foo; // arg #1
+    let y@2: test_crate::Foo; // local
+    let z@3: test_crate::Foo; // local
     let @4: (); // anonymous local
 
     y@2 := copy (x@1)
@@ -52,7 +52,7 @@ fn issue_118_generic_copy::copy_foo(@1: issue_118_generic_copy::Foo)
     return
 }
 
-fn issue_118_generic_copy::copy_generic<T>(@1: T)
+fn test_crate::copy_generic<T>(@1: T)
 where
     [@TraitClause0]: core::marker::Copy<T>,
 {
@@ -74,7 +74,7 @@ where
     return
 }
 
-trait issue_118_generic_copy::Trait<Self>
+trait test_crate::Trait<Self>
 {
     type Ty
         where
@@ -82,9 +82,9 @@ trait issue_118_generic_copy::Trait<Self>
             [@TraitClause1]: core::clone::Clone<Self::Ty>,
 }
 
-fn issue_118_generic_copy::copy_assoc_ty<T>(@1: @TraitClause0::Ty)
+fn test_crate::copy_assoc_ty<T>(@1: @TraitClause0::Ty)
 where
-    [@TraitClause0]: issue_118_generic_copy::Trait<T>,
+    [@TraitClause0]: test_crate::Trait<T>,
 {
     let @0: (); // return
     let x@1: @TraitClause0::Ty; // arg #1

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -92,7 +92,7 @@ impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26} 
     fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}::fmt
 }
 
-fn issue_4_traits::trait_error<'_0>(@1: &'_0 (Slice<u8>))
+fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
 {
     let @0: (); // return
     let s@1: &'_ (Slice<u8>); // arg #1

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -1,6 +1,6 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-fn issue_45_misc::map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
+fn test_crate::map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
 {
     let @0: i32; // return
     let state@1: &'_0 mut (()); // arg #1
@@ -27,7 +27,7 @@ where
     [@TraitClause0]: core::ops::function::FnMut<F, (T)>,
     (parents((parents(@TraitClause0)::[@TraitClause3]))::[@TraitClause0])::Output = U,
 
-fn issue_45_misc::map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
+fn test_crate::map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
 {
     let @0: Array<i32, 256 : usize>; // return
     let x@1: Array<i32, 256 : usize>; // arg #1
@@ -35,14 +35,14 @@ fn issue_45_misc::map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
     let @3: fn(i32) -> i32; // anonymous local
 
     @2 := copy (x@1)
-    @3 := {issue_45_misc::map::closure} {}
-    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[(closure:issue_45_misc::map::closure)](move (@2), move (@3))
+    @3 := {test_crate::map::closure} {}
+    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[(closure:test_crate::map::closure)](move (@2), move (@3))
     drop @3
     drop @2
     return
 }
 
-fn issue_45_misc::array<const LEN : usize>() -> Array<u8, const LEN : usize>
+fn test_crate::array<const LEN : usize>() -> Array<u8, const LEN : usize>
 {
     let @0: Array<u8, const LEN : usize>; // return
 
@@ -370,7 +370,7 @@ fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self:
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>
 
-fn issue_45_misc::cbd(@1: Array<u8, 33 : usize>)
+fn test_crate::cbd(@1: Array<u8, 33 : usize>)
 {
     let @0: (); // return
     let prf_input@1: Array<u8, 33 : usize>; // arg #1
@@ -450,7 +450,7 @@ opaque type core::fmt::Arguments<'a>
 
 fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
 
-fn issue_45_misc::select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
+fn test_crate::select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
 {
     let @0: (); // return
     let lhs@1: &'_ (Slice<u8>); // arg #1

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -1,19 +1,19 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-trait issue_72_hash_missing_impl::Hasher<Self>
+trait test_crate::Hasher<Self>
 
-struct issue_72_hash_missing_impl::DefaultHasher = {}
+struct test_crate::DefaultHasher = {}
 
-impl issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hasher for issue_72_hash_missing_impl::DefaultHasher} : issue_72_hash_missing_impl::Hasher<issue_72_hash_missing_impl::DefaultHasher>
+impl test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher} : test_crate::Hasher<test_crate::DefaultHasher>
 
-trait issue_72_hash_missing_impl::Hash<Self>
+trait test_crate::Hash<Self>
 {
-    fn hash : issue_72_hash_missing_impl::Hash::hash
+    fn hash : test_crate::Hash::hash
 }
 
-fn issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hash for u32#1}::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
+fn test_crate::{impl test_crate::Hash for u32#1}::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
 where
-    [@TraitClause0]: issue_72_hash_missing_impl::Hasher<H>,
+    [@TraitClause0]: test_crate::Hasher<H>,
 {
     let @0: (); // return
     let self@1: &'_ (u32); // arg #1
@@ -26,33 +26,33 @@ where
     return
 }
 
-impl issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hash for u32#1} : issue_72_hash_missing_impl::Hash<u32>
+impl test_crate::{impl test_crate::Hash for u32#1} : test_crate::Hash<u32>
 {
-    fn hash = issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hash for u32#1}::hash
+    fn hash = test_crate::{impl test_crate::Hash for u32#1}::hash
 }
 
-fn issue_72_hash_missing_impl::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
+fn test_crate::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
 where
-    [@TraitClause0]: issue_72_hash_missing_impl::Hasher<H>,
+    [@TraitClause0]: test_crate::Hasher<H>,
 
-fn issue_72_hash_missing_impl::main()
+fn test_crate::main()
 {
     let @0: (); // return
-    let hasher@1: issue_72_hash_missing_impl::DefaultHasher; // local
+    let hasher@1: test_crate::DefaultHasher; // local
     let @2: (); // anonymous local
     let @3: &'_ (u32); // anonymous local
     let @4: u32; // anonymous local
-    let @5: &'_ mut (issue_72_hash_missing_impl::DefaultHasher); // anonymous local
-    let @6: &'_ mut (issue_72_hash_missing_impl::DefaultHasher); // anonymous local
+    let @5: &'_ mut (test_crate::DefaultHasher); // anonymous local
+    let @6: &'_ mut (test_crate::DefaultHasher); // anonymous local
     let @7: (); // anonymous local
 
-    hasher@1 := issue_72_hash_missing_impl::DefaultHasher {  }
+    hasher@1 := test_crate::DefaultHasher {  }
     @fake_read(hasher@1)
     @4 := const (0 : u32)
     @3 := &@4
     @6 := &mut hasher@1
     @5 := &two-phase-mut *(@6)
-    @2 := issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hash for u32#1}::hash<issue_72_hash_missing_impl::DefaultHasher>[issue_72_hash_missing_impl::{impl issue_72_hash_missing_impl::Hasher for issue_72_hash_missing_impl::DefaultHasher}](move (@3), move (@5))
+    @2 := test_crate::{impl test_crate::Hash for u32#1}::hash<test_crate::DefaultHasher>[test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher}](move (@3), move (@5))
     drop @5
     drop @3
     drop @6

--- a/charon/tests/ui/issue-73-extern.out
+++ b/charon/tests/ui/issue-73-extern.out
@@ -1,10 +1,10 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-unsafe fn issue_73_extern::foo(@1: i32)
+unsafe fn test_crate::foo(@1: i32)
 
-global issue_73_extern::CONST 
+global test_crate::CONST 
 
-opaque type issue_73_extern::Type
+opaque type test_crate::Type
 
 
 

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.out
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.out
@@ -1,20 +1,20 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-enum issue_92_nonpositive_variant_indices::Ordering =
+enum test_crate::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
-fn issue_92_nonpositive_variant_indices::main()
+fn test_crate::main()
 {
     let @0: (); // return
-    let @1: issue_92_nonpositive_variant_indices::Ordering; // anonymous local
+    let @1: test_crate::Ordering; // anonymous local
     let @2: (); // anonymous local
     let @3: (); // anonymous local
     let @4: (); // anonymous local
 
-    @1 := issue_92_nonpositive_variant_indices::Ordering::Less {  }
+    @1 := test_crate::Ordering::Less {  }
     @fake_read(@1)
     match @1 {
         0 => {

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -1,34 +1,34 @@
 [ INFO charon_driver::driver:338] [translate]: # Final LLBC before serialization:
 
-trait issue_97_missing_parent_item_clause::Ord<Self>
+trait test_crate::Ord<Self>
 
-struct issue_97_missing_parent_item_clause::AVLTree<T> =
+struct test_crate::AVLTree<T> =
 {
   x: T
 }
 
-fn issue_97_missing_parent_item_clause::{issue_97_missing_parent_item_clause::AVLTree<T>}::insert<'_0, T>(@1: &'_0 mut (issue_97_missing_parent_item_clause::AVLTree<T>))
+fn test_crate::{test_crate::AVLTree<T>}::insert<'_0, T>(@1: &'_0 mut (test_crate::AVLTree<T>))
 where
-    [@TraitClause0]: issue_97_missing_parent_item_clause::Ord<T>,
+    [@TraitClause0]: test_crate::Ord<T>,
 {
     let @0: (); // return
-    let self@1: &'_ mut (issue_97_missing_parent_item_clause::AVLTree<T>); // arg #1
+    let self@1: &'_ mut (test_crate::AVLTree<T>); // arg #1
 
     panic
 }
 
-impl issue_97_missing_parent_item_clause::{impl issue_97_missing_parent_item_clause::Ord for u32#1} : issue_97_missing_parent_item_clause::Ord<u32>
+impl test_crate::{impl test_crate::Ord for u32#1} : test_crate::Ord<u32>
 
-fn issue_97_missing_parent_item_clause::test(@1: issue_97_missing_parent_item_clause::AVLTree<u32>)
+fn test_crate::test(@1: test_crate::AVLTree<u32>)
 {
     let @0: (); // return
-    let tree@1: issue_97_missing_parent_item_clause::AVLTree<u32>; // arg #1
+    let tree@1: test_crate::AVLTree<u32>; // arg #1
     let @2: (); // anonymous local
-    let @3: &'_ mut (issue_97_missing_parent_item_clause::AVLTree<u32>); // anonymous local
+    let @3: &'_ mut (test_crate::AVLTree<u32>); // anonymous local
     let @4: (); // anonymous local
 
     @3 := &two-phase-mut tree@1
-    @2 := issue_97_missing_parent_item_clause::{issue_97_missing_parent_item_clause::AVLTree<T>}::insert<u32>[issue_97_missing_parent_item_clause::{impl issue_97_missing_parent_item_clause::Ord for u32#1}](move (@3))
+    @2 := test_crate::{test_crate::AVLTree<T>}::insert<u32>[test_crate::{impl test_crate::Ord for u32#1}](move (@3))
     drop @3
     drop @2
     @4 := ()

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
             inherit cargoArtifacts;
             buildPhase = ''
               # Run the tests for Charon
-              DEST=$out CHARON="${charon}/bin/charon --cargo-no-rust-version" \
+              DEST=$out CARGO_NO_RUST_VERSION=1 CHARON_DRIVER="${charon}/bin/charon-driver" \
               make charon-tests
             '';
             doCheck = false;

--- a/tests-polonius/Makefile
+++ b/tests-polonius/Makefile
@@ -1,4 +1,5 @@
 CURRENT_DIR = $(shell pwd)
+# Call `charon` instead of `charon-driver` because we have dependencies in `Cargo.toml`.
 CHARON ?= $(CURRENT_DIR)/../bin/charon
 DEST ?= .
 OPTIONS += --polonius
@@ -43,25 +44,24 @@ test-betree_main: OPTIONS += --opaque=betree_utils
 # =============================================================================
 
 .PHONY: test-%
-# Call `charon` instead of `charon-driver` because we have dependencies in `Cargo.toml`.
 test-%: CHARON_CMD = $(CHARON) --crate $* --input src/$*.rs $(OPTIONS)
 test-%: build
 
 ifeq (, $(NOT_ALL_TESTS))
 
 test-%:
-	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
-#	$(CHARON_CMD) --dest-file $(DEST)/ullbc/$*.ullbc --ullbc
+	$(CHARON_CMD) --dest $(DEST)/llbc
+#	$(CHARON_CMD) --dest $(DEST)/ullbc --ullbc
 # TODO: this fails for now (it seems some closures are turned into globals,
 # and I don't know how to handle them).
-#	$(CHARON_CMD) --dest-file $(DEST)/llbc_prom/$*.llbc --mir_promoted
+#	$(CHARON_CMD) --dest $(DEST)/llbc_prom --mir_promoted
 # TODO: this fails for now (there is some very low-level desugaring happening)
-#	$(CHARON_CMD) --dest-file $(DEST)/llbc_opt/$*.llbc --mir_optimized
+#	$(CHARON_CMD) --dest $(DEST)/llbc_opt --mir_optimized
 
 else
 
 .PHONY: test-%
 test-%:
-	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
+	$(CHARON_CMD) --dest $(DEST)/llbc
 
 endif

--- a/tests-polonius/Makefile
+++ b/tests-polonius/Makefile
@@ -50,18 +50,18 @@ test-%: build
 ifeq (, $(NOT_ALL_TESTS))
 
 test-%:
-	$(CHARON_CMD) --dest $(DEST)/llbc
-#	$(CHARON_CMD) --dest $(DEST)/ullbc --ullbc
+	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
+#	$(CHARON_CMD) --dest-file $(DEST)/ullbc/$*.ullbc --ullbc
 # TODO: this fails for now (it seems some closures are turned into globals,
 # and I don't know how to handle them).
-#	$(CHARON_CMD) --dest $(DEST)/llbc_prom --mir_promoted
+#	$(CHARON_CMD) --dest-file $(DEST)/llbc_prom/$*.llbc --mir_promoted
 # TODO: this fails for now (there is some very low-level desugaring happening)
-#	$(CHARON_CMD) --dest $(DEST)/llbc_opt --mir_optimized
+#	$(CHARON_CMD) --dest-file $(DEST)/llbc_opt/$*.llbc --mir_optimized
 
 else
 
 .PHONY: test-%
 test-%:
-	$(CHARON_CMD) --dest $(DEST)/llbc
+	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
 
 endif

--- a/tests-polonius/Makefile
+++ b/tests-polonius/Makefile
@@ -43,6 +43,7 @@ test-betree_main: OPTIONS += --opaque=betree_utils
 # =============================================================================
 
 .PHONY: test-%
+# Call `charon` instead of `charon-driver` because we have dependencies in `Cargo.toml`.
 test-%: CHARON_CMD = $(CHARON) --crate $* --input src/$*.rs $(OPTIONS)
 test-%: build
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -73,17 +73,17 @@ clean:
 ifeq (, $(NOT_ALL_TESTS))
 
 test-%:
-	$(CHARON_CMD) --dest $(DEST)/llbc
-#	$(CHARON_CMD) --dest $(DEST)/ullbc --ullbc
+	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
+#	$(CHARON_CMD) --dest-file $(DEST)/ullbc/$*.ullbc --ullbc
 # TODO: this fails for now (it seems some closures are turned into globals,
 # and I don't know how to handle them).
-#	$(CHARON_CMD) --dest $(DEST)/llbc_prom --mir_promoted
+#	$(CHARON_CMD) --dest-file $(DEST)/llbc_prom/$*.llbc --mir_promoted
 # TODO: this fails for now (there is some very low-level desugaring happening)
-#	$(CHARON_CMD) --dest $(DEST)/llbc_opt --mir_optimized
+#	$(CHARON_CMD) --dest-file $(DEST)/llbc_opt/$*.llbc --mir_optimized
 
 else
 
 test-%:
-	$(CHARON_CMD) --dest $(DEST)/llbc
+	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
 
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,7 +59,7 @@ test-demo:
 # =============================================================================
 
 .PHONY: test-%
-# The opt-level is set byy default by cargo; some tests need it.
+# The opt-level is set by default by cargo; some tests need it.
 test-%: CHARON_CMD = $(CHARON_DRIVER) rustc src/$*.rs -C opt-level=3 -- --crate $* $(OPTIONS)
 test-%: build
 
@@ -73,17 +73,17 @@ clean:
 ifeq (, $(NOT_ALL_TESTS))
 
 test-%:
-	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
-#	$(CHARON_CMD) --dest-file $(DEST)/ullbc/$*.ullbc --ullbc
+	$(CHARON_CMD) --dest $(DEST)/llbc
+#	$(CHARON_CMD) --dest $(DEST)/ullbc --ullbc
 # TODO: this fails for now (it seems some closures are turned into globals,
 # and I don't know how to handle them).
-#	$(CHARON_CMD) --dest-file $(DEST)/llbc_prom/$*.llbc --mir_promoted
+#	$(CHARON_CMD) --dest $(DEST)/llbc_prom --mir_promoted
 # TODO: this fails for now (there is some very low-level desugaring happening)
-#	$(CHARON_CMD) --dest-file $(DEST)/llbc_opt/$*.llbc --mir_optimized
+#	$(CHARON_CMD) --dest $(DEST)/llbc_opt --mir_optimized
 
 else
 
 test-%:
-	$(CHARON_CMD) --dest-file $(DEST)/llbc/$*.llbc
+	$(CHARON_CMD) --dest $(DEST)/llbc
 
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR = $(shell pwd)
-CHARON ?= $(CURRENT_DIR)/../bin/charon
+CHARON_DRIVER ?= $(CURRENT_DIR)/../bin/charon-driver
 DEST ?= .
 OPTIONS ?=
 CHARON_CMD :=
@@ -59,7 +59,8 @@ test-demo:
 # =============================================================================
 
 .PHONY: test-%
-test-%: CHARON_CMD = $(CHARON) --crate $* --input src/$*.rs $(OPTIONS)
+# The opt-level is set byy default by cargo; some tests need it.
+test-%: CHARON_CMD = $(CHARON_DRIVER) rustc src/$*.rs -C opt-level=3 -- --crate $* $(OPTIONS)
 test-%: build
 
 .PHONY: clean


### PR DESCRIPTION
We avoid invoking the cargo machinery when not needed. `tests-polonius` still need `cargo` because they depend on `serde`.