### PR TITLE
Make `RawStatement::Sequence` contain a `Vec`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.10"
+let supported_charon_version = "0.1.11"

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -60,10 +60,21 @@ and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
         let* i = int_of_json i in
         Ok (Continue i)
     | `String "Nop" -> Ok Nop
-    | `Assoc [ ("Sequence", `List [ st1; st2 ]) ] ->
-        let* st1 = statement_of_json id_to_file st1 in
-        let* st2 = statement_of_json id_to_file st2 in
-        Ok (Sequence (st1, st2))
+    (* We get a list from the rust side, which we fold into our recursive `Sequence` representation. *)
+    | `Assoc [ ("Sequence", `List seq) ] -> (
+        let seq = List.map (statement_of_json id_to_file) seq in
+        match List.rev seq with
+        | [] -> Ok Nop
+        | last :: rest ->
+            let* seq =
+              List.fold_left
+                (fun acc st ->
+                  let* st = st in
+                  let* acc = acc in
+                  Ok { span = st.span; content = Sequence (st, acc) })
+                last rest
+            in
+            Ok seq.content)
     | `Assoc [ ("Switch", tgt) ] ->
         let* switch = switch_of_json id_to_file tgt in
         Ok (Switch switch)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -43,7 +43,7 @@ pub struct Var {
 }
 
 /// Marker to indicate that a declaration is opaque (i.e. we don't inspect its body).
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Opaque;
 
 /// An expression body.

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -55,11 +55,9 @@ pub enum RawStatement {
     Continue(usize),
     /// No-op.
     Nop,
-    /// The left statement must NOT be a sequence.
-    /// For instance, `(s0; s1); s2` is forbidden and should be rewritten
-    /// to the semantically equivalent statement `s0; (s1; s2)`
-    /// To ensure that, use [Sequence::then] to build sequences.
-    Sequence(Box<Statement>, Box<Statement>),
+    /// The contained statements must NOT be sequences. To ensure that, use [Sequence::then] to
+    /// build sequences.
+    Sequence(Vec<Statement>),
     Switch(Switch),
     Loop(Box<Statement>),
     Error(String),

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -58,7 +58,7 @@ pub enum RawStatement {
     /// The left statement must NOT be a sequence.
     /// For instance, `(s0; s1); s2` is forbidden and should be rewritten
     /// to the semantically equivalent statement `s0; (s1; s2)`
-    /// To ensure that, use [crate::llbc_ast_utils::new_sequence] to build sequences.
+    /// To ensure that, use [Sequence::then] to build sequences.
     Sequence(Box<Statement>, Box<Statement>),
     Switch(Switch),
     Loop(Box<Statement>),

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -96,11 +96,10 @@ impl Statement {
         Statement::new(span, RawStatement::Sequence(vec))
     }
 
-    // FIXME: remove boxes
-    pub fn then_opt(self: Box<Self>, other: Option<Box<Statement>>) -> Box<Statement> {
+    pub fn then_opt(self: Self, other: Option<Statement>) -> Statement {
         match other {
-            Some(other) => self.then(*other).into_box(),
             None => self,
+            Some(other) => self.then(other),
         }
     }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -15,6 +15,7 @@ use crate::{
     values::*,
 };
 use hax_frontend_exporter as hax;
+use itertools::Itertools;
 
 /// Format the AST type as a string.
 pub trait FmtWithCtx<C> {
@@ -862,11 +863,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for llbc::Statement {
             RawStatement::Break(index) => format!("{tab}break {index}"),
             RawStatement::Continue(index) => format!("{tab}continue {index}"),
             RawStatement::Nop => format!("{tab}nop"),
-            RawStatement::Sequence(st1, st2) => format!(
-                "{}\n{}",
-                st1.fmt_with_ctx_and_indent(tab, ctx),
-                st2.fmt_with_ctx_and_indent(tab, ctx)
-            ),
+            RawStatement::Sequence(vec) => vec
+                .iter()
+                .map(|st| st.fmt_with_ctx_and_indent(tab, ctx))
+                .join("\n"),
             RawStatement::Switch(switch) => match switch {
                 Switch::If(discr, true_st, false_st) => {
                     let inner_tab = format!("{tab}{TAB_INCR}");

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -6,6 +6,7 @@ use crate::{
     gast,
     ids::Vector,
     llbc_ast::{self as llbc, *},
+    meta::*,
     names::*,
     reorder_decls::*,
     translate_predicates::NonLocalTraitClause,
@@ -1453,6 +1454,12 @@ impl std::fmt::Display for LiteralTy {
             LiteralTy::Char => write!(f, "char"),
             LiteralTy::Bool => write!(f, "bool"),
         }
+    }
+}
+
+impl std::fmt::Display for Loc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(f, "{}:{}", self.line, self.col)
     }
 }
 

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -207,7 +207,7 @@ impl<'a> Visitor<'a> {
         self.span = None;
 
         // Reparenthesize sequences we messed up while traversing.
-        st.reparenthesize();
+        st.flatten();
 
         // We potentially collected statements to prepend to this one.
         let seq = std::mem::take(&mut self.statements);

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -24,7 +24,7 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
         );
         let assign_st = Statement::new(st.span, RawStatement::Assign(ret_place, unit_value));
         let ret_st = Statement::new(st.span, RawStatement::Return);
-        st.content = RawStatement::Sequence(Box::new(assign_st), Box::new(ret_st));
+        st.content = assign_st.then(ret_st).content;
     };
     None
 }

--- a/charon/src/transform/reconstruct_asserts.rs
+++ b/charon/src/transform/reconstruct_asserts.rs
@@ -25,7 +25,7 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
                         expected: false,
                     }),
                 );
-                st1.into_box().then_box(st2).content
+                st1.then(*st2).content
             });
         }
     }

--- a/charon/src/transform/reconstruct_asserts.rs
+++ b/charon/src/transform/reconstruct_asserts.rs
@@ -25,8 +25,7 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
                         expected: false,
                     }),
                 );
-                let st1 = Box::new(st1);
-                RawStatement::Sequence(st1, st2)
+                st1.into_box().then_box(st2).content
             });
         }
     }

--- a/charon/src/transform/remove_arithmetic_overflow_checks.rs
+++ b/charon/src/transform/remove_arithmetic_overflow_checks.rs
@@ -24,63 +24,64 @@ impl Transform {
     /// z := x + y;
     /// ```
     fn update_statement(s: &mut Statement) {
-        if let RawStatement::Sequence(s0, s1) = &mut s.content {
-            if let RawStatement::Sequence(s1, s2) = &mut s1.content {
-                // TODO: the last statement is not necessarily a sequence
-                if let RawStatement::Sequence(s2, _) = &mut s2.content {
-                    if let (
-                        RawStatement::Assign(
-                            binop,
-                            Rvalue::BinaryOp(
-                                op @ (BinOp::CheckedAdd | BinOp::CheckedSub | BinOp::CheckedMul),
-                                _,
-                                _,
-                            ),
-                        ),
-                        RawStatement::Assert(Assert {
-                            cond: Operand::Move(assert_cond),
-                            expected: false,
-                        }),
-                        RawStatement::Assign(final_value, Rvalue::Use(Operand::Move(assigned))),
-                    ) = (&mut s0.content, &s1.content, &mut s2.content)
-                    {
-                        // assigned should be: binop.0
-                        // assert_cond should be: binop.1
-                        if let (
-                            [ProjectionElem::Field(FieldProjKind::Tuple(..), fid0)],
-                            [ProjectionElem::Field(FieldProjKind::Tuple(..), fid1)],
-                        ) = (
-                            assigned.projection.as_slice(),
-                            assert_cond.projection.as_slice(),
-                        ) {
-                            if assert_cond.var_id == binop.var_id
-                                && assigned.var_id == binop.var_id
-                                && binop.projection.len() == 0
-                                && fid0.index() == 0
-                                && fid1.index() == 1
-                            {
-                                // Switch to the unchecked operation.
-                                *op = match op {
-                                    BinOp::CheckedAdd => BinOp::Add,
-                                    BinOp::CheckedSub => BinOp::Sub,
-                                    BinOp::CheckedMul => BinOp::Mul,
-                                    _ => unreachable!(),
-                                };
-                                // Assign to the correct value in `s0`.
-                                std::mem::swap(binop, final_value);
-                                // Remove `s1` and `s2`.
-                                take(s, |s| {
-                                    let (s0, s1) = s.content.to_sequence();
-                                    let (_s1, s2) = s1.content.to_sequence();
-                                    let (_s2, s3) = s2.content.to_sequence();
-                                    Statement {
-                                        span: s0.span,
-                                        content: RawStatement::Sequence(s0, s3),
-                                    }
-                                });
-                            }
+        let mut seq = s.sequence_to_vec_mut();
+        if let [Statement {
+            content:
+                RawStatement::Assign(
+                    binop,
+                    Rvalue::BinaryOp(
+                        op @ (BinOp::CheckedAdd | BinOp::CheckedSub | BinOp::CheckedMul),
+                        _,
+                        _,
+                    ),
+                ),
+            ..
+        }, Statement {
+            content:
+                RawStatement::Assert(Assert {
+                    cond: Operand::Move(assert_cond),
+                    expected: false,
+                }),
+            ..
+        }, Statement {
+            content: RawStatement::Assign(final_value, Rvalue::Use(Operand::Move(assigned))),
+            ..
+        }, ..] = seq.as_mut_slice()
+        {
+            // assigned should be: binop.0
+            // assert_cond should be: binop.1
+            if let (
+                [ProjectionElem::Field(FieldProjKind::Tuple(..), fid0)],
+                [ProjectionElem::Field(FieldProjKind::Tuple(..), fid1)],
+            ) = (
+                assigned.projection.as_slice(),
+                assert_cond.projection.as_slice(),
+            ) {
+                if assert_cond.var_id == binop.var_id
+                    && assigned.var_id == binop.var_id
+                    && binop.projection.len() == 0
+                    && fid0.index() == 0
+                    && fid1.index() == 1
+                {
+                    // Switch to the unchecked operation.
+                    *op = match op {
+                        BinOp::CheckedAdd => BinOp::Add,
+                        BinOp::CheckedSub => BinOp::Sub,
+                        BinOp::CheckedMul => BinOp::Mul,
+                        _ => unreachable!(),
+                    };
+                    // Assign to the correct value in `s0`.
+                    std::mem::swap(binop, final_value);
+                    // Remove `s1` and `s2`.
+                    take(s, |s| {
+                        let (s0, s1) = s.content.to_sequence();
+                        let (_s1, s2) = s1.content.to_sequence();
+                        let (_s2, s3) = s2.content.to_sequence();
+                        Statement {
+                            span: s0.span,
+                            content: s0.then_box(s3).content,
                         }
-                    }
+                    });
                 }
             }
         }

--- a/charon/src/transform/remove_drop_never.rs
+++ b/charon/src/transform/remove_drop_never.rs
@@ -13,22 +13,13 @@ use super::ctx::LlbcPass;
 /// Filter the statement by replacing it with `Nop` if it is a `Drop(x)` where
 /// `x` has type `Never`. Otherwise leave it unchanged.
 fn transform_st(locals: &Vector<VarId, Var>, st: &mut Statement) {
-    // Shall we filter the statement?
-    let filter = match &mut st.content {
-        RawStatement::Drop(p) => {
-            if p.projection.is_empty() {
-                let var = locals.get(p.var_id).unwrap();
-                var.ty.is_never()
-            } else {
-                false
+    if let RawStatement::Drop(p) = &st.content {
+        if p.projection.is_empty() {
+            let var = locals.get(p.var_id).unwrap();
+            if var.ty.is_never() {
+                st.content = RawStatement::Nop;
             }
         }
-        _ => false,
-    };
-
-    // If we filter the statement, we simply replace it with `nop`
-    if filter {
-        *st = Statement::new(st.span, RawStatement::Nop);
     }
 }
 

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1732,13 +1732,7 @@ fn is_terminal_explore(num_loops: usize, st: &tgt::Statement) -> bool {
         tgt::RawStatement::Abort(..) | tgt::RawStatement::Return => true,
         tgt::RawStatement::Break(index) => *index >= num_loops,
         tgt::RawStatement::Continue(_index) => true,
-        tgt::RawStatement::Sequence(st1, st2) => {
-            if is_terminal_explore(num_loops, st1) {
-                true
-            } else {
-                is_terminal_explore(num_loops, st2)
-            }
-        }
+        tgt::RawStatement::Sequence(seq) => seq.iter().any(|st| is_terminal_explore(num_loops, st)),
         tgt::RawStatement::Switch(switch) => switch
             .get_targets()
             .iter()

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -120,7 +120,7 @@ fn spans() -> Result<(), Box<dyn Error>> {
     let body = &crate_data.bodies[body_id].as_structured().unwrap().body;
     // The whole function declaration.
     assert_eq!(repr_span(body.span), "2:8-10:9");
-    let seq = body.clone().sequence_to_vec();
+    let seq = body.clone().into_sequence();
     let the_loop = seq.iter().find(|st| st.content.is_loop()).unwrap();
     // That's not a very precise span :/
     assert_eq!(repr_span(the_loop.span), "4:12-10:9");

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -71,38 +71,42 @@ fn test_crate::test3(@1: test_crate::E2) -> u32
 {
     let @0: u32; // return
     let x@1: test_crate::E2; // arg #1
-    let y@2: u32; // local
-    let n@3: u32; // local
-    let z@4: u32; // local
-    let @5: u32; // anonymous local
+    let @2: (); // anonymous local
+    let y@3: u32; // local
+    let n@4: u32; // local
+    let z@5: u32; // local
     let @6: u32; // anonymous local
+    let @7: u32; // anonymous local
 
+    @2 := ()
+    @fake_read(@2)
+    drop @2
     @fake_read(x@1)
     match x@1 {
         0 => {
-            n@3 := copy ((x@1 as variant @0).0)
-            y@2 := copy (n@3)
-            drop n@3
+            n@4 := copy ((x@1 as variant @0).0)
+            y@3 := copy (n@4)
+            drop n@4
         },
         1 => {
-            n@3 := copy ((x@1 as variant @1).0)
-            y@2 := copy (n@3)
-            drop n@3
+            n@4 := copy ((x@1 as variant @1).0)
+            y@3 := copy (n@4)
+            drop n@4
         },
         2 => {
-            y@2 := const (0 : u32)
+            y@3 := const (0 : u32)
         }
     }
-    @fake_read(y@2)
-    z@4 := test_crate::id<u32>(const (3 : u32))
-    @fake_read(z@4)
-    @5 := copy (y@2)
-    @6 := copy (z@4)
-    @0 := move (@5) + move (@6)
+    @fake_read(y@3)
+    z@5 := test_crate::id<u32>(const (3 : u32))
+    @fake_read(z@5)
+    @6 := copy (y@3)
+    @7 := copy (z@5)
+    @0 := move (@6) + move (@7)
+    drop @7
     drop @6
-    drop @5
-    drop z@4
-    drop y@2
+    drop z@5
+    drop y@3
     return
 }
 

--- a/charon/tests/ui/matches.rs
+++ b/charon/tests/ui/matches.rs
@@ -31,7 +31,7 @@ pub enum E1 {
 /// especially because it makes the control-flow reconstruction more ad-hoc. The
 /// main problem is that it would be difficult to make the distinction between
 /// a goto we need to ignore, and a "real" goto.
-/// Consequently, whenever branhces are fused, don't use `--no-code-duplication`.
+/// Consequently, whenever branches are fused, don't use `--no-code-duplication`.
 pub fn test1(x: E1) -> bool {
     match x {
         E1::V1 | E1::V2 => true,
@@ -61,6 +61,7 @@ pub fn test2(x: E2) -> u32 {
 
 /// Similar to test2
 pub fn test3(x: E2) -> u32 {
+    let () = (); // Test that we don't assume the match is the first statement.
     let y = match x {
         E2::V1(n) | E2::V2(n) => n,
         E2::V3 => 0,


### PR DESCRIPTION
This is more convenient to use from rustc and avoids the high risk of overflow whenever we traverse a function body. It's likely a lot faster too. `charon-ml` users won't see the difference.

One surprising consequence is that this changes some loop spans in Aeneas tests. For a reason I don't understand, Aeneas usually had loop spans that pointed to the whole function instead of just the loop. Now it uses the span that is supposed to cover just the loop. Unfortunately spans are hard so they tend to be wrong anyway.

Fixes #122 