### PR TITLE
Simplify item translation

### DIFF
--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -10,7 +10,7 @@ use hax_frontend_exporter::SInto;
 use rustc_hir::{Defaultness, ForeignItemKind, ImplItem, ImplItemKind, Item, ItemKind};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     fn register_local_hir_impl_item(&mut self, _top_item: bool, impl_item: &ImplItem) {
@@ -228,15 +228,15 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         }
     }
 
-    pub(crate) fn translate_item(&mut self, id: OrdRustId) {
-        let rust_id = id.get_id();
+    pub(crate) fn translate_item(&mut self, ord_id: OrdRustId, trans_id: AnyTransId) {
+        let rust_id = ord_id.get_id();
         self.with_def_id(rust_id, |ctx| {
-            let res = match id {
-                OrdRustId::Type(id) => ctx.translate_type(id),
-                OrdRustId::Fun(id) | OrdRustId::ConstFun(id) => ctx.translate_function(id),
-                OrdRustId::Global(id) => ctx.translate_global(id),
-                OrdRustId::TraitDecl(id) => ctx.translate_trait_decl(id),
-                OrdRustId::TraitImpl(id) => ctx.translate_trait_impl(id),
+            let res = match trans_id {
+                AnyTransId::Type(id) => ctx.translate_type(id, rust_id),
+                AnyTransId::Fun(id) => ctx.translate_function(id, rust_id),
+                AnyTransId::Global(id) => ctx.translate_global(id, rust_id),
+                AnyTransId::TraitDecl(id) => ctx.translate_trait_decl(id, rust_id),
+                AnyTransId::TraitImpl(id) => ctx.translate_trait_impl(id, rust_id),
             };
             if res.is_err() {
                 let span = ctx.tcx.def_span(rust_id);
@@ -287,7 +287,7 @@ pub fn translate<'tcx, 'ctx>(
             crate_name,
             ..TranslatedCrate::default()
         },
-        priority_queue: BTreeSet::new(),
+        priority_queue: Default::default(),
     };
 
     // First push all the items in the stack of items to translate.
@@ -330,9 +330,9 @@ pub fn translate<'tcx, 'ctx>(
     // Note that the order in which we translate the definitions doesn't matter:
     // we never need to lookup a translated definition, and only use the map
     // from Rust ids to translated ids.
-    while let Some(id) = ctx.priority_queue.pop_first() {
-        trace!("About to translate id: {:?}", id);
-        ctx.translate_item(id);
+    while let Some((ord_id, trans_id)) = ctx.priority_queue.pop_first() {
+        trace!("About to translate id: {:?}", ord_id);
+        ctx.translate_item(ord_id, trans_id);
     }
 
     // Return the context, dropping the hax state and rustc `tcx`.

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -25,7 +25,7 @@ use rustc_hir::Node as HirNode;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use std::cmp::{Ord, Ordering, PartialOrd};
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt;
 
 macro_rules! register_error_or_panic {
@@ -250,9 +250,9 @@ pub struct TranslateCtx<'tcx, 'ctx> {
     /// Context for tracking and reporting errors.
     pub errors: ErrorCtx<'ctx>,
     /// The declarations we came accross and which we haven't translated yet.
-    /// We use an ordered set to make sure we translate them in a specific
+    /// We use an ordered map to make sure we translate them in a specific
     /// order (this avoids stealing issues when querying the MIR bodies).
-    pub priority_queue: BTreeSet<OrdRustId>,
+    pub priority_queue: BTreeMap<OrdRustId, AnyTransId>,
 }
 
 /// A translation context for type/global/function bodies.
@@ -648,8 +648,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         match self.translated.id_map.get(&rust_id) {
             Some(tid) => *tid,
             None => {
-                // Add the id to the stack of declarations to translate
-                self.priority_queue.insert(id);
                 let trans_id = match id {
                     OrdRustId::Type(_) => AnyTransId::Type(self.translated.type_id_gen.fresh_id()),
                     OrdRustId::TraitDecl(_) => {
@@ -665,6 +663,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                         AnyTransId::Fun(self.translated.fun_id_gen.fresh_id())
                     }
                 };
+                // Add the id to the queue of declarations to translate
+                self.priority_queue.insert(id, trans_id);
                 self.translated.id_map.insert(id.get_id(), trans_id);
                 self.translated.reverse_id_map.insert(trans_id, id.get_id());
                 self.translated.all_ids.insert(trans_id);

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1789,14 +1789,21 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Translate one function.
-    pub(crate) fn translate_function(&mut self, rust_id: DefId) -> Result<(), Error> {
-        self.translate_function_aux(rust_id)
+    pub(crate) fn translate_function(
+        &mut self,
+        decl_id: FunDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
+        self.translate_function_aux(decl_id, rust_id)
     }
 
     /// Auxliary helper to properly handle errors, see [translate_function].
-    pub fn translate_function_aux(&mut self, rust_id: DefId) -> Result<(), Error> {
+    pub fn translate_function_aux(
+        &mut self,
+        def_id: FunDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
         trace!("About to translate function:\n{:?}", rust_id);
-        let def_id = self.register_fun_decl_id(&None, rust_id);
         let def_span = self.tcx.def_span(rust_id);
 
         // Compute the meta information
@@ -1855,16 +1862,22 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     /// Translate one global.
-    pub(crate) fn translate_global(&mut self, rust_id: DefId) -> Result<(), Error> {
-        self.translate_global_aux(rust_id)
+    pub(crate) fn translate_global(
+        &mut self,
+        decl_id: GlobalDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
+        self.translate_global_aux(decl_id, rust_id)
     }
 
     /// Auxliary helper to properly handle errors, see [translate_global].
-    pub fn translate_global_aux(&mut self, rust_id: DefId) -> Result<(), Error> {
+    pub fn translate_global_aux(
+        &mut self,
+        def_id: GlobalDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
         trace!("About to translate global:\n{:?}", rust_id);
         let span = self.tcx.def_span(rust_id);
-
-        let def_id = self.register_global_decl_id(&None, rust_id);
 
         // Compute the meta information
         let item_meta = self.translate_item_meta_from_rid(rust_id);

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1789,20 +1789,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Translate one function.
-    pub(crate) fn translate_function(
-        &mut self,
-        decl_id: FunDeclId,
-        rust_id: DefId,
-    ) -> Result<(), Error> {
-        self.translate_function_aux(decl_id, rust_id)
-    }
-
-    /// Auxliary helper to properly handle errors, see [translate_function].
-    pub fn translate_function_aux(
+    pub fn translate_function(
         &mut self,
         def_id: FunDeclId,
         rust_id: DefId,
-    ) -> Result<(), Error> {
+    ) -> Result<FunDecl, Error> {
         trace!("About to translate function:\n{:?}", rust_id);
         let def_span = self.tcx.def_span(rust_id);
 
@@ -1843,39 +1834,24 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             None
         };
 
-        // Save the new function
-        self.translated.fun_decls.insert(
+        Ok(FunDecl {
             def_id,
-            FunDecl {
-                def_id,
-                rust_id,
-                item_meta,
-                is_local: rust_id.is_local(),
-                name,
-                signature,
-                kind,
-                body,
-            },
-        );
-
-        Ok(())
+            rust_id,
+            item_meta,
+            is_local: rust_id.is_local(),
+            name,
+            signature,
+            kind,
+            body,
+        })
     }
 
     /// Translate one global.
-    pub(crate) fn translate_global(
-        &mut self,
-        decl_id: GlobalDeclId,
-        rust_id: DefId,
-    ) -> Result<(), Error> {
-        self.translate_global_aux(decl_id, rust_id)
-    }
-
-    /// Auxliary helper to properly handle errors, see [translate_global].
-    pub fn translate_global_aux(
+    pub fn translate_global(
         &mut self,
         def_id: GlobalDeclId,
         rust_id: DefId,
-    ) -> Result<(), Error> {
+    ) -> Result<GlobalDecl, Error> {
         trace!("About to translate global:\n{:?}", rust_id);
         let span = self.tcx.def_span(rust_id);
 
@@ -1921,23 +1897,17 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             Err(_) => None,
         };
 
-        // Save the new global
-        self.translated.global_decls.insert(
+        Ok(GlobalDecl {
             def_id,
-            GlobalDecl {
-                def_id,
-                rust_id,
-                item_meta,
-                is_local: rust_id.is_local(),
-                name,
-                generics,
-                preds,
-                ty,
-                kind,
-                body,
-            },
-        );
-
-        Ok(())
+            rust_id,
+            item_meta,
+            is_local: rust_id.is_local(),
+            name,
+            generics,
+            preds,
+            ty,
+            kind,
+            body,
+        })
     }
 }

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -235,22 +235,21 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         Ok(TraitItemName(name.to_string()))
     }
 
-    pub(crate) fn translate_trait_decl(&mut self, rust_id: DefId) -> Result<(), Error> {
-        self.translate_trait_decl_aux(rust_id)
+    pub(crate) fn translate_trait_decl(
+        &mut self,
+        def_id: TraitDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
+        self.translate_trait_decl_aux(def_id, rust_id)
     }
 
     /// Auxliary helper to properly handle errors, see [translate_trait_decl].
-    fn translate_trait_decl_aux(&mut self, rust_id: DefId) -> Result<(), Error> {
+    fn translate_trait_decl_aux(
+        &mut self,
+        def_id: TraitDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
         trace!("About to translate trait decl:\n{:?}", rust_id);
-
-        let def_id = self.register_trait_decl_id(&None, rust_id)?;
-        // We may need to ignore the trait (happens if the trait is a marker
-        // trait like [core::marker::Sized]
-        if def_id.is_none() {
-            return Ok(());
-        }
-        let def_id = def_id.unwrap();
-
         trace!("Trait decl id:\n{:?}", def_id);
 
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
@@ -421,20 +420,21 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         Ok(())
     }
 
-    pub(crate) fn translate_trait_impl(&mut self, rust_id: DefId) -> Result<(), Error> {
-        self.translate_trait_impl_aux(rust_id)
+    pub(crate) fn translate_trait_impl(
+        &mut self,
+        def_id: TraitImplId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
+        self.translate_trait_impl_aux(def_id, rust_id)
     }
 
     /// Auxliary helper to properly handle errors, see [translate_impl_decl].
-    fn translate_trait_impl_aux(&mut self, rust_id: DefId) -> Result<(), Error> {
+    fn translate_trait_impl_aux(
+        &mut self,
+        def_id: TraitImplId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
         trace!("About to translate trait impl:\n{:?}", rust_id);
-
-        let def_id = self.register_trait_impl_id(&None, rust_id)?;
-        // We may need to ignore the trait
-        if def_id.is_none() {
-            return Ok(());
-        }
-        let def_id = def_id.unwrap();
         trace!("Trait impl id:\n{:?}", def_id);
 
         let tcx = self.tcx;

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -235,20 +235,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         Ok(TraitItemName(name.to_string()))
     }
 
-    pub(crate) fn translate_trait_decl(
+    pub fn translate_trait_decl(
         &mut self,
         def_id: TraitDeclId,
         rust_id: DefId,
-    ) -> Result<(), Error> {
-        self.translate_trait_decl_aux(def_id, rust_id)
-    }
-
-    /// Auxliary helper to properly handle errors, see [translate_trait_decl].
-    fn translate_trait_decl_aux(
-        &mut self,
-        def_id: TraitDeclId,
-        rust_id: DefId,
-    ) -> Result<(), Error> {
+    ) -> Result<TraitDecl, Error> {
         trace!("About to translate trait decl:\n{:?}", rust_id);
         trace!("Trait decl id:\n{:?}", def_id);
 
@@ -402,7 +393,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // In case of a trait implementation, some values may not have been
         // provided, in case the declaration provided default values. We
         // check those, and lookup the relevant values.
-        let trait_decl = ast::TraitDecl {
+        Ok(ast::TraitDecl {
             def_id,
             is_local: rust_id.is_local(),
             name,
@@ -414,26 +405,14 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             types,
             required_methods,
             provided_methods,
-        };
-        self.translated.trait_decls.insert(def_id, trait_decl);
-
-        Ok(())
+        })
     }
 
-    pub(crate) fn translate_trait_impl(
+    pub fn translate_trait_impl(
         &mut self,
         def_id: TraitImplId,
         rust_id: DefId,
-    ) -> Result<(), Error> {
-        self.translate_trait_impl_aux(def_id, rust_id)
-    }
-
-    /// Auxliary helper to properly handle errors, see [translate_impl_decl].
-    fn translate_trait_impl_aux(
-        &mut self,
-        def_id: TraitImplId,
-        rust_id: DefId,
-    ) -> Result<(), Error> {
+    ) -> Result<TraitImpl, Error> {
         trace!("About to translate trait impl:\n{:?}", rust_id);
         trace!("Trait impl id:\n{:?}", def_id);
 
@@ -616,7 +595,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
         }
 
-        let trait_impl = ast::TraitImpl {
+        Ok(ast::TraitImpl {
             def_id,
             is_local: rust_id.is_local(),
             name,
@@ -629,9 +608,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             types,
             required_methods,
             provided_methods,
-        };
-        self.translated.trait_impls.insert(def_id, trait_impl);
-
-        Ok(())
+        })
     }
 }

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -710,16 +710,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Note that we translate the types one by one: we don't need to take into
     /// account the fact that some types are mutually recursive at this point
     /// (we will need to take that into account when generating the code in a file).
-    pub(crate) fn translate_type(
+    pub fn translate_type(
         &mut self,
         trans_id: TypeDeclId,
         rust_id: DefId,
-    ) -> Result<(), Error> {
-        self.translate_type_aux(trans_id, rust_id)
-    }
-
-    /// Auxliary helper to properly handle errors, see [translate_type].
-    fn translate_type_aux(&mut self, trans_id: TypeDeclId, rust_id: DefId) -> Result<(), Error> {
+    ) -> Result<TypeDecl, Error> {
         let is_transparent = self.id_is_transparent(rust_id)?;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
@@ -770,8 +765,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             type_def.fmt_with_ctx(&self.into_fmt())
         );
 
-        self.translated.type_decls.insert(trans_id, type_def);
-
-        Ok(())
+        Ok(type_def)
     }
 }

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -710,13 +710,16 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Note that we translate the types one by one: we don't need to take into
     /// account the fact that some types are mutually recursive at this point
     /// (we will need to take that into account when generating the code in a file).
-    pub(crate) fn translate_type(&mut self, rust_id: DefId) -> Result<(), Error> {
-        self.translate_type_aux(rust_id)
+    pub(crate) fn translate_type(
+        &mut self,
+        trans_id: TypeDeclId,
+        rust_id: DefId,
+    ) -> Result<(), Error> {
+        self.translate_type_aux(trans_id, rust_id)
     }
 
     /// Auxliary helper to properly handle errors, see [translate_type].
-    fn translate_type_aux(&mut self, rust_id: DefId) -> Result<(), Error> {
-        let trans_id = self.register_type_decl_id(&None, rust_id);
+    fn translate_type_aux(&mut self, trans_id: TypeDeclId, rust_id: DefId) -> Result<(), Error> {
         let is_transparent = self.id_is_transparent(rust_id)?;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 


### PR DESCRIPTION
Before this, the various `translate_*` functions registered the `DefId` they got passed, but this id must already be registered if we're trying to translate this item. This PR keeps around the `TransId` to avoid this redundancy.

Moreover, I try to avoid mixing computation and side-effects, so the `translate_*` functions no longer store the newly constructed item by themselves. Instead they return the item and some other function stores it.