### PR TITLE
New workflow to run `rustc-tests` periodically

### DIFF
--- a/.github/workflows/rustc-tests.yml
+++ b/.github/workflows/rustc-tests.yml
@@ -1,0 +1,25 @@
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  rustc-tests:
+    runs-on: [self-hosted, linux, nix]
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          nix build -L '.#rustc-tests'
+          echo "Summary of the results:" > message.txt
+          cat result/charon-results | cut -d' ' -f 2 | sort | uniq -c >> message.txt
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const message = fs.readFileSync('./message.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: 145,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message,
+            });


### PR DESCRIPTION
This adds a weekly cron job to post results from `rustc-tests` to #145 