### PR TITLE
Fix linking on Mac

### DIFF
--- a/charon/src/main.rs
+++ b/charon/src/main.rs
@@ -32,10 +32,13 @@
 
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
-use charon_lib::cli_options::{CliOpts, CHARON_ARGS};
-use charon_lib::logger;
+// Don't link with the `charon_lib` crate so that the `charon` binary doesn't have to dynamically
+// link to `librustc_driver.so` etc.
+mod cli_options;
+mod logger;
+
 use clap::Parser;
-use log::trace;
+use cli_options::{CliOpts, CHARON_ARGS};
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR = $(shell pwd)
 # Outside of CI, ensure the correct toolchain is available (for the dynamic libraries).
 # FIXME: don't hardcode the toolchain
-TOOLCHAIN := nightly-2023-06-02-x86_64-unknown-linux-gnu
+TOOLCHAIN := nightly-2023-06-02
 CHARON_DRIVER ?= rustup run $(TOOLCHAIN) $(CURRENT_DIR)/../bin/charon-driver
 DEST ?= .
 OPTIONS ?=


### PR DESCRIPTION
I accidentally set a linux-only toolchain in #133. This should fix `make test` on Mac