### PR TITLE
Support diverging functions

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.8"
+let supported_charon_version = "0.1.9"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -361,6 +361,7 @@ let rec ty_of_json (js : json) : (ty, string) result =
         let* inputs = list_of_json ty_of_json inputs in
         let* output = ty_of_json output in
         Ok (TArrow (regions, inputs, output))
+    | `String "Never" -> Ok TNever
     | _ -> Error "")
 
 and trait_ref_of_json (js : json) : (trait_ref, string) result =

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -66,9 +66,10 @@ module Ast = struct
     | Drop (p, bid) ->
         indent ^ "drop " ^ place_to_string env p ^ ";\n" ^ indent ^ "goto "
         ^ block_id_to_string bid
-    | Call (call, bid) ->
+    | Call (call, bid) -> (
         call_to_string env indent call
-        ^ ";\n" ^ indent ^ "goto " ^ block_id_to_string bid
+        ^ ";\n" ^ indent ^ "goto "
+        ^ match bid with Some bid -> block_id_to_string bid | None -> "!")
     | Assert (a, bid) ->
         assertion_to_string env indent a
         ^ ";\n" ^ indent ^ "goto " ^ block_id_to_string bid

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -89,7 +89,7 @@ and raw_terminator =
   | Return
   | Unreachable
   | Drop of place * block_id
-  | Call of call * block_id
+  | Call of call * block_id option
   | Assert of assertion * block_id
 [@@deriving
   show,

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -64,7 +64,7 @@ let call_of_json (js : json) : (raw_terminator, string) result =
     (match js with
     | `Assoc [ ("call", call); ("target", target) ] ->
         let* call = call_of_json call in
-        let* target = BlockId.id_of_json target in
+        let* target = option_of_json BlockId.id_of_json target in
 
         Ok (Call (call, target))
     | _ -> Error "")

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/assumed.rs
+++ b/charon/src/ast/assumed.rs
@@ -76,13 +76,13 @@ pub fn is_marker_trait(name: &Name) -> bool {
 
 pub fn get_type_id_from_name(name: &Name) -> Option<AssumedTy> {
     if name.equals_ref_name(&BOX_NAME) {
-        Option::Some(AssumedTy::Box)
+        Some(AssumedTy::Box)
     } else if name.equals_ref_name(&PTR_UNIQUE_NAME) {
-        Option::Some(AssumedTy::PtrUnique)
+        Some(AssumedTy::PtrUnique)
     } else if name.equals_ref_name(&PTR_NON_NULL_NAME) {
-        Option::Some(AssumedTy::PtrNonNull)
+        Some(AssumedTy::PtrNonNull)
     } else {
-        Option::None
+        None
     }
 }
 
@@ -99,12 +99,12 @@ pub fn get_name_from_type_id(id: AssumedTy) -> Vec<String> {
 
 fn get_fun_id_from_name_full(name: &Name) -> Option<FunId> {
     if name.equals_ref_name(&PANIC_NAME) {
-        Option::Some(FunId::Panic)
+        Some(FunId::Panic)
     } else if name.equals_ref_name(&BEGIN_PANIC_NAME) || name.equals_ref_name(&BEGIN_PANIC_RT_NAME)
     {
-        Option::Some(FunId::BeginPanic)
+        Some(FunId::BeginPanic)
     } else if name.equals_ref_name(&BOX_FREE_NAME) {
-        Option::Some(FunId::BoxFree)
+        Some(FunId::BoxFree)
     } else {
         // Box::new is peculiar because there is an impl block
         use PathElem::*;
@@ -125,35 +125,35 @@ fn get_fun_id_from_name_full(name: &Name) -> Option<FunId> {
                                 && trait_refs.is_empty()
                             {
                                 match types.as_slice() {
-                                    [Ty::TypeVar(_)] => Option::Some(FunId::BoxNew),
-                                    _ => Option::None,
+                                    [Ty::TypeVar(_)] => Some(FunId::BoxNew),
+                                    _ => None,
                                 }
                             } else {
-                                Option::None
+                                None
                             }
                         }
-                        _ => Option::None,
+                        _ => None,
                     }
                 } else {
-                    Option::None
+                    None
                 }
             }
-            _ => Option::None,
+            _ => None,
         }
     }
 }
 
 pub fn get_fun_id_from_name(name: &Name) -> Option<ullbc_ast::AssumedFunId> {
     match get_fun_id_from_name_full(name) {
-        Option::Some(id) => {
+        Some(id) => {
             let id = match id {
                 FunId::Panic | FunId::BeginPanic => unreachable!(),
                 FunId::BoxNew => ullbc_ast::AssumedFunId::BoxNew,
                 FunId::BoxFree => ullbc_ast::AssumedFunId::BoxFree,
             };
-            Option::Some(id)
+            Some(id)
         }
-        Option::None => Option::None,
+        None => None,
     }
 }
 
@@ -164,8 +164,8 @@ pub fn get_fun_id_from_name(name: &Name) -> Option<ullbc_ast::AssumedFunId> {
 pub fn type_to_used_params(name: &Name) -> Option<Vec<bool>> {
     trace!("{:?}", name);
     match get_type_id_from_name(name) {
-        Option::None => Option::None,
-        Option::Some(id) => {
+        None => None,
+        Some(id) => {
             let id = match id {
                 AssumedTy::Box => {
                     vec![true, false]
@@ -178,7 +178,7 @@ pub fn type_to_used_params(name: &Name) -> Option<Vec<bool>> {
                 }
                 AssumedTy::Array | AssumedTy::Slice => vec![true],
             };
-            Option::Some(id)
+            Some(id)
         }
     }
 }
@@ -193,8 +193,8 @@ pub struct FunInfo {
 pub fn function_to_info(name: &Name) -> Option<FunInfo> {
     trace!("{:?}", name);
     match get_fun_id_from_name_full(name) {
-        Option::None => Option::None,
-        Option::Some(id) => {
+        None => None,
+        Some(id) => {
             let info = match id {
                 FunId::Panic => FunInfo {
                     used_type_params: vec![],
@@ -213,7 +213,7 @@ pub fn function_to_info(name: &Name) -> Option<FunInfo> {
                     used_args: vec![true, false],
                 },
             };
-            Option::Some(info)
+            Some(info)
         }
     }
 }

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -318,9 +318,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             ItemKind::ExternCrate(..) => {
                 // We ignore this -
                 // TODO: investigate when extern crates appear, and why
-                Option::None
+                None
             }
-            ItemKind::Use(..) => Option::None,
+            ItemKind::Use(..) => None,
             ItemKind::TyAlias(..)
             | ItemKind::Enum(..)
             | ItemKind::Struct(..)
@@ -331,7 +331,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             | ItemKind::Const(..)
             | ItemKind::Static(..)
             | ItemKind::Macro(..)
-            | ItemKind::Trait(..) => Option::Some(self.def_id_to_name(def_id)?),
+            | ItemKind::Trait(..) => Some(self.def_id_to_name(def_id)?),
             _ => {
                 unimplemented!("{:?}", item.kind);
             }

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -67,11 +67,11 @@ pub enum RawTerminator {
         place: Place,
         target: BlockId,
     },
-    /// Function call.
-    /// For now, we only accept calls to top-level functions.
+    /// Function call. If `target` is `None`, the function is guaranteed to diverge.
+    /// For now, we don't support dynamic calls (i.e. to a function pointer in memory).
     Call {
         call: Call,
-        target: BlockId,
+        target: Option<BlockId>,
     },
     /// A built-in assert, which corresponds to runtime checks that we remove, namely: bounds
     /// checks, over/underflow checks, div/rem by zero checks, pointer alignement check.

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -272,9 +272,11 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.visit_block_id(target);
     }
 
-    fn visit_call_statement(&mut self, call: &Call, target: &BlockId) {
+    fn visit_call_statement(&mut self, call: &Call, target: &Option<BlockId>) {
         self.visit_call(call);
-        self.visit_block_id(target);
+        if let Some(target) = target {
+            self.visit_block_id(target);
+        }
     }
 
     fn visit_assert(&mut self, cond: &Operand, expected: &bool, target: &BlockId) {

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -984,7 +984,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
             }
             RawTerminator::Call { call, target } => {
                 let (call_s, _) = fmt_call(ctx, call);
-                format!("{} := {call_s} -> bb{target}", call.dest.fmt_with_ctx(ctx),)
+                let target = if let Some(target) = target {
+                    format!("bb{target}")
+                } else {
+                    format!("!")
+                };
+                format!("{} := {call_s} -> {target}", call.dest.fmt_with_ctx(ctx),)
             }
             RawTerminator::Assert {
                 cond,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -126,8 +126,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for DeclarationGroup {
 impl<C: AstFormatter> FmtWithCtx<C> for Field {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match &self.name {
-            Option::Some(name) => format!("{}: {}", name, self.ty.fmt_with_ctx(ctx)),
-            Option::None => self.ty.fmt_with_ctx(ctx),
+            Some(name) => format!("{}: {}", name, self.ty.fmt_with_ctx(ctx)),
+            None => self.ty.fmt_with_ctx(ctx),
         }
     }
 }
@@ -664,8 +664,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for RawConstantExpr {
                 // we need the type (which contains the type def id).
                 // Anyway, the printing utilities are mostly for debugging.
                 let variant_id = match variant_id {
-                    Option::Some(id) => format!("Some({id})"),
-                    Option::None => "None".to_string(),
+                    Some(id) => format!("Some({id})"),
+                    None => "None".to_string(),
                 };
                 let values: Vec<String> = values.iter().map(|v| v.fmt_with_ctx(ctx)).collect();
                 format!("ConstAdt {} [{}]", variant_id, values.join(", "))

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -350,12 +350,12 @@ impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
                 // The definition may not be available yet, especially if we print-debug
                 // while translating the crate
                 match translated.type_decls.get(def_id) {
-                    Option::None => format!(
+                    None => format!(
                         "{}::{}",
                         def_id.to_pretty_string(),
                         variant_id.to_pretty_string()
                     ),
-                    Option::Some(def) => {
+                    Some(def) => {
                         let variants = def.kind.as_enum();
                         let mut name = def.name.fmt_with_ctx(self);
                         let variant_name = &variants.get(variant_id).unwrap().name;
@@ -375,12 +375,12 @@ impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
         let (def_id, opt_variant_id, field_id) = id;
         match &self.translated {
             None => match opt_variant_id {
-                Option::None => format!(
+                None => format!(
                     "{}::{}",
                     def_id.to_pretty_string(),
                     field_id.to_pretty_string()
                 ),
-                Option::Some(variant_id) => format!(
+                Some(variant_id) => format!(
                     "{}::{}::{}",
                     def_id.to_pretty_string(),
                     variant_id.to_pretty_string(),
@@ -392,20 +392,20 @@ impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
             // print-debug while translating the crate
             {
                 match translated.type_decls.get(def_id) {
-                    Option::None => match opt_variant_id {
-                        Option::None => format!(
+                    None => match opt_variant_id {
+                        None => format!(
                             "{}::{}",
                             def_id.to_pretty_string(),
                             field_id.to_pretty_string()
                         ),
-                        Option::Some(variant_id) => format!(
+                        Some(variant_id) => format!(
                             "{}::{}::{}",
                             def_id.to_pretty_string(),
                             variant_id.to_pretty_string(),
                             field_id.to_pretty_string()
                         ),
                     },
-                    Option::Some(gen_def) => match (&gen_def.kind, opt_variant_id) {
+                    Some(gen_def) => match (&gen_def.kind, opt_variant_id) {
                         (TypeDeclKind::Enum(variants), Some(variant_id)) => {
                             let field = variants
                                 .get(variant_id)
@@ -414,15 +414,15 @@ impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
                                 .get(field_id)
                                 .unwrap();
                             match &field.name {
-                                Option::Some(name) => name.clone(),
-                                Option::None => field_id.to_string(),
+                                Some(name) => name.clone(),
+                                None => field_id.to_string(),
                             }
                         }
                         (TypeDeclKind::Struct(fields), None) => {
                             let field = fields.get(field_id).unwrap();
                             match &field.name {
-                                Option::Some(name) => name.clone(),
-                                Option::None => field_id.to_string(),
+                                Some(name) => name.clone(),
+                                None => field_id.to_string(),
                             }
                         }
                         _ => unreachable!(),

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -71,7 +71,7 @@ impl<'a> Visitor<'a> {
                 // Push the statement:
                 //`tmp0 = & proj`
                 let buf_borrow_ty = Ty::Ref(Region::Erased, Box::new(buf_ty), ref_kind);
-                let buf_borrow_var = self.fresh_var(Option::None, buf_borrow_ty);
+                let buf_borrow_var = self.fresh_var(None, buf_borrow_ty);
                 let borrow_st = RawStatement::Assign(
                     Place::new(buf_borrow_var),
                     Rvalue::Ref(
@@ -91,7 +91,7 @@ impl<'a> Visitor<'a> {
                 // Push the statement:
                 // `tmp1 = Array{Mut,Shared}Index(move tmp0, copy i)`
                 let elem_borrow_ty = Ty::Ref(Region::Erased, Box::new(elem_ty.clone()), ref_kind);
-                let elem_borrow_var = self.fresh_var(Option::None, elem_borrow_ty);
+                let elem_borrow_var = self.fresh_var(None, elem_borrow_ty);
                 let arg_buf = Operand::Move(Place::new(buf_borrow_var));
                 let index_dest = Place::new(elem_borrow_var);
                 let index_id = FunIdOrTraitMethodRef::mk_assumed(index_id);
@@ -185,9 +185,9 @@ impl<'a> MutAstVisitor for Visitor<'a> {
 
     fn visit_statement(&mut self, st: &mut Statement) {
         // Retrieve the span information
-        self.span = Option::Some(st.span);
+        self.span = Some(st.span);
         self.visit_raw_statement(&mut st.content);
-        self.span = Option::None;
+        self.span = None;
     }
 
     fn visit_raw_statement(&mut self, st: &mut RawStatement) {
@@ -224,7 +224,7 @@ fn transform_st(locals: &mut Vector<VarId, Var>, s: &mut Statement) -> Option<Ve
     let mut visitor = Visitor {
         locals,
         statements: Vec::new(),
-        span: Option::None,
+        span: None,
     };
     visitor.visit_statement(s);
 

--- a/charon/src/transform/remove_unused_locals.rs
+++ b/charon/src/transform/remove_unused_locals.rs
@@ -37,10 +37,10 @@ impl SharedTypeVisitor for ComputeUsedLocals {}
 impl SharedExprVisitor for ComputeUsedLocals {
     fn visit_var_id(&mut self, vid: &VarId) {
         match self.vars.get_mut(vid) {
-            Option::None => {
+            None => {
                 let _ = self.vars.insert(*vid, 1);
             }
-            Option::Some(cnt) => *cnt += 1,
+            Some(cnt) => *cnt += 1,
         }
     }
 }

--- a/charon/src/transform/remove_unused_locals.rs
+++ b/charon/src/transform/remove_unused_locals.rs
@@ -102,10 +102,6 @@ fn update_locals(
         }
     }
 
-    // Check there are no remaining variables with type `Never`
-    for v in &locals {
-        assert!(!v.ty.contains_never());
-    }
     (locals, vids_map)
 }
 
@@ -119,7 +115,5 @@ impl LlbcPass for Transform {
             UpdateUsedLocals::update_statement(vids_map, &mut b.body);
             b
         });
-        // Check that there are no remaining locals with the type `Never`
-        assert!(b.locals.iter().all(|v| !v.ty.is_never()));
     }
 }

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -216,7 +216,7 @@ impl Deps {
 
     fn set_current_id(&mut self, ctx: &TransformCtx, id: AnyTransId) {
         self.insert_node(id);
-        self.current_id = Option::Some(id);
+        self.current_id = Some(id);
 
         // Add the id of the trait impl trait this item belongs to, if necessary
         use AnyTransId::*;

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1818,7 +1818,7 @@ fn translate_block(
     } else if is_switch {
         *info.exits_info.owned_switch_exits.get(&block_id).unwrap()
     } else {
-        Option::None
+        None
     };
 
     // If we enter a switch, add the exit block to the set
@@ -1826,8 +1826,8 @@ fn translate_block(
     let nswitch_exit_blocks = if is_switch {
         let mut nexit_blocks = switch_exit_blocks.clone();
         match next_block {
-            Option::None => nexit_blocks,
-            Option::Some(bid) => {
+            None => nexit_blocks,
+            Some(bid) => {
                 nexit_blocks.insert(bid);
                 nexit_blocks
             }

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -60,17 +60,17 @@ fn get_block_targets(body: &src::ExprBody, block_id: src::BlockId) -> Vec<src::B
 
     match &block.terminator.content {
         src::RawTerminator::Goto { target }
-        | src::RawTerminator::Drop { place: _, target }
-        | src::RawTerminator::Call { call: _, target }
-        | src::RawTerminator::Assert {
-            cond: _,
-            expected: _,
-            target,
-        } => {
+        | src::RawTerminator::Drop { target, .. }
+        | src::RawTerminator::Call {
+            target: Some(target),
+            ..
+        }
+        | src::RawTerminator::Assert { target, .. } => {
             vec![*target]
         }
-        src::RawTerminator::Switch { discr: _, targets } => targets.get_targets(),
-        src::RawTerminator::Panic
+        src::RawTerminator::Switch { targets, .. } => targets.get_targets(),
+        src::RawTerminator::Call { target: None, .. }
+        | src::RawTerminator::Panic
         | src::RawTerminator::Unreachable
         | src::RawTerminator::Return => {
             vec![]
@@ -1445,21 +1445,15 @@ fn get_goto_kind(
     next_block_id: src::BlockId,
 ) -> GotoKind {
     // First explore the parent loops in revert order
-    let len = parent_loops.len();
-    for i in 0..len {
-        let loop_id = parent_loops.get(len - i - 1).unwrap();
-
+    for (i, loop_id) in parent_loops.iter().rev().enumerate() {
         // If we goto a loop entry node: this is a 'continue'
         if next_block_id == *loop_id {
             return GotoKind::Continue(i);
         } else {
             // If we goto a loop exit node: this is a 'break'
-            match exits_info.loop_exits.get(loop_id).unwrap() {
-                None => (),
-                Some(exit_id) => {
-                    if *exit_id == next_block_id {
-                        return GotoKind::Break(i);
-                    }
+            if let Some(exit_id) = exits_info.loop_exits.get(loop_id).unwrap() {
+                if next_block_id == *exit_id {
+                    return GotoKind::Break(i);
                 }
             }
         }
@@ -1583,13 +1577,17 @@ fn translate_terminator(
             Some(combine_statement_and_statement(st, opt_child))
         }
         src::RawTerminator::Call { call, target } => {
-            let opt_child = translate_child_block(
-                info,
-                parent_loops,
-                switch_exit_blocks,
-                terminator.span,
-                *target,
-            );
+            let opt_child = if let Some(target) = target {
+                translate_child_block(
+                    info,
+                    parent_loops,
+                    switch_exit_blocks,
+                    terminator.span,
+                    *target,
+                )
+            } else {
+                None
+            };
             let st = tgt::RawStatement::Call(call.clone());
             let st = Box::new(tgt::Statement::new(src_span, st));
             Some(combine_statement_and_statement(st, opt_child))

--- a/charon/src/translate/translate_constants.rs
+++ b/charon/src/translate/translate_constants.rs
@@ -88,7 +88,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     // TODO: the user_ty is not always None
                     .map(|f| self.translate_constant_expr_to_constant_expr(span, f))
                     .try_collect()?;
-                RawConstantExpr::Adt(Option::None, fields)
+                RawConstantExpr::Adt(None, fields)
             }
             ConstantExprKind::TraitConst { impl_expr, name } => {
                 let trait_ref = self.translate_trait_impl_expr(span, erase_regions, impl_expr)?;

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -81,12 +81,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // opaque) and inside an opaque module (or sub-module), we ignore it.
         if top_item {
             match self.hir_item_to_name(item)? {
-                Option::None => {
+                None => {
                     // This kind of item is to be ignored
                     trace!("Ignoring {:?} (ignoring item kind)", item.item_id());
                     return Ok(());
                 }
-                Option::Some(item_name) => {
+                Some(item_name) => {
                     if self.is_opaque_name(&item_name) {
                         trace!("Ignoring {:?} (marked as opaque)", item.item_id());
                         return Ok(());

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -136,11 +136,11 @@ impl PartialOrd for OrdRustId {
         let (vid0, _) = self.variant_index_arity();
         let (vid1, _) = other.variant_index_arity();
         if vid0 != vid1 {
-            Option::Some(vid0.cmp(&vid1))
+            Some(vid0.cmp(&vid1))
         } else {
             let id0 = self.get_id();
             let id1 = other.get_id();
-            Option::Some(id0.cmp(&id1))
+            Some(id0.cmp(&id1))
         }
     }
 }
@@ -399,8 +399,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     fn register_file(&mut self, filename: FileName) -> FileId {
         // Lookup the file if it was already registered
         match self.translated.file_to_id.get(&filename) {
-            Option::Some(id) => *id,
-            Option::None => {
+            Some(id) => *id,
+            None => {
                 // Generate the fresh id
                 let id = match &filename {
                     FileName::Local(_) => {

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -970,42 +970,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 trait_refs
             );
 
-            if !is_prim {
-                // Two cases depending on whether we call a trait method or not
-                match trait_info {
-                    None => {
-                        // "Regular" function call
-                        let def_id = self.register_fun_decl_id(span, rust_id);
-                        let func = FunIdOrTraitMethodRef::Fun(FunId::Regular(def_id));
-                        let func = FnPtr { func, generics };
-                        let sfid = SubstFunId { func, args };
-                        Ok(SubstFunIdOrPanic::Fun(sfid))
-                    }
-                    Some(trait_info) => {
-                        // Trait method
-                        let rust_id = DefId::from(def_id);
-                        let impl_expr =
-                            self.translate_trait_impl_expr(span, erase_regions, trait_info)?;
-                        // The impl source should be Some(...): trait markers (that we may
-                        // eliminate) don't have methods.
-                        let impl_expr = impl_expr.unwrap();
-
-                        trace!("{:?}", rust_id);
-
-                        let trait_method_fun_id = self.register_fun_decl_id(span, rust_id);
-                        let method_name = self.t_ctx.translate_trait_item_name(rust_id)?;
-
-                        let func = FunIdOrTraitMethodRef::Trait(
-                            impl_expr,
-                            method_name,
-                            trait_method_fun_id,
-                        );
-                        let func = FnPtr { func, generics };
-                        let sfid = SubstFunId { func, args };
-                        Ok(SubstFunIdOrPanic::Fun(sfid))
-                    }
-                }
-            } else {
+            if is_prim {
                 // Primitive function.
                 //
                 // Note that there are subtleties with regards to the way types parameters
@@ -1058,6 +1023,41 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 };
                 let sfid = SubstFunId { func, args };
                 Ok(SubstFunIdOrPanic::Fun(sfid))
+            } else {
+                // Two cases depending on whether we call a trait method or not
+                match trait_info {
+                    None => {
+                        // "Regular" function call
+                        let def_id = self.register_fun_decl_id(span, rust_id);
+                        let func = FunIdOrTraitMethodRef::Fun(FunId::Regular(def_id));
+                        let func = FnPtr { func, generics };
+                        let sfid = SubstFunId { func, args };
+                        Ok(SubstFunIdOrPanic::Fun(sfid))
+                    }
+                    Some(trait_info) => {
+                        // Trait method
+                        let rust_id = DefId::from(def_id);
+                        let impl_expr =
+                            self.translate_trait_impl_expr(span, erase_regions, trait_info)?;
+                        // The impl source should be Some(...): trait markers (that we may
+                        // eliminate) don't have methods.
+                        let impl_expr = impl_expr.unwrap();
+
+                        trace!("{:?}", rust_id);
+
+                        let trait_method_fun_id = self.register_fun_decl_id(span, rust_id);
+                        let method_name = self.t_ctx.translate_trait_item_name(rust_id)?;
+
+                        let func = FunIdOrTraitMethodRef::Trait(
+                            impl_expr,
+                            method_name,
+                            trait_method_fun_id,
+                        );
+                        let func = FnPtr { func, generics };
+                        let sfid = SubstFunId { func, args };
+                        Ok(SubstFunIdOrPanic::Fun(sfid))
+                    }
+                }
             }
         }
     }

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1361,13 +1361,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         Ok(RawTerminator::Panic)
                     }
                     SubstFunIdOrPanic::Fun(fid) => {
-                        let next_block = target.unwrap_or_else(|| {
-                            panic!("Expected a next block after the call to {:?}.\n\nSubsts: {:?}\n\nArgs: {:?}:", rust_id, generics, args)
-                        });
-
-                        // Translate the target
                         let lval = self.translate_place(span, destination)?;
-                        let next_block = self.translate_basic_block_id(next_block);
+                        let next_block = target.map(|target| self.translate_basic_block_id(target));
 
                         let call = Call {
                             func: FnOperand::Regular(fid.func),
@@ -1387,12 +1382,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 // The function
                 let p = self.translate_place(span, p)?;
 
-                // Translate the target
-                let next_block = target.unwrap_or_else(|| {
-                    panic!("Expected a next block after the call to {:?}.\n\nSubsts: {:?}\n\nArgs: {:?}:", p, generics, args)
-                });
                 let lval = self.translate_place(span, destination)?;
-                let next_block = self.translate_basic_block_id(next_block);
+                let next_block = target.map(|target| self.translate_basic_block_id(target));
 
                 // TODO: we may have a problem here because as we don't
                 // know which function is being called, we may not be

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -585,9 +585,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         generics,
                     ) => {
                         if aty.is_array() {
-                            Option::Some(generics.const_generics[0].clone())
+                            Some(generics.const_generics[0].clone())
                         } else {
-                            Option::None
+                            None
                         }
                     }
                     _ => unreachable!(),
@@ -808,7 +808,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
                         use hax::AdtKind;
                         let variant_id = match kind {
-                            AdtKind::Struct => Option::None,
+                            AdtKind::Struct => None,
                             AdtKind::Enum => {
                                 let variant_id = translate_variant_id(*variant_idx);
                                 Some(variant_id)
@@ -928,14 +928,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             // Retrieve the lists of used parameters, in case of non-local
             // definitions
             let (used_type_args, used_args) = if is_local {
-                (Option::None, Option::None)
+                (None, None)
             } else {
                 match assumed::function_to_info(&name) {
-                    Option::None => (Option::None, Option::None),
-                    Option::Some(used) => (
-                        Option::Some(used.used_type_params),
-                        Option::Some(used.used_args),
-                    ),
+                    None => (None, None),
+                    Some(used) => (Some(used.used_type_params), Some(used.used_args)),
                 }
             };
 
@@ -976,7 +973,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             if !is_prim {
                 // Two cases depending on whether we call a trait method or not
                 match trait_info {
-                    Option::None => {
+                    None => {
                         // "Regular" function call
                         let def_id = self.register_fun_decl_id(span, rust_id);
                         let func = FunIdOrTraitMethodRef::Fun(FunId::Regular(def_id));
@@ -984,7 +981,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         let sfid = SubstFunId { func, args };
                         Ok(SubstFunIdOrPanic::Fun(sfid))
                     }
-                    Option::Some(trait_info) => {
+                    Some(trait_info) => {
                         // Trait method
                         let rust_id = DefId::from(def_id);
                         let impl_expr =
@@ -1437,8 +1434,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         args: &Vec<hax::Operand>,
     ) -> Result<Vec<Operand>, Error> {
         let args: Vec<&hax::Operand> = match used_args {
-            Option::None => args.iter().collect(),
-            Option::Some(used_args) => {
+            None => args.iter().collect(),
+            Some(used_args) => {
                 assert!(args.len() == used_args.len());
                 args.iter()
                     .zip(used_args.into_iter())

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -218,7 +218,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
                 // Retrieve the list of used arguments
                 let used_params = if adt_did.is_local() {
-                    Option::None
+                    None
                 } else {
                     let name = self.t_ctx.def_id_to_name(DefId::from(def_id))?;
                     assumed::type_to_used_params(&name)
@@ -420,8 +420,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trace!("{:?}", substs);
         // Filter the parameters
         let substs: Vec<&hax::GenericArg> = match used_params {
-            Option::None => substs.iter().collect(),
-            Option::Some(used_args) => {
+            None => substs.iter().collect(),
+            Some(used_args) => {
                 error_assert!(self, span, substs.len() == used_args.len());
                 substs
                     .iter()
@@ -487,11 +487,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             // Retrieve the type name
             let name = self.t_ctx.hax_def_id_to_name(def_id)?;
             match assumed::get_type_id_from_name(&name) {
-                Option::Some(id) => {
+                Some(id) => {
                     // The type has primitive support
                     Ok(TypeId::Assumed(id))
                 }
-                Option::None => {
+                None => {
                     // The type is external
                     Ok(TypeId::Adt(self.register_type_decl_id(span, rust_id)))
                 }
@@ -578,7 +578,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             let mut fields: Vector<FieldId, Field> = Default::default();
             /* This is for sanity: check that either all the fields have names, or
              * none of them has */
-            let mut have_names: Option<bool> = Option::None;
+            let mut have_names: Option<bool> = None;
             for (j, field_def) in var_def.fields.into_iter().enumerate() {
                 trace!("variant {i}: field {j}: {field_def:?}");
                 let field_span = field_def.span.rust_span_data.unwrap().span();
@@ -590,13 +590,13 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let field_name = field_def.name;
                 // Sanity check
                 match &have_names {
-                    Option::None => {
+                    None => {
                         have_names = match &field_name {
-                            Option::None => Some(false),
-                            Option::Some(_) => Some(true),
+                            None => Some(false),
+                            Some(_) => Some(true),
                         }
                     }
-                    Option::Some(b) => {
+                    Some(b) => {
                         error_assert!(self, field_span, *b == field_name.is_some());
                     }
                 };

--- a/charon/tests/ui/diverging.out
+++ b/charon/tests/ui/diverging.out
@@ -1,0 +1,31 @@
+# Final LLBC before serialization:
+
+fn test_crate::my_panic(@1: u32) -> !
+{
+    let @0: !; // return
+    let _x@1: u32; // arg #1
+
+    panic
+}
+
+fn test_crate::do_something_else()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+fn test_crate::call_my_panic()
+{
+    let @0: (); // return
+    let @1: !; // anonymous local
+
+    @1 := test_crate::my_panic(const (0 : u32))
+}
+
+
+

--- a/charon/tests/ui/diverging.rs
+++ b/charon/tests/ui/diverging.rs
@@ -1,0 +1,10 @@
+fn my_panic(_x: u32) -> ! {
+    panic!()
+}
+
+fn do_something_else() {}
+
+fn call_my_panic() {
+    my_panic(0);
+    do_something_else();
+}


### PR DESCRIPTION
This adds support for user-written diverging functions. They previously were not supported because they give a `TerminatorKind::Call` with no target. The PR also includes some drive-by improvements.

This is needed for the next rustc update, which does weird things with `panic!()`.