### PR TITLE
Run aeneas in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
       - run: nix build -L .#charon-ml
       - run: nix flake check -L
 
+  aeneas:
+    needs: [check_if_skip_duplicate_job, nix]
+    if: needs.check_if_skip_duplicate_job.outputs.should_skip != 'true'
+    runs-on: [self-hosted, linux, nix]
+    steps:
+      - run: nix build -L github:aeneasverif/aeneas --override-input charon github:aeneasverif/charon/${{ github.ref }}
+
   eurydice:
     needs: [check_if_skip_duplicate_job, nix]
     if: needs.check_if_skip_duplicate_job.outputs.should_skip != 'true'


### PR DESCRIPTION
This is a straightforward extension of https://github.com/AeneasVerif/charon/pull/155. I thought I had to clean up aeneas tests before we could do that but turns out that no.