### PR TITLE
Fix CI

### DIFF
--- a/charon/tests/ui/unsupported/vec-push.out
+++ b/charon/tests/ui/unsupported/vec-push.out
@@ -16,7 +16,7 @@ error[HaxFront]: Supposely unreachable place in the Rust AST. The label is "Plac
 error: Thread panicked when extracting body.
  --> /rustc/d59363ad0b6391b7fc5bbb02c9ccf9300eef3753/library/alloc/src/vec/mod.rs:1824:5
 
-[ INFO charon_lib::driver:332] [translate]: # Final LLBC before serialization:
+# Final LLBC before serialization:
 
 struct core::ptr::non_null::NonNull<T> =
 {
@@ -63,7 +63,7 @@ fn test_crate::vec<'_0>(@1: &'_0 mut (alloc::vec::Vec<u32, alloc::alloc::Global>
 
 
 
-error: The external definition DefId(5:6777 ~ alloc[6cf4]::vec::{impl#1}::push) triggered errors. It is (transitively) used at the following location(s):
+error: The external definition `alloc::vec::{impl#1}::push` triggered errors. It is (transitively) used at the following location(s):
  --> tests/ui/unsupported/vec-push.rs:5:5
   |
 5 |     x.push(42)


### PR DESCRIPTION
There was a race condition because we merged a few PRs in succession and they affected each other. We should probably move to [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to manage that cleanly.

In the mean time, this fixes CI.