### PR TITLE
Globally index function and global bodies

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.7"
+let supported_charon_version = "0.1.8"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1130,7 +1130,7 @@ let gfun_decl_of_json (bodies : 'body gexpr_body option list)
           }
     | _ -> Error "")
 
-let gglobal_decl_of_json (body_of_json : json -> ('body, string) result)
+let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) :
     ('body gexpr_body option gglobal_decl, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1154,10 +1154,9 @@ let gglobal_decl_of_json (body_of_json : json -> ('body, string) result)
         let* generics = generic_params_of_json id_to_file generics in
         let* preds = predicates_of_json preds in
         let* ty = ty_of_json ty in
-        let* body =
-          option_of_json (gexpr_body_of_json body_of_json id_to_file) body
-        in
         let* kind = item_kind_of_json kind in
+        let* body_id = BodyId.id_of_json body in
+        let body = List.nth bodies (BodyId.to_int body_id) in
         let global =
           {
             def_id = global_id;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1094,6 +1094,17 @@ let item_kind_of_json (js : json) : (item_kind, string) result =
         Ok (TraitItemProvided (trait_id, item_name))
     | _ -> Error "")
 
+let maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
+    (js : json) : ('body gexpr_body option, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Ok", body) ] ->
+        let* body_id = BodyId.id_of_json body in
+        let body = List.nth bodies (BodyId.to_int body_id) in
+        Ok body
+    | `Assoc [ ("Err", `Null) ] -> Ok None
+    | _ -> Error "")
+
 let gfun_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) : ('body gfun_decl, string) result
     =
@@ -1115,8 +1126,7 @@ let gfun_decl_of_json (bodies : 'body gexpr_body option list)
         let* name = name_of_json id_to_file name in
         let* signature = fun_sig_of_json id_to_file signature in
         let* kind = item_kind_of_json kind in
-        let* body_id = BodyId.id_of_json body in
-        let body = List.nth bodies (BodyId.to_int body_id) in
+        let* body = maybe_opaque_body_of_json bodies body in
         Ok
           {
             def_id;
@@ -1155,8 +1165,7 @@ let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
         let* preds = predicates_of_json preds in
         let* ty = ty_of_json ty in
         let* kind = item_kind_of_json kind in
-        let* body_id = BodyId.id_of_json body in
-        let body = List.nth bodies (BodyId.to_int body_id) in
+        let* body = maybe_opaque_body_of_json bodies body in
         let global =
           {
             def_id = global_id;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1094,7 +1094,7 @@ let item_kind_of_json (js : json) : (item_kind, string) result =
         Ok (TraitItemProvided (trait_id, item_name))
     | _ -> Error "")
 
-let gfun_decl_of_json (body_of_json : json -> ('body, string) result)
+let gfun_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) : ('body gfun_decl, string) result
     =
   combine_error_msgs js __FUNCTION__
@@ -1115,9 +1115,8 @@ let gfun_decl_of_json (body_of_json : json -> ('body, string) result)
         let* name = name_of_json id_to_file name in
         let* signature = fun_sig_of_json id_to_file signature in
         let* kind = item_kind_of_json kind in
-        let* body =
-          option_of_json (gexpr_body_of_json body_of_json id_to_file) body
-        in
+        let* body_id = BodyId.id_of_json body in
+        let body = List.nth bodies (BodyId.to_int body_id) in
         Ok
           {
             def_id;

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -69,7 +69,8 @@ and switch =
         concrete = true;
       }]
 
-type fun_body = statement gexpr_body [@@deriving show]
+type expr_body = statement gexpr_body [@@deriving show]
+type fun_body = expr_body [@@deriving show]
 type fun_decl = statement gfun_decl [@@deriving show]
 
 (* TODO: the function id should be an option *)

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -111,10 +111,16 @@ and switch_of_json (id_to_file : id_to_file_map) (js : json) :
         Ok (Match (p, tgts, otherwise))
     | _ -> Error "")
 
-let fun_decl_of_json (id_to_file : id_to_file_map) (js : json) :
-    (fun_decl, string) result =
+let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
+    (expr_body, string) result =
   combine_error_msgs js __FUNCTION__
-    (gfun_decl_of_json (statement_of_json id_to_file) id_to_file js)
+    (match js with
+    | `Assoc [ ("Structured", body) ] ->
+        let* body =
+          gexpr_body_of_json (statement_of_json id_to_file) id_to_file body
+        in
+        Ok body
+    | _ -> Error "")
 
 (** Strict type for the number of function declarations (see {!global_to_fun_id} below) *)
 type global_id_converter = { fun_count : int } [@@deriving show]
@@ -203,6 +209,7 @@ let crate_of_json (js : json) : (crate, string) result =
         ("types", types);
         ("functions", functions);
         ("globals", globals);
+        ("bodies", bodies);
         ("trait_decls", trait_decls);
         ("trait_impls", trait_impls);
       ] ->
@@ -226,8 +233,11 @@ let crate_of_json (js : json) : (crate, string) result =
              list_of_json declaration_group_of_json declarations
            in
            let* types = list_of_json (type_decl_of_json id_to_file) types in
+           let* bodies =
+             list_of_json (option_of_json (expr_body_of_json id_to_file)) bodies
+           in
            let* functions =
-             list_of_json (fun_decl_of_json id_to_file) functions
+             list_of_json (gfun_decl_of_json bodies id_to_file) functions
            in
            (* When deserializing the globals, we split the global declarations
             * between the globals themselves and their bodies, which are simply

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -136,13 +136,12 @@ let global_to_fun_id (conv : global_id_converter) (gid : GlobalDeclId.id) :
 (** Deserialize a global declaration, and decompose it into a global declaration
     and a function declaration.
  *)
-let global_decl_of_json (id_to_file : id_to_file_map) (js : json)
-    (gid_conv : global_id_converter) : (global_decl * fun_decl, string) result =
+let global_decl_of_json (bodies : expr_body option list)
+    (id_to_file : id_to_file_map) (js : json) (gid_conv : global_id_converter) :
+    (global_decl * fun_decl, string) result =
   combine_error_msgs js __FUNCTION__
     ((* Deserialize the global declaration *)
-     let* global =
-       gglobal_decl_of_json (statement_of_json id_to_file) id_to_file js
-     in
+     let* global = gglobal_decl_of_json bodies id_to_file js in
      let {
        def_id = global_id;
        item_meta;
@@ -247,7 +246,7 @@ let crate_of_json (js : json) : (crate, string) result =
            let gid_conv = { fun_count = List.length functions } in
            let* globals =
              list_of_json
-               (fun js -> global_decl_of_json id_to_file js gid_conv)
+               (fun js -> global_decl_of_json bodies id_to_file js gid_conv)
                globals
            in
            let globals, global_bodies = List.split globals in

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -15,6 +15,7 @@ module RegionId = IdGen ()
 module RegionGroupId = IdGen ()
 module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
+module BodyId = IdGen ()
 
 (** We define this type to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -127,11 +127,6 @@ let blocks_of_json (id_to_file : id_to_file_map) (js : json) :
   combine_error_msgs js __FUNCTION__
     (list_of_json (block_of_json id_to_file) js)
 
-let global_decl_of_json (id_to_file : id_to_file_map) (js : json) :
-    (global_decl, string) result =
-  combine_error_msgs js __FUNCTION__
-    (gglobal_decl_of_json (blocks_of_json id_to_file) id_to_file js)
-
 let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
     (expr_body, string) result =
   combine_error_msgs js __FUNCTION__
@@ -183,7 +178,7 @@ let crate_of_json (js : json) : (crate, string) result =
              list_of_json (gfun_decl_of_json bodies id_to_file) functions
            in
            let* globals =
-             list_of_json (global_decl_of_json id_to_file) globals
+             list_of_json (gglobal_decl_of_json bodies id_to_file) globals
            in
            let* trait_decls =
              list_of_json (trait_decl_of_json id_to_file) trait_decls

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -135,9 +135,9 @@ pub struct FunDecl {
     pub body: BodyId,
 }
 
-/// A global variable definition, either opaque or transparent.
+/// A global variable definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GGlobalDecl<T> {
+pub struct GlobalDecl {
     pub def_id: GlobalDeclId,
     #[serde(skip)]
     #[serde(default = "dummy_def_id")]
@@ -153,7 +153,7 @@ pub struct GGlobalDecl<T> {
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
     pub kind: ItemKind,
-    pub body: Option<GExprBody<T>>,
+    pub body: BodyId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -41,6 +41,10 @@ pub struct Var {
     pub ty: Ty,
 }
 
+/// Marker to indicate that a declaration is opaque (i.e. we don't inspect its body).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Opaque;
+
 /// An expression body.
 /// TODO: arg_count should be stored in GFunDecl below. But then,
 ///       the print is obfuscated and Aeneas may need some refactoring.
@@ -129,10 +133,10 @@ pub struct FunDecl {
     pub signature: FunSig,
     /// The function kind: "regular" function, trait method declaration, etc.
     pub kind: ItemKind,
-    /// The function body, in case the function is not opaque.
+    /// The function body, unless the function is opaque.
     /// Opaque functions are: external functions, or local functions tagged
     /// as opaque.
-    pub body: BodyId,
+    pub body: Result<BodyId, Opaque>,
 }
 
 /// A global variable definition
@@ -153,7 +157,7 @@ pub struct GlobalDecl {
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
     pub kind: ItemKind,
-    pub body: BodyId,
+    pub body: Result<BodyId, Opaque>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -2,7 +2,9 @@
 
 use crate::gast::*;
 use crate::ids::Vector;
+use crate::llbc_ast;
 use crate::types::*;
+use crate::ullbc_ast;
 use crate::values::*;
 
 /// Makes a lambda that generates a new variable id, pushes a new variable in
@@ -20,5 +22,37 @@ pub fn make_locals_generator(locals: &mut Vector<VarId, Var>) -> impl FnMut(Ty) 
 impl FunIdOrTraitMethodRef {
     pub(crate) fn mk_assumed(aid: AssumedFunId) -> Self {
         Self::Fun(FunId::Assumed(aid))
+    }
+}
+
+impl Body {
+    pub fn as_unstructured(&self) -> Option<&ullbc_ast::ExprBody> {
+        if let Self::Unstructured(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+    pub fn as_unstructured_mut(&mut self) -> Option<&mut ullbc_ast::ExprBody> {
+        if let Self::Unstructured(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_structured(&self) -> Option<&llbc_ast::ExprBody> {
+        if let Self::Structured(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+    pub fn as_structured_mut(&mut self) -> Option<&mut llbc_ast::ExprBody> {
+        if let Self::Structured(v) = self {
+            Some(v)
+        } else {
+            None
+        }
     }
 }

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -114,10 +114,8 @@ pub enum Switch {
     ),
 }
 
-pub type ExprBody = GExprBody<Statement>;
+pub type BodyContents = Statement;
+pub type ExprBody = GExprBody<BodyContents>;
 
-pub type FunDecl = GFunDecl<Statement>;
-pub type FunDecls = Vector<FunDeclId, FunDecl>;
-
-pub type GlobalDecl = GGlobalDecl<Statement>;
+pub type GlobalDecl = GGlobalDecl<BodyContents>;
 pub type GlobalDecls = Vector<GlobalDeclId, GlobalDecl>;

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -7,7 +7,6 @@
 //! from MIR to use Statement only.
 
 pub use crate::gast::*;
-use crate::ids::Vector;
 pub use crate::llbc_ast_utils::*;
 use crate::meta::Span;
 use crate::types::*;
@@ -116,6 +115,3 @@ pub enum Switch {
 
 pub type BodyContents = Statement;
 pub type ExprBody = GExprBody<BodyContents>;
-
-pub type GlobalDecl = GGlobalDecl<BodyContents>;
-pub type GlobalDecls = Vector<GlobalDeclId, GlobalDecl>;

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -16,12 +16,10 @@ generate_index_type!(BlockId, "Block");
 // The entry block of a function is always the block with id 0
 pub static START_BLOCK_ID: BlockId = BlockId::ZERO;
 
-pub type ExprBody = GExprBody<Vector<BlockId, BlockData>>;
+pub type BodyContents = Vector<BlockId, BlockData>;
+pub type ExprBody = GExprBody<BodyContents>;
 
-pub type FunDecl = GFunDecl<Vector<BlockId, BlockData>>;
-pub type FunDecls = Vector<FunDeclId, FunDecl>;
-
-pub type GlobalDecl = GGlobalDecl<Vector<BlockId, BlockData>>;
+pub type GlobalDecl = GGlobalDecl<BodyContents>;
 pub type GlobalDecls = Vector<GlobalDeclId, GlobalDecl>;
 
 /// A raw statement: a statement without meta data.

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -19,9 +19,6 @@ pub static START_BLOCK_ID: BlockId = BlockId::ZERO;
 pub type BodyContents = Vector<BlockId, BlockData>;
 pub type ExprBody = GExprBody<BodyContents>;
 
-pub type GlobalDecl = GGlobalDecl<BodyContents>;
-pub type GlobalDecls = Vector<GlobalDeclId, GlobalDecl>;
-
 /// A raw statement: a statement without meta data.
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize, Deserialize)]
 pub enum RawStatement {

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -309,7 +309,7 @@ pub fn translate(
         }
 
         trace!("# Final LLBC:\n");
-        for def in &ctx.translated.structured_fun_decls {
+        for def in &ctx.translated.fun_decls {
             trace!("#{}\n", ctx.into_fmt().format_object(def));
         }
 

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 /// stable as possible. This is used for both ULLBC and LLBC.
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "Crate")]
-pub struct GCrateData {
+pub struct CrateData {
     /// The version of charon currently being used. `charon-ml` inspects this and errors if it is
     /// trying to read an incompatible version (for now we compare versions for equality).
     pub charon_version: String,
@@ -35,7 +35,7 @@ pub struct GCrateData {
     pub has_errors: bool,
 }
 
-impl GCrateData {
+impl CrateData {
     pub fn new(ctx: &TransformCtx) -> Self {
         // Transform the map file id -> file into a vector.
         // Sort the vector to make the serialized file as stable as possible.
@@ -54,7 +54,7 @@ impl GCrateData {
         let bodies = ctx.translated.bodies.clone();
         let trait_decls = ctx.translated.trait_decls.iter().cloned().collect();
         let trait_impls = ctx.translated.trait_impls.iter().cloned().collect();
-        GCrateData {
+        CrateData {
             charon_version: crate::VERSION.to_owned(),
             name: ctx.translated.crate_name.clone(),
             id_to_file,
@@ -107,30 +107,5 @@ impl GCrateData {
             info!("Generated the file: {}", target_filename.to_str().unwrap());
         }
         Ok(())
-    }
-}
-
-/// The two kinds of crate data we construct.
-pub enum CrateData {
-    ULLBC(GCrateData),
-    LLBC(GCrateData),
-}
-
-impl CrateData {
-    pub fn new_ullbc(ctx: &TransformCtx) -> Self {
-        Self::ULLBC(GCrateData::new(ctx))
-    }
-
-    pub fn new_llbc(ctx: &TransformCtx) -> Self {
-        Self::LLBC(GCrateData::new(ctx))
-    }
-
-    /// Export the translated definitions to a JSON file.
-    #[allow(clippy::result_unit_err)]
-    pub fn serialize_to_file(&self, dest_file: &Path) -> Result<(), ()> {
-        match self {
-            CrateData::ULLBC(crate_data) => crate_data.serialize_to_file(dest_file),
-            CrateData::LLBC(crate_data) => crate_data.serialize_to_file(dest_file),
-        }
     }
 }

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -40,6 +40,10 @@ where
         self.vector.get(i).map(Option::as_ref).flatten()
     }
 
+    pub fn get_mut(&mut self, i: I) -> Option<&mut T> {
+        self.vector.get_mut(i).map(Option::as_mut).flatten()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.vector.is_empty()
     }
@@ -106,6 +110,10 @@ where
     }
 
     /// Iterate over all slots, even empty ones.
+    pub fn iter_all_slots(&self) -> impl Iterator<Item = &Option<T>> {
+        self.vector.iter()
+    }
+
     pub fn iter_indexed_all_slots(&self) -> impl Iterator<Item = (I, &Option<T>)> {
         self.vector.iter_enumerated()
     }
@@ -157,7 +165,19 @@ where
     type IntoIter = impl Iterator<Item = &'a T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.vector).into_iter().flat_map(|opt| opt.as_ref())
+        self.vector.iter().flat_map(|opt| opt.as_ref())
+    }
+}
+
+impl<'a, I, T> IntoIterator for &'a mut Vector<I, T>
+where
+    I: Idx,
+{
+    type Item = &'a mut T;
+    type IntoIter = impl Iterator<Item = &'a mut T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vector.iter_mut().flat_map(|opt| opt.as_mut())
     }
 }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -474,12 +474,17 @@ where
         );
 
         // Body
-        // FIXME: pass the indent here somehow
-        let body = ctx.format_object(self.body);
-        let body = if body == "<opaque>" {
-            String::new()
-        } else {
-            format!("\n{tab}{{\n{body}\n{tab}}}")
+        let body = match self.body {
+            Ok(body_id) => {
+                // FIXME: pass the indent here somehow
+                let body = ctx.format_object(body_id);
+                if body == "<error>" {
+                    String::new()
+                } else {
+                    format!("\n{tab}{{\n{body}\n{tab}}}")
+                }
+            }
+            Err(Opaque) => String::new(),
         };
 
         // Put everything together
@@ -513,12 +518,17 @@ where
         let name = self.name.fmt_with_ctx(ctx);
 
         // Body
-        // FIXME: pass the indent here somehow
-        let body = ctx.format_object(self.body);
-        let body = if body == "<opaque>" {
-            String::new()
-        } else {
-            format!(" {{\n{body}\n{tab}}}")
+        let body = match self.body {
+            Ok(body_id) => {
+                // FIXME: pass the indent here somehow
+                let body = ctx.format_object(body_id);
+                if body == "<error>" {
+                    String::new()
+                } else {
+                    format!(" {{\n{body}\n{tab}}}")
+                }
+            }
+            Err(Opaque) => String::new(),
         };
 
         // Put everything together

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -261,9 +261,9 @@ impl<'a> Formatter<ast::FunDeclId> for FmtCtx<'a> {
 impl<'a> Formatter<BodyId> for FmtCtx<'a> {
     fn format_object(&self, id: BodyId) -> String {
         match &self.translated {
-            None => "<opaque>".to_owned(),
+            None => "<error>".to_owned(),
             Some(translated) => match translated.bodies.get(id) {
-                None => "<opaque>".to_owned(),
+                None => "<error>".to_owned(),
                 Some(d) => d.fmt_with_ctx(self),
             },
         }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -171,6 +171,7 @@ pub trait AstFormatter = Formatter<TypeVarId>
     + Formatter<ConstGenericVarId>
     + Formatter<FunDeclId>
     + Formatter<GlobalDeclId>
+    + Formatter<BodyId>
     + Formatter<TraitDeclId>
     + Formatter<TraitImplId>
     + Formatter<TraitClauseId>
@@ -252,6 +253,18 @@ impl<'a> Formatter<ast::FunDeclId> for FmtCtx<'a> {
             Some(translated) => match translated.fun_decls.get(id) {
                 None => id.to_pretty_string(),
                 Some(d) => d.name.fmt_with_ctx(self),
+            },
+        }
+    }
+}
+
+impl<'a> Formatter<BodyId> for FmtCtx<'a> {
+    fn format_object(&self, id: BodyId) -> String {
+        match &self.translated {
+            None => "<opaque>".to_owned(),
+            Some(translated) => match translated.bodies.get(id) {
+                None => "<opaque>".to_owned(),
+                Some(d) => d.fmt_with_ctx(self),
             },
         }
     }
@@ -480,13 +493,7 @@ impl<'a> Formatter<&llbc_ast::ExprBody> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<&ullbc_ast::FunDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &ullbc_ast::FunDecl) -> String {
-        def.fmt_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&llbc_ast::FunDecl> for FmtCtx<'a> {
+impl<'a> Formatter<&gast::FunDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &llbc_ast::FunDecl) -> String {
         def.fmt_with_ctx(self)
     }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -469,18 +469,6 @@ impl<'a> Formatter<&TypeDecl> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<&ullbc_ast::GlobalDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &ullbc_ast::GlobalDecl) -> String {
-        def.fmt_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&llbc_ast::GlobalDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &llbc_ast::GlobalDecl) -> String {
-        def.fmt_with_ctx(self)
-    }
-}
-
 impl<'a> Formatter<&ullbc_ast::ExprBody> for FmtCtx<'a> {
     fn format_object(&self, body: &ullbc_ast::ExprBody) -> String {
         body.fmt_with_ctx(self)
@@ -495,6 +483,12 @@ impl<'a> Formatter<&llbc_ast::ExprBody> for FmtCtx<'a> {
 
 impl<'a> Formatter<&gast::FunDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &llbc_ast::FunDecl) -> String {
+        def.fmt_with_ctx(self)
+    }
+}
+
+impl<'a> Formatter<&gast::GlobalDecl> for FmtCtx<'a> {
+    fn format_object(&self, def: &llbc_ast::GlobalDecl) -> String {
         def.fmt_with_ctx(self)
     }
 }

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -1,11 +1,10 @@
 use crate::formatter::{FmtCtx, IntoFormatter};
-use crate::gast::{Body, BodyId, FunDecl, FunDeclId};
+use crate::gast::{Body, BodyId, FunDecl, FunDeclId, GlobalDecl, GlobalDeclId};
 use crate::ids::Vector;
 use crate::llbc_ast;
 use crate::names::Name;
 use crate::pretty::FmtWithCtx;
 use crate::translate_ctx::{ErrorCtx, TransOptions, TranslatedCrate};
-use crate::ullbc_ast as ast;
 use crate::ullbc_ast;
 use rustc_error_messages::MultiSpan;
 use rustc_hir::def_id::DefId;
@@ -36,7 +35,7 @@ pub trait UllbcPass: Sync {
     fn transform_function(
         &self,
         ctx: &mut TransformCtx<'_>,
-        _decl: &mut ullbc_ast::FunDecl,
+        _decl: &mut FunDecl,
         body: Option<&mut ullbc_ast::ExprBody>,
     ) {
         if let Some(body) = body {
@@ -45,8 +44,15 @@ pub trait UllbcPass: Sync {
     }
 
     /// Transform a global declaration. This forwards to `transform_body` by default.
-    fn transform_global(&self, ctx: &mut TransformCtx<'_>, decl: &mut ullbc_ast::GlobalDecl) {
-        self.transform_body(ctx, decl.body.as_mut().unwrap())
+    fn transform_global(
+        &self,
+        ctx: &mut TransformCtx<'_>,
+        _decl: &mut GlobalDecl,
+        body: Option<&mut ullbc_ast::ExprBody>,
+    ) {
+        if let Some(body) = body {
+            self.transform_body(ctx, body)
+        }
     }
 
     /// The name of the pass, used for debug logging. The default implementation uses the type
@@ -86,7 +92,7 @@ pub trait LlbcPass: Sync {
     fn transform_function(
         &self,
         ctx: &mut TransformCtx<'_>,
-        _decl: &mut llbc_ast::FunDecl,
+        _decl: &mut FunDecl,
         body: Option<&mut llbc_ast::ExprBody>,
     ) {
         if let Some(body) = body {
@@ -95,8 +101,15 @@ pub trait LlbcPass: Sync {
     }
 
     /// Transform a global declaration. This forwards to `transform_body` by default.
-    fn transform_global(&self, ctx: &mut TransformCtx<'_>, decl: &mut llbc_ast::GlobalDecl) {
-        self.transform_body(ctx, decl.body.as_mut().unwrap())
+    fn transform_global(
+        &self,
+        ctx: &mut TransformCtx<'_>,
+        _decl: &mut GlobalDecl,
+        body: Option<&mut llbc_ast::ExprBody>,
+    ) {
+        if let Some(body) = body {
+            self.transform_body(ctx, body)
+        }
     }
 
     /// The name of the pass, used for debug logging. The default implementation uses the type
@@ -142,15 +155,14 @@ impl TransformPass for dyn UllbcPass {
                         })
                     }
                 });
-                ctx.with_mut_unstructured_global_decls(|ctx, global_decls| {
+                ctx.with_mut_global_decls(|ctx, global_decls| {
                     for decl in global_decls.iter_mut() {
-                        let body = &decl.body;
-                        self.log_before_body(ctx, &decl.name, body.as_ref());
-                        if let Some(_body) = body {
-                            ctx.with_def_id(decl.rust_id, |ctx| {
-                                self.transform_global(ctx, decl);
-                            })
-                        }
+                        let body = bodies.get_mut(decl.body);
+                        let body = body.map(|b| b.as_unstructured_mut()).flatten();
+                        self.log_before_body(ctx, &decl.name, body.as_deref());
+                        ctx.with_def_id(decl.rust_id, |ctx| {
+                            self.transform_global(ctx, decl, body);
+                        })
                     }
                 });
             },
@@ -173,15 +185,14 @@ impl TransformPass for dyn LlbcPass {
                         })
                     }
                 });
-                ctx.with_mut_structured_global_decls(|ctx, global_decls| {
+                ctx.with_mut_global_decls(|ctx, global_decls| {
                     for decl in global_decls.iter_mut() {
-                        let body = &decl.body;
-                        self.log_before_body(ctx, &decl.name, body.as_ref());
-                        if let Some(_body) = body {
-                            ctx.with_def_id(decl.rust_id, |ctx| {
-                                self.transform_global(ctx, decl);
-                            })
-                        }
+                        let body = bodies.get_mut(decl.body);
+                        let body = body.map(|b| b.as_structured_mut()).flatten();
+                        self.log_before_body(ctx, &decl.name, body.as_deref());
+                        ctx.with_def_id(decl.rust_id, |ctx| {
+                            self.transform_global(ctx, decl, body);
+                        })
                     }
                 });
             },
@@ -234,23 +245,13 @@ impl<'ctx> TransformCtx<'ctx> {
         ret
     }
     /// Get mutable access to both the ctx and the global declarations.
-    pub(crate) fn with_mut_unstructured_global_decls<R>(
+    pub(crate) fn with_mut_global_decls<R>(
         &mut self,
-        f: impl FnOnce(&mut Self, &mut ast::GlobalDecls) -> R,
+        f: impl FnOnce(&mut Self, &mut Vector<GlobalDeclId, GlobalDecl>) -> R,
     ) -> R {
         let mut global_decls = std::mem::take(&mut self.translated.global_decls);
         let ret = f(self, &mut global_decls);
         self.translated.global_decls = global_decls;
-        ret
-    }
-    /// Get mutable access to both the ctx and the global declarations.
-    pub(crate) fn with_mut_structured_global_decls<R>(
-        &mut self,
-        f: impl FnOnce(&mut Self, &mut llbc_ast::GlobalDecls) -> R,
-    ) -> R {
-        let mut global_decls = std::mem::take(&mut self.translated.structured_global_decls);
-        let ret = f(self, &mut global_decls);
-        self.translated.structured_global_decls = global_decls;
         ret
     }
 }
@@ -265,6 +266,6 @@ impl<'a> IntoFormatter for &'a TransformCtx<'_> {
 
 impl fmt::Display for TransformCtx<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.translated.fmt_with_ullbc_defs(f)
+        self.translated.fmt(f)
     }
 }

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -31,9 +31,16 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
 
 pub struct Transform;
 impl LlbcPass for Transform {
-    fn transform_function(&self, ctx: &mut TransformCtx, decl: &mut FunDecl) {
+    fn transform_function(
+        &self,
+        ctx: &mut TransformCtx,
+        decl: &mut FunDecl,
+        body: Option<&mut ExprBody>,
+    ) {
         if decl.signature.output.is_unit() {
-            self.transform_body(ctx, decl.body.as_mut().unwrap())
+            if let Some(body) = body {
+                self.transform_body(ctx, body)
+            }
         }
     }
     fn transform_global(&self, ctx: &mut TransformCtx, decl: &mut GlobalDecl) {

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -43,9 +43,16 @@ impl LlbcPass for Transform {
             }
         }
     }
-    fn transform_global(&self, ctx: &mut TransformCtx, decl: &mut GlobalDecl) {
+    fn transform_global(
+        &self,
+        ctx: &mut TransformCtx,
+        decl: &mut GlobalDecl,
+        body: Option<&mut ExprBody>,
+    ) {
         if decl.ty.is_unit() {
-            self.transform_body(ctx, decl.body.as_mut().unwrap())
+            if let Some(body) = body {
+                self.transform_body(ctx, body)
+            }
         }
     }
     fn transform_body(&self, _ctx: &mut TransformCtx<'_>, body: &mut ExprBody) {

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -5,7 +5,7 @@
 //! an extra assignment just before returning.
 
 use crate::expressions::*;
-use crate::llbc_ast::{ExprBody, FunDecl, GlobalDecl, RawStatement, Statement};
+use crate::llbc_ast::{ExprBody, FunDecl, GlobalDecl, Opaque, RawStatement, Statement};
 use crate::transform::TransformCtx;
 use crate::types::*;
 use crate::values::*;
@@ -35,10 +35,10 @@ impl LlbcPass for Transform {
         &self,
         ctx: &mut TransformCtx,
         decl: &mut FunDecl,
-        body: Option<&mut ExprBody>,
+        body: Result<&mut ExprBody, Opaque>,
     ) {
         if decl.signature.output.is_unit() {
-            if let Some(body) = body {
+            if let Ok(body) = body {
                 self.transform_body(ctx, body)
             }
         }
@@ -47,10 +47,10 @@ impl LlbcPass for Transform {
         &self,
         ctx: &mut TransformCtx,
         decl: &mut GlobalDecl,
-        body: Option<&mut ExprBody>,
+        body: Result<&mut ExprBody, Opaque>,
     ) {
         if decl.ty.is_unit() {
-            if let Some(body) = body {
+            if let Ok(body) = body {
                 self.transform_body(ctx, body)
             }
         }

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -326,8 +326,8 @@ impl SharedExprVisitor for Deps {}
 impl SharedAstVisitor for Deps {}
 
 impl Deps {
-    fn visit_body(&mut self, body: Option<&ExprBody>) {
-        if let Some(body) = body {
+    fn visit_body(&mut self, body: Option<&Body>) {
+        if let Some(Body::Unstructured(body)) = body {
             for v in &body.locals {
                 self.visit_ty(&v.ty);
             }
@@ -432,9 +432,8 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> Deps {
                     graph.visit_ty(&sig.output);
 
                     // Explore the body
-                    if let Some(Body::Unstructured(body)) = ctx.translated.bodies.get(d.body) {
-                        graph.visit_body(Some(body));
-                    }
+                    let body = ctx.translated.bodies.get(d.body);
+                    graph.visit_body(body);
                 } else {
                     // There may have been errors
                     assert!(ctx.has_errors());
@@ -443,7 +442,8 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> Deps {
             AnyTransId::Global(id) => {
                 if let Some(d) = ctx.translated.global_decls.get(*id) {
                     // Explore the body
-                    graph.visit_body(d.body.as_ref());
+                    let body = ctx.translated.bodies.get(d.body);
+                    graph.visit_body(body);
                 } else {
                     // There may have been errors
                     assert!(ctx.has_errors());

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -431,9 +431,11 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> Deps {
                     }
                     graph.visit_ty(&sig.output);
 
-                    // Explore the body
-                    let body = ctx.translated.bodies.get(d.body);
-                    graph.visit_body(body);
+                    if let Ok(id) = d.body {
+                        // Explore the body
+                        let body = ctx.translated.bodies.get(id);
+                        graph.visit_body(body);
+                    }
                 } else {
                     // There may have been errors
                     assert!(ctx.has_errors());
@@ -441,9 +443,11 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> Deps {
             }
             AnyTransId::Global(id) => {
                 if let Some(d) = ctx.translated.global_decls.get(*id) {
-                    // Explore the body
-                    let body = ctx.translated.bodies.get(d.body);
-                    graph.visit_body(body);
+                    if let Ok(id) = d.body {
+                        // Explore the body
+                        let body = ctx.translated.bodies.get(id);
+                        graph.visit_body(body);
+                    }
                 } else {
                     // There may have been errors
                     assert!(ctx.has_errors());

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -26,9 +26,8 @@ use crate::formatter::{Formatter, IntoFormatter};
 use crate::gast;
 use crate::llbc_ast as tgt;
 use crate::meta::{combine_span, Span};
-use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
-use crate::ullbc_ast::{self as src, GlobalDeclId};
+use crate::ullbc_ast::{self as src};
 use crate::values as v;
 use hashlink::linked_hash_map::LinkedHashMap;
 use im::Vector;
@@ -1956,47 +1955,11 @@ fn translate_body(no_code_duplication: bool, body: &mut gast::Body) {
     *body = Structured(tgt_body);
 }
 
-fn translate_global(ctx: &TransformCtx, global_id: GlobalDeclId) -> Option<tgt::GlobalDecl> {
-    // Retrieve the global definition
-    let src_def = ctx.translated.global_decls.get(global_id)?;
-    let fctx = ctx.into_fmt();
-    trace!(
-        "# About to reconstruct: {}\n\n{}",
-        src_def.name.fmt_with_ctx(&fctx),
-        fctx.format_object(src_def)
-    );
-
-    Some(tgt::GlobalDecl {
-        def_id: src_def.def_id,
-        rust_id: src_def.rust_id,
-        item_meta: src_def.item_meta.clone(),
-        is_local: src_def.is_local,
-        name: src_def.name.clone(),
-        generics: src_def.generics.clone(),
-        preds: src_def.preds.clone(),
-        ty: src_def.ty.clone(),
-        kind: src_def.kind.clone(),
-        body: src_def
-            .body
-            .as_ref()
-            .map(|b| translate_body_aux(ctx.options.no_code_duplication, b)),
-    })
-}
-
 /// Translate the functions by reconstructing the control-flow.
 pub fn translate_functions(ctx: &mut TransformCtx) {
     // Translate the bodies one at a time.
     for body in &mut ctx.translated.bodies {
         translate_body(ctx.options.no_code_duplication, body);
-    }
-
-    // Translate the bodies one at a time. We are careful to keep the same indices for the bodies.
-    for (id, _) in ctx.translated.global_decls.iter_indexed_all_slots() {
-        let new_id = ctx.translated.structured_global_decls.reserve_slot();
-        assert_eq!(new_id, id);
-        if let Some(decl) = translate_global(ctx, id) {
-            ctx.translated.structured_global_decls.set_slot(id, decl);
-        }
     }
 
     // Print the functions
@@ -2009,7 +1972,7 @@ pub fn translate_functions(ctx: &mut TransformCtx) {
         );
     }
     // Print the global variables
-    for global in &ctx.translated.structured_global_decls {
+    for global in &ctx.translated.global_decls {
         trace!(
             "# Type:\n{}\n\n# Global definition:\n{}\n",
             fmt_ctx.format_object(&global.ty),

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -23,11 +23,11 @@
 use crate::common::ensure_sufficient_stack;
 use crate::expressions::Place;
 use crate::formatter::{Formatter, IntoFormatter};
+use crate::gast;
 use crate::llbc_ast as tgt;
 use crate::meta::{combine_span, Span};
 use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
-use crate::ullbc_ast::FunDeclId;
 use crate::ullbc_ast::{self as src, GlobalDeclId};
 use crate::values as v;
 use hashlink::linked_hash_map::LinkedHashMap;
@@ -39,8 +39,6 @@ use petgraph::Direction;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
-
-pub type Defs = (tgt::FunDecls, tgt::GlobalDecls);
 
 /// Control-Flow Graph
 type Cfg = DiGraphMap<src::BlockId, ()>;
@@ -1903,7 +1901,7 @@ fn translate_block(
     }
 }
 
-fn translate_body(no_code_duplication: bool, src_body: &src::ExprBody) -> tgt::ExprBody {
+fn translate_body_aux(no_code_duplication: bool, src_body: &src::ExprBody) -> tgt::ExprBody {
     // Explore the function body to create the control-flow graph without backward
     // edges, and identify the loop entries (which are destinations of backward edges).
     let cfg_info = build_cfg_partial_info(src_body);
@@ -1949,30 +1947,13 @@ fn translate_body(no_code_duplication: bool, src_body: &src::ExprBody) -> tgt::E
     }
 }
 
-fn translate_function(ctx: &TransformCtx, src_def_id: FunDeclId) -> Option<tgt::FunDecl> {
-    // Retrieve the function definition
-    let src_def = ctx.translated.fun_decls.get(src_def_id)?;
-    let fctx = ctx.into_fmt();
-    trace!(
-        "# About to reconstruct: {}\n\n{}",
-        src_def.name.fmt_with_ctx(&fctx),
-        fctx.into_fmt().format_object(src_def)
-    );
-
-    // Return the translated definition
-    Some(tgt::FunDecl {
-        def_id: src_def.def_id,
-        rust_id: src_def.rust_id,
-        item_meta: src_def.item_meta.clone(),
-        is_local: src_def.is_local,
-        name: src_def.name.clone(),
-        signature: src_def.signature.clone(),
-        kind: src_def.kind.clone(),
-        body: src_def
-            .body
-            .as_ref()
-            .map(|b| translate_body(ctx.options.no_code_duplication, b)),
-    })
+fn translate_body(no_code_duplication: bool, body: &mut gast::Body) {
+    use gast::Body::{Structured, Unstructured};
+    let Unstructured(src_body) = body else {
+        panic!("Called `ullbc_to_llbc` on an already restructured body")
+    };
+    let tgt_body = translate_body_aux(no_code_duplication, src_body);
+    *body = Structured(tgt_body);
 }
 
 fn translate_global(ctx: &TransformCtx, global_id: GlobalDeclId) -> Option<tgt::GlobalDecl> {
@@ -1998,20 +1979,18 @@ fn translate_global(ctx: &TransformCtx, global_id: GlobalDeclId) -> Option<tgt::
         body: src_def
             .body
             .as_ref()
-            .map(|b| translate_body(ctx.options.no_code_duplication, b)),
+            .map(|b| translate_body_aux(ctx.options.no_code_duplication, b)),
     })
 }
 
 /// Translate the functions by reconstructing the control-flow.
 pub fn translate_functions(ctx: &mut TransformCtx) {
-    // Translate the bodies one at a time. We are careful to keep the same indices for the bodies.
-    for (id, _) in ctx.translated.fun_decls.iter_indexed_all_slots() {
-        let new_id = ctx.translated.structured_fun_decls.reserve_slot();
-        assert_eq!(new_id, id);
-        if let Some(decl) = translate_function(ctx, id) {
-            ctx.translated.structured_fun_decls.set_slot(id, decl);
-        }
+    // Translate the bodies one at a time.
+    for body in &mut ctx.translated.bodies {
+        translate_body(ctx.options.no_code_duplication, body);
     }
+
+    // Translate the bodies one at a time. We are careful to keep the same indices for the bodies.
     for (id, _) in ctx.translated.global_decls.iter_indexed_all_slots() {
         let new_id = ctx.translated.structured_global_decls.reserve_slot();
         assert_eq!(new_id, id);
@@ -2022,7 +2001,7 @@ pub fn translate_functions(ctx: &mut TransformCtx) {
 
     // Print the functions
     let fmt_ctx = ctx.into_fmt();
-    for fun in &ctx.translated.structured_fun_decls {
+    for fun in &ctx.translated.fun_decls {
         trace!(
             "# Signature:\n{}\n\n# Function definition:\n{}\n",
             fmt_ctx.format_object(&fun.signature),

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -56,7 +56,11 @@ impl MutExprVisitor for ClosureStateAccess {
 
 impl MutAstVisitor for ClosureStateAccess {}
 
-fn transform_function(_ctx: &TransformCtx, def: &mut FunDecl) -> Result<(), Error> {
+fn transform_function(
+    _ctx: &TransformCtx,
+    def: &mut FunDecl,
+    body: Option<&mut ExprBody>,
+) -> Result<(), Error> {
     let FunSig {
         closure_info,
         inputs,
@@ -134,7 +138,7 @@ fn transform_function(_ctx: &TransformCtx, def: &mut FunDecl) -> Result<(), Erro
         // We also update the corresponding field accesses in the body of
         // the function.
 
-        if let Some(body) = &mut def.body {
+        if let Some(body) = body {
             body.arg_count += 1;
 
             // Update the type of the local 1 (which is the closure)
@@ -156,8 +160,13 @@ fn transform_function(_ctx: &TransformCtx, def: &mut FunDecl) -> Result<(), Erro
 
 pub struct Transform;
 impl LlbcPass for Transform {
-    fn transform_function(&self, ctx: &mut TransformCtx, def: &mut FunDecl) {
+    fn transform_function(
+        &self,
+        ctx: &mut TransformCtx,
+        def: &mut FunDecl,
+        body: Option<&mut ExprBody>,
+    ) {
         // Ignore the errors, which should have been reported
-        let _ = transform_function(ctx, def);
+        let _ = transform_function(ctx, def, body);
     }
 }

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -164,9 +164,9 @@ impl LlbcPass for Transform {
         &self,
         ctx: &mut TransformCtx,
         def: &mut FunDecl,
-        body: Option<&mut ExprBody>,
+        body: Result<&mut ExprBody, Opaque>,
     ) {
         // Ignore the errors, which should have been reported
-        let _ = transform_function(ctx, def, body);
+        let _ = transform_function(ctx, def, body.ok());
     }
 }

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -1073,33 +1073,28 @@ impl<'a> FmtCtx<'a> {
 
 impl<'tcx, 'ctx> fmt::Display for TranslateCtx<'tcx, 'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.translated.fmt_with_ullbc_defs(f)
+        self.translated.fmt(f)
     }
 }
 
-impl TranslatedCrate {
-    pub(crate) fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl fmt::Display for TranslatedCrate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let fmt: FmtCtx = self.into_fmt();
-
         match &self.ordered_decls {
             None => {
                 // We do simple: types, globals, traits, functions
                 for d in &self.type_decls {
                     writeln!(f, "{}\n", fmt.format_object(d))?
                 }
-
                 for d in &self.global_decls {
                     writeln!(f, "{}\n", fmt.format_object(d))?
                 }
-
                 for d in &self.trait_decls {
                     writeln!(f, "{}\n", fmt.format_object(d))?
                 }
-
                 for d in &self.trait_impls {
                     writeln!(f, "{}\n", fmt.format_object(d))?
                 }
-
                 for d in &self.fun_decls {
                     writeln!(f, "{}\n", fmt.format_object(d))?
                 }
@@ -1116,26 +1111,7 @@ impl TranslatedCrate {
                     }
                 }
             }
-        };
-
+        }
         fmt::Result::Ok(())
-    }
-
-    pub(crate) fn fmt_with_ullbc_defs(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.fmt(f)
-    }
-
-    pub(crate) fn fmt_with_llbc_defs(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.fmt(f)
-    }
-}
-
-pub struct LlbcFmtCtx<'a> {
-    pub translated: &'a TranslatedCrate,
-}
-
-impl<'a> fmt::Display for LlbcFmtCtx<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.translated.fmt_with_llbc_defs(f)
     }
 }

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1898,13 +1898,15 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
 
         // Translate its body like the body of a function. This returns `None` if we can't/decide
         // not to translate this body.
-        let body = match bt_ctx.translate_body(rust_id, 0, &item_meta) {
-            Ok(Some(Body::Unstructured(body))) => Some(body),
-            Ok(Some(Body::Structured(_))) => unreachable!(),
-            Ok(None) => None,
+        let body_id = bt_ctx.t_ctx.translated.bodies.reserve_slot();
+        match bt_ctx.translate_body(rust_id, 0, &item_meta) {
+            Ok(Some(body)) => {
+                self.translated.bodies.set_slot(body_id, body);
+            }
+            Ok(None) => {}
             // Error case: we could have a specific variant
-            Err(_) => None,
-        };
+            Err(_) => {}
+        }
 
         Ok(GlobalDecl {
             def_id,
@@ -1916,7 +1918,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             preds,
             ty,
             kind,
-            body,
+            body: body_id,
         })
     }
 }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -5,13 +5,13 @@ use itertools::Itertools;
 use std::{error::Error, fs::File, io::BufReader, process::Command};
 
 use charon_lib::{
-    export::GCrateData,
+    export::CrateData,
     logger,
     meta::InlineAttr,
     names::{Name, PathElem},
 };
 
-fn translate(code: impl std::fmt::Display) -> Result<GCrateData, Box<dyn Error>> {
+fn translate(code: impl std::fmt::Display) -> Result<CrateData, Box<dyn Error>> {
     // Initialize the logger
     logger::initialize_logger();
 
@@ -37,7 +37,7 @@ fn translate(code: impl std::fmt::Display) -> Result<GCrateData, Box<dyn Error>>
         .try_success()?;
 
     // Extract the computed crate data.
-    let crate_data: GCrateData = {
+    let crate_data: CrateData = {
         let file = File::open(output_path)?;
         let reader = BufReader::new(file);
         serde_json::from_reader(reader)?

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -13,7 +13,7 @@ use charon_lib::{
 
 fn translate(
     code: impl std::fmt::Display,
-) -> Result<GCrateData<llbc_ast::FunDecl, llbc_ast::GlobalDecl>, Box<dyn Error>> {
+) -> Result<GCrateData<llbc_ast::GlobalDecl>, Box<dyn Error>> {
     // Initialize the logger
     logger::initialize_logger();
 
@@ -39,7 +39,7 @@ fn translate(
         .try_success()?;
 
     // Extract the computed crate data.
-    let crate_data: GCrateData<_, _> = {
+    let crate_data: GCrateData<_> = {
         let file = File::open(output_path)?;
         let reader = BufReader::new(file);
         serde_json::from_reader(reader)?

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -6,14 +6,12 @@ use std::{error::Error, fs::File, io::BufReader, process::Command};
 
 use charon_lib::{
     export::GCrateData,
-    llbc_ast, logger,
+    logger,
     meta::InlineAttr,
     names::{Name, PathElem},
 };
 
-fn translate(
-    code: impl std::fmt::Display,
-) -> Result<GCrateData<llbc_ast::GlobalDecl>, Box<dyn Error>> {
+fn translate(code: impl std::fmt::Display) -> Result<GCrateData, Box<dyn Error>> {
     // Initialize the logger
     logger::initialize_logger();
 
@@ -39,7 +37,7 @@ fn translate(
         .try_success()?;
 
     // Extract the computed crate data.
-    let crate_data: GCrateData<_> = {
+    let crate_data: GCrateData = {
         let file = File::open(output_path)?;
         let reader = BufReader::new(file);
         serde_json::from_reader(reader)?

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -6,5 +6,5 @@ error: Unsupported statement kind: intrinsic
 
 error: aborting due to previous error
 
-[ ERROR charon_driver:227] The extraction encountered 1 errors
+[ ERROR charon_driver:231] The extraction encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/issue-165-vec-macro.out
+++ b/charon/tests/ui/unsupported/issue-165-vec-macro.out
@@ -8,5 +8,5 @@ error: Nullary operations are not supported
 
 error: aborting due to previous error
 
-[ ERROR charon_driver:227] The extraction encountered 1 errors
+[ ERROR charon_driver:231] The extraction encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/projection-index-from-end.out
+++ b/charon/tests/ui/unsupported/projection-index-from-end.out
@@ -6,5 +6,5 @@ error: Unexpected ProjectionElem::ConstantIndex
 
 error: aborting due to previous error
 
-[ ERROR charon_driver:227] The extraction encountered 1 errors
+[ ERROR charon_driver:231] The extraction encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/unbound-lifetime.out
+++ b/charon/tests/ui/unsupported/unbound-lifetime.out
@@ -27,5 +27,5 @@ error: Ignoring the following item due to an error: test_crate::get
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0261`.
-[ ERROR charon_driver:227] The extraction encountered 2 errors
+[ ERROR charon_driver:231] The extraction encountered 2 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/well-formedness-bound.out
+++ b/charon/tests/ui/unsupported/well-formedness-bound.out
@@ -14,5 +14,5 @@ error: Ignoring the following item due to an error: test_crate::get
 
 error: aborting due to 2 previous errors
 
-[ ERROR charon_driver:227] The extraction encountered 2 errors
+[ ERROR charon_driver:231] The extraction encountered 2 errors
 Error: Charon driver exited with code 1


### PR DESCRIPTION
Bodies are a big source of duplication between functions and globals. This PR does the following:
- Each body is now indexed by a `BodyId` and stored separately. `FunDecl` and `GlobalDecl` store a `BodyId` instead of a body;
- Because of that, `FunDecl` and `GlobalDecl` aren't type-generic anymore. There's a single definition used by both llbc and ullbc;
- The bodies are stored as `Vector<BodyId, Body>`, where `Body` is an enum with two variants: one for ullbc, one for llbc. When we reconstruct control flow, we change this variant.

All of this removes a decent amount of duplication and paves the way for more.

Fixes #217 