### PR TITLE
Fix the linking situation

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -534,6 +535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,9 +666,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libtest-mimic"
@@ -998,9 +1008,9 @@ checksum = "598f48ce2a421542b3e64828aa742b687cc1b91d2f96591cfdb7ac5988cd6366"
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1323,6 +1333,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1506,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yansi"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -9,10 +9,15 @@ name = "charon_lib"
 path = "src/lib.rs"
 
 [[bin]]
+# The main entrypoint. This is a wrapper that handles toolchain and cargo
+# management and calls `charon-driver` for the real work.
 name = "charon"
 path = "src/main.rs"
 
 [[bin]]
+# The rustc driver. The resulting binary dynamically links to rust dylibs
+# including `librustc_driver.so`. Do not call directly, call charon instead to
+# let it set up the right paths.
 name = "charon-driver"
 path = "src/charon-driver.rs"
 

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -42,6 +42,7 @@ serial_test = "0.5.1"
 take_mut = "0.2.2"
 toml = "0.5.10"
 walkdir = "2.3.2"
+which = "6.0.1"
 
 hax-frontend-exporter = { git = "https://github.com/Nadrieril/hax", branch = "fix-parent-item-clauses" }
 hax-frontend-exporter-options = { git = "https://github.com/Nadrieril/hax", branch = "fix-parent-item-clauses" }

--- a/charon/macros/src/lib.rs
+++ b/charon/macros/src/lib.rs
@@ -6,9 +6,6 @@ extern crate proc_macro;
 extern crate syn;
 use proc_macro::{Span, TokenStream};
 use quote::ToTokens;
-use serde::Deserialize;
-use std::fs::File;
-use std::io::Read;
 use std::vec::Vec;
 use syn::punctuated::Punctuated;
 use syn::token::{Add, Comma};
@@ -857,32 +854,6 @@ pub fn derive_enum_as_getters(item: TokenStream) -> TokenStream {
 #[proc_macro_derive(EnumToGetters)]
 pub fn derive_enum_to_getters(item: TokenStream) -> TokenStream {
     derive_enum_variant_method(item, EnumMethodKind::EnumToGetters)
-}
-
-/// This struct is used to deserialize the "rust-toolchain" file.
-#[derive(Deserialize)]
-struct RustToolchain {
-    toolchain: Toolchain,
-}
-
-#[allow(dead_code)]
-#[derive(Deserialize)]
-struct Toolchain {
-    channel: String,
-    components: Vec<String>,
-}
-
-/// The following macro retrieves the rust compiler version from the
-/// "rust-toolchain" file at compile time. We need it at exactly one place.
-#[proc_macro]
-pub fn rust_version(_item: TokenStream) -> TokenStream {
-    let mut file = File::open("rust-toolchain").unwrap();
-    let mut contents = String::new();
-    file.read_to_string(&mut contents).unwrap();
-    let toolchain: RustToolchain = toml::from_str(&contents).unwrap();
-    format!("\"+{}\"", toolchain.toolchain.channel)
-        .parse()
-        .unwrap()
 }
 
 #[test]

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -115,13 +115,6 @@ performs: `y := (x as E2).1`). Producing a better reconstruction is non-trivial.
     #[clap(long = "extract-opaque-bodies")]
     #[serde(default)]
     pub extract_opaque_bodies: bool,
-    /// Do not provide a Rust version argument to Cargo (e.g., `+nightly-2022-01-29`).
-    /// This is for Nix: outside of Nix, we use Rustup to call the proper version
-    /// of Cargo (and thus need this argument), but within Nix we build and call a very
-    /// specific version of Cargo.
-    #[clap(long = "cargo-no-rust-version", env = "CARGO_NO_RUST_VERSION")]
-    #[serde(default)]
-    pub cargo_no_rust_version: bool,
     /// Panic on the first error. This is useful for debugging.
     #[clap(long = "abort-on-error")]
     #[serde(default)]

--- a/charon/src/cli_options.rs
+++ b/charon/src/cli_options.rs
@@ -115,6 +115,11 @@ performs: `y := (x as E2).1`). Producing a better reconstruction is non-trivial.
     #[clap(long = "extract-opaque-bodies")]
     #[serde(default)]
     pub extract_opaque_bodies: bool,
+    /// Do not run cargo; instead, run the driver directly.
+    // FIXME: use a subcommand instead, when we update clap to support flattening.
+    #[clap(long = "no-cargo")]
+    #[serde(default)]
+    pub no_cargo: bool,
     /// Panic on the first error. This is useful for debugging.
     #[clap(long = "abort-on-error")]
     #[serde(default)]

--- a/charon/src/logger.rs
+++ b/charon/src/logger.rs
@@ -106,6 +106,16 @@ macro_rules! error {
     }};
 }
 
+/// A custom log warn macro. Uses the log crate.
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)+) => {{
+        use colored::Colorize;
+        let msg = format!($($arg)+);
+        log::warn!("[{}]:\n{}", $crate::function_name!().yellow(), msg)
+    }};
+}
+
 /// A custom log info macro. Uses the log crate.
 #[macro_export]
 macro_rules! info {

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
             inherit cargoArtifacts;
             buildPhase = ''
               # Run the tests for Charon
-              DEST=$out CHARON_DRIVER="${charon}/bin/charon-driver" make charon-tests
+              DEST=$out CHARON="${charon}/bin/charon" make charon-tests
             '';
             doCheck = false;
             dontInstall = true;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,5 @@
 CURRENT_DIR = $(shell pwd)
-# Outside of CI, ensure the correct toolchain is available (for the dynamic libraries).
-# FIXME: don't hardcode the toolchain
-TOOLCHAIN := nightly-2023-06-02
-CHARON_DRIVER ?= rustup run $(TOOLCHAIN) $(CURRENT_DIR)/../bin/charon-driver
+CHARON ?= $(CURRENT_DIR)/../bin/charon
 DEST ?= .
 OPTIONS ?=
 CHARON_CMD :=
@@ -62,8 +59,7 @@ test-demo:
 # =============================================================================
 
 .PHONY: test-%
-# The opt-level is set by default by cargo; some tests need it.
-test-%: CHARON_CMD = $(CHARON_DRIVER) rustc src/$*.rs -C opt-level=3 -- --crate $* $(OPTIONS)
+test-%: CHARON_CMD = $(CHARON) --no-cargo --input src/$*.rs --crate $* $(OPTIONS)
 test-%: build
 
 .PHONY: clean


### PR DESCRIPTION
We have three sets of users to support:
- Those who build the nix flake;
- Those who build the project using rustup;
- Those who build the project by hand using a nix-provided toolchain.

We should now correctly support all three, with error messages when we're in an unexpected situation. The setup is now as follows: `charon-driver` is never called directly; instead, call `charon --no-cargo`. In general, `charon` is the entrypoint that makes sure we have the right toolchain around.