### PR TITLE
ci: cancel old runs when updating a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
+          cancel_others: 'true'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
 


### PR DESCRIPTION
When we update a branch, this feature from https://github.com/fkirc/skip-duplicate-actions cancels workflow runs that were started for the same branch. I was surprised to learn that GitHub doesn't do that automatically.