### PR TITLE
Update version of `hax-frontend-exporter`

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#bdd123337ebf800f77255b85ad79df7de6ac18ba"
+source = "git+https://github.com/hacspec/hax?branch=main#a483afff1dbb321ee31727a92e2a2a7b4a55eab6"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#bdd123337ebf800f77255b85ad79df7de6ac18ba"
+source = "git+https://github.com/hacspec/hax?branch=main#a483afff1dbb321ee31727a92e2a2a7b4a55eab6"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#bdd123337ebf800f77255b85ad79df7de6ac18ba"
+source = "git+https://github.com/hacspec/hax?branch=main#a483afff1dbb321ee31727a92e2a2a7b4a55eab6"
 dependencies = [
  "schemars",
  "serde",


### PR DESCRIPTION
This PR bumps the version of `hax-frontend-exporter`, so that Charon uses a hax frontend in which https://github.com/hacspec/hax/issues/680 is fixed. This is useful for extracting the `libcrux-sha3` crate.