### PR TITLE
Support default systems (including aarch64-darwin) in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
   };
 
   outputs = { self, flake-utils, nixpkgs, rust-overlay, crane, flake-compat }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -40,6 +40,7 @@
         };
 
         charon = craneLib.buildPackage (craneArgs // {
+          buildInputs = [ pkgs.zlib ];
           # It's important to pass the same `RUSTFLAGS` to dependencies otherwise we'll have to rebuild them.
           cargoArtifacts = craneLib.buildDepsOnly craneArgs;
           # Check the `ui_llbc` files are correct instead of overwriting them.


### PR DESCRIPTION
These changes enable MacOs (and potentially other platforms) to build Charon via nix (I need to use this workflow because my Ocaml installation is horribly broken somehow). 

I tested this on MacOS and it seems to work, although the UI tests fail because rustc generates different `DefId`s, it seems. I haven't tested this on x86-64 linux however.