### PR TITLE
Catch panics in `translate_body`

### DIFF
--- a/charon/tests/ui/unsupported/slice_index.rs
+++ b/charon/tests/ui/unsupported/slice_index.rs
@@ -1,4 +1,4 @@
-//@ known-panic
+//@ known-failure
 //@ no-check-output
 //@ charon-args=--extract-opaque-bodies
 

--- a/charon/tests/ui/unsupported/vec-push.out
+++ b/charon/tests/ui/unsupported/vec-push.out
@@ -13,5 +13,62 @@ error[HaxFront]: Supposely unreachable place in the Rust AST. The label is "Plac
   = note: ⚠️ This is a bug in Hax's frontend.
           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-error: aborting due to previous error
+error: Thread panicked when extracting body.
+ --> /rustc/d59363ad0b6391b7fc5bbb02c9ccf9300eef3753/library/alloc/src/vec/mod.rs:1824:5
 
+[ INFO charon_lib::driver:332] [translate]: # Final LLBC before serialization:
+
+struct core::ptr::non_null::NonNull<T> =
+{
+  pointer: *mut T
+}
+
+struct core::marker::PhantomData<T> = {}
+
+struct core::ptr::unique::Unique<T> =
+{
+  pointer: core::ptr::non_null::NonNull<T>,
+  _marker: core::marker::PhantomData<T>
+}
+
+struct alloc::raw_vec::RawVec<T, A> =
+{
+  ptr: core::ptr::unique::Unique<T>,
+  cap: usize,
+  alloc: A
+}
+
+struct alloc::vec::Vec<T, A> =
+{
+  buf: alloc::raw_vec::RawVec<T, A>,
+  len: usize
+}
+
+struct alloc::alloc::Global = {}
+
+fn alloc::vec::{alloc::vec::Vec<T, A>#1}::push<'_0, T, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>), @2: T)
+
+fn test_crate::vec<'_0>(@1: &'_0 mut (alloc::vec::Vec<u32, alloc::alloc::Global>))
+{
+    let @0: (); // return
+    let x@1: &'_ mut (alloc::vec::Vec<u32, alloc::alloc::Global>); // arg #1
+    let @2: &'_ mut (alloc::vec::Vec<u32, alloc::alloc::Global>); // anonymous local
+
+    @2 := &two-phase-mut *(x@1)
+    @0 := alloc::vec::{alloc::vec::Vec<T, A>#1}::push<u32, alloc::alloc::Global>(move (@2), const (42 : u32))
+    drop @2
+    @0 := ()
+    return
+}
+
+
+
+error: The external definition DefId(5:6777 ~ alloc[6cf4]::vec::{impl#1}::push) triggered errors. It is (transitively) used at the following location(s):
+ --> tests/ui/unsupported/vec-push.rs:5:5
+  |
+5 |     x.push(42)
+  |     ^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+[ ERROR charon_driver:180] The extraction encountered 1 errors

--- a/charon/tests/ui/unsupported/vec-push.rs
+++ b/charon/tests/ui/unsupported/vec-push.rs
@@ -1,4 +1,4 @@
-//@ known-panic
+//@ known-failure
 //@ charon-args=--extract-opaque-bodies
 
 fn vec(x: &mut Vec<u32>) {


### PR DESCRIPTION
This is a bit dirty, but allows users to make progress on their code even when some functions fail to extract. This only catches errors when extracting function bodies, we could extend that to other things if needed.

Fixes https://github.com/AeneasVerif/charon/issues/131