### PR TITLE
Use printf instead of echo -n in Makefile to avoid portability issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format:
 charon-ml/src/CharonVersion.ml: charon/Cargo.toml
 	echo '(* This is an automatically generated file, generated from `charon/Cargo.toml`. *)' > "$@"
 	echo '(* To re-generate this file, rune `make` in the root directory *)' >> "$@"
-	echo -n 'let supported_charon_version = ' >> "$@"
+	printf 'let supported_charon_version = ' >> "$@"
 	grep '^version =' charon/Cargo.toml | head -1 | sed 's/^version = \(".*"\)/\1/' >> "$@"
 
 # Build the project in release mode, after formatting the code


### PR DESCRIPTION
As described in the title.
I've recently been having issues when regenerating CharonVersion.ml through `echo -n` on MacOS, where the echo version used does not seem to recognize the `-n` option, leading to printing it in the file and hence to syntax errors.

Following this [StackOverflow post](https://stackoverflow.com/questions/11193466/echo-n-prints-n), this PR replaces the `echo -n` call by `printf`, which apparently has more consistent behavior across platforms.