### PR TITLE
Grow stack in deep recursions

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "snapbox",
+ "stacker",
  "take_mut",
  "tempfile",
  "toml",
@@ -924,6 +925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1249,19 @@ name = "snapbox-macros"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c4b838b05d15ab22754068cb73500b2f3b07bf09d310e15b27f88160f1de40"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -45,6 +45,7 @@ rustc_version = "0.2"
 serde_json = "1.0.91"
 serde = { version = "1.0.152", features = ["derive"] }
 serial_test = "0.5.1"
+stacker = "0.1"
 take_mut = "0.2.2"
 toml = { version = "0.8", features = ["parse"] }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "fmt" ] }

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -1,5 +1,6 @@
 //! Implementations for [crate::llbc_ast]
 
+use crate::common::ensure_sufficient_stack;
 use crate::expressions::{MutExprVisitor, Operand, Place, Rvalue};
 use crate::llbc_ast::{Assert, RawStatement, Statement, Switch};
 use crate::meta;
@@ -132,7 +133,9 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
 
     fn default_visit_statement(&mut self, st: &Statement) {
         self.visit_span(&st.span);
-        self.visit_raw_statement(&st.content)
+        ensure_sufficient_stack(|| {
+            self.visit_raw_statement(&st.content)
+        })
     }
 
     fn visit_statement(&mut self, st: &Statement) {

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -20,6 +20,7 @@
 //! only be performed by terminators -, meaning that MIR graphs don't have that
 //! many nodes and edges).
 
+use crate::common::ensure_sufficient_stack;
 use crate::expressions::Place;
 use crate::formatter::{Formatter, IntoFormatter};
 use crate::llbc_ast as tgt;
@@ -1506,7 +1507,9 @@ fn translate_child_block(
         GotoKind::ExitBlock => None,
         GotoKind::Goto => {
             // "Standard" goto: just recursively translate
-            translate_block(info, parent_loops, switch_exit_blocks, child_id)
+            ensure_sufficient_stack(|| {
+                translate_block(info, parent_loops, switch_exit_blocks, child_id)
+            })
         }
     }
 }
@@ -1864,7 +1867,9 @@ fn translate_block(
 
         // Add the exit block
         if let Some(exit_block_id) = next_block {
-            let next_exp = translate_block(info, parent_loops, switch_exit_blocks, exit_block_id);
+            let next_exp = ensure_sufficient_stack(|| {
+                translate_block(info, parent_loops, switch_exit_blocks, exit_block_id)
+            });
             combine_expressions(Some(exp), next_exp)
         } else {
             Some(exp)
@@ -1880,7 +1885,9 @@ fn translate_block(
             // doesn't end with `panic`, `return`, etc.).
             assert!(!is_terminal(&exp));
 
-            let next_exp = translate_block(info, parent_loops, switch_exit_blocks, exit_block_id);
+            let next_exp = ensure_sufficient_stack(|| {
+                translate_block(info, parent_loops, switch_exit_blocks, exit_block_id)
+            });
             combine_expressions(Some(exp), next_exp)
         } else {
             Some(exp)


### PR DESCRIPTION
We use recursion freely in charon, which can lead to stack overflows when analyzing complex code. This PR uses `stacker` to grow the stack as needed, mimicking what rustc does to solve the same problem. This is not a complete solution: any deep recursion should be manually broken with `ensure_sufficient_stack` and there are likely others in `charon`. This fixes the stack overflow I found on libcrux though.

Fixes #225 