### PR TITLE
ci: ensure we update the version number when `charon-ml` changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
       - run: nix build -L .#charon-ml
       - run: nix flake check -L
 
+  check-version-number:
+    runs-on: [self-hosted, linux, nix]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # deep clone in order to get access to other commits
+      - run: nix develop --command ./scripts/ci-check-version-number.sh
+
   aeneas:
     needs: [check_if_skip_duplicate_job, nix]
     if: needs.check_if_skip_duplicate_job.outputs.should_skip != 'true'

--- a/scripts/ci-check-version-number.sh
+++ b/scripts/ci-check-version-number.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Compares this version with `main`, and checks that if `charon-ml` changed,
+# then so did the version in `Cargo.toml`.
+if git diff origin/main --quiet -- charon-ml; then
+    echo '`charon-ml` was not changed in this PR; all good.'
+else
+    echo -n '`charon-ml` was changed in this PR '
+    if git diff origin/main --quiet -- charon-ml/src/CharonVersion.ml; then
+        echo 'but the charon verion was not updated properly!'
+        exit 1
+    else
+        echo 'and the charon version was updated properly.'
+    fi
+fi


### PR DESCRIPTION
New attempt at detecting when we should update the version number: if a PR changed `charon-ml`, this new check will ensure we also updated the version number.

This assumes we don't change charon-ml for other reasons, which is true most of the time. We can ignore this check on a case-by-case basis.