### PR TITLE
Rework ids

### DIFF
--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -12,7 +12,7 @@ use std::vec::Vec;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Place {
     // TODO: update to transform to a recursive type
-    pub var_id: VarId::Id,
+    pub var_id: VarId,
     pub projection: Projection,
 }
 
@@ -61,19 +61,19 @@ pub enum ProjectionElem {
     /// (adt identifier, variant id, etc.). This information can be valuable
     /// (for pretty printing for instance). We retrieve it through
     /// type-checking.
-    Field(FieldProjKind, FieldId::Id),
+    Field(FieldProjKind, FieldId),
     /// MIR imposes that the argument to an index projection be a local variable, meaning
     /// that even constant indices into arrays are let-bound as separate variables.
     /// We also keep the type of the array/slice that we index for convenience purposes
     /// (this is not necessary).
     /// We **eliminate** this variant in a micro-pass.
-    Index(VarId::Id, Ty),
+    Index(VarId, Ty),
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, EnumIsA, EnumAsGetters, Serialize, Deserialize)]
 pub enum FieldProjKind {
     #[serde(rename = "ProjAdt")]
-    Adt(TypeDeclId::Id, Option<VariantId::Id>),
+    Adt(TypeDeclId, Option<VariantId>),
     /// If we project from a tuple, the projection kind gives the arity of the tuple.
     #[serde(rename = "ProjTuple")]
     Tuple(usize),
@@ -191,7 +191,7 @@ pub enum Operand {
 pub enum FunId {
     /// A "regular" function (function local to the crate, external function
     /// not treated as a primitive one).
-    Regular(FunDeclId::Id),
+    Regular(FunDeclId),
     /// A primitive function, coming from a standard library (for instance:
     /// `alloc::boxed::Box::new`).
     /// TODO: rename to "Primitive"
@@ -260,7 +260,7 @@ pub enum FunIdOrTraitMethodRef {
     /// If a trait: the reference to the trait and the id of the trait method.
     /// The fun decl id is not really necessary - we put it here for convenience
     /// purposes.
-    Trait(TraitRef, TraitItemName, FunDeclId::Id),
+    Trait(TraitRef, TraitItemName, FunDeclId),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -308,7 +308,7 @@ pub enum RawConstantExpr {
     /// Less frequently: arbitrary ADT values.
     ///
     /// We eliminate this case in a micro-pass.
-    Adt(Option<VariantId::Id>, Vec<ConstantExpr>),
+    Adt(Option<VariantId>, Vec<ConstantExpr>),
     ///
     /// The value is a top-level value.
     ///
@@ -328,7 +328,7 @@ pub enum RawConstantExpr {
     ///   let l = V::<N, T>::LEN; // We need to provided a substitution here
     /// }
     /// ```
-    Global(GlobalDeclId::Id, GenericArgs),
+    Global(GlobalDeclId, GenericArgs),
     ///
     /// A trait constant.
     ///
@@ -348,7 +348,7 @@ pub enum RawConstantExpr {
     /// We eliminate this case in a micro-pass.
     Ref(Box<ConstantExpr>),
     /// A const generic var
-    Var(ConstGenericVarId::Id),
+    Var(ConstGenericVarId),
     /// Function pointer
     FnPtr(FnPtr),
 }
@@ -374,7 +374,7 @@ pub enum Rvalue {
     /// of the type from which we read the discriminant.
     ///
     /// This case is filtered in [crate::remove_read_discriminant]
-    Discriminant(Place, TypeDeclId::Id),
+    Discriminant(Place, TypeDeclId),
     /// Creates an aggregate value, like a tuple, a struct or an enum:
     /// ```text
     /// l = List::Cons { value:x, tail:tl };
@@ -398,7 +398,7 @@ pub enum Rvalue {
     /// in operands in [extract_global_assignments.rs].
     ///
     /// Note that globals *can* have generic parameters.
-    Global(GlobalDeclId::Id, GenericArgs),
+    Global(GlobalDeclId, GenericArgs),
     /// Length of a memory location. The run-time length of e.g. a vector or a slice is
     /// represented differently (but pretty-prints the same, FIXME).
     /// Should be seen as a function of signature:
@@ -420,12 +420,12 @@ pub enum Rvalue {
 
 #[derive(Debug, Clone, VariantIndexArity, Serialize, Deserialize)]
 pub enum AggregateKind {
-    Adt(TypeId, Option<VariantId::Id>, GenericArgs),
+    Adt(TypeId, Option<VariantId>, GenericArgs),
     /// We don't put this with the ADT cas because this is the only assumed type
     /// with aggregates, and it is a primitive type. In particular, it makes
     /// sense to treat it differently because it has a variable number of fields.
     Array(Ty, ConstGeneric),
     /// Aggregated values for closures group the function id together with its
     /// state.
-    Closure(FunDeclId::Id, GenericArgs),
+    Closure(FunDeclId, GenericArgs),
 }

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -8,7 +8,7 @@ use macros::make_generic_in_borrows;
 use std::vec::Vec;
 
 impl Place {
-    pub fn new(var_id: VarId::Id) -> Place {
+    pub fn new(var_id: VarId) -> Place {
         Place {
             var_id,
             projection: Vec::new(),
@@ -30,7 +30,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
         self.visit_projection(&p.projection);
     }
 
-    fn visit_var_id(&mut self, _: &VarId::Id) {}
+    fn visit_var_id(&mut self, _: &VarId) {}
 
     fn visit_projection(&mut self, p: &Projection) {
         for pe in p.iter() {
@@ -55,7 +55,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
     fn visit_deref(&mut self) {}
     fn visit_deref_box(&mut self) {}
     fn visit_deref_raw_ptr(&mut self) {}
-    fn visit_projection_field(&mut self, _: &FieldProjKind, _: &FieldId::Id) {}
+    fn visit_projection_field(&mut self, _: &FieldProjKind, _: &FieldId) {}
 
     fn default_visit_operand(&mut self, o: &Operand) {
         match o {
@@ -110,7 +110,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
         }
     }
 
-    fn visit_constant_expr_adt(&mut self, _oid: &Option<VariantId::Id>, ops: &Vec<ConstantExpr>) {
+    fn visit_constant_expr_adt(&mut self, _oid: &Option<VariantId>, ops: &Vec<ConstantExpr>) {
         for op in ops {
             self.visit_constant_expr(op)
         }
@@ -165,7 +165,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
         self.visit_operand(o2);
     }
 
-    fn visit_discriminant(&mut self, p: &Place, adt_id: &TypeDeclId::Id) {
+    fn visit_discriminant(&mut self, p: &Place, adt_id: &TypeDeclId) {
         self.visit_place(p);
         self.visit_type_decl_id(adt_id);
     }
@@ -197,7 +197,7 @@ pub trait ExprVisitor: crate::types::TypeVisitor {
         }
     }
 
-    fn visit_global(&mut self, _: &GlobalDeclId::Id) {}
+    fn visit_global(&mut self, _: &GlobalDeclId) {}
 
     fn visit_len(&mut self, p: &Place, ty: &Ty, cg: &Option<ConstGeneric>) {
         self.visit_place(p);

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -2,6 +2,7 @@
 pub use crate::expressions::*;
 pub use crate::gast_utils::*;
 use crate::generate_index_type;
+use crate::ids::Vector;
 use crate::meta::{ItemMeta, Meta};
 use crate::names::Name;
 pub use crate::types::GlobalDeclId;
@@ -48,7 +49,7 @@ pub struct GExprBody<T> {
     /// - the local used for the return value
     /// - the input arguments
     /// - the remaining locals, used for the intermediate computations
-    pub locals: VarId::Vector<Var>,
+    pub locals: Vector<VarId::Id, Var>,
     pub body: T,
 }
 
@@ -198,7 +199,7 @@ pub struct TraitDecl {
     /// ```
     /// TODO: actually, as of today, we consider that all trait clauses of
     /// trait declarations are parent clauses.
-    pub parent_clauses: TraitClauseId::Vector<TraitClause>,
+    pub parent_clauses: Vector<TraitClauseId::Id, TraitClause>,
     /// The associated constants declared in the trait.
     ///
     /// The optional id is for the default value.
@@ -250,7 +251,7 @@ pub struct TraitImpl {
     pub generics: GenericParams,
     pub preds: Predicates,
     /// The trait references for the parent clauses (see [TraitDecl]).
-    pub parent_trait_refs: TraitClauseId::Vector<TraitRef>,
+    pub parent_trait_refs: Vector<TraitClauseId::Id, TraitRef>,
     /// The associated constants declared in the trait.
     pub consts: Vec<(TraitItemName, (Ty, GlobalDeclId::Id))>,
     /// The associated types declared in the trait.

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -28,7 +28,7 @@ fn dummy_def_id() -> rustc_hir::def_id::DefId {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Var {
     /// Unique index identifying the variable
-    pub index: VarId::Id,
+    pub index: VarId,
     /// Variable name - may be `None` if the variable was introduced by Rust
     /// through desugaring.
     pub name: Option<String>,
@@ -49,7 +49,7 @@ pub struct GExprBody<T> {
     /// - the local used for the return value
     /// - the input arguments
     /// - the remaining locals, used for the intermediate computations
-    pub locals: Vector<VarId::Id, Var>,
+    pub locals: Vector<VarId, Var>,
     pub body: T,
 }
 
@@ -81,25 +81,25 @@ pub enum ItemKind {
     /// Trait item implementation
     TraitItemImpl {
         /// The trait implementation block the method belongs to
-        impl_id: TraitImplId::Id,
+        impl_id: TraitImplId,
         /// The id of the trait decl the method belongs to
-        trait_id: TraitDeclId::Id,
+        trait_id: TraitDeclId,
         /// The name of the item
         item_name: TraitItemName,
         /// True if this item *re-implements* a provided item
         provided: bool,
     },
     /// Trait item declaration
-    TraitItemDecl(TraitDeclId::Id, TraitItemName),
+    TraitItemDecl(TraitDeclId, TraitItemName),
     /// Provided trait item (trait item declaration which defines
     /// a default implementation at the same time)
-    TraitItemProvided(TraitDeclId::Id, TraitItemName),
+    TraitItemProvided(TraitDeclId, TraitItemName),
 }
 
 /// A function definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GFunDecl<T> {
-    pub def_id: FunDeclId::Id,
+    pub def_id: FunDeclId,
     #[serde(skip)]
     #[serde(default = "dummy_def_id")]
     pub rust_id: rustc_hir::def_id::DefId,
@@ -123,7 +123,7 @@ pub struct GFunDecl<T> {
 /// A global variable definition, either opaque or transparent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GGlobalDecl<T> {
-    pub def_id: GlobalDeclId::Id,
+    pub def_id: GlobalDeclId,
     #[serde(skip)]
     #[serde(default = "dummy_def_id")]
     pub rust_id: rustc_hir::def_id::DefId,
@@ -179,7 +179,7 @@ pub struct TraitItemName(pub String);
 #[allow(clippy::type_complexity)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraitDecl {
-    pub def_id: TraitDeclId::Id,
+    pub def_id: TraitDeclId,
     /// [true] if the decl is a local decl, [false] if it comes from
     /// an external crate.
     pub is_local: bool,
@@ -199,23 +199,23 @@ pub struct TraitDecl {
     /// ```
     /// TODO: actually, as of today, we consider that all trait clauses of
     /// trait declarations are parent clauses.
-    pub parent_clauses: Vector<TraitClauseId::Id, TraitClause>,
+    pub parent_clauses: Vector<TraitClauseId, TraitClause>,
     /// The associated constants declared in the trait.
     ///
     /// The optional id is for the default value.
-    pub consts: Vec<(TraitItemName, (Ty, Option<GlobalDeclId::Id>))>,
+    pub consts: Vec<(TraitItemName, (Ty, Option<GlobalDeclId>))>,
     /// The associated types declared in the trait.
     pub types: Vec<(TraitItemName, (Vec<TraitClause>, Option<Ty>))>,
     /// The *required* methods.
     ///
     /// The required methods are the methods declared by the trait but with
     /// no default implementation.
-    pub required_methods: Vec<(TraitItemName, FunDeclId::Id)>,
+    pub required_methods: Vec<(TraitItemName, FunDeclId)>,
     /// The *provided* methods.
     ///
     /// The provided methods are the methods with a default implementation.
     ///
-    /// We include the [FunDeclId::Id] identifiers *only* for the local
+    /// We include the [FunDeclId] identifiers *only* for the local
     /// trait declarations. Otherwise, it would mean we extract *all* the
     /// provided methods, which is not something we want to do *yet* for
     /// the external traits.
@@ -223,7 +223,7 @@ pub struct TraitDecl {
     /// TODO: allow to optionnaly extract information. For instance: attempt
     /// to extract, and fail nicely if we don't succeed (definition not in
     /// the supported subset, etc.).
-    pub provided_methods: Vec<(TraitItemName, Option<FunDeclId::Id>)>,
+    pub provided_methods: Vec<(TraitItemName, Option<FunDeclId>)>,
 }
 
 /// A trait **implementation**.
@@ -238,7 +238,7 @@ pub struct TraitDecl {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraitImpl {
-    pub def_id: TraitImplId::Id,
+    pub def_id: TraitImplId,
     /// [true] if the decl is a local decl, [false] if it comes from
     /// an external crate.
     pub is_local: bool,
@@ -251,15 +251,15 @@ pub struct TraitImpl {
     pub generics: GenericParams,
     pub preds: Predicates,
     /// The trait references for the parent clauses (see [TraitDecl]).
-    pub parent_trait_refs: Vector<TraitClauseId::Id, TraitRef>,
+    pub parent_trait_refs: Vector<TraitClauseId, TraitRef>,
     /// The associated constants declared in the trait.
-    pub consts: Vec<(TraitItemName, (Ty, GlobalDeclId::Id))>,
+    pub consts: Vec<(TraitItemName, (Ty, GlobalDeclId))>,
     /// The associated types declared in the trait.
     pub types: Vec<(TraitItemName, (Vec<TraitRef>, Ty))>,
     /// The implemented required methods
-    pub required_methods: Vec<(TraitItemName, FunDeclId::Id)>,
+    pub required_methods: Vec<(TraitItemName, FunDeclId)>,
     /// The re-implemented provided methods
-    pub provided_methods: Vec<(TraitItemName, FunDeclId::Id)>,
+    pub provided_methods: Vec<(TraitItemName, FunDeclId)>,
 }
 
 /// A function operand is used in function calls.

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -10,7 +10,7 @@ use rustc_hir::def_id::DefId;
 /// Iterate on the declarations' non-empty bodies with their corresponding name and type.
 /// TODO: generalize this with visitors
 pub fn iter_function_bodies<T>(
-    funs: &mut Map<FunDeclId::Id, GFunDecl<T>>,
+    funs: &mut Map<FunDeclId, GFunDecl<T>>,
 ) -> impl Iterator<Item = (DefId, &Name, &mut GExprBody<T>)> {
     funs.iter_mut().flat_map(|f| match f.body.as_mut() {
         None => None, // Option::map was complaining about borrowing f
@@ -22,7 +22,7 @@ pub fn iter_function_bodies<T>(
 /// Same as [iter_function_bodies] (but the `flat_map` lambda cannot be generic).
 /// TODO: generalize this with visitors
 pub fn iter_global_bodies<T>(
-    globals: &mut Map<GlobalDeclId::Id, GGlobalDecl<T>>,
+    globals: &mut Map<GlobalDeclId, GGlobalDecl<T>>,
 ) -> impl Iterator<Item = (DefId, &Name, &mut GExprBody<T>)> {
     globals.iter_mut().flat_map(|g| match g.body.as_mut() {
         None => None, // Option::map was complaining about borrowing g
@@ -32,9 +32,7 @@ pub fn iter_global_bodies<T>(
 
 /// Makes a lambda that generates a new variable id, pushes a new variable in
 /// the body locals with the given type and returns its id.
-pub fn make_locals_generator(
-    locals: &mut Vector<VarId::Id, Var>,
-) -> impl FnMut(Ty) -> VarId::Id + '_ {
+pub fn make_locals_generator(locals: &mut Vector<VarId, Var>) -> impl FnMut(Ty) -> VarId + '_ {
     move |ty| {
         locals.push_with(|index| Var {
             index,

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -1,6 +1,7 @@
 //! Implementations for [crate::gast]
 
 use crate::gast::*;
+use crate::ids::{Map, Vector};
 use crate::names::Name;
 use crate::types::*;
 use crate::values::*;
@@ -9,7 +10,7 @@ use rustc_hir::def_id::DefId;
 /// Iterate on the declarations' non-empty bodies with their corresponding name and type.
 /// TODO: generalize this with visitors
 pub fn iter_function_bodies<T>(
-    funs: &mut FunDeclId::Map<GFunDecl<T>>,
+    funs: &mut Map<FunDeclId::Id, GFunDecl<T>>,
 ) -> impl Iterator<Item = (DefId, &Name, &mut GExprBody<T>)> {
     funs.iter_mut().flat_map(|f| match f.body.as_mut() {
         None => None, // Option::map was complaining about borrowing f
@@ -21,7 +22,7 @@ pub fn iter_function_bodies<T>(
 /// Same as [iter_function_bodies] (but the `flat_map` lambda cannot be generic).
 /// TODO: generalize this with visitors
 pub fn iter_global_bodies<T>(
-    globals: &mut GlobalDeclId::Map<GGlobalDecl<T>>,
+    globals: &mut Map<GlobalDeclId::Id, GGlobalDecl<T>>,
 ) -> impl Iterator<Item = (DefId, &Name, &mut GExprBody<T>)> {
     globals.iter_mut().flat_map(|g| match g.body.as_mut() {
         None => None, // Option::map was complaining about borrowing g
@@ -31,7 +32,9 @@ pub fn iter_global_bodies<T>(
 
 /// Makes a lambda that generates a new variable id, pushes a new variable in
 /// the body locals with the given type and returns its id.
-pub fn make_locals_generator(locals: &mut VarId::Vector<Var>) -> impl FnMut(Ty) -> VarId::Id + '_ {
+pub fn make_locals_generator(
+    locals: &mut Vector<VarId::Id, Var>,
+) -> impl FnMut(Ty) -> VarId::Id + '_ {
     move |ty| {
         locals.push_with(|index| Var {
             index,

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -31,7 +31,7 @@ pub struct Assert {
 pub enum RawStatement {
     Assign(Place, Rvalue),
     FakeRead(Place),
-    SetDiscriminant(Place, VariantId::Id),
+    SetDiscriminant(Place, VariantId),
     Drop(Place),
     Assert(Assert),
     Call(Call),
@@ -108,7 +108,7 @@ pub enum Switch {
     /// switch into a match).
     Match(
         Place,
-        Vec<(Vec<VariantId::Id>, Statement)>,
+        Vec<(Vec<VariantId>, Statement)>,
         Option<Box<Statement>>,
     ),
 }
@@ -116,7 +116,7 @@ pub enum Switch {
 pub type ExprBody = GExprBody<Statement>;
 
 pub type FunDecl = GFunDecl<Statement>;
-pub type FunDecls = Map<FunDeclId::Id, FunDecl>;
+pub type FunDecls = Map<FunDeclId, FunDecl>;
 
 pub type GlobalDecl = GGlobalDecl<Statement>;
-pub type GlobalDecls = Map<GlobalDeclId::Id, GlobalDecl>;
+pub type GlobalDecls = Map<GlobalDeclId, GlobalDecl>;

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -7,6 +7,7 @@
 //! from MIR to use Statement only.
 
 pub use crate::gast::*;
+use crate::ids::Map;
 pub use crate::llbc_ast_utils::*;
 use crate::meta::Meta;
 use crate::types::*;
@@ -115,7 +116,7 @@ pub enum Switch {
 pub type ExprBody = GExprBody<Statement>;
 
 pub type FunDecl = GFunDecl<Statement>;
-pub type FunDecls = FunDeclId::Map<FunDecl>;
+pub type FunDecls = Map<FunDeclId::Id, FunDecl>;
 
 pub type GlobalDecl = GGlobalDecl<Statement>;
-pub type GlobalDecls = GlobalDeclId::Map<GlobalDecl>;
+pub type GlobalDecls = Map<GlobalDeclId::Id, GlobalDecl>;

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -194,7 +194,7 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.visit_place(p);
     }
 
-    fn visit_set_discriminant(&mut self, p: &Place, _: &VariantId::Id) {
+    fn visit_set_discriminant(&mut self, p: &Place, _: &VariantId) {
         self.visit_place(p);
     }
 
@@ -260,7 +260,7 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
     fn visit_match(
         &mut self,
         scrut: &Place,
-        branches: &Vec<(Vec<VariantId::Id>, Statement)>,
+        branches: &Vec<(Vec<VariantId>, Statement)>,
         otherwise: &Option<Box<Statement>>,
     ) {
         self.visit_place(scrut);

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -7,28 +7,23 @@ use serde::{Deserialize, Serialize};
 generate_index_type!(LocalFileId);
 generate_index_type!(VirtualFileId);
 
-#[allow(non_snake_case)]
-pub mod FileId {
-    use crate::meta::*;
-
-    #[derive(
-        Debug,
-        Clone,
-        Copy,
-        Hash,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        EnumIsA,
-        EnumAsGetters,
-        Serialize,
-        Deserialize,
-    )]
-    pub enum Id {
-        LocalId(LocalFileId::Id),
-        VirtualId(VirtualFileId::Id),
-    }
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumIsA,
+    EnumAsGetters,
+    Serialize,
+    Deserialize,
+)]
+pub enum FileId {
+    LocalId(LocalFileId),
+    VirtualId(VirtualFileId),
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -47,7 +42,7 @@ fn dummy_span_data() -> rustc_span::SpanData {
 /// Span information
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct Span {
-    pub file_id: FileId::Id,
+    pub file_id: FileId,
     pub beg: Loc,
     pub end: Loc,
     /// We keep the rust span so as to be able to leverage Rustc to print

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -9,13 +9,13 @@ generate_index_type!(Disambiguator);
 /// See the comments for [Name]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, EnumIsA, EnumAsGetters)]
 pub enum PathElem {
-    Ident(String, Disambiguator::Id),
+    Ident(String, Disambiguator),
     Impl(ImplElem),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImplElem {
-    pub disambiguator: Disambiguator::Id,
+    pub disambiguator: Disambiguator,
     pub generics: GenericParams,
     pub preds: Predicates,
     pub kind: ImplElemKind,
@@ -72,7 +72,7 @@ pub enum ImplElemKind {
 /// in the other situations (i.e., the disambiguator is always equal to 0).
 ///
 /// Moreover, the items are uniquely disambiguated by their (integer) ids
-/// (`TypeDeclId::Id`, etc.), and when extracting the code we have to deal with
+/// (`TypeDeclId`, etc.), and when extracting the code we have to deal with
 /// name clashes anyway. Still, we might want to be more precise in the future.
 ///
 /// Also note that the first path element in the name is always the crate name.

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -158,7 +158,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
         for cur_id in parents {
             let data = tcx.def_key(cur_id).disambiguated_data;
             // Match over the key data
-            let disambiguator = Disambiguator::Id::new(data.disambiguator as usize);
+            let disambiguator = Disambiguator::new(data.disambiguator as usize);
             use rustc_hir::definitions::DefPathData;
             match &data.data {
                 DefPathData::TypeNs(symbol) => {
@@ -279,7 +279,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
 
         // We always add the crate name
         if !found_crate_name {
-            name.push(PathElem::Ident(crate_name, Disambiguator::Id::new(0)));
+            name.push(PathElem::Ident(crate_name, Disambiguator::new(0)));
         }
 
         trace!("{:?}", name);

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,4 +1,5 @@
 pub use crate::gast::{FunDeclId, TraitItemName};
+use crate::ids::{Map, Vector};
 use crate::meta::{ItemMeta, Meta};
 use crate::names::Name;
 pub use crate::types_utils::*;
@@ -304,9 +305,9 @@ pub struct GenericArgs {
 /// be filled with witnesses/instances.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenericParams {
-    pub regions: RegionId::Vector<RegionVar>,
-    pub types: TypeVarId::Vector<TypeVar>,
-    pub const_generics: ConstGenericVarId::Vector<ConstGenericVar>,
+    pub regions: Vector<RegionId::Id, RegionVar>,
+    pub types: Vector<TypeVarId::Id, TypeVar>,
+    pub const_generics: Vector<ConstGenericVarId::Id, ConstGenericVar>,
     // TODO: rename to match [GenericArgs]?
     // Remark: we use a regular [Vec], not a [TraitClauseId::Vector], because due to the
     // filtering of some trait clauses (for the marker traits for instance) the indexation
@@ -364,8 +365,8 @@ pub struct TypeDecl {
 
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, Serialize, Deserialize)]
 pub enum TypeDeclKind {
-    Struct(FieldId::Vector<Field>),
-    Enum(VariantId::Vector<Variant>),
+    Struct(Vector<FieldId::Id, Field>),
+    Enum(Vector<VariantId::Id, Variant>),
     /// An opaque type.
     ///
     /// Either a local type marked as opaque, or an external type.
@@ -379,7 +380,7 @@ pub enum TypeDeclKind {
 pub struct Variant {
     pub meta: Meta,
     pub name: String,
-    pub fields: FieldId::Vector<Field>,
+    pub fields: Vector<FieldId::Id, Field>,
     /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
     /// `SwitchInt` targets with the corresponding `Variant`.
     pub discriminant: ScalarValue,
@@ -475,7 +476,7 @@ pub enum TypeId {
     Assumed(AssumedTy),
 }
 
-pub type TypeDecls = TypeDeclId::Map<TypeDecl>;
+pub type TypeDecls = Map<TypeDeclId::Id, TypeDecl>;
 
 /// Types of primitive values. Either an integer, bool, char
 #[derive(
@@ -587,7 +588,7 @@ pub enum Ty {
     /// This is essentially a "constrained" function signature:
     /// arrow types can only contain generic lifetime parameters
     /// (no generic types), no predicates, etc.
-    Arrow(RegionId::Vector<RegionVar>, Vec<Ty>, Box<Ty>),
+    Arrow(Vector<RegionId::Id, RegionVar>, Vec<Ty>, Box<Ty>),
 }
 
 /// Assumed types identifiers.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -29,7 +29,7 @@ generate_index_type!(GlobalDeclId, "Global");
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TypeVar {
     /// Unique index identifying the variable
-    pub index: TypeVarId::Id,
+    pub index: TypeVarId,
     /// Variable name
     pub name: String,
 }
@@ -38,7 +38,7 @@ pub struct TypeVar {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
 pub struct RegionVar {
     /// Unique index identifying the variable
-    pub index: RegionId::Id,
+    pub index: RegionId,
     /// Region name
     pub name: Option<String>,
 }
@@ -47,7 +47,7 @@ pub struct RegionVar {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConstGenericVar {
     /// Unique index identifying the variable
-    pub index: ConstGenericVarId::Id,
+    pub index: ConstGenericVarId,
     /// Const generic name
     pub name: String,
     /// Type of the const generic
@@ -99,7 +99,7 @@ pub enum Region {
     ///                                De Bruijn: 1
     ///                                   Var id: 1
     /// ```
-    BVar(DeBruijnId, RegionId::Id),
+    BVar(DeBruijnId, RegionId),
     /// Erased region
     Erased,
     /// For error reporting.
@@ -117,11 +117,11 @@ pub enum Region {
 pub enum TraitInstanceId {
     ///
     /// A specific implementation
-    TraitImpl(TraitImplId::Id),
+    TraitImpl(TraitImplId),
     ///
     /// A specific builtin trait implementation like [core::marker::Sized] or
     /// auto trait implementation like [core::marker::Syn].
-    BuiltinOrAuto(TraitDeclId::Id),
+    BuiltinOrAuto(TraitDeclId),
     ///
     /// One of the local clauses.
     ///
@@ -131,11 +131,11 @@ pub enum TraitInstanceId {
     ///                    ^^^^^^^
     ///                    Clause(0)
     /// ```
-    Clause(TraitClauseId::Id),
+    Clause(TraitClauseId),
     ///
     /// A parent clause
     ///
-    /// Remark: the [TraitDeclId::Id] gives the trait declaration which is
+    /// Remark: the [TraitDeclId] gives the trait declaration which is
     /// implemented by the instance id from which we take the parent clause
     /// (see example below). It is not necessary and included for convenience.
     ///
@@ -159,12 +159,12 @@ pub enum TraitInstanceId {
     ///              clause 0 implements Bar
     /// }
     /// ```
-    ParentClause(Box<TraitInstanceId>, TraitDeclId::Id, TraitClauseId::Id),
+    ParentClause(Box<TraitInstanceId>, TraitDeclId, TraitClauseId),
     ///
     /// A clause bound in a trait item (typically a trait clause in an
     /// associated type).
     ///
-    /// Remark: the [TraitDeclId::Id] gives the trait declaration which is
+    /// Remark: the [TraitDeclId] gives the trait declaration which is
     /// implemented by the trait implementation from which we take the item
     /// (see below). It is not necessary and provided for convenience.
     ///
@@ -190,9 +190,9 @@ pub enum TraitInstanceId {
     ///
     ItemClause(
         Box<TraitInstanceId>,
-        TraitDeclId::Id,
+        TraitDeclId,
         TraitItemName,
-        TraitClauseId::Id,
+        TraitClauseId,
     ),
     /// Happens when we use a function pointer as an object implementing a
     /// trait like `Fn` or `FnMut`.
@@ -211,7 +211,7 @@ pub enum TraitInstanceId {
     /// It is important to differentiate the cases, because closures have a
     /// state. Whenever we create a closure, we actually create an aggregated
     /// value with a function pointer and a state.
-    Closure(FunDeclId::Id, GenericArgs),
+    Closure(FunDeclId, GenericArgs),
     ///
     /// Self, in case of trait declarations/implementations.
     ///
@@ -226,7 +226,7 @@ pub enum TraitInstanceId {
     /// haven't been registered yet. This variant is purely internal: after we
     /// finished solving the trait obligations, all the remaining unsolved
     /// clauses (in case we don't fail hard on error) are converted to [Unknown].
-    Unsolved(TraitDeclId::Id, GenericArgs),
+    Unsolved(TraitDeclId, GenericArgs),
     /// For error reporting.
     /// Can appear only if the option [CliOpts::continue_on_failure] is used.
     Unknown(String),
@@ -251,7 +251,7 @@ pub struct TraitRef {
 /// The substitution is: `[String, bool]`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct TraitDeclRef {
-    pub trait_id: TraitDeclId::Id,
+    pub trait_id: TraitDeclId,
     pub generics: GenericArgs,
 }
 
@@ -305,9 +305,9 @@ pub struct GenericArgs {
 /// be filled with witnesses/instances.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenericParams {
-    pub regions: Vector<RegionId::Id, RegionVar>,
-    pub types: Vector<TypeVarId::Id, TypeVar>,
-    pub const_generics: Vector<ConstGenericVarId::Id, ConstGenericVar>,
+    pub regions: Vector<RegionId, RegionVar>,
+    pub types: Vector<TypeVarId, TypeVar>,
+    pub const_generics: Vector<ConstGenericVarId, ConstGenericVar>,
     // TODO: rename to match [GenericArgs]?
     // Remark: we use a regular [Vec], not a [TraitClauseId::Vector], because due to the
     // filtering of some trait clauses (for the marker traits for instance) the indexation
@@ -325,10 +325,10 @@ pub struct TraitClause {
     /// We use this id when solving trait constraints, to be able to refer
     /// to specific where clauses when the selected trait actually is linked
     /// to a parameter.
-    pub clause_id: TraitClauseId::Id,
+    pub clause_id: TraitClauseId,
     #[derivative(PartialEq = "ignore")]
     pub meta: Option<Meta>,
-    pub trait_id: TraitDeclId::Id,
+    pub trait_id: TraitDeclId,
     /// Remark: the trait refs list in the [generics] field should be empty.
     pub generics: GenericArgs,
 }
@@ -350,7 +350,7 @@ impl Eq for TraitClause {}
 /// inlined in MIR.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeDecl {
-    pub def_id: TypeDeclId::Id,
+    pub def_id: TypeDeclId,
     /// Meta information associated with the type.
     pub item_meta: ItemMeta,
     /// [true] if the type decl is a local type decl, [false] if it comes from
@@ -365,8 +365,8 @@ pub struct TypeDecl {
 
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, Serialize, Deserialize)]
 pub enum TypeDeclKind {
-    Struct(Vector<FieldId::Id, Field>),
-    Enum(Vector<VariantId::Id, Variant>),
+    Struct(Vector<FieldId, Field>),
+    Enum(Vector<VariantId, Variant>),
     /// An opaque type.
     ///
     /// Either a local type marked as opaque, or an external type.
@@ -380,7 +380,7 @@ pub enum TypeDeclKind {
 pub struct Variant {
     pub meta: Meta,
     pub name: String,
-    pub fields: Vector<FieldId::Id, Field>,
+    pub fields: Vector<FieldId, Field>,
     /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
     /// `SwitchInt` targets with the corresponding `Variant`.
     pub discriminant: ScalarValue,
@@ -464,7 +464,7 @@ pub enum TypeId {
     ///
     /// Includes transparent ADTs and opaque ADTs (local ADTs marked as opaque,
     /// and external ADTs).
-    Adt(TypeDeclId::Id),
+    Adt(TypeDeclId),
     Tuple,
     /// Assumed type. Either a primitive type like array or slice, or a
     /// non-primitive type coming from a standard library
@@ -476,7 +476,7 @@ pub enum TypeId {
     Assumed(AssumedTy),
 }
 
-pub type TypeDecls = Map<TypeDeclId::Id, TypeDecl>;
+pub type TypeDecls = Map<TypeDeclId, TypeDecl>;
 
 /// Types of primitive values. Either an integer, bool, char
 #[derive(
@@ -519,9 +519,9 @@ pub enum LiteralTy {
 )]
 pub enum ConstGeneric {
     /// A global constant
-    Global(GlobalDeclId::Id),
+    Global(GlobalDeclId),
     /// A const generic variable
-    Var(ConstGenericVarId::Id),
+    Var(ConstGenericVarId),
     /// A concrete value
     Value(Literal),
 }
@@ -552,7 +552,7 @@ pub enum Ty {
     /// The information on the nature of the ADT is stored in (`TypeId`)[TypeId].
     /// The last list is used encode const generics, e.g., the size of an array
     Adt(TypeId, GenericArgs),
-    TypeVar(TypeVarId::Id),
+    TypeVar(TypeVarId),
     Literal(LiteralTy),
     /// The never type, for computations which don't return. It is sometimes
     /// necessary for intermediate variables. For instance, if we do (coming
@@ -588,7 +588,7 @@ pub enum Ty {
     /// This is essentially a "constrained" function signature:
     /// arrow types can only contain generic lifetime parameters
     /// (no generic types), no predicates, etc.
-    Arrow(Vector<RegionId::Id, RegionVar>, Vec<Ty>, Box<Ty>),
+    Arrow(Vector<RegionId, RegionVar>, Vec<Ty>, Box<Ty>),
 }
 
 /// Assumed types identifiers.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,4 +1,5 @@
 //! This file groups everything which is linked to implementations about [crate::types]
+use crate::ids::Vector;
 use crate::types::*;
 use crate::values::*;
 use hax_frontend_exporter as hax;
@@ -45,9 +46,9 @@ impl GenericParams {
 
     pub fn empty() -> Self {
         GenericParams {
-            regions: RegionId::Vector::new(),
-            types: TypeVarId::Vector::new(),
-            const_generics: ConstGenericVarId::Vector::new(),
+            regions: Vector::new(),
+            types: Vector::new(),
+            const_generics: Vector::new(),
             trait_clauses: Vec::new(),
         }
     }
@@ -144,7 +145,7 @@ impl TypeDecl {
     pub fn get_fields(
         &self,
         variant_id: Option<VariantId::Id>,
-    ) -> Result<&FieldId::Vector<Field>, ()> {
+    ) -> Result<&Vector<FieldId::Id, Field>, ()> {
         match &self.kind {
             TypeDeclKind::Enum(variants) => Ok(&variants.get(variant_id.unwrap()).unwrap().fields),
             TypeDeclKind::Struct(fields) => {
@@ -506,11 +507,11 @@ make_generic_in_borrows! {
 // TODO: we should use traits with default implementations to allow overriding
 // the default behavior (that would also prevent problems with naming collisions)
 pub trait TypeVisitor {
-    fn default_enter_region_group(&mut self, regions: &RegionId::Vector<RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
+    fn default_enter_region_group(&mut self, regions: &Vector<RegionId::Id, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
         visitor(self)
     }
 
-    fn enter_region_group(&mut self, regions: &RegionId::Vector<RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
+    fn enter_region_group(&mut self, regions: &Vector<RegionId::Id, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
         self.default_enter_region_group(regions, visitor)
     }
 
@@ -545,7 +546,7 @@ pub trait TypeVisitor {
 
     fn visit_region_bvar(&mut self, _grid: &DeBruijnId, _rid: &RegionId::Id) {}
 
-    fn visit_arrow(&mut self, regions: &RegionId::Vector<RegionVar>, inputs: &Vec<Ty>, output: &Ty) {
+    fn visit_arrow(&mut self, regions: &Vector<RegionId::Id, RegionVar>, inputs: &Vec<Ty>, output: &Ty) {
         for r in regions.iter() {
             self.visit_region_var(r);
         }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -24,7 +24,7 @@ impl DeBruijnId {
 }
 
 impl TypeVar {
-    pub fn new(index: TypeVarId::Id, name: String) -> TypeVar {
+    pub fn new(index: TypeVarId, name: String) -> TypeVar {
         TypeVar { index, name }
     }
 }
@@ -142,10 +142,7 @@ impl TypeDecl {
     /// The variant id should be `None` if it is a structure and `Some` if it
     /// is an enumeration.
     #[allow(clippy::result_unit_err)]
-    pub fn get_fields(
-        &self,
-        variant_id: Option<VariantId::Id>,
-    ) -> Result<&Vector<FieldId::Id, Field>, ()> {
+    pub fn get_fields(&self, variant_id: Option<VariantId>) -> Result<&Vector<FieldId, Field>, ()> {
         match &self.kind {
             TypeDeclKind::Enum(variants) => Ok(&variants.get(variant_id.unwrap()).unwrap().fields),
             TypeDeclKind::Struct(fields) => {
@@ -221,7 +218,7 @@ impl IntegerTy {
     }
 }
 
-pub fn bound_region_var_to_pretty_string(grid: DeBruijnId, rid: RegionId::Id) -> String {
+pub fn bound_region_var_to_pretty_string(grid: DeBruijnId, rid: RegionId) -> String {
     format!("'_{}_{}", grid.index, rid.to_string())
 }
 
@@ -316,8 +313,8 @@ pub struct TySubst {
     /// In case the regions are not erased, we must be careful with the
     /// static region.
     pub regions_map: HashMap<Region, Region>,
-    pub type_vars_map: HashMap<TypeVarId::Id, Ty>,
-    pub const_generics_map: HashMap<ConstGenericVarId::Id, ConstGeneric>,
+    pub type_vars_map: HashMap<TypeVarId, Ty>,
+    pub const_generics_map: HashMap<ConstGenericVarId, ConstGeneric>,
 }
 
 macro_rules! check_ok_return {
@@ -458,8 +455,8 @@ impl TySubst {
 impl TySubst {
     #[allow(clippy::result_unit_err)]
     pub fn unify_args_with_fixed(
-        fixed_type_vars: impl std::iter::Iterator<Item = TypeVarId::Id>,
-        fixed_const_generic_vars: impl std::iter::Iterator<Item = ConstGenericVarId::Id>,
+        fixed_type_vars: impl std::iter::Iterator<Item = TypeVarId>,
+        fixed_const_generic_vars: impl std::iter::Iterator<Item = ConstGenericVarId>,
         src: &crate::gast::GenericArgs,
         tgt: &crate::gast::GenericArgs,
     ) -> Result<Self, ()> {
@@ -507,11 +504,11 @@ make_generic_in_borrows! {
 // TODO: we should use traits with default implementations to allow overriding
 // the default behavior (that would also prevent problems with naming collisions)
 pub trait TypeVisitor {
-    fn default_enter_region_group(&mut self, regions: &Vector<RegionId::Id, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
+    fn default_enter_region_group(&mut self, regions: &Vector<RegionId, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
         visitor(self)
     }
 
-    fn enter_region_group(&mut self, regions: &Vector<RegionId::Id, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
+    fn enter_region_group(&mut self, regions: &Vector<RegionId, RegionVar>, visitor: &mut dyn FnMut(&mut Self)) {
         self.default_enter_region_group(regions, visitor)
     }
 
@@ -544,9 +541,9 @@ pub trait TypeVisitor {
         }
     }
 
-    fn visit_region_bvar(&mut self, _grid: &DeBruijnId, _rid: &RegionId::Id) {}
+    fn visit_region_bvar(&mut self, _grid: &DeBruijnId, _rid: &RegionId) {}
 
-    fn visit_arrow(&mut self, regions: &Vector<RegionId::Id, RegionVar>, inputs: &Vec<Ty>, output: &Ty) {
+    fn visit_arrow(&mut self, regions: &Vector<RegionId, RegionVar>, inputs: &Vec<Ty>, output: &Ty) {
         for r in regions.iter() {
             self.visit_region_var(r);
         }
@@ -573,7 +570,7 @@ pub trait TypeVisitor {
 
     fn visit_region_var(&mut self, r: &RegionVar) {}
 
-    fn visit_ty_type_var(&mut self, vid: &TypeVarId::Id) {
+    fn visit_ty_type_var(&mut self, vid: &TypeVarId) {
         self.visit_type_var_id(vid);
     }
 
@@ -599,7 +596,7 @@ pub trait TypeVisitor {
         }
     }
 
-    fn visit_type_decl_id(&mut self, _: &TypeDeclId::Id) {}
+    fn visit_type_decl_id(&mut self, _: &TypeDeclId) {}
 
     fn visit_assumed_ty(&mut self, _: &AssumedTy) {}
 
@@ -622,9 +619,9 @@ pub trait TypeVisitor {
         // Ignoring the name and type
     }
 
-    fn visit_global_decl_id(&mut self, _: &GlobalDeclId::Id) {}
-    fn visit_type_var_id(&mut self, _: &TypeVarId::Id) {}
-    fn visit_const_generic_var_id(&mut self, _: &ConstGenericVarId::Id) {}
+    fn visit_global_decl_id(&mut self, _: &GlobalDeclId) {}
+    fn visit_type_var_id(&mut self, _: &TypeVarId) {}
+    fn visit_const_generic_var_id(&mut self, _: &ConstGenericVarId) {}
 
     fn visit_literal(&mut self, _: &Literal) {}
 
@@ -648,9 +645,9 @@ pub trait TypeVisitor {
         self.visit_generic_args(generics);
     }
 
-    fn visit_trait_decl_id(&mut self, _: &TraitDeclId::Id) {}
-    fn visit_trait_impl_id(&mut self, _: &TraitImplId::Id) {}
-    fn visit_trait_clause_id(&mut self, _: &TraitClauseId::Id) {}
+    fn visit_trait_decl_id(&mut self, _: &TraitDeclId) {}
+    fn visit_trait_impl_id(&mut self, _: &TraitImplId) {}
+    fn visit_trait_clause_id(&mut self, _: &TraitClauseId) {}
 
     fn default_visit_trait_instance_id(&mut self, id: &TraitInstanceId) {
         match id {
@@ -790,7 +787,7 @@ pub trait TypeVisitor {
         self.visit_ty(ty);
     }
 
-    fn visit_fun_decl_id(&mut self, _: &FunDeclId::Id) {}
+    fn visit_fun_decl_id(&mut self, _: &FunDeclId) {}
 }
 
 } // make_generic_in_borrows

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -1,6 +1,7 @@
 //! "Unstructured LLBC" ast (ULLBC). This is LLBC before the control-flow
 //! reconstruction. In effect, this is a cleaned up version of MIR.
 pub use crate::gast::*;
+use crate::ids::{Map, Vector};
 use crate::meta::Meta;
 pub use crate::types::GlobalDeclId;
 use crate::types::*;
@@ -15,16 +16,16 @@ generate_index_type!(BlockId, "Block");
 // The entry block of a function is always the block with id 0
 pub static START_BLOCK_ID: BlockId::Id = BlockId::ZERO;
 
-pub type ExprBody = GExprBody<BlockId::Vector<BlockData>>;
+pub type ExprBody = GExprBody<Vector<BlockId::Id, BlockData>>;
 
-pub type FunDecl = GFunDecl<BlockId::Vector<BlockData>>;
-pub type FunDecls = FunDeclId::Map<FunDecl>;
+pub type FunDecl = GFunDecl<Vector<BlockId::Id, BlockData>>;
+pub type FunDecls = Map<FunDeclId::Id, FunDecl>;
 
-pub type GlobalDecl = GGlobalDecl<BlockId::Vector<BlockData>>;
-pub type GlobalDecls = GlobalDeclId::Map<GlobalDecl>;
+pub type GlobalDecl = GGlobalDecl<Vector<BlockId::Id, BlockData>>;
+pub type GlobalDecls = Map<GlobalDeclId::Id, GlobalDecl>;
 
-pub type TraitDecls = TraitDeclId::Map<TraitDecl>;
-pub type TraitImpls = TraitImplId::Map<TraitImpl>;
+pub type TraitDecls = Map<TraitDeclId::Id, TraitDecl>;
+pub type TraitImpls = Map<TraitImplId::Id, TraitImpl>;
 
 /// A raw statement: a statement without meta data.
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize, Deserialize)]

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -14,27 +14,27 @@ use serde::{Deserialize, Serialize};
 generate_index_type!(BlockId, "Block");
 
 // The entry block of a function is always the block with id 0
-pub static START_BLOCK_ID: BlockId::Id = BlockId::ZERO;
+pub static START_BLOCK_ID: BlockId = BlockId::ZERO;
 
-pub type ExprBody = GExprBody<Vector<BlockId::Id, BlockData>>;
+pub type ExprBody = GExprBody<Vector<BlockId, BlockData>>;
 
-pub type FunDecl = GFunDecl<Vector<BlockId::Id, BlockData>>;
-pub type FunDecls = Map<FunDeclId::Id, FunDecl>;
+pub type FunDecl = GFunDecl<Vector<BlockId, BlockData>>;
+pub type FunDecls = Map<FunDeclId, FunDecl>;
 
-pub type GlobalDecl = GGlobalDecl<Vector<BlockId::Id, BlockData>>;
-pub type GlobalDecls = Map<GlobalDeclId::Id, GlobalDecl>;
+pub type GlobalDecl = GGlobalDecl<Vector<BlockId, BlockData>>;
+pub type GlobalDecls = Map<GlobalDeclId, GlobalDecl>;
 
-pub type TraitDecls = Map<TraitDeclId::Id, TraitDecl>;
-pub type TraitImpls = Map<TraitImplId::Id, TraitImpl>;
+pub type TraitDecls = Map<TraitDeclId, TraitDecl>;
+pub type TraitImpls = Map<TraitImplId, TraitImpl>;
 
 /// A raw statement: a statement without meta data.
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize, Deserialize)]
 pub enum RawStatement {
     Assign(Place, Rvalue),
     FakeRead(Place),
-    SetDiscriminant(Place, VariantId::Id),
+    SetDiscriminant(Place, VariantId),
     /// We translate this to [crate::llbc_ast::RawStatement::Drop] in LLBC
-    StorageDead(VarId::Id),
+    StorageDead(VarId),
     /// We translate this to [crate::llbc_ast::RawStatement::Drop] in LLBC
     Deinit(Place),
 }
@@ -50,18 +50,18 @@ pub struct Statement {
 )]
 pub enum SwitchTargets {
     /// Gives the `if` block and the `else` block
-    If(BlockId::Id, BlockId::Id),
+    If(BlockId, BlockId),
     /// Gives the integer type, a map linking values to switch branches, and the
     /// otherwise block. Note that matches over enumerations are performed by
     /// switching over the discriminant, which is an integer.
-    SwitchInt(IntegerTy, Vec<(ScalarValue, BlockId::Id)>, BlockId::Id),
+    SwitchInt(IntegerTy, Vec<(ScalarValue, BlockId)>, BlockId),
 }
 
 /// A raw terminator: a terminator without meta data.
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, Serialize, Deserialize)]
 pub enum RawTerminator {
     Goto {
-        target: BlockId::Id,
+        target: BlockId,
     },
     Switch {
         discr: Operand,
@@ -72,20 +72,20 @@ pub enum RawTerminator {
     Unreachable,
     Drop {
         place: Place,
-        target: BlockId::Id,
+        target: BlockId,
     },
     /// Function call.
     /// For now, we only accept calls to top-level functions.
     Call {
         call: Call,
-        target: BlockId::Id,
+        target: BlockId,
     },
     /// A built-in assert, which corresponds to runtime checks that we remove, namely: bounds
     /// checks, over/underflow checks, div/rem by zero checks, pointer alignement check.
     Assert {
         cond: Operand,
         expected: bool,
-        target: BlockId::Id,
+        target: BlockId,
     },
 }
 

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -1,4 +1,5 @@
 //! Implementations for [crate::ullbc_ast]
+use crate::ids::Vector;
 use crate::meta::Meta;
 use crate::types::*;
 use crate::ullbc_ast::*;
@@ -139,7 +140,7 @@ impl BlockData {
 /// containing the operand. `f` should explore the operand it receives, and
 /// push statements to the vector it receives as input.
 pub fn body_transform_operands<F: FnMut(&Meta, &mut Vec<Statement>, &mut Operand)>(
-    blocks: &mut BlockId::Vector<BlockData>,
+    blocks: &mut Vector<BlockId::Id, BlockData>,
     f: &mut F,
 ) {
     for block in blocks.iter_mut() {

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -8,7 +8,7 @@ use macros::make_generic_in_borrows;
 use take_mut::take;
 
 impl SwitchTargets {
-    pub fn get_targets(&self) -> Vec<BlockId::Id> {
+    pub fn get_targets(&self) -> Vec<BlockId> {
         match self {
             SwitchTargets::If(then_tgt, else_tgt) => {
                 vec![*then_tgt, *else_tgt]
@@ -140,7 +140,7 @@ impl BlockData {
 /// containing the operand. `f` should explore the operand it receives, and
 /// push statements to the vector it receives as input.
 pub fn body_transform_operands<F: FnMut(&Meta, &mut Vec<Statement>, &mut Operand)>(
-    blocks: &mut Vector<BlockId::Id, BlockData>,
+    blocks: &mut Vector<BlockId, BlockData>,
     f: &mut F,
 ) {
     for block in blocks.iter_mut() {
@@ -199,11 +199,11 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.visit_place(p);
     }
 
-    fn visit_set_discriminant(&mut self, p: &Place, _vid: &VariantId::Id) {
+    fn visit_set_discriminant(&mut self, p: &Place, _vid: &VariantId) {
         self.visit_place(p);
     }
 
-    fn visit_storage_dead(&mut self, vid: &VarId::Id) {
+    fn visit_storage_dead(&mut self, vid: &VarId) {
         self.visit_var_id(vid);
     }
 
@@ -248,7 +248,7 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.default_visit_raw_terminator(st);
     }
 
-    fn visit_goto(&mut self, target: &BlockId::Id) {
+    fn visit_goto(&mut self, target: &BlockId) {
         self.visit_block_id(target)
     }
 
@@ -263,22 +263,22 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
 
     fn visit_unreachable(&mut self) {}
 
-    fn visit_drop(&mut self, place: &Place, target: &BlockId::Id) {
+    fn visit_drop(&mut self, place: &Place, target: &BlockId) {
         self.visit_place(place);
         self.visit_block_id(target);
     }
 
-    fn visit_call_statement(&mut self, call: &Call, target: &BlockId::Id) {
+    fn visit_call_statement(&mut self, call: &Call, target: &BlockId) {
         self.visit_call(call);
         self.visit_block_id(target);
     }
 
-    fn visit_assert(&mut self, cond: &Operand, expected: &bool, target: &BlockId::Id) {
+    fn visit_assert(&mut self, cond: &Operand, expected: &bool, target: &BlockId) {
         self.visit_operand(cond);
         self.visit_block_id(target);
     }
 
-    fn visit_block_id(&mut self, id: &BlockId::Id) {}
+    fn visit_block_id(&mut self, id: &BlockId) {}
 
     fn visit_switch_targets(&mut self, targets: &SwitchTargets) {
         use SwitchTargets::*;
@@ -290,7 +290,7 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         }
     }
 
-    fn visit_if(&mut self, then_id: &BlockId::Id, else_id: &BlockId::Id) {
+    fn visit_if(&mut self, then_id: &BlockId, else_id: &BlockId) {
         self.visit_block_id(then_id);
         self.visit_block_id(else_id);
     }
@@ -298,8 +298,8 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
     fn visit_switch_int(
         &mut self,
         int_ty: &IntegerTy,
-        branches: &Vec<(ScalarValue, BlockId::Id)>,
-        otherwise: &BlockId::Id,
+        branches: &Vec<(ScalarValue, BlockId)>,
+        otherwise: &BlockId,
     ) {
         for (_, br) in branches {
             self.visit_block_id(br);

--- a/charon/src/divergent.rs
+++ b/charon/src/divergent.rs
@@ -5,7 +5,7 @@ use crate::ullbc_ast as ast;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
-fn statement_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, st: &llbc::Statement) -> bool {
+fn statement_diverges(divergent: &HashMap<ast::FunDeclId, bool>, st: &llbc::Statement) -> bool {
     match &st.content {
         RawStatement::Assign(_, _)
         | RawStatement::FakeRead(_)
@@ -48,7 +48,7 @@ fn statement_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, st: &llbc::
     }
 }
 
-fn fun_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, def: &llbc::FunDecl) -> bool {
+fn fun_diverges(divergent: &HashMap<ast::FunDeclId, bool>, def: &llbc::FunDecl) -> bool {
     match &def.body {
         Option::Some(body) => statement_diverges(divergent, &body.body),
         Option::None => {
@@ -67,11 +67,11 @@ fn fun_diverges(divergent: &HashMap<ast::FunDeclId::Id, bool>, def: &llbc::FunDe
 pub fn compute_divergent_functions(
     decls: &OrderedDecls,
     defs: &llbc::FunDecls,
-) -> HashSet<ast::FunDeclId::Id> {
+) -> HashSet<ast::FunDeclId> {
     // For sanity, we use a map rather than a set, so that we can check
     // that we have indeed computed the divergence for the previous
     // declarations.
-    let mut divergent_map: HashMap<ast::FunDeclId::Id, bool> = HashMap::new();
+    let mut divergent_map: HashMap<ast::FunDeclId, bool> = HashMap::new();
 
     // The declarations in decls have been reordered so that the dependencies
     // of every group of declarations is either in the group itself (in case
@@ -97,7 +97,7 @@ pub fn compute_divergent_functions(
     }
 
     // Convert the map to a set
-    let divergent_set: HashSet<ast::FunDeclId::Id> = HashSet::from_iter(
+    let divergent_set: HashSet<ast::FunDeclId> = HashSet::from_iter(
         divergent_map
             .iter()
             .filter(|(_, div)| **div)

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -23,7 +23,7 @@ pub struct GCrateData<FD, GD> {
     /// The `id_to_file` map is serialized as a vector.
     /// We use this map for the spans: the spans only store the file ids, not
     /// the file names, in order to save space.
-    pub id_to_file: Vec<(FileId::Id, FileName)>,
+    pub id_to_file: Vec<(FileId, FileName)>,
     pub declarations: Vec<DeclarationGroup>,
     pub types: Vec<TypeDecl>,
     pub functions: Vec<FD>,
@@ -39,15 +39,15 @@ impl<FD: Serialize + Clone, GD: Serialize + Clone> GCrateData<FD, GD> {
     pub fn new(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &Map<FunDeclId::Id, FD>,
-        global_decls: &Map<GlobalDeclId::Id, GD>,
+        fun_decls: &Map<FunDeclId, FD>,
+        global_decls: &Map<GlobalDeclId, GD>,
     ) -> Self {
         // Transform the map file id -> file into a vector.
         // Sort the vector to make the serialized file as stable as possible.
         let id_to_file = &ctx.id_to_file;
-        let mut file_ids: Vec<FileId::Id> = id_to_file.keys().copied().collect();
+        let mut file_ids: Vec<FileId> = id_to_file.keys().copied().collect();
         file_ids.sort();
-        let id_to_file: Vec<(FileId::Id, FileName)> = file_ids
+        let id_to_file: Vec<(FileId, FileName)> = file_ids
             .into_iter()
             .map(|id| (id, id_to_file.get(&id).unwrap().clone()))
             .collect();
@@ -125,8 +125,8 @@ impl CrateData {
     pub fn new_ullbc(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &Map<FunDeclId::Id, ullbc_ast::FunDecl>,
-        global_decls: &Map<GlobalDeclId::Id, ullbc_ast::GlobalDecl>,
+        fun_decls: &Map<FunDeclId, ullbc_ast::FunDecl>,
+        global_decls: &Map<GlobalDeclId, ullbc_ast::GlobalDecl>,
     ) -> Self {
         Self::ULLBC(GCrateData::new(ctx, crate_name, fun_decls, global_decls))
     }
@@ -134,8 +134,8 @@ impl CrateData {
     pub fn new_llbc(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &Map<FunDeclId::Id, llbc_ast::FunDecl>,
-        global_decls: &Map<GlobalDeclId::Id, llbc_ast::GlobalDecl>,
+        fun_decls: &Map<FunDeclId, llbc_ast::FunDecl>,
+        global_decls: &Map<GlobalDeclId, llbc_ast::GlobalDecl>,
     ) -> Self {
         Self::LLBC(GCrateData::new(ctx, crate_name, fun_decls, global_decls))
     }

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -1,3 +1,4 @@
+use crate::ids::Map;
 use crate::llbc_ast;
 use crate::meta::{FileId, FileName};
 use crate::reorder_decls::DeclarationGroup;
@@ -38,8 +39,8 @@ impl<FD: Serialize + Clone, GD: Serialize + Clone> GCrateData<FD, GD> {
     pub fn new(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &FunDeclId::Map<FD>,
-        global_decls: &GlobalDeclId::Map<GD>,
+        fun_decls: &Map<FunDeclId::Id, FD>,
+        global_decls: &Map<GlobalDeclId::Id, GD>,
     ) -> Self {
         // Transform the map file id -> file into a vector.
         // Sort the vector to make the serialized file as stable as possible.
@@ -124,8 +125,8 @@ impl CrateData {
     pub fn new_ullbc(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &FunDeclId::Map<ullbc_ast::FunDecl>,
-        global_decls: &GlobalDeclId::Map<ullbc_ast::GlobalDecl>,
+        fun_decls: &Map<FunDeclId::Id, ullbc_ast::FunDecl>,
+        global_decls: &Map<GlobalDeclId::Id, ullbc_ast::GlobalDecl>,
     ) -> Self {
         Self::ULLBC(GCrateData::new(ctx, crate_name, fun_decls, global_decls))
     }
@@ -133,8 +134,8 @@ impl CrateData {
     pub fn new_llbc(
         ctx: &TransCtx,
         crate_name: String,
-        fun_decls: &FunDeclId::Map<llbc_ast::FunDecl>,
-        global_decls: &GlobalDeclId::Map<llbc_ast::GlobalDecl>,
+        fun_decls: &Map<FunDeclId::Id, llbc_ast::FunDecl>,
+        global_decls: &Map<GlobalDeclId::Id, llbc_ast::GlobalDecl>,
     ) -> Self {
         Self::LLBC(GCrateData::new(ctx, crate_name, fun_decls, global_decls))
     }

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -2,6 +2,10 @@ pub mod generator;
 pub mod map;
 pub mod vector;
 
+pub use generator::{Generator, MapGenerator};
+pub use map::Map;
+pub use vector::Vector;
+
 /// Generate an `Index` module which contains an index type and a generator
 /// for fresh indices. We use it because we need manipulate
 /// a lot of different indices (for various kinds of declarations, variables, blocks,
@@ -26,11 +30,6 @@ macro_rules! generate_index_type {
                 // Must fit in an u32 for serialization.
                 MAX_INDEX = std::u32::MAX as usize;
             }
-
-            pub type Vector<T> = crate::ids::vector::Vector<Id, T>;
-            pub type Map<T> = crate::ids::map::Map<Id, T>;
-            pub type Generator = crate::ids::generator::Generator<Id>;
-            pub type MapGenerator<K> = crate::ids::generator::MapGenerator<K, Id>;
 
             impl Id {
                 pub fn is_zero(&self) -> bool {

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -23,32 +23,28 @@ macro_rules! generate_index_type {
         $crate::generate_index_type!($name, stringify!($name));
     };
     ($name:ident, $pretty_name:expr) => {
-        #[allow(non_snake_case)]
-        pub mod $name {
-            index_vec::define_index_type! {
-                pub struct Id = usize;
-                // Must fit in an u32 for serialization.
-                MAX_INDEX = std::u32::MAX as usize;
+        index_vec::define_index_type! {
+            pub struct $name = usize;
+            // Must fit in an u32 for serialization.
+            MAX_INDEX = std::u32::MAX as usize;
+        }
+
+        impl $name {
+            pub const ZERO: Self = Self { _raw: 0 };
+            pub fn is_zero(&self) -> bool {
+                self.index() == 0
             }
-
-            impl Id {
-                pub fn is_zero(&self) -> bool {
-                    self.index() == 0
-                }
-                pub fn to_pretty_string(self) -> String {
-                    format!("@{}{}", $pretty_name, self)
-                }
+            pub fn to_pretty_string(self) -> String {
+                format!("@{}{}", $pretty_name, self)
             }
+        }
 
-            pub static ZERO: Id = Id { _raw: 0 };
-
-            impl std::fmt::Display for Id {
-                fn fmt(
-                    &self,
-                    f: &mut std::fmt::Formatter<'_>,
-                ) -> std::result::Result<(), std::fmt::Error> {
-                    f.write_str(self.index().to_string().as_str())
-                }
+        impl std::fmt::Display for $name {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                f.write_str(self.index().to_string().as_str())
             }
         }
     };

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -6,14 +6,10 @@ pub use generator::{Generator, MapGenerator};
 pub use map::Map;
 pub use vector::Vector;
 
-/// Generate an `Index` module which contains an index type and a generator
-/// for fresh indices. We use it because we need manipulate
-/// a lot of different indices (for various kinds of declarations, variables, blocks,
-/// etc.).
-/// For sanity purposes, we prevent any confusion between the different kinds
-/// of indices by using different types. The following macro allows us to
-/// easily derive those types, and the needed utilities (casts, vectors indexed
-/// by those opaque indices, etc.).
+/// Generate an `Index` index type. We use it because we need manipulate a lot of different indices
+/// (for various kinds of declarations, variables, blocks, etc.).
+/// For sanity, we prevent any confusion between the different kinds of indices by using different
+/// types. The following macro allows us to easily derive those types.
 ///
 /// The `name` parameter should contain the name of the module to declare. The `pretty_name`
 /// parameter is used to implement `Id::to_pretty_string`; if not provided, it defaults to `name`.

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -125,6 +125,7 @@ where
     }
 }
 
+// FIXME: this impl is a footgun
 impl<I, T> FromIterator<T> for Vector<I, T>
 where
     I: Idx,
@@ -137,6 +138,7 @@ where
     }
 }
 
+// FIXME: this impl is a footgun
 impl<I, T> From<Vec<T>> for Vector<I, T>
 where
     I: Idx,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -3,6 +3,7 @@ use crate::{
     assumed::get_name_from_type_id,
     common::TAB_INCR,
     formatter::*,
+    ids::Vector,
     llbc_ast::{self as llbc, *},
     names::*,
     reorder_decls::*,
@@ -1663,7 +1664,7 @@ where
 }
 
 pub(crate) fn fmt_body_blocks_with_ctx<C>(
-    body: &BlockId::Vector<BlockData>,
+    body: &Vector<BlockId::Id, BlockData>,
     tab: &str,
     ctx: &C,
 ) -> String

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -458,7 +458,7 @@ impl<T> GFunDecl<T> {
         let mut args: Vec<String> = Vec::new();
         for i in 0..self.signature.inputs.len() {
             // The input variables start at index 1
-            let id = VarId::Id::new(i + 1);
+            let id = VarId::new(i + 1);
             let arg_ty = &self.signature.inputs.get(i).unwrap();
             args.push(
                 format!("{}: {}", id.to_pretty_string(), arg_ty.fmt_with_ctx(ctx)).to_string(),
@@ -801,7 +801,7 @@ impl Rvalue {
                                 // Format every field
                                 let mut fields = vec![];
                                 for (i, op) in ops.iter().enumerate() {
-                                    let field_id = FieldId::Id::new(i);
+                                    let field_id = FieldId::new(i);
                                     let field_name =
                                         ctx.format_object((*def_id, *variant_id, field_id));
                                     fields.push(format!(
@@ -1184,7 +1184,7 @@ impl TraitImpl {
                 .iter()
                 .enumerate()
                 .map(|(i, clause)| {
-                    let i = TraitClauseId::Id::new(i);
+                    let i = TraitClauseId::new(i);
                     format!(
                         "{TAB_INCR}parent_clause{i} = {}\n",
                         clause.fmt_with_ctx(ctx)
@@ -1664,7 +1664,7 @@ where
 }
 
 pub(crate) fn fmt_body_blocks_with_ctx<C>(
-    body: &Vector<BlockId::Id, BlockData>,
+    body: &Vector<BlockId, BlockData>,
     tab: &str,
     ctx: &C,
 ) -> String

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -1,5 +1,6 @@
 use crate::common::TAB_INCR;
 use crate::gast;
+use crate::ids::Vector;
 use crate::llbc_ast;
 use crate::llbc_ast::*;
 use crate::pretty::fmt_with_ctx;
@@ -105,13 +106,13 @@ impl<'a, 'b> SetGenerics<'a> for FmtCtx<'b> {
 pub trait SetLocals<'a> {
     type C: 'a + AstFormatter;
 
-    fn set_locals(&'a self, locals: &'a VarId::Vector<ast::Var>) -> Self::C;
+    fn set_locals(&'a self, locals: &'a Vector<VarId::Id, ast::Var>) -> Self::C;
 }
 
 impl<'a, 'b> SetLocals<'a> for FmtCtx<'b> {
     type C = FmtCtx<'a>;
 
-    fn set_locals(&'a self, locals: &'a VarId::Vector<ast::Var>) -> Self::C {
+    fn set_locals(&'a self, locals: &'a Vector<VarId::Id, ast::Var>) -> Self::C {
         let FmtCtx {
             type_decls,
             fun_decls,
@@ -149,13 +150,13 @@ impl<'a, 'b> SetLocals<'a> for FmtCtx<'b> {
 pub trait PushBoundRegions<'a> {
     type C: 'a + AstFormatter;
 
-    fn push_bound_regions(&'a self, regions: &RegionId::Vector<RegionVar>) -> Self::C;
+    fn push_bound_regions(&'a self, regions: &Vector<RegionId::Id, RegionVar>) -> Self::C;
 }
 
 impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
     type C = FmtCtx<'a>;
 
-    fn push_bound_regions(&'a self, regions: &RegionId::Vector<RegionVar>) -> Self::C {
+    fn push_bound_regions(&'a self, regions: &Vector<RegionId::Id, RegionVar>) -> Self::C {
         let FmtCtx {
             type_decls,
             fun_decls,
@@ -204,7 +205,7 @@ pub trait AstFormatter = Formatter<TypeVarId::Id>
     + Formatter<VarId::Id>
     + Formatter<(TypeDeclId::Id, VariantId::Id)>
     + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
-    + for<'a> Formatter<&'a ullbc_ast::BlockId::Vector<ullbc_ast::BlockData>>
+    + for<'a> Formatter<&'a Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>>
     + for<'a> Formatter<&'a llbc_ast::Statement>
     + for<'a> SetGenerics<'a>
     + for<'a> SetLocals<'a>
@@ -227,10 +228,10 @@ pub struct FmtCtx<'a> {
     pub trait_decls: Option<&'a ast::TraitDecls>,
     pub trait_impls: Option<&'a ast::TraitImpls>,
     /// The region variables are not an option, because we need to be able to push/pop
-    pub region_vars: im::Vector<RegionId::Vector<RegionVar>>,
-    pub type_vars: Option<&'a TypeVarId::Vector<TypeVar>>,
-    pub const_generic_vars: Option<&'a ConstGenericVarId::Vector<ConstGenericVar>>,
-    pub locals: Option<&'a VarId::Vector<ast::Var>>,
+    pub region_vars: im::Vector<Vector<RegionId::Id, RegionVar>>,
+    pub type_vars: Option<&'a Vector<TypeVarId::Id, TypeVar>>,
+    pub const_generic_vars: Option<&'a Vector<ConstGenericVarId::Id, ConstGenericVar>>,
+    pub locals: Option<&'a Vector<VarId::Id, ast::Var>>,
 }
 
 impl<'a> IntoFormatter for FmtCtx<'a> {
@@ -480,8 +481,8 @@ impl<'a> Formatter<&llbc_ast::Statement> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<&ullbc_ast::BlockId::Vector<ullbc_ast::BlockData>> for FmtCtx<'a> {
-    fn format_object(&self, x: &ullbc_ast::BlockId::Vector<ullbc_ast::BlockData>) -> String {
+impl<'a> Formatter<&Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>> for FmtCtx<'a> {
+    fn format_object(&self, x: &Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>) -> String {
         fmt_with_ctx::fmt_body_blocks_with_ctx(x, TAB_INCR, self)
     }
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -15,7 +15,7 @@ use crate::values::*;
 /// context. For instance, because values use value ids to point to other values,
 /// we need a context to give us the mapping from value ids to values when pretty
 /// printing. As the `EvalContext` data structure handles such a mapping, we
-/// implement the `Formatter<ValueId::Id>` trait for it.
+/// implement the `Formatter<ValueId>` trait for it.
 ///
 /// Our way of implementing pretty-printing for data-structures while factorizing
 /// the code is as follows:
@@ -106,13 +106,13 @@ impl<'a, 'b> SetGenerics<'a> for FmtCtx<'b> {
 pub trait SetLocals<'a> {
     type C: 'a + AstFormatter;
 
-    fn set_locals(&'a self, locals: &'a Vector<VarId::Id, ast::Var>) -> Self::C;
+    fn set_locals(&'a self, locals: &'a Vector<VarId, ast::Var>) -> Self::C;
 }
 
 impl<'a, 'b> SetLocals<'a> for FmtCtx<'b> {
     type C = FmtCtx<'a>;
 
-    fn set_locals(&'a self, locals: &'a Vector<VarId::Id, ast::Var>) -> Self::C {
+    fn set_locals(&'a self, locals: &'a Vector<VarId, ast::Var>) -> Self::C {
         let FmtCtx {
             type_decls,
             fun_decls,
@@ -150,13 +150,13 @@ impl<'a, 'b> SetLocals<'a> for FmtCtx<'b> {
 pub trait PushBoundRegions<'a> {
     type C: 'a + AstFormatter;
 
-    fn push_bound_regions(&'a self, regions: &Vector<RegionId::Id, RegionVar>) -> Self::C;
+    fn push_bound_regions(&'a self, regions: &Vector<RegionId, RegionVar>) -> Self::C;
 }
 
 impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
     type C = FmtCtx<'a>;
 
-    fn push_bound_regions(&'a self, regions: &Vector<RegionId::Id, RegionVar>) -> Self::C {
+    fn push_bound_regions(&'a self, regions: &Vector<RegionId, RegionVar>) -> Self::C {
         let FmtCtx {
             type_decls,
             fun_decls,
@@ -193,19 +193,19 @@ impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
     }
 }
 
-pub trait AstFormatter = Formatter<TypeVarId::Id>
-    + Formatter<TypeDeclId::Id>
-    + Formatter<ConstGenericVarId::Id>
-    + Formatter<FunDeclId::Id>
-    + Formatter<GlobalDeclId::Id>
-    + Formatter<TraitDeclId::Id>
-    + Formatter<TraitImplId::Id>
-    + Formatter<TraitClauseId::Id>
-    + Formatter<(DeBruijnId, RegionId::Id)>
-    + Formatter<VarId::Id>
-    + Formatter<(TypeDeclId::Id, VariantId::Id)>
-    + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
-    + for<'a> Formatter<&'a Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>>
+pub trait AstFormatter = Formatter<TypeVarId>
+    + Formatter<TypeDeclId>
+    + Formatter<ConstGenericVarId>
+    + Formatter<FunDeclId>
+    + Formatter<GlobalDeclId>
+    + Formatter<TraitDeclId>
+    + Formatter<TraitImplId>
+    + Formatter<TraitClauseId>
+    + Formatter<(DeBruijnId, RegionId)>
+    + Formatter<VarId>
+    + Formatter<(TypeDeclId, VariantId)>
+    + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
+    + for<'a> Formatter<&'a Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>>
     + for<'a> Formatter<&'a llbc_ast::Statement>
     + for<'a> SetGenerics<'a>
     + for<'a> SetLocals<'a>
@@ -228,10 +228,10 @@ pub struct FmtCtx<'a> {
     pub trait_decls: Option<&'a ast::TraitDecls>,
     pub trait_impls: Option<&'a ast::TraitImpls>,
     /// The region variables are not an option, because we need to be able to push/pop
-    pub region_vars: im::Vector<Vector<RegionId::Id, RegionVar>>,
-    pub type_vars: Option<&'a Vector<TypeVarId::Id, TypeVar>>,
-    pub const_generic_vars: Option<&'a Vector<ConstGenericVarId::Id, ConstGenericVar>>,
-    pub locals: Option<&'a Vector<VarId::Id, ast::Var>>,
+    pub region_vars: im::Vector<Vector<RegionId, RegionVar>>,
+    pub type_vars: Option<&'a Vector<TypeVarId, TypeVar>>,
+    pub const_generic_vars: Option<&'a Vector<ConstGenericVarId, ConstGenericVar>>,
+    pub locals: Option<&'a Vector<VarId, ast::Var>>,
 }
 
 impl<'a> IntoFormatter for FmtCtx<'a> {
@@ -264,8 +264,8 @@ impl<'a> Default for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<TypeDeclId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: TypeDeclId::Id) -> String {
+impl<'a> Formatter<TypeDeclId> for FmtCtx<'a> {
+    fn format_object(&self, id: TypeDeclId) -> String {
         match &self.type_decls {
             None => id.to_pretty_string(),
             Some(type_decls) => match type_decls.get(id) {
@@ -276,8 +276,8 @@ impl<'a> Formatter<TypeDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<GlobalDeclId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: GlobalDeclId::Id) -> String {
+impl<'a> Formatter<GlobalDeclId> for FmtCtx<'a> {
+    fn format_object(&self, id: GlobalDeclId) -> String {
         match &self.global_decls {
             None => id.to_pretty_string(),
             Some(global_decls) => match global_decls.get(id) {
@@ -288,8 +288,8 @@ impl<'a> Formatter<GlobalDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ast::FunDeclId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::FunDeclId::Id) -> String {
+impl<'a> Formatter<ast::FunDeclId> for FmtCtx<'a> {
+    fn format_object(&self, id: ast::FunDeclId) -> String {
         match &self.fun_decls {
             None => id.to_pretty_string(),
             Some(fun_decls) => match fun_decls.get(id) {
@@ -300,8 +300,8 @@ impl<'a> Formatter<ast::FunDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ast::TraitDeclId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitDeclId::Id) -> String {
+impl<'a> Formatter<ast::TraitDeclId> for FmtCtx<'a> {
+    fn format_object(&self, id: ast::TraitDeclId) -> String {
         match &self.trait_decls {
             None => id.to_pretty_string(),
             Some(trait_decls) => match trait_decls.get(id) {
@@ -312,8 +312,8 @@ impl<'a> Formatter<ast::TraitDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ast::TraitImplId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitImplId::Id) -> String {
+impl<'a> Formatter<ast::TraitImplId> for FmtCtx<'a> {
+    fn format_object(&self, id: ast::TraitImplId) -> String {
         match &self.trait_impls {
             None => id.to_pretty_string(),
             Some(trait_impls) => match trait_impls.get(id) {
@@ -324,8 +324,8 @@ impl<'a> Formatter<ast::TraitImplId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<(DeBruijnId, RegionId::Id)> for FmtCtx<'a> {
-    fn format_object(&self, (grid, id): (DeBruijnId, RegionId::Id)) -> String {
+impl<'a> Formatter<(DeBruijnId, RegionId)> for FmtCtx<'a> {
+    fn format_object(&self, (grid, id): (DeBruijnId, RegionId)) -> String {
         match self.region_vars.get(grid.index) {
             None => bound_region_var_to_pretty_string(grid, id),
             Some(gr) => match gr.get(id) {
@@ -336,8 +336,8 @@ impl<'a> Formatter<(DeBruijnId, RegionId::Id)> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<TypeVarId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: TypeVarId::Id) -> String {
+impl<'a> Formatter<TypeVarId> for FmtCtx<'a> {
+    fn format_object(&self, id: TypeVarId) -> String {
         match &self.type_vars {
             None => id.to_pretty_string(),
             Some(vars) => match vars.get(id) {
@@ -348,8 +348,8 @@ impl<'a> Formatter<TypeVarId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ConstGenericVarId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: ConstGenericVarId::Id) -> String {
+impl<'a> Formatter<ConstGenericVarId> for FmtCtx<'a> {
+    fn format_object(&self, id: ConstGenericVarId) -> String {
         match &self.const_generic_vars {
             None => id.to_pretty_string(),
             Some(vars) => match vars.get(id) {
@@ -360,15 +360,15 @@ impl<'a> Formatter<ConstGenericVarId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ast::TraitClauseId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitClauseId::Id) -> String {
+impl<'a> Formatter<ast::TraitClauseId> for FmtCtx<'a> {
+    fn format_object(&self, id: ast::TraitClauseId) -> String {
         id.to_pretty_string()
     }
 }
 
 /// For enum values: `List::Cons`
-impl<'a> Formatter<(TypeDeclId::Id, VariantId::Id)> for FmtCtx<'a> {
-    fn format_object(&self, id: (TypeDeclId::Id, VariantId::Id)) -> String {
+impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
+    fn format_object(&self, id: (TypeDeclId, VariantId)) -> String {
         let (def_id, variant_id) = id;
         match &self.type_decls {
             None => format!(
@@ -400,8 +400,8 @@ impl<'a> Formatter<(TypeDeclId::Id, VariantId::Id)> for FmtCtx<'a> {
 }
 
 /// For struct/enum values: retrieve a field name
-impl<'a> Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)> for FmtCtx<'a> {
-    fn format_object(&self, id: (TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)) -> String {
+impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
+    fn format_object(&self, id: (TypeDeclId, Option<VariantId>, FieldId)) -> String {
         let (def_id, opt_variant_id, field_id) = id;
         match &self.type_decls {
             None => match opt_variant_id {
@@ -463,8 +463,8 @@ impl<'a> Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)> for Fmt
     }
 }
 
-impl<'a> Formatter<VarId::Id> for FmtCtx<'a> {
-    fn format_object(&self, id: VarId::Id) -> String {
+impl<'a> Formatter<VarId> for FmtCtx<'a> {
+    fn format_object(&self, id: VarId) -> String {
         match &self.locals {
             None => id.to_pretty_string(),
             Some(vars) => match vars.get(id) {
@@ -481,8 +481,8 @@ impl<'a> Formatter<&llbc_ast::Statement> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<&Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>> for FmtCtx<'a> {
-    fn format_object(&self, x: &Vector<ullbc_ast::BlockId::Id, ullbc_ast::BlockData>) -> String {
+impl<'a> Formatter<&Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>> for FmtCtx<'a> {
+    fn format_object(&self, x: &Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>) -> String {
         fmt_with_ctx::fmt_body_blocks_with_ctx(x, TAB_INCR, self)
     }
 }
@@ -553,8 +553,8 @@ impl<'a> Formatter<&gast::TraitImpl> for FmtCtx<'a> {
     }
 }
 
-impl<'a> DeclFormatter<TypeDeclId::Id> for FmtCtx<'a> {
-    fn format_decl(&self, id: TypeDeclId::Id) -> String {
+impl<'a> DeclFormatter<TypeDeclId> for FmtCtx<'a> {
+    fn format_decl(&self, id: TypeDeclId) -> String {
         match &self.type_decls {
             None => format!("Unknown decl: {:?}", id),
             Some(decls) => match decls.get(id) {
@@ -567,8 +567,8 @@ impl<'a> DeclFormatter<TypeDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> DeclFormatter<GlobalDeclId::Id> for FmtCtx<'a> {
-    fn format_decl(&self, id: GlobalDeclId::Id) -> String {
+impl<'a> DeclFormatter<GlobalDeclId> for FmtCtx<'a> {
+    fn format_decl(&self, id: GlobalDeclId) -> String {
         match &self.global_decls {
             None => format!("Unknown decl: {:?}", id),
             Some(decls) => match decls.get(id) {
@@ -581,8 +581,8 @@ impl<'a> DeclFormatter<GlobalDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> DeclFormatter<FunDeclId::Id> for FmtCtx<'a> {
-    fn format_decl(&self, id: FunDeclId::Id) -> String {
+impl<'a> DeclFormatter<FunDeclId> for FmtCtx<'a> {
+    fn format_decl(&self, id: FunDeclId) -> String {
         match &self.fun_decls {
             None => format!("Unknown decl: {:?}", id),
             Some(decls) => match decls.get(id) {
@@ -595,8 +595,8 @@ impl<'a> DeclFormatter<FunDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> DeclFormatter<TraitDeclId::Id> for FmtCtx<'a> {
-    fn format_decl(&self, id: TraitDeclId::Id) -> String {
+impl<'a> DeclFormatter<TraitDeclId> for FmtCtx<'a> {
+    fn format_decl(&self, id: TraitDeclId) -> String {
         match &self.trait_decls {
             None => format!("Unknown decl: {:?}", id),
             Some(decls) => match decls.get(id) {
@@ -609,8 +609,8 @@ impl<'a> DeclFormatter<TraitDeclId::Id> for FmtCtx<'a> {
     }
 }
 
-impl<'a> DeclFormatter<TraitImplId::Id> for FmtCtx<'a> {
-    fn format_decl(&self, id: TraitImplId::Id) -> String {
+impl<'a> DeclFormatter<TraitImplId> for FmtCtx<'a> {
+    fn format_decl(&self, id: TraitImplId) -> String {
         match &self.trait_impls {
             None => format!("Unknown impl: {:?}", id),
             Some(decls) => match decls.get(id) {

--- a/charon/src/reorder_decls.rs
+++ b/charon/src/reorder_decls.rs
@@ -1,12 +1,13 @@
 use crate::common::*;
 use crate::formatter::{AstFormatter, IntoFormatter};
 use crate::graphs::*;
+pub use crate::translate_ctx::AnyTransId;
 use crate::translate_ctx::TransCtx;
 use crate::types::*;
 use crate::ullbc_ast::*;
 use hashlink::linked_hash_map::LinkedHashMap;
 use linked_hash_set::LinkedHashSet;
-use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
+use macros::{VariantIndexArity, VariantName};
 use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
 use serde::{Deserialize, Serialize};
@@ -115,28 +116,6 @@ impl DeclarationGroup {
         );
         DeclarationGroup::TraitImpl(GDeclarationGroup::NonRec(gr[0]))
     }
-}
-
-#[derive(
-    PartialEq,
-    Eq,
-    Hash,
-    EnumIsA,
-    EnumAsGetters,
-    VariantName,
-    VariantIndexArity,
-    Copy,
-    Clone,
-    Debug,
-    PartialOrd,
-    Ord,
-)]
-pub enum AnyTransId {
-    Type(TypeDeclId),
-    Fun(FunDeclId),
-    Global(GlobalDeclId),
-    TraitDecl(TraitDeclId),
-    TraitImpl(TraitImplId),
 }
 
 #[derive(Clone, Copy)]

--- a/charon/src/reorder_decls.rs
+++ b/charon/src/reorder_decls.rs
@@ -27,15 +27,15 @@ pub enum GDeclarationGroup<Id> {
 #[derive(Debug, Clone, VariantIndexArity, VariantName, Serialize, Deserialize)]
 pub enum DeclarationGroup {
     /// A type declaration group
-    Type(GDeclarationGroup<TypeDeclId::Id>),
+    Type(GDeclarationGroup<TypeDeclId>),
     /// A function declaration group
-    Fun(GDeclarationGroup<FunDeclId::Id>),
+    Fun(GDeclarationGroup<FunDeclId>),
     /// A global declaration group
-    Global(GDeclarationGroup<GlobalDeclId::Id>),
+    Global(GDeclarationGroup<GlobalDeclId>),
     ///
-    TraitDecl(GDeclarationGroup<TraitDeclId::Id>),
+    TraitDecl(GDeclarationGroup<TraitDeclId>),
     ///
-    TraitImpl(GDeclarationGroup<TraitImplId::Id>),
+    TraitImpl(GDeclarationGroup<TraitImplId>),
 }
 
 impl<Id: Copy> GDeclarationGroup<Id> {
@@ -49,7 +49,7 @@ impl<Id: Copy> GDeclarationGroup<Id> {
 }
 
 impl DeclarationGroup {
-    fn make_type_group(is_rec: bool, gr: impl Iterator<Item = TypeDeclId::Id>) -> Self {
+    fn make_type_group(is_rec: bool, gr: impl Iterator<Item = TypeDeclId>) -> Self {
         let gr: Vec<_> = gr.collect();
         if is_rec {
             DeclarationGroup::Type(GDeclarationGroup::Rec(gr))
@@ -59,7 +59,7 @@ impl DeclarationGroup {
         }
     }
 
-    fn make_fun_group(is_rec: bool, gr: impl Iterator<Item = FunDeclId::Id>) -> Self {
+    fn make_fun_group(is_rec: bool, gr: impl Iterator<Item = FunDeclId>) -> Self {
         let gr: Vec<_> = gr.collect();
         if is_rec {
             DeclarationGroup::Fun(GDeclarationGroup::Rec(gr))
@@ -69,7 +69,7 @@ impl DeclarationGroup {
         }
     }
 
-    fn make_global_group(is_rec: bool, gr: impl Iterator<Item = GlobalDeclId::Id>) -> Self {
+    fn make_global_group(is_rec: bool, gr: impl Iterator<Item = GlobalDeclId>) -> Self {
         let gr: Vec<_> = gr.collect();
         if is_rec {
             DeclarationGroup::Global(GDeclarationGroup::Rec(gr))
@@ -82,7 +82,7 @@ impl DeclarationGroup {
     fn make_trait_decl_group(
         _ctx: &TransCtx,
         _is_rec: bool,
-        gr: impl Iterator<Item = TraitDeclId::Id>,
+        gr: impl Iterator<Item = TraitDeclId>,
     ) -> Self {
         let gr: Vec<_> = gr.collect();
         // Trait declarations often refer to `Self`, like below,
@@ -101,7 +101,7 @@ impl DeclarationGroup {
     fn make_trait_impl_group(
         ctx: &TransCtx,
         is_rec: bool,
-        gr: impl Iterator<Item = TraitImplId::Id>,
+        gr: impl Iterator<Item = TraitImplId>,
     ) -> Self {
         let gr: Vec<_> = gr.collect();
         let ctx = ctx.into_fmt();
@@ -175,8 +175,7 @@ impl Display for DeclarationGroup {
     }
 }
 
-pub type AnyTransId =
-    AnyDeclId<TypeDeclId::Id, FunDeclId::Id, GlobalDeclId::Id, TraitDeclId::Id, TraitImplId::Id>;
+pub type AnyTransId = AnyDeclId<TypeDeclId, FunDeclId, GlobalDeclId, TraitDeclId, TraitImplId>;
 
 pub struct Deps {
     dgraph: DiGraphMap<AnyTransId, ()>,
@@ -225,7 +224,7 @@ pub struct Deps {
     /// //                                       ^^^^^^^^^^^^^^^
     /// //                                    refers to the trait impl
     /// ```
-    impl_trait_id: Option<TraitImplId::Id>,
+    impl_trait_id: Option<TraitImplId>,
 }
 
 impl Deps {
@@ -297,17 +296,17 @@ impl Deps {
 }
 
 impl SharedTypeVisitor for Deps {
-    fn visit_type_decl_id(&mut self, id: &TypeDeclId::Id) {
+    fn visit_type_decl_id(&mut self, id: &TypeDeclId) {
         let id = AnyDeclId::Type(*id);
         self.insert_edge(id);
     }
 
-    fn visit_global_decl_id(&mut self, id: &GlobalDeclId::Id) {
+    fn visit_global_decl_id(&mut self, id: &GlobalDeclId) {
         let id = AnyDeclId::Global(*id);
         self.insert_edge(id);
     }
 
-    fn visit_trait_impl_id(&mut self, id: &TraitImplId::Id) {
+    fn visit_trait_impl_id(&mut self, id: &TraitImplId) {
         // If the impl is the impl this item belongs to, we ignore it
         // TODO: this is not very satisfying but this is the only way
         // we have of preventing mutually recursive groups between
@@ -321,7 +320,7 @@ impl SharedTypeVisitor for Deps {
         }
     }
 
-    fn visit_trait_decl_id(&mut self, id: &TraitDeclId::Id) {
+    fn visit_trait_decl_id(&mut self, id: &TraitDeclId) {
         let id = AnyDeclId::TraitDecl(*id);
         self.insert_edge(id);
     }
@@ -340,7 +339,7 @@ impl SharedTypeVisitor for Deps {
         self.visit_generic_args(&tr.generics);
     }
 
-    fn visit_fun_decl_id(&mut self, id: &FunDeclId::Id) {
+    fn visit_fun_decl_id(&mut self, id: &FunDeclId) {
         let id = AnyDeclId::Fun(*id);
         self.insert_edge(id);
     }
@@ -375,7 +374,7 @@ impl Deps {
     }
 
     /// Lookup a function and visit its signature
-    fn visit_fun_signature_from_trait(&mut self, ctx: &TransCtx, fid: FunDeclId::Id) {
+    fn visit_fun_signature_from_trait(&mut self, ctx: &TransCtx, fid: FunDeclId) {
         let decl = ctx.fun_decls.get(fid).unwrap();
         self.visit_fun_sig(&decl.signature);
     }

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -20,14 +20,14 @@ use std::mem::replace;
 /// store the new statements inside the visitor. Once we've finished exploring
 /// the statement, we insert those before the statement.
 struct Transform<'a> {
-    locals: &'a mut Vector<VarId::Id, Var>,
+    locals: &'a mut Vector<VarId, Var>,
     statements: Vec<Statement>,
     /// Meta information of the outer statement
     meta: Option<Meta>,
 }
 
 impl<'a> Transform<'a> {
-    fn fresh_var(&mut self, name: Option<String>, ty: Ty) -> VarId::Id {
+    fn fresh_var(&mut self, name: Option<String>, ty: Ty) -> VarId {
         self.locals.push_with(|index| Var { index, name, ty })
     }
 
@@ -223,7 +223,7 @@ impl<'a> MutAstVisitor for Transform<'a> {
     }
 }
 
-fn transform_st(locals: &mut Vector<VarId::Id, Var>, s: &mut Statement) -> Option<Vec<Statement>> {
+fn transform_st(locals: &mut Vector<VarId, Var>, s: &mut Statement) -> Option<Vec<Statement>> {
     // Explore the places/operands
     let mut visitor = Transform {
         locals,

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -3,6 +3,7 @@
 use crate::expressions::{BorrowKind, MutExprVisitor, Operand, Place, ProjectionElem, Rvalue};
 use crate::formatter::{Formatter, IntoFormatter};
 use crate::gast::{Call, GenericArgs, Var};
+use crate::ids::Vector;
 use crate::llbc_ast::*;
 use crate::meta::Meta;
 use crate::translate_ctx::TransCtx;
@@ -19,7 +20,7 @@ use std::mem::replace;
 /// store the new statements inside the visitor. Once we've finished exploring
 /// the statement, we insert those before the statement.
 struct Transform<'a> {
-    locals: &'a mut VarId::Vector<Var>,
+    locals: &'a mut Vector<VarId::Id, Var>,
     statements: Vec<Statement>,
     /// Meta information of the outer statement
     meta: Option<Meta>,
@@ -222,7 +223,7 @@ impl<'a> MutAstVisitor for Transform<'a> {
     }
 }
 
-fn transform_st(locals: &mut VarId::Vector<Var>, s: &mut Statement) -> Option<Vec<Statement>> {
+fn transform_st(locals: &mut Vector<VarId::Id, Var>, s: &mut Statement) -> Option<Vec<Statement>> {
     // Explore the places/operands
     let mut visitor = Transform {
         locals,

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -17,7 +17,7 @@ use crate::values::*;
 fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
     if let RawStatement::Return = &mut st.content {
         let ret_place = Place {
-            var_id: VarId::Id::new(0),
+            var_id: VarId::new(0),
             projection: Projection::new(),
         };
         let unit_value = Rvalue::Aggregate(

--- a/charon/src/transform/remove_drop_never.rs
+++ b/charon/src/transform/remove_drop_never.rs
@@ -4,13 +4,14 @@
 //! filtering). Then, we filter the unused variables ([crate::remove_unused_locals]).
 
 use crate::formatter::{Formatter, IntoFormatter};
+use crate::ids::Vector;
 use crate::llbc_ast::{FunDecls, GlobalDecls, RawStatement, Statement, Var};
 use crate::translate_ctx::TransCtx;
 use crate::values::*;
 
 /// Filter the statement by replacing it with `Nop` if it is a `Drop(x)` where
 /// `x` has type `Never`. Otherwise leave it unchanged.
-fn transform_st(locals: &VarId::Vector<Var>, st: &mut Statement) {
+fn transform_st(locals: &Vector<VarId::Id, Var>, st: &mut Statement) {
     // Shall we filter the statement?
     let filter = match &mut st.content {
         RawStatement::Drop(p) => {

--- a/charon/src/transform/remove_drop_never.rs
+++ b/charon/src/transform/remove_drop_never.rs
@@ -11,7 +11,7 @@ use crate::values::*;
 
 /// Filter the statement by replacing it with `Nop` if it is a `Drop(x)` where
 /// `x` has type `Never`. Otherwise leave it unchanged.
-fn transform_st(locals: &Vector<VarId::Id, Var>, st: &mut Statement) {
+fn transform_st(locals: &Vector<VarId, Var>, st: &mut Statement) {
     // Shall we filter the statement?
     let filter = match &mut st.content {
         RawStatement::Drop(p) => {

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -93,7 +93,7 @@ impl<'a, 'tcx, 'ctx> Visitor<'a, 'tcx, 'ctx> {
 
                         // Convert between discriminants and variant indices. Remark: the discriminant can
                         // be of any *signed* integer type (`isize`, `i8`, etc.).
-                        let discr_to_id: HashMap<ScalarValue, VariantId::Id> = variants
+                        let discr_to_id: HashMap<ScalarValue, VariantId> = variants
                             .iter_indexed_values()
                             .map(|(id, variant)| (variant.discriminant, id))
                             .collect();

--- a/charon/src/transform/remove_unused_locals.rs
+++ b/charon/src/transform/remove_unused_locals.rs
@@ -4,6 +4,7 @@
 //! remaining afterwards.
 use crate::expressions::{MutExprVisitor, SharedExprVisitor};
 use crate::formatter::{Formatter, IntoFormatter};
+use crate::ids::Vector;
 use crate::llbc_ast::{FunDecls, GlobalDecls, MutAstVisitor, SharedAstVisitor, Statement};
 use crate::translate_ctx::TransCtx;
 use crate::types::{MutTypeVisitor, SharedTypeVisitor};
@@ -82,9 +83,9 @@ impl MutAstVisitor for UpdateUsedLocals {
 /// mapping from variable index to variable index.
 fn update_locals(
     num_inputs: usize,
-    old_locals: VarId::Vector<Var>,
+    old_locals: Vector<VarId::Id, Var>,
     st: &Statement,
-) -> (VarId::Vector<Var>, HashMap<VarId::Id, VarId::Id>) {
+) -> (Vector<VarId::Id, Var>, HashMap<VarId::Id, VarId::Id>) {
     // Compute the set of used locals
     let mut used_locals: HashSet<VarId::Id> = HashSet::new();
     // We always register the return variable and the input arguments
@@ -103,7 +104,7 @@ fn update_locals(
     // Filter: only keep the variables which are used, and update
     // their indices so as not to have "holes"
     let mut vids_map: HashMap<VarId::Id, VarId::Id> = HashMap::new();
-    let mut locals: VarId::Vector<Var> = VarId::Vector::new();
+    let mut locals: Vector<VarId::Id, Var> = Vector::new();
     for var in old_locals {
         if used_locals.contains(&var.index) {
             let old_id = var.index;

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -19,7 +19,7 @@ use crate::ullbc_ast::{make_locals_generator, RawStatement, Statement};
 use crate::ullbc_ast_utils::body_transform_operands;
 use crate::values::VarId;
 
-fn make_aggregate_kind(ty: &Ty, var_index: Option<VariantId::Id>) -> AggregateKind {
+fn make_aggregate_kind(ty: &Ty, var_index: Option<VariantId>) -> AggregateKind {
     let (id, generics) = ty.as_adt();
     AggregateKind::Adt(*id, var_index, generics.clone())
 }
@@ -30,7 +30,7 @@ fn make_aggregate_kind(ty: &Ty, var_index: Option<VariantId::Id>) -> AggregateKi
 ///
 /// Goes fom e.g. `f(T::A(x, y))` to `let a = T::A(x, y); f(a)`.
 /// The function is recursively called on the aggregate fields (e.g. here x and y).
-fn transform_constant_expr<F: FnMut(Ty) -> VarId::Id>(
+fn transform_constant_expr<F: FnMut(Ty) -> VarId>(
     meta: &Meta,
     nst: &mut Vec<Statement>,
     val: ConstantExpr,
@@ -100,7 +100,7 @@ fn transform_constant_expr<F: FnMut(Ty) -> VarId::Id>(
     }
 }
 
-fn transform_operand<F: FnMut(Ty) -> VarId::Id>(
+fn transform_operand<F: FnMut(Ty) -> VarId>(
     meta: &Meta,
     nst: &mut Vec<Statement>,
     op: &mut Operand,

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -8,7 +8,7 @@ use crate::translate_ctx::TransCtx;
 use crate::types::*;
 
 struct InsertRegions<'a> {
-    regions: &'a mut Vector<RegionId::Id, RegionVar>,
+    regions: &'a mut Vector<RegionId, RegionVar>,
     /// The number of region groups we dived into (we don't count the regions
     /// at the declaration level). We use this for the DeBruijn indices.
     depth: usize,
@@ -27,7 +27,7 @@ impl<'a> MutTypeVisitor for InsertRegions<'a> {
 
     fn enter_region_group(
         &mut self,
-        _regions: &mut Vector<RegionId::Id, RegionVar>,
+        _regions: &mut Vector<RegionId, RegionVar>,
         visitor: &mut dyn FnMut(&mut Self),
     ) {
         self.depth += 1;
@@ -88,7 +88,7 @@ fn transform_function(_ctx: &TransCtx, def: &mut FunDecl) -> Result<(), Error> {
             ClosureKind::FnOnce => state,
             ClosureKind::Fn | ClosureKind::FnMut => {
                 // We introduce an erased region, that we replace later
-                //let index = RegionId::Id::new(generics.regions.len());
+                //let index = RegionId::new(generics.regions.len());
                 //generics.regions.push_back(RegionVar { index, name: None });
 
                 let mutability = if info.kind == ClosureKind::Fn {

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -2,12 +2,13 @@
 //! closure itself. This is not consistent with the closure signature,
 //! which ignores this first variable. This micro-pass updates this.
 use crate::common::*;
+use crate::ids::Vector;
 use crate::llbc_ast::*;
 use crate::translate_ctx::TransCtx;
 use crate::types::*;
 
 struct InsertRegions<'a> {
-    regions: &'a mut RegionId::Vector<RegionVar>,
+    regions: &'a mut Vector<RegionId::Id, RegionVar>,
     /// The number of region groups we dived into (we don't count the regions
     /// at the declaration level). We use this for the DeBruijn indices.
     depth: usize,
@@ -26,7 +27,7 @@ impl<'a> MutTypeVisitor for InsertRegions<'a> {
 
     fn enter_region_group(
         &mut self,
-        _regions: &mut RegionId::Vector<RegionVar>,
+        _regions: &mut Vector<RegionId::Id, RegionVar>,
         visitor: &mut dyn FnMut(&mut Self),
     ) {
         self.depth += 1;

--- a/charon/src/translate/translate_constants.rs
+++ b/charon/src/translate/translate_constants.rs
@@ -80,7 +80,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let vid = if info.typ_is_struct {
                     None
                 } else {
-                    Some(VariantId::Id::new(info.variant_index))
+                    Some(VariantId::new(info.variant_index))
                 };
                 RawConstantExpr::Adt(vid, fields)
             }

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -1,7 +1,7 @@
 use crate::cli_options::CliOpts;
 use crate::common::*;
 use crate::get_mir::{extract_constants_at_top_level, MirLevel};
-use crate::ids::{Generator, Map, MapGenerator};
+use crate::ids::{Generator, Map};
 use crate::translate_ctx::*;
 use crate::translate_functions_to_ullbc;
 
@@ -265,16 +265,17 @@ pub fn translate<'tcx, 'ctx>(
         dep_sources: HashMap::new(),
         decls_with_errors: HashSet::new(),
         ignored_failed_decls: HashSet::new(),
-        type_id_map: MapGenerator::new(),
+        id_map: HashMap::new(),
+        reverse_id_map: HashMap::new(),
+        type_id_gen: Generator::new(),
         type_decls: Map::new(),
-        fun_id_map: MapGenerator::new(),
+        fun_id_gen: Generator::new(),
         fun_decls: Map::new(),
-        global_id_map: MapGenerator::new(),
+        global_id_gen: Generator::new(),
         global_decls: Map::new(),
-        trait_decl_id_map: MapGenerator::new(),
+        trait_decl_id_gen: Generator::new(),
         trait_decls: Map::new(),
-        trait_impl_id_map: MapGenerator::new(),
-        trait_impl_id_to_def_id: HashMap::new(),
+        trait_impl_id_gen: Generator::new(),
         trait_impls: Map::new(),
         ordered_decls: None,
     };

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -1,11 +1,10 @@
 use crate::cli_options::CliOpts;
 use crate::common::*;
 use crate::get_mir::{extract_constants_at_top_level, MirLevel};
-use crate::meta;
+use crate::ids::{Generator, Map, MapGenerator};
 use crate::translate_ctx::*;
 use crate::translate_functions_to_ullbc;
-use crate::types as ty;
-use crate::ullbc_ast as ast;
+
 use hax_frontend_exporter as hax;
 use hax_frontend_exporter::SInto;
 use linked_hash_set::LinkedHashSet;
@@ -261,22 +260,22 @@ pub fn translate<'tcx, 'ctx>(
         def_id: None,
         file_to_id: HashMap::new(),
         id_to_file: HashMap::new(),
-        real_file_counter: meta::LocalFileId::Generator::new(),
-        virtual_file_counter: meta::VirtualFileId::Generator::new(),
+        real_file_counter: Generator::new(),
+        virtual_file_counter: Generator::new(),
         dep_sources: HashMap::new(),
         decls_with_errors: HashSet::new(),
         ignored_failed_decls: HashSet::new(),
-        type_id_map: ty::TypeDeclId::MapGenerator::new(),
-        type_decls: ty::TypeDeclId::Map::new(),
-        fun_id_map: ast::FunDeclId::MapGenerator::new(),
-        fun_decls: ast::FunDeclId::Map::new(),
-        global_id_map: ast::GlobalDeclId::MapGenerator::new(),
-        global_decls: ast::GlobalDeclId::Map::new(),
-        trait_decl_id_map: ast::TraitDeclId::MapGenerator::new(),
-        trait_decls: ast::TraitDeclId::Map::new(),
-        trait_impl_id_map: ast::TraitImplId::MapGenerator::new(),
+        type_id_map: MapGenerator::new(),
+        type_decls: Map::new(),
+        fun_id_map: MapGenerator::new(),
+        fun_decls: Map::new(),
+        global_id_map: MapGenerator::new(),
+        global_decls: Map::new(),
+        trait_decl_id_map: MapGenerator::new(),
+        trait_decls: Map::new(),
+        trait_impl_id_map: MapGenerator::new(),
         trait_impl_id_to_def_id: HashMap::new(),
-        trait_impls: ast::TraitImplId::Map::new(),
+        trait_impls: Map::new(),
         ordered_decls: None,
     };
 

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -989,11 +989,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         let clauses: Vector<TraitClauseId, TraitClause> = self
             .trait_clauses
             .iter()
-            .filter_map(|(_, x)| {
-                x.to_trait_clause_with_id(&|id| match id {
-                    TraitInstanceId::ParentClause(box TraitInstanceId::SelfId, _, id) => Some(*id),
-                    _ => None,
-                })
+            .filter_map(|(_, x)| match &x.clause_id {
+                TraitInstanceId::ParentClause(box TraitInstanceId::SelfId, _, clause_id) => {
+                    Some(x.to_trait_clause_with_id(*clause_id))
+                }
+                _ => None,
             })
             .collect();
         // Sanity check

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -11,6 +11,7 @@ use crate::common::*;
 use crate::expressions::*;
 use crate::formatter::{Formatter, IntoFormatter};
 use crate::get_mir::{boxes_are_desugared, get_mir_for_def_id_and_level};
+use crate::ids::Vector;
 use crate::translate_ctx::*;
 use crate::translate_types;
 use crate::types::*;
@@ -1520,7 +1521,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
         // We need to convert the blocks map to an index vector
         // We clone things while we could move them...
-        let mut blocks = BlockId::Vector::new();
+        let mut blocks = Vector::new();
         for (id, block) in mem::take(&mut self.blocks) {
             let new_id = blocks.push(block);
             // Sanity check to make sure we don't mess with the indices

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -34,13 +34,13 @@ pub(crate) enum SubstFunIdOrPanic {
     Fun(SubstFunId),
 }
 
-fn translate_variant_id(id: hax::VariantIdx) -> VariantId::Id {
-    VariantId::Id::new(id)
+fn translate_variant_id(id: hax::VariantIdx) -> VariantId {
+    VariantId::new(id)
 }
 
-fn translate_field_id(id: hax::FieldIdx) -> FieldId::Id {
+fn translate_field_id(id: hax::FieldIdx) -> FieldId {
     use rustc_index::Idx;
-    FieldId::Id::new(id.index())
+    FieldId::new(id.index())
 }
 
 /// Translate a `BorrowKind`
@@ -278,7 +278,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     }
 
     /// Translate a basic block id and register it, if it hasn't been done.
-    fn translate_basic_block_id(&mut self, block_id: hax::BasicBlock) -> BlockId::Id {
+    fn translate_basic_block_id(&mut self, block_id: hax::BasicBlock) -> BlockId {
         match self.blocks_map.get(&block_id) {
             None => {
                 // Generate a fresh id - this also registers the block
@@ -354,7 +354,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         &mut self,
         span: rustc_span::Span,
         place: &hax::Place,
-    ) -> Result<(VarId::Id, Projection), Error> {
+    ) -> Result<(VarId, Projection), Error> {
         let erase_regions = true;
         match &place.kind {
             hax::PlaceKind::Local(local) => {
@@ -1308,7 +1308,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             }
             hax::SwitchTargets::SwitchInt(_, targets_map, otherwise) => {
                 let int_ty = *switch_ty.as_literal().as_integer();
-                let targets_map: Vec<(ScalarValue, BlockId::Id)> = targets_map
+                let targets_map: Vec<(ScalarValue, BlockId)> = targets_map
                     .iter()
                     .map(|(v, tgt)| {
                         let v = ScalarValue::from_le_bytes(int_ty, v.data_le_bytes);

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -56,16 +56,13 @@ impl NonLocalTraitClause {
         }
     }
 
-    pub(crate) fn to_trait_clause_with_id(
-        &self,
-        get_id: &dyn Fn(&TraitInstanceId) -> Option<TraitClauseId>,
-    ) -> Option<TraitClause> {
-        get_id(&self.clause_id).map(|clause_id| TraitClause {
+    pub(crate) fn to_trait_clause_with_id(&self, clause_id: TraitClauseId) -> TraitClause {
+        TraitClause {
             clause_id,
             meta: self.meta,
             trait_id: self.trait_id,
             generics: self.generics.clone(),
-        })
+        }
     }
 }
 

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -38,7 +38,7 @@ pub(crate) struct NonLocalTraitClause {
     /// [Some] if this is the top clause, [None] if this is about a parent/
     /// associated type clause.
     pub meta: Option<Meta>,
-    pub trait_id: TraitDeclId::Id,
+    pub trait_id: TraitDeclId,
     pub generics: GenericArgs,
 }
 
@@ -58,7 +58,7 @@ impl NonLocalTraitClause {
 
     pub(crate) fn to_trait_clause_with_id(
         &self,
-        get_id: &dyn Fn(&TraitInstanceId) -> Option<TraitClauseId::Id>,
+        get_id: &dyn Fn(&TraitInstanceId) -> Option<TraitClauseId>,
     ) -> Option<TraitClause> {
         get_id(&self.clause_id).map(|clause_id| TraitClause {
             clause_id,
@@ -281,7 +281,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// of the parent must be registered as parent clauses.
     pub(crate) fn translate_predicates_of(
         &mut self,
-        parent_trait_id: Option<TraitDeclId::Id>,
+        parent_trait_id: Option<TraitDeclId>,
         def_id: DefId,
     ) -> Result<(), Error> {
         trace!("def_id: {:?}", def_id);
@@ -347,7 +347,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// in the registered trait clauses.
     pub(crate) fn translate_predicates_solve_trait_obligations_of(
         &mut self,
-        parent_trait_id: Option<TraitDeclId::Id>,
+        parent_trait_id: Option<TraitDeclId>,
         def_id: DefId,
     ) -> Result<(), Error> {
         let span = self.t_ctx.tcx.def_span(def_id);
@@ -749,7 +749,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                                 Box::new(trait_id),
                                 current_trait_decl_id,
                                 TraitItemName(item.name.clone()),
-                                TraitClauseId::Id::new(*index),
+                                TraitClauseId::new(*index),
                             );
                             current_trait_decl_id = self
                                 .translate_trait_decl_id(
@@ -766,7 +766,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                             trait_id = TraitInstanceId::ParentClause(
                                 Box::new(trait_id),
                                 current_trait_decl_id,
-                                TraitClauseId::Id::new(*index),
+                                TraitClauseId::new(*index),
                             );
                             current_trait_decl_id = self
                                 .translate_trait_decl_id(
@@ -875,7 +875,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     fn match_trait_clauses(
         &self,
-        trait_id: TraitDeclId::Id,
+        trait_id: TraitDeclId,
         generics: &GenericArgs,
         clause: &NonLocalTraitClause,
     ) -> bool {
@@ -912,7 +912,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// TODO: having to do this is very annoying. Isn't there a better way?
     fn find_trait_clause_for_param(
         &self,
-        trait_id: TraitDeclId::Id,
+        trait_id: TraitDeclId,
         generics: &GenericArgs,
     ) -> TraitInstanceId {
         trace!(
@@ -975,7 +975,7 @@ struct TraitInstancesSolver<'a, 'tcx, 'ctx, 'ctx1> {
     /// some instances).
     pub unsolved_count: usize,
     /// The unsolved clauses.
-    pub unsolved: Vec<(TraitDeclId::Id, GenericArgs)>,
+    pub unsolved: Vec<(TraitDeclId, GenericArgs)>,
     /// For error messages
     pub span: rustc_span::Span,
     /// The current context

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -75,7 +75,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     fn translate_const_from_trait_item(
         &mut self,
         item: &rustc_middle::ty::AssocItem,
-    ) -> Result<(TraitItemName, (Ty, GlobalDeclId::Id)), Error> {
+    ) -> Result<(TraitItemName, (Ty, GlobalDeclId)), Error> {
         let ty = self.translate_ty_from_trait_item(item)?;
         let name = TraitItemName(item.name.to_string());
         let span = self.t_ctx.tcx.def_span(self.def_id);
@@ -150,7 +150,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// We call this when translating trait impls and trait impl items.
     pub(crate) fn add_trait_impl_self_trait_clause(
         &mut self,
-        impl_id: TraitImplId::Id,
+        impl_id: TraitImplId,
     ) -> Result<(), Error> {
         let def_id = *self.t_ctx.trait_impl_id_to_def_id.get(&impl_id).unwrap();
         trace!("id: {:?}", def_id);
@@ -188,7 +188,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     pub(crate) fn with_parent_trait_clauses<T>(
         &mut self,
         clause_id: TraitInstanceId,
-        trait_decl_id: TraitDeclId::Id,
+        trait_decl_id: TraitDeclId,
         f: &mut dyn FnMut(&mut Self) -> T,
     ) -> T {
         let mut parent_clause_id_gen = Generator::new();
@@ -203,7 +203,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     pub(crate) fn with_item_trait_clauses<T>(
         &mut self,
         clause_id: TraitInstanceId,
-        trait_decl_id: TraitDeclId::Id,
+        trait_decl_id: TraitDeclId,
         item_name: String,
         f: &mut dyn FnMut(&mut Self) -> T,
     ) -> T {
@@ -522,8 +522,7 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
             );
             let parent_trait_refs: Vec<TraitRef> =
                 bt_ctx.translate_trait_impl_exprs(span, erase_regions, &parent_trait_refs)?;
-            // FIXME: these ids are entirely wrong.
-            let parent_trait_refs: Vector<TraitClauseId::Id, TraitRef> = parent_trait_refs.into();
+            let parent_trait_refs: Vector<TraitClauseId, TraitRef> = parent_trait_refs.into();
 
             let generics = GenericArgs {
                 regions,

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -358,22 +358,14 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
                     let item_trait_clauses: Vec<_> = bt_ctx
                         .trait_clauses
                         .values()
-                        .filter_map(|c| {
-                            c.to_trait_clause_with_id(&|id| match id {
-                                TraitInstanceId::ItemClause(
-                                    box TraitInstanceId::SelfId,
-                                    _,
-                                    TraitItemName(item_name),
-                                    clause_id,
-                                ) => {
-                                    if item_name == &name {
-                                        Some(*clause_id)
-                                    } else {
-                                        None
-                                    }
-                                }
-                                _ => None,
-                            })
+                        .filter_map(|c| match &c.clause_id {
+                            TraitInstanceId::ItemClause(
+                                box TraitInstanceId::SelfId,
+                                _,
+                                TraitItemName(item_name),
+                                clause_id,
+                            ) if item_name == &name => Some(c.to_trait_clause_with_id(*clause_id)),
+                            _ => None,
                         })
                         .collect();
 

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -1,6 +1,7 @@
 use crate::common::*;
 use crate::formatter::IntoFormatter;
 use crate::gast::*;
+use crate::ids::{Generator, Vector};
 use crate::translate_ctx::*;
 use crate::types::*;
 use crate::ullbc_ast as ast;
@@ -190,7 +191,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trait_decl_id: TraitDeclId::Id,
         f: &mut dyn FnMut(&mut Self) -> T,
     ) -> T {
-        let mut parent_clause_id_gen = TraitClauseId::Generator::new();
+        let mut parent_clause_id_gen = Generator::new();
         let parent_trait_instance_id_gen = Box::new(move || {
             let fresh_id = parent_clause_id_gen.fresh_id();
             TraitInstanceId::ParentClause(Box::new(clause_id.clone()), trait_decl_id, fresh_id)
@@ -206,7 +207,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         item_name: String,
         f: &mut dyn FnMut(&mut Self) -> T,
     ) -> T {
-        let mut item_clause_id_gen = TraitClauseId::Generator::new();
+        let mut item_clause_id_gen = Generator::new();
         let item_clause_id_gen = Box::new(move || {
             let fresh_id = item_clause_id_gen.fresh_id();
             TraitInstanceId::ItemClause(
@@ -521,8 +522,8 @@ impl<'tcx, 'ctx> TransCtx<'tcx, 'ctx> {
             );
             let parent_trait_refs: Vec<TraitRef> =
                 bt_ctx.translate_trait_impl_exprs(span, erase_regions, &parent_trait_refs)?;
-            let parent_trait_refs: TraitClauseId::Vector<TraitRef> =
-                TraitClauseId::Vector::from(parent_trait_refs);
+            // FIXME: these ids are entirely wrong.
+            let parent_trait_refs: Vector<TraitClauseId::Id, TraitRef> = parent_trait_refs.into();
 
             let generics = GenericArgs {
                 regions,

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -152,7 +152,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         &mut self,
         impl_id: TraitImplId,
     ) -> Result<(), Error> {
-        let def_id = *self.t_ctx.trait_impl_id_to_def_id.get(&impl_id).unwrap();
+        let def_id = *self
+            .t_ctx
+            .reverse_id_map
+            .get(&AnyTransId::TraitImpl(impl_id))
+            .unwrap();
         trace!("id: {:?}", def_id);
 
         // Retrieve the trait ref representing "self"

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -2,6 +2,7 @@ use crate::assumed;
 use crate::common::*;
 use crate::formatter::IntoFormatter;
 use crate::gast::*;
+use crate::ids::Vector;
 use crate::translate_ctx::*;
 use crate::types::*;
 use crate::values::ScalarValue;
@@ -540,7 +541,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         }
 
         // The type is transparent: explore the variants
-        let mut variants: VariantId::Vector<Variant> = Default::default();
+        let mut variants: Vector<VariantId::Id, Variant> = Default::default();
         let erase_regions = false;
         for (i, (rust_var_id, var_def)) in adt.variants().iter_enumerated().enumerate() {
             let var_def: hax::VariantDef = var_def.sinto(&self.hax_state);
@@ -557,7 +558,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 ScalarValue::Isize(0)
             };
 
-            let mut fields: FieldId::Vector<Field> = Default::default();
+            let mut fields: Vector<FieldId::Id, Field> = Default::default();
             /* This is for sanity: check that either all the fields have names, or
              * none of them has */
             let mut have_names: Option<bool> = Option::None;

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -505,7 +505,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// struct with only public fields).
     fn translate_type_body(
         &mut self,
-        trans_id: TypeDeclId::Id,
+        trans_id: TypeDeclId,
         rust_id: DefId,
     ) -> Result<TypeDeclKind, Error> {
         use rustc_middle::ty::AdtKind;
@@ -541,7 +541,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         }
 
         // The type is transparent: explore the variants
-        let mut variants: Vector<VariantId::Id, Variant> = Default::default();
+        let mut variants: Vector<VariantId, Variant> = Default::default();
         let erase_regions = false;
         for (i, (rust_var_id, var_def)) in adt.variants().iter_enumerated().enumerate() {
             let var_def: hax::VariantDef = var_def.sinto(&self.hax_state);
@@ -558,7 +558,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 ScalarValue::Isize(0)
             };
 
-            let mut fields: Vector<FieldId::Id, Field> = Default::default();
+            let mut fields: Vector<FieldId, Field> = Default::default();
             /* This is for sanity: check that either all the fields have names, or
              * none of them has */
             let mut have_names: Option<bool> = Option::None;

--- a/charon/src/ullbc_to_llbc.rs
+++ b/charon/src/ullbc_to_llbc.rs
@@ -22,6 +22,7 @@
 
 use crate::expressions::Place;
 use crate::formatter::{Formatter, IntoFormatter};
+use crate::ids::Map;
 use crate::llbc_ast as tgt;
 use crate::meta::{combine_meta, Meta};
 use crate::translate_ctx::TransCtx;
@@ -2000,8 +2001,8 @@ fn translate_global(ctx: &TransCtx, global_id: GlobalDeclId::Id) -> tgt::GlobalD
 
 /// Translate the functions by reconstructing the control-flow.
 pub fn translate_functions(ctx: &TransCtx) -> Defs {
-    let mut tgt_funs = FunDeclId::Map::new();
-    let mut tgt_globals = GlobalDeclId::Map::new();
+    let mut tgt_funs = Map::new();
+    let mut tgt_globals = Map::new();
 
     // Translate the bodies one at a time
     for (fun_id, _) in ctx.fun_decls.iter_indexed() {


### PR DESCRIPTION
This is a little bit of a simplification of how we deal with ids in charon. Specifically:
- the id-generating macro generated a module with type aliases which is unconventional and wasn't saving much code;
- the `MapGenerator`s entangled id generation with remembering `DefId`s; I think these two things should be kept separate, especially as we work to detangle the dependency on rustc;
- this made it possible to regroup the `register_` functions which were doing very similar work.

Some of the commits are big replacements; better review one commit at a time.