### PR TITLE
Add cool tests for the name matcher

### DIFF
--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -218,6 +218,19 @@ let ctx_to_fmt_env (ctx : ctx) : PrintLlbcAst.fmt_env =
     locals = [];
   }
 
+let ctx_from_crate (crate : LlbcAst.crate) : ctx =
+  let {
+    LlbcAst.type_decls;
+    fun_decls;
+    global_decls;
+    trait_decls;
+    trait_impls;
+    _;
+  } =
+    crate
+  in
+  { type_decls; global_decls; trait_decls; fun_decls; trait_impls }
+
 (** Match configuration *)
 type match_config = {
   map_vars_to_vars : bool;

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -1,9 +1,10 @@
 open Charon
+open Charon.Expressions
+open Charon.LlbcAst
 open Logging
 open NameMatcher
 
 let log = main_log
-let _ = log#linfo (lazy "Name matcher tests: starting")
 
 let parse_tests () =
   let patterns : string list =
@@ -57,8 +58,141 @@ let name_map_tests () =
     (fun (p, i) -> assert (snd (NameMatcherMap.replace p (-1) m) = Some i))
     bindings
 
-let run_tests () =
-  parse_tests ();
-  name_map_tests ()
+(* Annotations in rust code like `#[pattern::pass("<pattern>")]`. The exact syntax is:
+   - `#[pattern::pass("<pattern>")]`: the item name must match that pattern.
+   - `#[pattern::pass(call[<number>], "<pattern>")]`: for functions only; the
+          `number`th `Call` statement must match that pattern.
+   And the same with `fail` instead of `pass` for negative tests.
+*)
+module PatternTest = struct
+  type t = { pattern : pattern; call_idx : int option; success : bool }
 
-let _ = log#linfo (lazy "Name matcher tests: success")
+  type env = {
+    ctx : ctx;
+    match_config : match_config;
+    fmt_env : PrintLlbcAst.fmt_env;
+    print_config : print_config;
+    to_pat_config : to_pat_config;
+  }
+
+  let mk_env (ctx : ctx) : env =
+    let tgt = TkPattern in
+    let match_with_trait_decl_refs = true in
+    {
+      ctx;
+      match_config = { map_vars_to_vars = false; match_with_trait_decl_refs };
+      print_config = { tgt };
+      fmt_env = ctx_to_fmt_env ctx;
+      to_pat_config = { tgt; use_trait_decl_refs = match_with_trait_decl_refs };
+    }
+
+  (* Parse a test from the annotation string as given by Charon. *)
+  let parse (whole_attribute : string) : t option =
+    match Core.String.chop_prefix whole_attribute ~prefix:"pattern::" with
+    | None -> None
+    | Some attribute -> (
+        let re =
+          Re.compile
+            (Re.Pcre.re
+               "^(pass|fail)\\((call\\s*\\[(\\d+)\\],\\s*)?\"(.*)\"\\)$")
+        in
+        match Re.exec_opt re attribute with
+        | Some groups ->
+            let success = Re.Group.get groups 1 = "pass" in
+            let call_idx =
+              Option.map int_of_string (Re.Group.get_opt groups 3)
+            in
+            let pattern = parse_pattern (Re.Group.get groups 4) in
+            Some { pattern; call_idx; success }
+        | None ->
+            failwith ("Couldn't parse attribute: `" ^ whole_attribute ^ "`"))
+
+  (* Check that the given function declaration matches the pattern. *)
+  let check_fun_decl (env : env) (decl : fun_decl) (test : t) : bool =
+    let fn_ptr =
+      match test.call_idx with
+      | None ->
+          {
+            func = FunId (FRegular decl.def_id);
+            generics = Charon.TypesUtils.empty_generic_args;
+          }
+      | Some idx ->
+          (* Find the nth function call in the function body. *)
+          let rec list_calls (statement : statement) : call list =
+            match statement.content with
+            | Call call -> [ call ]
+            | Sequence (st1, st2) -> list_calls st1 @ list_calls st2
+            | Switch _ | Loop _ ->
+                failwith
+                  "Switches and loops are unsupported in name matcher tests"
+            | _ -> []
+          in
+          let calls = list_calls (Option.get decl.body).body in
+          let fn_ptrs =
+            List.map
+              (fun call ->
+                match call.func with
+                | FnOpRegular fn_ptr -> fn_ptr
+                | FnOpMove _ ->
+                    failwith
+                      "Indirect calls are unsupported un name matcher tests")
+              calls
+          in
+          List.nth fn_ptrs idx
+    in
+    let match_success =
+      match_fn_ptr env.ctx env.match_config test.pattern fn_ptr
+    in
+    if test.success && not match_success then (
+      log#error "Pattern %s failed to match function %s\n"
+        (pattern_to_string env.print_config test.pattern)
+        (pattern_to_string env.print_config
+           (fn_ptr_to_pattern env.ctx env.to_pat_config decl.signature.generics
+              fn_ptr));
+      false)
+    else if (not test.success) && match_success then (
+      log#error "Pattern %s matches function %s but shouldn't\n"
+        (pattern_to_string env.print_config test.pattern)
+        (PrintTypes.name_to_string env.fmt_env decl.name);
+      false)
+    else true
+end
+
+(* This reads the output generated from the `ui/name-matcher-tests.rs` test
+   file, and verifies that for each `#[pattern::...]` annotation, the item
+   matches the pattern. See the `PatternTest` module for details of what
+   annotations are available. *)
+let annotated_rust_tests test_file =
+  (* We read the llbc file generated from the annotated rust file. *)
+  log#ldebug (lazy ("Deserializing LLBC file: " ^ test_file));
+  let json = Yojson.Basic.from_file test_file in
+  let (crate : crate) =
+    match LlbcOfJson.crate_of_json json with
+    | Error s ->
+        log#error "Error when deserializing file %s: %s\n" test_file s;
+        exit 1
+    | Ok crate -> crate
+  in
+
+  (* We look through all declarations for our special attributes and check each case. *)
+  let ctx = ctx_from_crate crate in
+  let env = PatternTest.mk_env ctx in
+  let all_pass =
+    T.FunDeclId.Map.for_all
+      (fun _ (decl : fun_decl) ->
+        let tests =
+          List.filter_map PatternTest.parse decl.item_meta.attributes
+        in
+        let test_results =
+          List.map (PatternTest.check_fun_decl env decl) tests
+        in
+        List.for_all (fun b -> b) test_results)
+      crate.fun_decls
+  in
+
+  if all_pass then log#linfo (lazy "Name matcher tests: success") else exit 1
+
+let run_tests test_file =
+  parse_tests ();
+  name_map_tests ();
+  annotated_rust_tests test_file

--- a/charon-ml/tests/Tests.ml
+++ b/charon-ml/tests/Tests.ml
@@ -13,4 +13,6 @@ let () =
 
 (* Call the tests *)
 let () = Test_Deserialize.run_tests "../../../tests/serialized"
-let () = Test_NameMatcher.run_tests ()
+
+let () =
+  Test_NameMatcher.run_tests "../../../tests/serialized/name-matcher-tests.llbc"

--- a/charon-ml/tests/dune
+++ b/charon-ml/tests/dune
@@ -1,4 +1,6 @@
 (tests
  (names Tests)
  (modules Tests Test_Deserialize Test_NameMatcher)
- (libraries charon))
+ (deps
+  (glob_files ./serialized/*.llbc))
+ (libraries core charon))

--- a/charon/tests/ui/name-matcher-tests.out
+++ b/charon/tests/ui/name-matcher-tests.out
@@ -1,0 +1,186 @@
+# Final LLBC before serialization:
+
+fn test_crate::foo::bar()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+trait test_crate::Trait<Self, T>
+{
+    fn method : test_crate::Trait::method
+}
+
+enum core::option::Option<T> =
+|  None()
+|  Some(T)
+
+
+fn test_crate::{impl test_crate::Trait<core::option::Option<T>> for alloc::boxed::Box<T>}::method<T, U>()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+impl<T> test_crate::{impl test_crate::Trait<core::option::Option<T>> for alloc::boxed::Box<T>}<T> : test_crate::Trait<alloc::boxed::Box<T>, core::option::Option<T>>
+{
+    fn method = test_crate::{impl test_crate::Trait<core::option::Option<T>> for alloc::boxed::Box<T>}::method
+}
+
+fn test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}::method<T, U, V>()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+impl<T, U> test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}<T, U> : test_crate::Trait<core::option::Option<U>, alloc::boxed::Box<T>>
+{
+    fn method = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}::method
+}
+
+struct core::ops::range::RangeFrom<Idx> =
+{
+  start: Idx
+}
+
+fn core::option::{core::option::Option<T>}::is_some<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> bool
+
+trait core::slice::index::private_slice_index::Sealed<Self>
+
+trait core::slice::index::SliceIndex<Self, T>
+{
+    parent_clause_0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
+    type Output
+    fn get : core::slice::index::SliceIndex::get
+    fn get_mut : core::slice::index::SliceIndex::get_mut
+    fn get_unchecked : core::slice::index::SliceIndex::get_unchecked
+    fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
+    fn index : core::slice::index::SliceIndex::index
+    fn index_mut : core::slice::index::SliceIndex::index_mut
+}
+
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index : core::ops::index::Index::index
+}
+
+fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause0::Output)
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
+
+impl<T, I> core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I> : core::ops::index::Index<Slice<T>, I>
+where
+    [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
+{
+    type Output = @TraitClause0::Output with []
+    fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
+}
+
+impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>#3} : core::slice::index::private_slice_index::Sealed<core::ops::range::RangeFrom<usize>>
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>
+
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked<T>(@1: core::ops::range::RangeFrom<usize>, @2: *mut Slice<T>) -> *mut Slice<T>
+
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked_mut<T>(@1: core::ops::range::RangeFrom<usize>, @2: *const Slice<T>) -> *const Slice<T>
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+
+impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}<T> : core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, Slice<T>>
+{
+    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>#3}
+    type Output = Slice<T> with []
+    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get
+    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_mut
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked_mut
+    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index
+    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index_mut
+}
+
+fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
+
+fn test_crate::foo()
+{
+    let @0: (); // return
+    let @1: bool; // anonymous local
+    let @2: &'_ (core::option::Option<i32>); // anonymous local
+    let @3: core::option::Option<i32>; // anonymous local
+    let slice@4: &'_ (Slice<bool>); // local
+    let @5: &'_ (Array<bool, 1 : usize>); // anonymous local
+    let @6: &'_ (Array<bool, 1 : usize>); // anonymous local
+    let @7: Array<bool, 1 : usize>; // anonymous local
+    let @8: &'_ (Slice<bool>); // anonymous local
+    let @9: &'_ (Slice<bool>); // anonymous local
+    let @10: &'_ (Slice<bool>); // anonymous local
+    let @11: core::ops::range::RangeFrom<usize>; // anonymous local
+    let @12: (); // anonymous local
+
+    @3 := core::option::Option::Some { 0: const (0 : i32) }
+    @2 := &@3
+    @1 := core::option::{core::option::Option<T>}::is_some<i32>(move (@2))
+    drop @2
+    @fake_read(@1)
+    drop @3
+    drop @1
+    @7 := [const (false); 1 : usize]
+    @6 := &@7
+    @5 := &*(@6)
+    slice@4 := @ArrayToSliceShared<'_, bool, 1 : usize>(move (@5))
+    drop @5
+    @fake_read(slice@4)
+    drop @6
+    @10 := &*(slice@4)
+    @11 := core::ops::range::RangeFrom { start: const (1 : usize) }
+    @9 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<bool, core::ops::range::RangeFrom<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}<bool>]::index(move (@10), move (@11))
+    drop @11
+    drop @10
+    @8 := &*(@9)
+    @fake_read(@8)
+    drop @8
+    @12 := ()
+    @0 := move (@12)
+    drop @9
+    drop @7
+    drop slice@4
+    @0 := ()
+    return
+}
+
+fn test_crate::Trait::method<Self, T, U>()
+
+fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>
+
+fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self::Output)>
+
+unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(@1: Self, @2: *mut T) -> *mut Self::Output
+
+unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(@1: Self, @2: *const T) -> *const Self::Output
+
+fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self::Output)
+
+fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self::Output)
+
+
+

--- a/charon/tests/ui/name-matcher-tests.rs
+++ b/charon/tests/ui/name-matcher-tests.rs
@@ -1,0 +1,61 @@
+#![feature(register_tool)]
+#![register_tool(pattern)]
+//! Tests for the ml name matcher. This is in the rust test suite so that the llbc file gets
+//! generated. Tests on the ml side will then inspect the file and check that each item matches the
+//! specified pattern.
+
+mod foo {
+    #[pattern::pass("test_crate::foo::bar")]
+    #[pattern::fail("crate::foo::bar")]
+    #[pattern::fail("foo::bar")]
+    fn bar() {}
+}
+
+trait Trait<T> {
+    fn method<U>();
+}
+
+impl<T> Trait<Option<T>> for Box<T> {
+    #[pattern::pass(
+        "test_crate::{test_crate::Trait<alloc::boxed::Box<@T>, core::option::Option<@T>>}::method"
+    )]
+    // `Box` is special: it can be abbreviated.
+    #[pattern::pass("test_crate::{test_crate::Trait<Box<@T>, core::option::Option<@T>>}::method")]
+    // Can't abbreviate `Option`, only `Box` is special like that.
+    #[pattern::fail("test_crate::{test_crate::Trait<Box<@T>, Option<@T>>}::method")]
+    // More general patterns work too.
+    #[pattern::pass(
+        "test_crate::{test_crate::Trait<alloc::boxed::Box<@T>, core::option::Option<@U>>}::method"
+    )]
+    #[pattern::pass("test_crate::{test_crate::Trait<@T, @U>}::method")]
+    #[pattern::fail("test_crate::Trait<@T, @U>::method")]
+    fn method<U>() {}
+}
+
+impl<T, U> Trait<Box<T>> for Option<U> {
+    // Using the same variable name twice means they must match. This is not the case here.
+    // TODO: this should not pass!
+    #[pattern::pass(
+        "test_crate::{test_crate::Trait<core::option::Option<@T>, alloc::boxed::Box<@T>>}::method"
+    )]
+    #[pattern::pass(
+        "test_crate::{test_crate::Trait<core::option::Option<@T>, alloc::boxed::Box<@U>>}::method"
+    )]
+    fn method<V>() {}
+}
+
+// `call[i]` is a hack to be able to refer to `Call` statements inside the function body.
+#[pattern::pass(call[0], "core::option::{core::option::Option<@T>}::is_some<i32>")]
+#[pattern::pass(call[0], "core::option::{core::option::Option<@T>}::is_some<@T>")]
+// Generic arguments are required.
+#[pattern::fail(call[0], "core::option::{core::option::Option<@T>}::is_some")]
+#[pattern::pass(call[1], "ArrayToSliceShared<'_, bool, 1>")]
+// This is a trait instance call.
+#[pattern::pass(call[2], "core::ops::index::Index<[bool], core::ops::range::RangeFrom<usize>>::index")]
+// We can't reference the method directly.
+#[pattern::fail(call[2], "core::slice::index::{core::ops::index::Index<[@T], @I>}::index<bool, core::ops::range::RangeFrom<usize>>")]
+fn foo() {
+    let _ = Some(0).is_some();
+    let slice: &[bool] = &[false];
+    let _ = &slice[1..];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
               '' else
                 "";
             propagatedBuildInputs = with ocamlPackages; [
+              core
               ppx_deriving
               visitors
               easy_logging


### PR DESCRIPTION
This adds a new kind of test for the name matcher. It takes the form of a rust file annotated with patterns, and the test runner ensures the patterns match the name of the corresponding item or function call.