### PR TITLE
Rework the representation of panics

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.9"
+let supported_charon_version = "0.1.10"

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -16,6 +16,7 @@ and raw_statement =
   | Drop of place
   | Assert of assertion
   | Call of call
+  (* FIXME: rename to `Abort` *)
   | Panic
   | Return
   | Break of int

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -51,7 +51,7 @@ and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
     | `Assoc [ ("Call", call) ] ->
         let* call = call_of_json call in
         Ok (Call call)
-    | `String "Panic" -> Ok Panic
+    | `Assoc [ ("Abort", _) ] -> Ok Panic
     | `String "Return" -> Ok Return
     | `Assoc [ ("Break", i) ] ->
         let* i = int_of_json i in

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -62,7 +62,6 @@ module Ast = struct
         ^ switch_to_string indent tgts
     | Panic -> indent ^ "panic"
     | Return -> indent ^ "return"
-    | Unreachable -> indent ^ "unreachable"
     | Drop (p, bid) ->
         indent ^ "drop " ^ place_to_string env p ^ ";\n" ^ indent ^ "goto "
         ^ block_id_to_string bid

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -85,9 +85,9 @@ type terminator = {
 and raw_terminator =
   | Goto of block_id
   | Switch of operand * switch
+  (* FIXME: rename to `Abort` *)
   | Panic
   | Return
-  | Unreachable
   | Drop of place * block_id
   | Call of call * block_id option
   | Assert of assertion * block_id

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -90,9 +90,8 @@ and raw_terminator_of_json (js : json) : (raw_terminator, string) result =
         let* discr = operand_of_json discr in
         let* targets = switch_of_json targets in
         Ok (Switch (discr, targets))
-    | `String "Panic" -> Ok Panic
+    | `Assoc [ ("Abort", _) ] -> Ok Panic
     | `String "Return" -> Ok Return
-    | `String "Unreachable" -> Ok Unreachable
     | `Assoc [ ("Drop", `Assoc [ ("place", place); ("target", target) ]) ] ->
         let* place = place_of_json place in
         let* target = BlockId.id_of_json target in

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -304,9 +304,9 @@ pub struct Call {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AbortKind {
-    /// A builtin panicking function.
-    Panic,
-    /// a MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
+    /// A built-in panicking function.
+    Panic(Name),
+    /// A MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
     /// machine.
     UndefinedBehavior,
 }

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -301,3 +301,12 @@ pub struct Call {
     pub args: Vec<Operand>,
     pub dest: Place,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AbortKind {
+    /// A builtin panicking function.
+    Panic,
+    /// a MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
+    /// machine.
+    UndefinedBehavior,
+}

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -34,8 +34,9 @@ pub enum RawStatement {
     Drop(Place),
     Assert(Assert),
     Call(Call),
-    /// Panic also handles "unreachable"
-    Panic,
+    /// Panic also handles "unreachable". We keep the name of the panicking function that was
+    /// called.
+    Abort(AbortKind),
     Return,
     /// Break to outer loops.
     /// The `usize` gives the index of the outer loop to break to:

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -164,8 +164,8 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
             RawStatement::Call(c) => {
                 self.visit_call(c);
             }
-            RawStatement::Panic => {
-                self.visit_panic();
+            RawStatement::Abort(..) => {
+                self.visit_abort();
             }
             RawStatement::Return => self.visit_return(),
             RawStatement::Break(i) => {
@@ -207,7 +207,7 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.visit_operand(&a.cond);
     }
 
-    fn visit_panic(&mut self) {}
+    fn visit_abort(&mut self) {}
     fn visit_return(&mut self) {}
     fn visit_break(&mut self, _: &usize) {}
     fn visit_continue(&mut self, _: &usize) {}

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -60,9 +60,9 @@ pub enum RawTerminator {
         discr: Operand,
         targets: SwitchTargets,
     },
-    Panic,
+    /// Handles panics and impossible cases.
+    Abort(AbortKind),
     Return,
-    Unreachable,
     Drop {
         place: Place,
         target: BlockId,

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -112,14 +112,10 @@ impl BlockData {
             } => {
                 f(span, &mut nst, cond);
             }
-            RawTerminator::Panic
+            RawTerminator::Abort(..)
             | RawTerminator::Return
-            | RawTerminator::Unreachable
-            | RawTerminator::Goto { target: _ }
-            | RawTerminator::Drop {
-                place: _,
-                target: _,
-            } => {
+            | RawTerminator::Goto { .. }
+            | RawTerminator::Drop { .. } => {
                 // Nothing to do
             }
         };
@@ -229,9 +225,8 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
             Switch { discr, targets } => {
                 self.visit_switch(discr, targets);
             }
-            Panic => self.visit_panic(),
+            Abort(..)  => self.visit_abort(),
             Return => self.visit_return(),
-            Unreachable => self.visit_unreachable(),
             Drop { place, target } => {
                 self.visit_drop(place, target);
             }
@@ -261,11 +256,9 @@ pub trait AstVisitor: crate::expressions::ExprVisitor {
         self.visit_switch_targets(targets);
     }
 
-    fn visit_panic(&mut self) {}
+    fn visit_abort(&mut self) {}
 
     fn visit_return(&mut self) {}
-
-    fn visit_unreachable(&mut self) {}
 
     fn visit_drop(&mut self, place: &Place, target: &BlockId) {
         self.visit_place(place);

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -51,9 +51,9 @@ pub trait FmtWithCtx<C> {
 }
 
 impl<C: AstFormatter> FmtWithCtx<C> for AbortKind {
-    fn fmt_with_ctx_and_indent(&self, tab: &str, _ctx: &C) -> String {
+    fn fmt_with_ctx_and_indent(&self, tab: &str, ctx: &C) -> String {
         match self {
-            AbortKind::Panic => format!("{tab}panic"),
+            AbortKind::Panic(name) => format!("{tab}panic({})", name.fmt_with_ctx(ctx)),
             AbortKind::UndefinedBehavior => format!("{tab}undefined_behavior"),
         }
     }

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -200,7 +200,7 @@ impl<'a> MutAstVisitor for Visitor<'a> {
             FakeRead(p) => {
                 self.visit_transform_place(false, p);
             }
-            Assign(..) | SetDiscriminant(..) | Drop(..) | Assert(..) | Call(..) | Panic
+            Assign(..) | SetDiscriminant(..) | Drop(..) | Assert(..) | Call(..) | Abort(..)
             | Return | Break(..) | Continue(..) | Nop | Switch(..) | Loop(..) | Error(..) => {
                 // Explore
                 self.default_visit_raw_statement(st)

--- a/charon/src/transform/reconstruct_asserts.rs
+++ b/charon/src/transform/reconstruct_asserts.rs
@@ -14,7 +14,7 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
     if let RawStatement::Switch(Switch::If(_, st1, _)) = &mut st.content {
         // Check if the first statement is a panic: if yes, replace
         // the if .. then ... else ... by an assertion.
-        if st1.content.is_panic() {
+        if st1.content.is_abort() {
             // Replace: we need to take the value
             take(&mut st.content, |st| {
                 let (op, st1, st2) = st.to_switch().to_if();

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -13,6 +13,7 @@ use crate::formatter::{Formatter, IntoFormatter};
 use crate::get_mir::{boxes_are_desugared, get_mir_for_def_id_and_level};
 use crate::ids::Vector;
 use crate::meta::ItemMeta;
+use crate::names::Name;
 use crate::pretty::FmtWithCtx;
 use crate::translate_ctx::*;
 use crate::translate_types;
@@ -32,7 +33,7 @@ pub(crate) struct SubstFunId {
 }
 
 pub(crate) enum SubstFunIdOrPanic {
-    Panic,
+    Panic(Name),
     Fun(SubstFunId),
 }
 
@@ -876,7 +877,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
         let builtin_fun = BuiltinFun::parse_name(&name);
         if matches!(builtin_fun, Some(BuiltinFun::Panic)) {
-            return Ok(SubstFunIdOrPanic::Panic);
+            return Ok(SubstFunIdOrPanic::Panic(name));
         }
 
         // There is something annoying: when going to MIR, the rust compiler
@@ -1354,13 +1355,13 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 )?;
 
                 match fid {
-                    SubstFunIdOrPanic::Panic => {
+                    SubstFunIdOrPanic::Panic(name) => {
                         // If the call is `panic!`, then the target is `None`.
                         // I don't know in which other cases it can be `None`.
                         assert!(target.is_none());
 
                         // We ignore the arguments
-                        Ok(RawTerminator::Abort(AbortKind::Panic))
+                        Ok(RawTerminator::Abort(AbortKind::Panic(name)))
                     }
                     SubstFunIdOrPanic::Fun(fid) => {
                         let lval = self.translate_place(span, destination)?;

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1188,7 +1188,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 error_or_panic!(self, rustc_span, "Unexpected terminator: UnwindTerminate")
             }
             TerminatorKind::Return => RawTerminator::Return,
-            TerminatorKind::Unreachable => RawTerminator::Unreachable,
+            // A MIR `Unreachable` terminator indicates undefined behavior of the rust abstract
+            // machine.
+            TerminatorKind::Unreachable => RawTerminator::Abort(AbortKind::UndefinedBehavior),
             TerminatorKind::Drop {
                 place,
                 target,
@@ -1358,7 +1360,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         assert!(target.is_none());
 
                         // We ignore the arguments
-                        Ok(RawTerminator::Panic)
+                        Ok(RawTerminator::Abort(AbortKind::Panic))
                     }
                     SubstFunIdOrPanic::Fun(fid) => {
                         let lval = self.translate_place(span, destination)?;

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -121,7 +121,7 @@ fn test_cargo_dependencies::main()
         @20 := &*(right_val@11)
         @19 := &*(@20)
         @21 := core::option::Option::None {  }
-        panic
+        panic(core::panicking::assert_failed)
     }
     drop @14
     drop @13

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -1210,7 +1210,7 @@ fn test_crate::sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u
     else {
         drop @8
         drop @6
-        panic
+        panic(core::panicking::panic)
     }
     drop @8
     drop @6

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -145,7 +145,7 @@ fn test_crate::list_nth<'a, T>(@1: &'a (test_crate::CList<T>), @2: u32) -> &'a (
             nop
         },
         1 => {
-            panic
+            panic(core::panicking::panic)
         }
     }
     x@3 := &(*(l@1) as variant @0).0
@@ -199,7 +199,7 @@ fn test_crate::list_nth_mut<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) 
             nop
         },
         1 => {
-            panic
+            panic(core::panicking::panic)
         }
     }
     x@5 := &mut (*(l@1) as variant @0).0
@@ -267,7 +267,7 @@ fn test_crate::list_nth_mut1<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32)
                 @3 := move (@12)
                 drop @11
                 drop @3
-                panic
+                panic(core::panicking::panic)
             }
         }
         x@5 := &mut (*(l@1) as variant @0).0

--- a/charon/tests/ui/diverging.out
+++ b/charon/tests/ui/diverging.out
@@ -5,7 +5,7 @@ fn test_crate::my_panic(@1: u32) -> !
     let @0: !; // return
     let _x@1: u32; // arg #1
 
-    panic
+    panic(core::panicking::panic)
 }
 
 fn test_crate::do_something_else()

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -534,7 +534,7 @@ fn test_crate::select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
             @23 := &*(right_val@14)
             @22 := &*(@23)
             @24 := core::option::Option::None {  }
-            panic
+            panic(core::panicking::assert_failed)
         }
     }
     else {

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -14,7 +14,7 @@ where
     let @0: (); // return
     let self@1: &'_ mut (test_crate::AVLTree<T>); // arg #1
 
-    panic
+    panic(core::panicking::panic)
 }
 
 impl test_crate::{impl test_crate::Ord for u32#1} : test_crate::Ord<u32>

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -680,7 +680,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @4
-        panic
+        panic(core::panicking::panic)
     }
     drop @4
     @25 := ()
@@ -696,7 +696,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @8
-        panic
+        panic(core::panicking::panic)
     }
     drop @8
     @26 := ()
@@ -712,7 +712,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @12
-        panic
+        panic(core::panicking::panic)
     }
     drop @12
     @27 := ()
@@ -728,7 +728,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @16
-        panic
+        panic(core::panicking::panic)
     }
     drop @16
     @28 := ()
@@ -744,7 +744,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @20
-        panic
+        panic(core::panicking::panic)
     }
     drop @20
     @29 := ()
@@ -760,7 +760,7 @@ fn test_crate::test_loops()
     }
     else {
         drop @24
-        panic
+        panic(core::panicking::panic)
     }
     drop @24
     @30 := ()
@@ -1750,7 +1750,7 @@ fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usi
                 nop
             },
             1 => {
-                panic
+                panic(core::panicking::panic)
             }
         }
         y@4 := &mut (*(ls@1) as variant @0).0
@@ -1812,7 +1812,7 @@ fn test_crate::list_nth_mut_loop_with_id<'_0, T>(@1: &'_0 mut (test_crate::List<
                 @3 := move (@11)
                 drop @10
                 drop @3
-                panic
+                panic(core::panicking::panic)
             }
         }
         x@5 := &mut (*(ls@1) as variant @0).0

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -318,7 +318,7 @@ fn test_crate::test_box1()
     }
     else {
         drop @8
-        panic
+        panic(core::panicking::panic)
     }
     drop @8
     @9 := ()
@@ -362,7 +362,7 @@ fn test_crate::test_unreachable(@1: bool)
         @0 := ()
         return
     }
-    panic
+    panic(core::panicking::panic)
 }
 
 fn test_crate::is_cons<'_0, T>(@1: &'_0 (test_crate::List<T>)) -> bool
@@ -397,7 +397,7 @@ fn test_crate::split_list<T>(@1: test_crate::List<T>) -> (T, test_crate::List<T>
             nop
         },
         _ => {
-            panic
+            panic(core::panicking::panic)
         }
     }
     hd@2 := move ((l@1 as variant @0).0)
@@ -511,7 +511,7 @@ fn test_crate::test_even_odd()
         nop
     }
     else {
-        panic
+        panic(core::panicking::panic)
     }
     @9 := ()
     @1 := move (@9)
@@ -522,7 +522,7 @@ fn test_crate::test_even_odd()
         nop
     }
     else {
-        panic
+        panic(core::panicking::panic)
     }
     @10 := ()
     @3 := move (@10)
@@ -533,7 +533,7 @@ fn test_crate::test_even_odd()
         nop
     }
     else {
-        panic
+        panic(core::panicking::panic)
     }
     @11 := ()
     @5 := move (@11)
@@ -544,7 +544,7 @@ fn test_crate::test_even_odd()
         nop
     }
     else {
-        panic
+        panic(core::panicking::panic)
     }
     @12 := ()
     @7 := move (@12)

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -95,8 +95,38 @@ fn test_crate::panic4()
 fn test_crate::panic5()
 {
     let @0: (); // return
+    let @1: (); // anonymous local
+    let @2: bool; // anonymous local
+    let @3: core::fmt::Arguments<'_>; // anonymous local
+    let @4: &'_ (Slice<&'_ (Str)>); // anonymous local
+    let @5: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @6: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @7: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @8: (); // anonymous local
+    let @9: (); // anonymous local
 
-    panic
+    @2 := const (false)
+    if move (@2) {
+        nop
+    }
+    else {
+        @7 := [const ("assert failed"); 1 : usize]
+        @6 := &@7
+        @5 := &*(@6)
+        @4 := @ArrayToSliceShared<'_, &'_ (Str), 1 : usize>(move (@5))
+        drop @5
+        @3 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_>(move (@4))
+        drop @4
+        panic
+    }
+    @8 := ()
+    @1 := move (@8)
+    drop @2
+    drop @1
+    @9 := ()
+    @0 := move (@9)
+    @0 := ()
+    return
 }
 
 fn test_crate::panic6()
@@ -107,6 +137,42 @@ fn test_crate::panic6()
 }
 
 fn test_crate::panic7()
+{
+    let @0: (); // return
+    let @1: core::fmt::Arguments<'_>; // anonymous local
+    let @2: &'_ (Slice<&'_ (Str)>); // anonymous local
+    let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @4: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @5: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @6: &'_ (Slice<core::fmt::rt::Argument<'_>>); // anonymous local
+    let @7: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
+    let @8: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
+    let @9: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
+
+    @5 := [const ("internal error: entered unreachable code: can't reach this"); 1 : usize]
+    @4 := &@5
+    @3 := &*(@4)
+    @2 := @ArrayToSliceShared<'_, &'_ (Str), 1 : usize>(move (@3))
+    drop @3
+    @9 := core::fmt::rt::{core::fmt::rt::Argument<'a>#1}::none<'_>()
+    @8 := &@9
+    @7 := &*(@8)
+    @6 := @ArrayToSliceShared<'_, core::fmt::rt::Argument<'_>, 0 : usize>(move (@7))
+    drop @7
+    @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'_>(move (@2), move (@6))
+    drop @6
+    drop @2
+    panic
+}
+
+fn test_crate::panic8()
+{
+    let @0: (); // return
+
+    panic
+}
+
+fn test_crate::panic9()
 {
     let @0: (); // return
 

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -4,7 +4,7 @@ fn test_crate::panic1()
 {
     let @0: (); // return
 
-    panic
+    panic(core::panicking::panic)
 }
 
 opaque type core::fmt::Arguments<'a>
@@ -29,7 +29,7 @@ fn test_crate::panic2()
     drop @3
     @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_>(move (@2))
     drop @2
-    panic
+    panic(core::panicking::panic_fmt)
 }
 
 opaque type core::fmt::rt::Argument<'a>
@@ -64,7 +64,7 @@ fn test_crate::panic3()
     @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'_>(move (@2), move (@6))
     drop @6
     drop @2
-    panic
+    panic(core::panicking::panic_fmt)
 }
 
 fn test_crate::panic4()
@@ -80,7 +80,7 @@ fn test_crate::panic4()
         nop
     }
     else {
-        panic
+        panic(core::panicking::panic)
     }
     @3 := ()
     @1 := move (@3)
@@ -117,7 +117,7 @@ fn test_crate::panic5()
         drop @5
         @3 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_>(move (@4))
         drop @4
-        panic
+        panic(core::panicking::panic_fmt)
     }
     @8 := ()
     @1 := move (@8)
@@ -133,7 +133,7 @@ fn test_crate::panic6()
 {
     let @0: (); // return
 
-    panic
+    panic(core::panicking::panic)
 }
 
 fn test_crate::panic7()
@@ -162,21 +162,21 @@ fn test_crate::panic7()
     @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'_>(move (@2), move (@6))
     drop @6
     drop @2
-    panic
+    panic(core::panicking::panic_fmt)
 }
 
 fn test_crate::panic8()
 {
     let @0: (); // return
 
-    panic
+    panic(core::panicking::panic)
 }
 
 fn test_crate::panic9()
 {
     let @0: (); // return
 
-    panic
+    panic(std::panicking::begin_panic)
 }
 
 

--- a/charon/tests/ui/panics.rs
+++ b/charon/tests/ui/panics.rs
@@ -12,11 +12,17 @@ fn panic4() {
     assert!(false);
 }
 fn panic5() {
-    unreachable!();
+    assert!(false, "assert failed");
 }
 fn panic6() {
-    todo!();
+    unreachable!();
 }
 fn panic7() {
+    unreachable!("can't reach {}", "this");
+}
+fn panic8() {
+    todo!();
+}
+fn panic9() {
     ::std::rt::begin_panic("explicit panic");
 }

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -22,7 +22,7 @@ fn test_crate::main()
     drop @3
     @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_>(move (@2))
     drop @2
-    panic
+    panic(core::panicking::panic_fmt)
 }
 
 

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -90,7 +90,7 @@ where
 {
     let @0: core::option::Option<@TraitClause1::S>; // return
 
-    panic
+    panic(core::panicking::panic)
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -640,7 +640,7 @@ fn test_crate::main()
         @64 := &*(right_val@55)
         @63 := &*(@64)
         @65 := core::option::Option::None {  }
-        panic
+        panic(core::panicking::assert_failed)
     }
     drop @58
     drop @57


### PR DESCRIPTION
This is a cosmetic change, in preparation for the coming rustc update. This PR clarifies the role of the MIR `Unreachable` terminator, and unifies how llbc and ullbc deal with panics and `Unreachable`.