### PR TITLE
Rewrite the macros using `quote`

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -727,6 +727,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 name = "macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]

--- a/charon/macros/Cargo.toml
+++ b/charon/macros/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0"
 quote = "1.0.21"
 syn = "1.0.102"

--- a/charon/macros/Cargo.toml
+++ b/charon/macros/Cargo.toml
@@ -10,4 +10,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.21"
-syn = "1.0.102"
+syn = { version = "1.0.102", features = ["full"] }
+
+[dev-dependencies]
+assert_tokens_eq = "0.1.0"

--- a/charon/macros/src/enum_helpers.rs
+++ b/charon/macros/src/enum_helpers.rs
@@ -1,63 +1,9 @@
-use proc_macro::TokenStream as TokenStream1;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
 use std::vec::Vec;
-use syn::punctuated::Punctuated;
-use syn::token::{Add, Comma};
-use syn::{
-    parse, Binding, Constraint, Data, DataEnum, DeriveInput, Expr, Fields, GenericArgument,
-    GenericParam, Ident, Lifetime, Lit, Path, PathArguments, PathSegment, TraitBound,
-    TraitBoundModifier, Type, TypeParamBound, TypePath, WhereClause, WherePredicate,
-};
+use syn::{parse2, Data, DataEnum, DeriveInput, Fields, Ident, Type};
 
-const _TAB: &'static str = "    ";
-const _TWO_TABS: &'static str = "        ";
-const THREE_TABS: &'static str = "            ";
-
-macro_rules! derive_variant_name_impl_code {
-    () => {
-        "impl{} {}{}{} {{
-    pub fn variant_name(&self) -> &'static str {{
-        match self {{
-{}
-        }}
-    }}
-}}"
-    };
-}
-
-macro_rules! derive_variant_index_arity_impl_code {
-    () => {
-        "impl{} {}{}{} {{
-    pub fn variant_index_arity(&self) -> (u32, usize) {{
-        match self {{
-{}
-        }}
-    }}
-}}"
-    };
-}
-
-macro_rules! derive_impl_block_code {
-    () => {
-        "impl{} {}{}{} {{
-{}
-}}"
-    };
-}
-
-macro_rules! derive_enum_variant_impl_code {
-    () => {
-        "    pub fn {}{}({}self) -> {} {{
-        match self {{
-{}
-        }}
-    }}"
-    };
-}
-
-fn lifetime_to_string(lf: &Lifetime) -> String {
-    format!("'{}", lf.ident.to_string()).to_string()
-}
+use self::EnumMethodKind::*;
 
 /// We initially used the convert-case crate, but it converts names like "I32"
 /// to "i_32", while we want to get "i32". We thus reimplemented our own converter
@@ -89,423 +35,53 @@ fn to_snake_case(s: &str) -> String {
     snake_case
 }
 
-/// TODO: this is also used to format field types, so we have to take all the
-/// cases into account
-fn type_to_string(ty: &Type) -> String {
-    match ty {
-        Type::Array(type_array) => format!(
-            "[{}; {}]",
-            type_to_string(&type_array.elem),
-            expr_to_string(&type_array.len)
-        )
-        .to_string(),
-        Type::BareFn(_) => {
-            panic!("type_to_string: unexpected type: BareFn");
-        }
-        Type::Group(_) => {
-            panic!("type_to_string: unexpected type: Group");
-        }
-        Type::ImplTrait(_) => {
-            panic!("type_to_string: unexpected type: ImplTrait");
-        }
-        Type::Infer(_) => {
-            panic!("type_to_string: unexpected type: Infer");
-        }
-        Type::Macro(_) => {
-            panic!("type_to_string: unexpected type: Macro");
-        }
-        Type::Never(_) => {
-            panic!("type_to_string: unexpected type: Never");
-        }
-        Type::Paren(_) => {
-            panic!("type_to_string: unexpected type: Paren");
-        }
-        Type::Path(p) => type_path_to_string(p),
-        Type::Ptr(_) => {
-            panic!("type_to_string: unexpected type: Ptr");
-        }
-        Type::Reference(type_ref) => {
-            let lifetime = match &type_ref.lifetime {
-                None => "".to_string(),
-                Some(lf) => lifetime_to_string(lf),
-            };
-            let mutability = if type_ref.mutability.is_some() {
-                format!("&{} mut", lifetime)
-            } else {
-                format!("&{}", lifetime)
-            };
-
-            format!("{} {}", mutability, type_to_string(&type_ref.elem)).to_string()
-        }
-        Type::Slice(type_slice) => format!("[{}]", type_to_string(&type_slice.elem)).to_string(),
-        Type::TraitObject(_) => {
-            panic!("type_to_string: unexpected type: TraitObject");
-        }
-        Type::Tuple(type_tuple) => {
-            let tys: Vec<String> = type_tuple
-                .elems
-                .iter()
-                .map(|ty| type_to_string(ty))
-                .collect();
-            format!("({})", tys.join(", ")).to_string()
-        }
-        Type::Verbatim(_) => {
-            panic!("type_to_string: unexpected type: Verbatim");
-        }
-        _ => {
-            panic!("type_to_string: unexpected type");
-        }
-    }
-}
-
-fn binding_to_string(b: &Binding) -> String {
-    format!("{} = {}", b.ident.to_string(), type_to_string(&b.ty)).to_string()
-}
-
-fn constraint_to_string(c: &Constraint) -> String {
-    format!(
-        "{} : {}",
-        c.ident.to_string(),
-        type_param_bounds_to_string(&c.bounds)
-    )
-    .to_string()
-}
-
-fn lit_to_string(l: &Lit) -> String {
-    match l {
-        Lit::Str(l) => l.value(),
-        Lit::ByteStr(_) => unimplemented!(),
-        Lit::Byte(l) => l.value().to_string(),
-        Lit::Char(l) => l.value().to_string(),
-        Lit::Int(l) => l.base10_digits().to_string(),
-        Lit::Float(l) => l.base10_digits().to_string(),
-        Lit::Bool(l) => l.value().to_string(),
-        Lit::Verbatim(_) => unimplemented!(),
-    }
-}
-
-/// Converts an expression to a string.
-/// For now, only supports the cases useful for the type definitions (literals)
-fn expr_to_string(e: &Expr) -> String {
-    match e {
-        Expr::Lit(lit) => lit_to_string(&lit.lit),
-        _ => unimplemented!(),
-    }
-}
-
-fn angle_bracketed_generic_arguments_to_string(
-    args: &Punctuated<GenericArgument, Comma>,
-) -> String {
-    let args: Vec<String> = args.iter().map(|a| generic_argument_to_string(a)).collect();
-    if args.is_empty() {
-        "".to_string()
-    } else {
-        format!("<{}>", args.join(", ")).to_string()
-    }
-}
-
-fn generic_argument_to_string(a: &GenericArgument) -> String {
-    match a {
-        GenericArgument::Lifetime(lf) => lifetime_to_string(lf),
-        GenericArgument::Type(ty) => type_to_string(ty),
-        GenericArgument::Binding(b) => binding_to_string(b),
-        GenericArgument::Constraint(c) => constraint_to_string(c),
-        GenericArgument::Const(e) => expr_to_string(e),
-    }
-}
-
-fn path_segment_to_string(ps: &PathSegment) -> String {
-    let seg = ps.ident.to_string();
-
-    match &ps.arguments {
-        PathArguments::None => seg,
-        PathArguments::AngleBracketed(args) => format!(
-            "{}{}",
-            seg,
-            angle_bracketed_generic_arguments_to_string(&args.args)
-        )
-        .to_string(),
-        PathArguments::Parenthesized(_) => {
-            // Don't know in which situation this may happen
-            unimplemented!()
-        }
-    }
-}
-
-fn path_to_string(path: &Path) -> String {
-    let path: Vec<String> = path
-        .segments
-        .iter()
-        .map(|x| path_segment_to_string(x))
-        .collect();
-    path.join("::")
-}
-
-fn type_path_to_string(tp: &TypePath) -> String {
-    // Don't know what to do with that
-    assert!(tp.qself.is_none());
-
-    path_to_string(&tp.path)
-}
-
-fn trait_bound_to_string(tb: &TraitBound) -> String {
-    // Sanity check
-    match tb.modifier {
-        TraitBoundModifier::None => (),
-        TraitBoundModifier::Maybe(_) => {
-            unimplemented!()
-        }
-    }
-
-    assert!(tb.lifetimes.is_none());
-
-    path_to_string(&tb.path)
-}
-
-fn type_param_bounds_to_string(bounds: &Punctuated<TypeParamBound, Add>) -> String {
-    let mut s: Vec<String> = vec![];
-
-    for p in bounds {
-        match p {
-            TypeParamBound::Trait(tb) => {
-                s.push(trait_bound_to_string(tb));
-            }
-            TypeParamBound::Lifetime(lf) => {
-                s.push(lifetime_to_string(lf));
-            }
-        }
-    }
-
-    s.join(" + ")
-}
-
-fn lifetime_bounds_to_string(bounds: &Punctuated<Lifetime, Add>) -> String {
-    let bounds: Vec<String> = bounds.iter().map(|lf| lifetime_to_string(lf)).collect();
-    bounds.join(" + ")
-}
-
-/// Auxiliary helper
-fn generic_param_with_opt_constraints_to_string(
-    param: &GenericParam,
-    with_constraints: bool,
-) -> String {
-    match param {
-        GenericParam::Type(type_param) => {
-            let ident = type_param.ident.to_string();
-
-            if type_param.bounds.is_empty() || !with_constraints {
-                ident
-            } else {
-                format!(
-                    "{} : {}",
-                    ident,
-                    type_param_bounds_to_string(&type_param.bounds)
-                )
-                .to_string()
-            }
-        }
-        GenericParam::Lifetime(lf_param) => {
-            let ident = lifetime_to_string(&lf_param.lifetime);
-
-            if lf_param.bounds.is_empty() || !with_constraints {
-                ident
-            } else {
-                format!(
-                    "{} : {}",
-                    ident,
-                    lifetime_bounds_to_string(&lf_param.bounds)
-                )
-                .to_string()
-            }
-        }
-        GenericParam::Const(_) => {
-            // Don't know what to do with const parameters
-            unimplemented!()
-        }
-    }
-}
-
-/// Generate a string from generic parameters.
-/// `with_constraints` constrols whether we should format the constraints or not.
-/// For instance, should we generate: `<'a, T1 : 'a, T2 : Clone>` or ``<'a, T1, T2>`?
-fn generic_params_with_opt_constraints_to_string(
-    params: &Punctuated<GenericParam, Comma>,
-    with_constraints: bool,
-) -> String {
-    let gens: Vec<String> = params
-        .iter()
-        .map(|g| generic_param_with_opt_constraints_to_string(g, with_constraints))
-        .collect();
-    if gens.is_empty() {
-        "".to_string()
-    } else {
-        format!("<{}>", gens.join(", "))
-    }
-}
-
-/// See [`generic_params_with_opt_constraints_to_string`](generic_params_with_opt_constraints_to_string)
-fn generic_params_to_string(params: &Punctuated<GenericParam, Comma>) -> String {
-    generic_params_with_opt_constraints_to_string(params, true)
-}
-
-/// See [`generic_params_with_opt_constraints_to_string`](generic_params_with_opt_constraints_to_string)
-fn generic_params_without_constraints_to_string(
-    params: &Punctuated<GenericParam, Comma>,
-) -> String {
-    generic_params_with_opt_constraints_to_string(params, false)
-}
-
-fn where_predicate_to_string(wp: &WherePredicate) -> String {
-    match wp {
-        WherePredicate::Type(pred_type) => {
-            assert!(pred_type.lifetimes.is_none());
-
-            let ty = type_to_string(&pred_type.bounded_ty);
-
-            if pred_type.bounds.is_empty() {
-                ty
-            } else {
-                format!(
-                    "{} : {}",
-                    ty,
-                    type_param_bounds_to_string(&pred_type.bounds)
-                )
-                .to_string()
-            }
-        }
-        WherePredicate::Lifetime(pred_lf) => format!(
-            "{} : {}",
-            lifetime_to_string(&pred_lf.lifetime),
-            lifetime_bounds_to_string(&pred_lf.bounds)
-        )
-        .to_string(),
-        WherePredicate::Eq(pred_eq) => format!(
-            "{} = {}",
-            type_to_string(&pred_eq.lhs_ty),
-            type_to_string(&pred_eq.rhs_ty)
-        )
-        .to_string(),
-    }
-}
-
-fn where_clause_to_string(wc: &WhereClause) -> String {
-    let preds = wc.predicates.iter().map(|p| where_predicate_to_string(p));
-    let preds: Vec<String> = preds.map(|p| format!("    {},\n", p).to_string()).collect();
-    format!("\nwhere\n{}", preds.join("")).to_string()
-}
-
-fn opt_where_clause_to_string(wc: &Option<WhereClause>) -> String {
-    match wc {
-        None => "".to_string(),
-        Some(wc) => where_clause_to_string(wc),
-    }
-}
-
 struct MatchPattern {
-    /// The variant id
-    variant_id: Ident,
-    /// The match pattern as a string.
-    /// For instance: `List::Cons(hd, tl)`
-    match_pattern: String,
+    /// The variant name, as a string.
+    variant_name: String,
+    /// The match pattern.
+    /// For instance: `List::Cons(x0, x1)`
+    pattern: TokenStream,
     /// The number of arguments in the match pattern (including anonymous
     /// arguments).
     num_args: usize,
     /// The variables we introduced in the match pattern.
-    /// `["hd", "tl"]` if the pattern is `List::Cons(hd, tl)`.
-    /// Empty vector if the variables are anonymous (i.e.: `_`).
-    named_args: Vec<String>,
+    /// `["x0", "x1"]` if the pattern is `List::Cons(hd, tl)`.
+    pattern_vars: Vec<Ident>,
     /// The types of the variables introduced in the match pattern
-    arg_types: Vec<String>,
+    arg_types: Vec<Type>,
 }
 
-/// Generate matching patterns for an enumeration
-/// `patvar_name` controls the name to give to the variables introduced in the
-/// pattern. We introduce anonymous variables if `None`.
-fn generate_variant_match_patterns(
-    enum_name: &String,
-    data: &DataEnum,
-    patvar_name: Option<&String>,
-) -> Vec<MatchPattern> {
+/// Generate matching patterns for an enumeration.
+fn generate_variant_match_patterns(enum_name: &Ident, data: &DataEnum) -> Vec<MatchPattern> {
     let mut patterns: Vec<MatchPattern> = vec![];
     for variant in &data.variants {
-        let variant_name = variant.ident.to_string();
-
-        // Indices for variables
-        let mut var_index: usize = 0;
-        fn generate_varname(var_index: &mut usize, patvar_name: Option<&String>) -> String {
-            match patvar_name {
-                None => "_".to_string(),
-                Some(v) => {
-                    let s = format!("{}{}", v, var_index).to_string();
-                    *var_index = var_index.checked_add(1).unwrap();
-                    s
-                }
-            }
-        }
-
         // Compute the pattern (without the variant constructor), the list
         // of introduced arguments and the list of field types.
-        let (pattern, num_vars, named_vars, vartypes) = match &variant.fields {
-            Fields::Named(fields) => {
-                let fields_vars: Vec<(String, String)> = fields
-                    .named
-                    .iter()
-                    .map(|f| {
-                        let var = generate_varname(&mut var_index, patvar_name);
-                        let field = format!("{}:{}", f.ident.as_ref().unwrap().to_string(), var)
-                            .to_string();
-                        (field, var)
-                    })
-                    .collect();
-                let (fields_pats, vars): (Vec<String>, Vec<String>) =
-                    fields_vars.into_iter().unzip();
+        let fields = &variant.fields;
+        let num_vars = fields.len();
+        let vars: Vec<Ident> = (0..num_vars)
+            .map(|i| Ident::new(&format!("_x{i}"), Span::mixed_site()))
+            .collect();
+        let vartypes: Vec<_> = fields.iter().map(|f| f.ty.clone()).collect();
 
-                let num_vars = fields.named.iter().count();
-
-                let vars = if patvar_name.is_none() { vec![] } else { vars };
-
-                let vartypes: Vec<String> =
-                    fields.named.iter().map(|f| type_to_string(&f.ty)).collect();
-
-                let pattern = format!("{{ {} }}", fields_pats.join(", ")).to_string();
-                (pattern, num_vars, vars, vartypes)
+        let pattern_vars = match fields {
+            Fields::Named(_) => {
+                let field_names: Vec<_> = fields.iter().map(|f| &f.ident).collect();
+                quote!({ #(#field_names : #vars,)* })
             }
-            Fields::Unnamed(fields) => {
-                let fields_vars: Vec<(String, String)> = fields
-                    .unnamed
-                    .iter()
-                    .map(|_| {
-                        let var = generate_varname(&mut var_index, patvar_name);
-                        (var.clone(), var)
-                    })
-                    .collect();
-
-                let (fields_pats, vars): (Vec<String>, Vec<String>) =
-                    fields_vars.into_iter().unzip();
-
-                let num_vars = fields.unnamed.iter().count();
-
-                let vars = if patvar_name.is_none() { vec![] } else { vars };
-
-                let vartypes: Vec<String> = fields
-                    .unnamed
-                    .iter()
-                    .map(|f| type_to_string(&f.ty))
-                    .collect();
-
-                let pattern = format!("({})", fields_pats.join(", ")).to_string();
-
-                (pattern, num_vars, vars, vartypes)
+            Fields::Unnamed(_) => {
+                quote!((#(#vars,)*))
             }
-            Fields::Unit => ("".to_string(), 0, vec![], vec![]),
+            Fields::Unit => quote!(),
         };
+        let variant_name = &variant.ident;
+        let pattern = quote!(#enum_name :: #variant_name #pattern_vars);
 
-        let pattern = format!("{}::{}{}", enum_name, variant_name, pattern).to_string();
         patterns.push(MatchPattern {
-            variant_id: variant.ident.clone(),
-            match_pattern: pattern,
+            variant_name: variant.ident.to_string(),
+            pattern,
             num_args: num_vars,
-            named_args: named_vars,
+            pattern_vars: vars,
             arg_types: vartypes,
         });
     }
@@ -515,120 +91,71 @@ fn generate_variant_match_patterns(
 
 /// Macro to derive a function `fn variant_name(&self) -> String` printing the
 /// constructor of an enumeration. Only works on enumerations, of course.
-pub fn derive_variant_name(item: TokenStream1) -> TokenStream {
+pub fn derive_variant_name(item: TokenStream) -> TokenStream {
     // Parse the input
-    let ast: DeriveInput = parse(item).unwrap();
-
-    // Generate the code
-    let adt_name = ast.ident.to_string();
-
-    // Retrieve and format the generic parameters
-    let generic_params_with_constraints = generic_params_to_string(&ast.generics.params);
-    let generic_params_without_constraints =
-        generic_params_without_constraints_to_string(&ast.generics.params);
-
-    // Generat the code for the `where` clause
-    let where_clause = opt_where_clause_to_string(&ast.generics.where_clause);
+    let ast: DeriveInput = parse2(item).unwrap();
 
     // Generate the code for the matches
-    let match_branches: Vec<String> = match &ast.data {
-        Data::Enum(data) => {
-            let patterns = generate_variant_match_patterns(&adt_name, data, None);
-            patterns
-                .iter()
-                .map(|mp| {
-                    format!(
-                        "{}{} => {{ \"{}\" }},",
-                        THREE_TABS,
-                        mp.match_pattern,
-                        mp.variant_id.to_string()
-                    )
-                    .to_string()
-                })
-                .collect()
-        }
-        Data::Struct(_) => {
-            panic!("VariantName macro can not be called on structs");
-        }
-        Data::Union(_) => {
-            panic!("VariantName macro can not be called on unions");
-        }
+    let Data::Enum(data) = &ast.data else {
+        panic!("VariantName macro can only be called on enums");
     };
+    let patterns = generate_variant_match_patterns(&ast.ident, data);
+    let match_branches: Vec<TokenStream> = patterns
+        .into_iter()
+        .map(|mp| {
+            let pattern = &mp.pattern;
+            let name = &mp.variant_name;
+            quote!( #pattern => #name )
+        })
+        .collect();
 
-    if match_branches.len() > 0 {
-        let match_branches = match_branches.join("\n");
-        let impl_code = format!(
-            derive_variant_name_impl_code!(),
-            generic_params_with_constraints,
-            adt_name,
-            generic_params_without_constraints,
-            where_clause,
-            match_branches
-        )
-        .to_string();
-        return impl_code.parse().unwrap();
-    } else {
-        "".parse().unwrap()
-    }
+    let adt_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    quote!(
+        impl #impl_generics #adt_name #ty_generics #where_clause {
+            pub fn variant_name(&self) -> &'static str {
+                match self {
+                    #(#match_branches,)*
+                }
+            }
+        }
+    )
 }
 
 /// Macro to derive a function `fn variant_index_arity(&self) -> (u32, usize)`
 /// the pair (variant index, variant arity).
 /// Only works on enumerations, of course.
-pub fn derive_variant_index_arity(item: TokenStream1) -> TokenStream {
+pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
     // Parse the input
-    let ast: DeriveInput = parse(item).unwrap();
-
-    // Generate the code
-    let adt_name = ast.ident.to_string();
-
-    // Retrieve and format the generic parameters
-    let generic_params_with_constraints = generic_params_to_string(&ast.generics.params);
-    let generic_params_without_constraints =
-        generic_params_without_constraints_to_string(&ast.generics.params);
-
-    // Generat the code for the `where` clause
-    let where_clause = opt_where_clause_to_string(&ast.generics.where_clause);
+    let ast: DeriveInput = parse2(item).unwrap();
 
     // Generate the code for the matches
-    let match_branches: Vec<String> = match &ast.data {
-        Data::Enum(data) => {
-            let patterns = generate_variant_match_patterns(&adt_name, data, None);
-            patterns
-                .iter()
-                .enumerate()
-                .map(|(i, mp)| {
-                    format!(
-                        "{}{} => {{ ({}, {}) }},",
-                        THREE_TABS, mp.match_pattern, i, mp.num_args
-                    )
-                    .to_string()
-                })
-                .collect()
-        }
-        Data::Struct(_) => {
-            panic!("VariantIndex macro can not be called on structs");
-        }
-        Data::Union(_) => {
-            panic!("VariantIndex macro can not be called on unions");
-        }
+    let Data::Enum(data) = &ast.data else {
+        panic!("VariantIndex macro can only be called on enums");
     };
+    let patterns = generate_variant_match_patterns(&ast.ident, data);
+    let match_branches: Vec<TokenStream> = patterns
+        .into_iter()
+        .enumerate()
+        .map(|(i, mp)| {
+            let pattern = &mp.pattern;
+            let i = i as u32;
+            let arity = mp.num_args;
+            quote!( #pattern => (#i, #arity) )
+        })
+        .collect();
 
-    if match_branches.len() > 0 {
-        let match_branches = match_branches.join("\n");
-        let impl_code = format!(
-            derive_variant_index_arity_impl_code!(),
-            generic_params_with_constraints,
-            adt_name,
-            generic_params_without_constraints,
-            where_clause,
-            match_branches
-        )
-        .to_string();
-        return impl_code.parse().unwrap();
-    } else {
-        "".parse().unwrap()
-    }
+    let adt_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    quote!(
+        impl #impl_generics #adt_name #ty_generics #where_clause {
+            pub fn variant_index_arity(&self) -> (u32, usize) {
+                match self {
+                    #(#match_branches,)*
+                }
+            }
+        }
+    )
 }
 
 #[derive(PartialEq, Eq)]
@@ -642,189 +169,161 @@ pub enum EnumMethodKind {
 impl EnumMethodKind {
     /// We have to write this by hand: we can't use the macros defined above on
     /// the declarations of this file...
-    fn variant_name(&self) -> String {
+    fn variant_name(&self) -> &'static str {
         match self {
-            EnumMethodKind::EnumIsA => "EnumIsA".to_string(),
-            EnumMethodKind::EnumAsGetters => "EnumAsGetters".to_string(),
-            EnumMethodKind::EnumAsMutGetters => "EnumAsMutGetters".to_string(),
-            EnumMethodKind::EnumToGetters => "EnumToGetters".to_string(),
+            EnumIsA => "EnumIsA",
+            EnumAsGetters => "EnumAsGetters",
+            EnumAsMutGetters => "EnumAsMutGetters",
+            EnumToGetters => "EnumToGetters",
         }
     }
 }
 
 /// Generic helper for `EnumIsA` and `EnumAsGetters`.
 /// This generates one function per variant.
-pub fn derive_enum_variant_method(item: TokenStream1, method_kind: EnumMethodKind) -> TokenStream {
-    use EnumMethodKind::*;
+pub fn derive_enum_variant_method(item: TokenStream, method_kind: EnumMethodKind) -> TokenStream {
     // Parse the input
-    let ast: DeriveInput = parse(item).unwrap();
+    let ast: DeriveInput = parse2(item).unwrap();
 
     // Generate the code
-    let adt_name = ast.ident.to_string();
-
-    // Retrieve and format the generic parameters
-    let generic_params_with_constraints = generic_params_to_string(&ast.generics.params);
-    let generic_params_without_constraints =
-        generic_params_without_constraints_to_string(&ast.generics.params);
-
-    // Generat the code for the `where` clause
-    let where_clause = opt_where_clause_to_string(&ast.generics.where_clause);
+    let adt_name = &ast.ident;
 
     // Generate the code for all the functions in the impl block
-    let impls: Vec<String> = match &ast.data {
-        Data::Enum(data) => {
-            // We start by generating the body of the function: the matches.
-            //
-            // If there is only one variant, we generate:
-            // ```
-            //  match self {
-            //      Foo::Variant(...) => ...,
-            // }
-            // ```
-            //
-            // If there is more than one variant, we generate an otherwise branch:
-            // ```
-            //  match self {
-            //      Foo::Variant(...) => ...,
-            //      _ => ...,
-            // }
-            // ```
-            //
-            // Finally, If there are no variants, we don't generate any function,
-            // so we don't really have to take that case into account...
-            let several_variants = data.variants.len() > 1;
-            let varbasename = match method_kind {
-                EnumIsA => None,
-                EnumAsGetters | EnumAsMutGetters | EnumToGetters => Some("x".to_string()),
+    let Data::Enum(data) = &ast.data else {
+        panic!(
+            "{} macro can only be called on enums",
+            method_kind.variant_name()
+        );
+    };
+    let patterns = generate_variant_match_patterns(&ast.ident, data);
+    let methods: Vec<TokenStream> = patterns
+        .into_iter()
+        .map(|mp| {
+            let pattern = &mp.pattern;
+            let name_prefix = match method_kind {
+                EnumIsA => "is_",
+                EnumAsGetters | EnumAsMutGetters => "as_",
+                EnumToGetters => "to_",
             };
-            let patterns = generate_variant_match_patterns(&adt_name, data, varbasename.as_ref());
-
+            let name_suffix = match method_kind {
+                EnumAsMutGetters => "_mut",
+                _ => "",
+            };
+            let ref_kind = match method_kind {
+                EnumAsGetters | EnumIsA => quote!(&),
+                EnumAsMutGetters => quote!(&mut),
+                EnumToGetters => quote!(),
+            };
+            // TODO: write our own to_snake_case function:
+            // names like "i32" become "i_32" with this one.
+            let variant_name = to_snake_case(&mp.variant_name);
+            let method_name = format!("{name_prefix}{variant_name}{name_suffix}");
+            let method_name = Ident::new(&method_name, Span::call_site());
             match method_kind {
                 EnumIsA => {
-                    patterns
-                        .iter()
-                        .map(|mp| {
-                            // Generate the branch for the target variant
-                            let true_pat =
-                                format!("{}{} => true,", THREE_TABS, mp.match_pattern,).to_string();
-                            // Add the otherwise branch, if necessary
-                            let complete_pat = if several_variants {
-                                format!("{}\n{}_ => false,", true_pat, THREE_TABS).to_string()
-                            } else {
-                                true_pat
-                            };
-
-                            // Generate the impl
-                            format!(
-                                derive_enum_variant_impl_code!(),
-                                "is_",
-                                to_snake_case(&mp.variant_id.to_string()),
-                                "&",
-                                "bool",
-                                complete_pat
-                            )
-                            .to_string()
-                        })
-                        .collect()
+                    quote!(
+                        pub fn #method_name(#ref_kind self) -> bool {
+                            #[allow(unreachable)]
+                            match self {
+                                #pattern => true,
+                                _ => false,
+                            }
+                        }
+                    )
                 }
                 EnumAsGetters | EnumAsMutGetters | EnumToGetters => {
-                    let ref_kind = match method_kind {
-                        EnumAsGetters => "&",
-                        EnumAsMutGetters => "&mut ",
-                        _ => "",
-                    };
-                    let name_prefix = match method_kind {
-                        EnumIsA => unreachable!(),
-                        EnumAsGetters | EnumAsMutGetters => "as_",
-                        EnumToGetters => "to_",
-                    };
-                    let name_suffix = match method_kind {
-                        EnumAsMutGetters => "_mut",
-                        _ => "",
-                    };
-                    patterns
-                        .iter()
-                        .map(|mp| {
-                            // Generate the branch for the target variant
-                            let vars = format!("({})", mp.named_args.join(", ")); // return value
-                            let variant_pat =
-                                format!("{}{} => {},", THREE_TABS, mp.match_pattern, vars);
-                            // Add the otherwise branch, if necessary
-                            let complete_pat = if several_variants {
-                                format!(
-                                    "{variant_pat}\n{THREE_TABS}_ => unreachable!(\"{adt_name}::{name_prefix}{}{name_suffix}: Not the proper variant\"),",
-                                    to_snake_case(&mp.variant_id.to_string()),
-                                )
-                                .to_string()
-                            } else {
-                                variant_pat
-                            };
+                    let vars = &mp.pattern_vars;
+                    let tys = &mp.arg_types;
+                    let unreachable_msg =
+                        format!("{adt_name}::{method_name}: Not the proper variant",);
 
-                            // The function's return type
-                            let ret_tys: Vec<String> = mp
-                                .arg_types
-                                .iter()
-                                .map(|ty| -> String {
-                                    format!("{ref_kind}({ty})")
-                                }
-                                )
-                                .collect();
-                            let ret_ty = format!("({})", ret_tys.join(", "));
-
-                            // Generate the impl
-                            format!(
-                                "    pub fn {name_prefix}{}{name_suffix}({ref_kind}self) -> {ret_ty} {{
-                                    match self {{
-                                        {complete_pat}
-                                    }}
-                                }}",
-                                // TODO: write our own to_snake_case function:
-                                // names like "i32" become "i_32" with this one.
-                                to_snake_case(&mp.variant_id.to_string()),
-                            )
-                            .to_string()
-                        })
-                        .collect()
+                    quote!(
+                        pub fn #method_name(#ref_kind self) -> ( #(#ref_kind #tys),* ) {
+                            #[allow(unreachable)]
+                            match self {
+                                #pattern => ( #(#vars),* ),
+                                _ => unreachable!(#unreachable_msg),
+                            }
+                        }
+                    )
                 }
             }
-        }
-        Data::Struct(_) => {
-            panic!(
-                "{} macro can not be called on structs",
-                method_kind.variant_name()
-            );
-        }
-        Data::Union(_) => {
-            panic!(
-                "{} macro can not be called on unions",
-                method_kind.variant_name()
-            );
-        }
-    };
+        })
+        .collect();
 
-    if impls.len() > 0 {
-        // Concatenate all the functions
-        let impls = impls.join("\n\n");
-
-        // Generate the impl block
-        let impl_code = format!(
-            derive_impl_block_code!(),
-            generic_params_with_constraints,
-            adt_name,
-            generic_params_without_constraints,
-            where_clause,
-            impls
-        )
-        .to_string();
-        return impl_code.parse().unwrap();
-    } else {
-        return "".parse().unwrap();
-    }
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    quote!(
+        impl #impl_generics #adt_name #ty_generics #where_clause {
+            #(#methods)*
+        }
+    )
 }
 
 #[test]
 fn test_snake_case() {
     let s = to_snake_case("ConstantValue");
     println!("{}", s);
-    assert!(s == "constant_value".to_string());
+    assert!(s == "constant_value");
+}
+
+#[test]
+fn test_generics() {
+    let s = quote!(
+        enum Foo<T: Clone>
+        where
+            T: Copy,
+        {
+            Variant1(T),
+            Variant2 { x: u32 },
+            Variant3,
+        }
+    );
+    assert_tokens_eq::assert_tokens_eq!(
+        derive_variant_index_arity(s.clone()),
+        quote! {
+            impl<T: Clone,> Foo<T,>
+            where
+                T: Copy,
+            {
+                pub fn variant_index_arity(&self) -> (u32, usize) {
+                    match self {
+                        Foo::Variant1(_x0) => (0u32, 1usize),
+                        Foo::Variant2 { x: _x0 } => (1u32, 1usize),
+                        Foo::Variant3 => (2u32, 0usize),
+                    }
+                }
+            }
+        }
+    );
+    assert_tokens_eq::assert_tokens_eq!(
+        derive_enum_variant_method(s, EnumAsMutGetters),
+        quote! {
+            impl<T: Clone,> Foo<T,>
+            where
+                T: Copy,
+            {
+                pub fn as_variant1_mut(&mut self) -> (&mut T) {
+                    #[allow(unreachable)]
+                    match self {
+                        Foo::Variant1(_x0) => (_x0),
+                        _ => unreachable!("Foo::as_variant1_mut: Not the proper variant"),
+                    }
+                }
+                pub fn as_variant2_mut(&mut self) -> (&mut u32) {
+                    #[allow(unreachable)]
+                    match self {
+                        Foo::Variant2 { x: _x0 } => (_x0),
+                        _ => unreachable!("Foo::as_variant2_mut: Not the proper variant"),
+                    }
+                }
+                pub fn as_variant3_mut(&mut self) -> () {
+                    #[allow(unreachable)]
+                    match self {
+                        Foo::Variant3 => (),
+                        _ => unreachable!("Foo::as_variant3_mut: Not the proper variant"),
+                    }
+                }
+            }
+        }
+    );
 }

--- a/charon/macros/src/lib.rs
+++ b/charon/macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! This module contains some macros for Charon. Due to technical reasons, Rust
 //! forces users to define such macros in a separate, dedicated library. Note
 //! that this doesn't apply to `macro_rules`.
+#![feature(non_exhaustive_omitted_patterns_lint)]
 
 extern crate proc_macro;
 
@@ -14,7 +15,7 @@ use enum_helpers::EnumMethodKind;
 
 #[proc_macro_derive(VariantName)]
 pub fn derive_variant_name(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_variant_name(item).into()
+    enum_helpers::derive_variant_name(item.into()).into()
 }
 
 /// Macro to derive a function `fn variant_index_arity(&self) -> (u32, usize)`
@@ -22,7 +23,7 @@ pub fn derive_variant_name(item: TokenStream) -> TokenStream {
 /// Only works on enumerations, of course.
 #[proc_macro_derive(VariantIndexArity)]
 pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_variant_index_arity(item).into()
+    enum_helpers::derive_variant_index_arity(item.into()).into()
 }
 
 /// Macro `EnumIsA`
@@ -36,7 +37,7 @@ pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
 /// our own code here (which is small) rather than doing PRs for this crate.
 #[proc_macro_derive(EnumIsA)]
 pub fn derive_enum_is_a(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumIsA).into()
+    enum_helpers::derive_enum_variant_method(item.into(), EnumMethodKind::EnumIsA).into()
 }
 
 /// Macro `EnumAsGetters`
@@ -46,10 +47,12 @@ pub fn derive_enum_is_a(item: TokenStream) -> TokenStream {
 /// Also see the comments for [crate::derive_enum_is_a]
 #[proc_macro_derive(EnumAsGetters)]
 pub fn derive_enum_as_getters(item: TokenStream) -> TokenStream {
-    let by_ref =
-        enum_helpers::derive_enum_variant_method(item.clone(), EnumMethodKind::EnumAsGetters);
+    let by_ref = enum_helpers::derive_enum_variant_method(
+        item.clone().into(),
+        EnumMethodKind::EnumAsGetters,
+    );
     let by_ref_mut =
-        enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumAsMutGetters);
+        enum_helpers::derive_enum_variant_method(item.into(), EnumMethodKind::EnumAsMutGetters);
     quote! {
         #by_ref #by_ref_mut
     }

--- a/charon/macros/src/lib.rs
+++ b/charon/macros/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use quote::quote;
 
 mod enum_helpers;
 mod make_generic_in_borrows;
@@ -13,7 +14,7 @@ use enum_helpers::EnumMethodKind;
 
 #[proc_macro_derive(VariantName)]
 pub fn derive_variant_name(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_variant_name(item)
+    enum_helpers::derive_variant_name(item).into()
 }
 
 /// Macro to derive a function `fn variant_index_arity(&self) -> (u32, usize)`
@@ -21,7 +22,7 @@ pub fn derive_variant_name(item: TokenStream) -> TokenStream {
 /// Only works on enumerations, of course.
 #[proc_macro_derive(VariantIndexArity)]
 pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_variant_index_arity(item)
+    enum_helpers::derive_variant_index_arity(item).into()
 }
 
 /// Macro `EnumIsA`
@@ -35,7 +36,7 @@ pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
 /// our own code here (which is small) rather than doing PRs for this crate.
 #[proc_macro_derive(EnumIsA)]
 pub fn derive_enum_is_a(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumIsA)
+    enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumIsA).into()
 }
 
 /// Macro `EnumAsGetters`
@@ -45,7 +46,14 @@ pub fn derive_enum_is_a(item: TokenStream) -> TokenStream {
 /// Also see the comments for [crate::derive_enum_is_a]
 #[proc_macro_derive(EnumAsGetters)]
 pub fn derive_enum_as_getters(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumAsGetters)
+    let by_ref =
+        enum_helpers::derive_enum_variant_method(item.clone(), EnumMethodKind::EnumAsGetters);
+    let by_ref_mut =
+        enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumAsMutGetters);
+    quote! {
+        #by_ref #by_ref_mut
+    }
+    .into()
 }
 
 /// Macro `EnumToGetters`
@@ -55,7 +63,7 @@ pub fn derive_enum_as_getters(item: TokenStream) -> TokenStream {
 /// Also see the comments for [crate::derive_enum_is_a]
 #[proc_macro_derive(EnumToGetters)]
 pub fn derive_enum_to_getters(item: TokenStream) -> TokenStream {
-    enum_helpers::derive_enum_variant_method(item, EnumMethodKind::EnumToGetters)
+    enum_helpers::derive_enum_variant_method(item.into(), EnumMethodKind::EnumToGetters).into()
 }
 
 #[proc_macro]

--- a/charon/macros/src/make_generic_in_borrows.rs
+++ b/charon/macros/src/make_generic_in_borrows.rs
@@ -181,21 +181,21 @@ fn generic_expr_to_mut(e: &mut Expr) {
 /// when defining an implementation generic over the borrow type.
 ///
 /// For instance, if we write:
-/// ```
+/// ```ignore
 /// make_generic_in_borrows! {
 ///   trait AstVisitor : ExprVisitor { ... }
 /// }
 /// ```
 ///
 /// We want to generate two definitions:
-/// ```
+/// ```ignore
 /// make_generic_in_borrows! {
 ///   trait SharedAstVisitor : SharedExprVisitor { ... }
 /// }
 /// ```
 ///
 /// and:
-/// ```
+/// ```ignore
 /// make_generic_in_borrows! {
 ///   trait MutAstVisitor : MutExprVisitor { ... }
 /// }


### PR DESCRIPTION
The derive macros were written without knowledge of the convenient amenities given by `syn` and `quote`. So I rewrote them this way.