### PR TITLE
Various improvements to trait clauses

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.12"
+let supported_charon_version = "0.1.13"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -516,6 +516,7 @@ let trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
         [
           ("clause_id", clause_id);
           ("span", span);
+          ("origin", _);
           ("trait_id", trait_id);
           ("generics", generics);
         ] ->

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -5,6 +5,7 @@
 use crate::common::*;
 use crate::names::*;
 use crate::translate_ctx::*;
+use crate::types::PredicateOrigin;
 use hax_frontend_exporter as hax;
 use hax_frontend_exporter::SInto;
 use rustc_hir::{Item, ItemKind};
@@ -213,7 +214,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                         .sinto(&bt_ctx.hax_state);
 
                     bt_ctx.translate_generic_params(id).unwrap();
-                    bt_ctx.translate_predicates_of(None, id).unwrap();
+                    bt_ctx
+                        .translate_predicates_of(None, id, PredicateOrigin::WhereClauseOnImpl)
+                        .unwrap();
                     let erase_regions = false;
                     // Two cases, depending on whether the impl block is
                     // a "regular" impl block (`impl Foo { ... }`) or a trait

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -194,25 +194,25 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     // a body translation context.
                     let id = cur_id;
 
-                    // Translate to hax types
-                    let s1 = &hax::State::new_from_state_and_id(&self.hax_state, id);
-                    let substs =
-                        rustc_middle::ty::GenericArgs::identity_for_item(tcx, id).sinto(s1);
-                    // TODO: use the bounds
-                    let _bounds: Vec<hax::Clause> = tcx
-                        .predicates_of(id)
-                        .predicates
-                        .iter()
-                        .map(|(x, _)| x.sinto(s1))
-                        .collect();
-                    let ty = tcx.type_of(id).instantiate_identity().sinto(s1);
-
                     // Translate from hax to LLBC
                     let mut bt_ctx = BodyTransCtx::new(id, self);
 
-                    bt_ctx
-                        .translate_generic_params_from_hax(span, &substs)
-                        .unwrap();
+                    // Translate to hax types
+                    // TODO: use the bounds
+                    let _bounds: Vec<hax::Clause> = bt_ctx
+                        .t_ctx
+                        .tcx
+                        .predicates_of(id)
+                        .predicates
+                        .iter()
+                        .map(|(x, _)| x.sinto(&bt_ctx.hax_state))
+                        .collect();
+                    let ty = tcx
+                        .type_of(id)
+                        .instantiate_identity()
+                        .sinto(&bt_ctx.hax_state);
+
+                    bt_ctx.translate_generic_params(id).unwrap();
                     bt_ctx.translate_predicates_of(None, id).unwrap();
                     let erase_regions = false;
                     // Two cases, depending on whether the impl block is
@@ -283,23 +283,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
 
         trace!("{:?}", name);
         Ok(Name { name })
-    }
-
-    pub(crate) fn make_hax_state_with_id(
-        &mut self,
-        def_id: DefId,
-    ) -> hax::State<hax::Base<'tcx>, (), (), DefId> {
-        hax::state::State {
-            thir: (),
-            mir: (),
-            owner_id: def_id,
-            base: hax::Base::new(
-                self.tcx,
-                hax::options::Options {
-                    inline_macro_calls: Vec::new(),
-                },
-            ),
-        }
     }
 
     /// Returns an optional name for an HIR item.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -335,6 +335,7 @@ generate_index_type!(TraitClauseId, "TraitClause");
 generate_index_type!(TraitDeclId, "TraitDecl");
 generate_index_type!(TraitImplId, "TraitImpl");
 
+/// A predicate of the form `Type: Trait<Args>`.
 #[derive(Debug, Clone, Serialize, Deserialize, Derivative, Drive, DriveMut)]
 #[derivative(PartialEq)]
 pub struct TraitClause {
@@ -344,12 +345,61 @@ pub struct TraitClause {
     pub clause_id: TraitClauseId,
     #[derivative(PartialEq = "ignore")]
     pub span: Option<Span>,
+    /// Where the predicate was written, relative to the item that requires it.
+    #[derivative(PartialEq = "ignore")]
+    pub origin: PredicateOrigin,
+    /// The trait that is implemented.
     pub trait_id: TraitDeclId,
+    /// The generics applied to the trait. Note: this includes the `Self` type.
     /// Remark: the trait refs list in the [generics] field should be empty.
     pub generics: GenericArgs,
 }
 
 impl Eq for TraitClause {}
+
+/// Where a given predicate came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Derivative, Drive, DriveMut)]
+pub enum PredicateOrigin {
+    // Note: we use this for globals too, but that's only available with an unstable feature.
+    // ```
+    // fn function<T: Clone>() {}
+    // fn function<T>() where T: Clone {}
+    // const NONE<T: Copy>: Option<T> = None;
+    // ```
+    WhereClauseOnFn,
+    // ```
+    // struct Struct<T: Clone> {}
+    // struct Struct<T> where T: Clone {}
+    // type TypeAlias<T: Clone> = ...;
+    // ```
+    WhereClauseOnType,
+    // Note: this is both trait impls and inherent impl blocks.
+    // ```
+    // impl<T: Clone> Type<T> {}
+    // impl<T> Type<T> where T: Clone {}
+    // impl<T> Trait for Type<T> where T: Clone {}
+    // ```
+    WhereClauseOnImpl,
+    // The special `Self: Trait` clause which is in scope inside the definition of `Foo` or an
+    // implementation of it.
+    // ```
+    // trait Trait {}
+    // ```
+    TraitSelf,
+    // Note: this also includes supertrait constraings.
+    // ```
+    // trait Trait<T: Clone> {}
+    // trait Trait<T> where T: Clone {}
+    // trait Trait: Clone {}
+    // ```
+    WhereClauseOnTrait,
+    // ```
+    // trait Trait {
+    //     type AssocType: Clone;
+    // }
+    // ```
+    TraitItem(TraitItemName),
+}
 
 /// A type declaration.
 ///

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -222,15 +222,7 @@ pub enum TraitInstanceId {
     /// is useful to give priority to the local clauses when solving the trait
     /// obligations which are fullfilled by the trait parameters.
     SelfId,
-    /// Clause which hasn't been solved yet.
-    /// This happens when we register clauses in the context: solving some
-    /// trait obligations/references might require to refer to clauses which
-    /// haven't been registered yet. This variant is purely internal: after we
-    /// finished solving the trait obligations, all the remaining unsolved
-    /// clauses (in case we don't fail hard on error) are converted to [Unknown].
-    Unsolved(TraitDeclId, GenericArgs),
     /// For error reporting.
-    /// Can appear only if the option [CliOpts::continue_on_failure] is used.
     Unknown(String),
 }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1188,13 +1188,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitInstanceId {
             TraitInstanceId::TraitImpl(id) => ctx.format_object(*id),
             TraitInstanceId::Clause(id) => ctx.format_object(*id),
             TraitInstanceId::BuiltinOrAuto(id) => ctx.format_object(*id),
-            TraitInstanceId::Unsolved(trait_id, generics) => {
-                format!(
-                    "Unsolved({}{})",
-                    ctx.format_object(*trait_id),
-                    generics.fmt_with_ctx(ctx),
-                )
-            }
             TraitInstanceId::Unknown(msg) => format!("UNKNOWN({msg})"),
         }
     }

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1411,7 +1411,6 @@ fn compute_loop_switch_exits(cfg_info: &CfgInfo) -> ExitInfo {
     exit_info
 }
 
-// FIXME: don't fold
 fn combine_statements_and_statement(
     statements: Vec<tgt::Statement>,
     next: Option<tgt::Statement>,

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -811,7 +811,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
 impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// Create a new `ExecContext`.
     pub(crate) fn new(def_id: DefId, t_ctx: &'ctx mut TranslateCtx<'tcx, 'ctx1>) -> Self {
-        let hax_state = t_ctx.make_hax_state_with_id(def_id);
+        let hax_state = hax::State::new_from_state_and_id(&t_ctx.hax_state, def_id);
         BodyTransCtx {
             def_id,
             t_ctx,

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -310,7 +310,7 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// `ImplExprAtom::LocalBound`, we use this to recover the specific trait reference it
     /// corresponds to.
     /// FIXME: hax should take care of this matching up.
-    pub trait_clauses: HashMap<TraitDeclId, Vec<NonLocalTraitClause>>,
+    pub trait_clauses: BTreeMap<TraitDeclId, Vec<NonLocalTraitClause>>,
     /// If [true] it means we are currently registering trait clauses in the
     /// local context. As a consequence, we allow not solving all the trait
     /// obligations, because the obligations for some clauses may be solved

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1670,11 +1670,15 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // Translate the predicates (in particular, the trait clauses)
         match &fun_kind {
             ItemKind::Regular | ItemKind::TraitItemImpl { .. } => {
-                self.translate_predicates_of(None, def_id)?;
+                self.translate_predicates_of(None, def_id, PredicateOrigin::WhereClauseOnFn)?;
             }
             ItemKind::TraitItemProvided(trait_decl_id, ..)
             | ItemKind::TraitItemDecl(trait_decl_id, ..) => {
-                self.translate_predicates_of(Some(*trait_decl_id), def_id)?;
+                self.translate_predicates_of(
+                    Some(*trait_decl_id),
+                    def_id,
+                    PredicateOrigin::WhereClauseOnFn,
+                )?;
             }
         }
 
@@ -1838,7 +1842,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // }
         // ```
         bt_ctx.translate_generic_params(rust_id)?;
-        bt_ctx.translate_predicates_of(None, rust_id)?;
+        bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnFn)?;
 
         let hax_state = &bt_ctx.hax_state;
 

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -66,21 +66,6 @@ fn translate_unaryop_kind(binop: hax::UnOp) -> UnOp {
     }
 }
 
-/// Small utility
-pub(crate) fn check_impl_item(impl_item: &rustc_hir::Impl<'_>) {
-    // TODO: make proper error messages
-    use rustc_hir::{Defaultness, ImplPolarity, Unsafety};
-    assert!(impl_item.unsafety == Unsafety::Normal);
-    // About polarity:
-    // [https://doc.rust-lang.org/beta/unstable-book/language-features/negative-impls.html]
-    // Not sure about what I should do about it. Should I do anything, actually?
-    // This seems useful to enforce some discipline on the user-side, but not
-    // necessary for analysis purposes.
-    assert!(impl_item.polarity == ImplPolarity::Positive);
-    // Not sure what this is about
-    assert!(impl_item.defaultness == Defaultness::Final);
-}
-
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     fn translate_binaryop_kind(
         &mut self,

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -818,41 +818,37 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // Could not find a clause.
         // Check if we are in the registration process, otherwise report an error.
         // TODO: we might be registering a where clause.
-        if self.registering_trait_clauses {
-            TraitInstanceId::Unsolved(trait_id, generics.clone())
-        } else {
-            let fmt_ctx = self.into_fmt();
-            let trait_ref = format!(
-                "{}{}",
-                fmt_ctx.format_object(trait_id),
-                generics.fmt_with_ctx(&fmt_ctx)
-            );
-            let clauses: Vec<String> = self
-                .trait_clauses
-                .values()
-                .flat_map(|x| x)
-                .map(|x| x.fmt_with_ctx(&fmt_ctx))
-                .collect();
+        let fmt_ctx = self.into_fmt();
+        let trait_ref = format!(
+            "{}{}",
+            fmt_ctx.format_object(trait_id),
+            generics.fmt_with_ctx(&fmt_ctx)
+        );
+        let clauses: Vec<String> = self
+            .trait_clauses
+            .values()
+            .flat_map(|x| x)
+            .map(|x| x.fmt_with_ctx(&fmt_ctx))
+            .collect();
 
-            if !self.t_ctx.continue_on_failure() {
-                let clauses = clauses.join("\n");
-                unreachable!(
-                    "Could not find a clause for parameter:\n- target param: {}\n- available clauses:\n{}\n- context: {:?}",
-                    trait_ref, clauses, self.def_id
-                );
-            } else {
-                // Return the UNKNOWN clause
-                log::warn!(
-                    "Could not find a clause for parameter:\n- target param: {}\n- available clauses:\n{}\n- context: {:?}",
-                    trait_ref, clauses.join("\n"), self.def_id
-                );
-                TraitInstanceId::Unknown(format!(
-                    "Could not find a clause for parameter: {} (available clauses: {}) (context: {:?})",
-                    trait_ref,
-                    clauses.join("; "),
-                    self.def_id
-                ))
-            }
+        if !self.t_ctx.continue_on_failure() {
+            let clauses = clauses.join("\n");
+            unreachable!(
+                "Could not find a clause for parameter:\n- target param: {}\n- available clauses:\n{}\n- context: {:?}",
+                trait_ref, clauses, self.def_id
+            );
+        } else {
+            // Return the UNKNOWN clause
+            log::warn!(
+                "Could not find a clause for parameter:\n- target param: {}\n- available clauses:\n{}\n- context: {:?}",
+                trait_ref, clauses.join("\n"), self.def_id
+            );
+            TraitInstanceId::Unknown(format!(
+                "Could not find a clause for parameter: {} (available clauses: {}) (context: {:?})",
+                trait_ref,
+                clauses.join("; "),
+                self.def_id
+            ))
         }
     }
 }

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -304,19 +304,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         Ok(())
     }
 
-    /// Translate the predicates then solve the unsolved trait obligations
-    /// in the registered trait clauses.
-    pub(crate) fn translate_predicates_solve_trait_obligations_of(
-        &mut self,
-        parent_trait_id: Option<TraitDeclId>,
-        def_id: DefId,
-    ) -> Result<(), Error> {
-        self.while_registering_trait_clauses(move |ctx| {
-            ctx.translate_predicates_of(parent_trait_id, def_id)?;
-            Ok(())
-        })
-    }
-
     pub(crate) fn translate_predicates(
         &mut self,
         preds: &hax::GenericPredicates,

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -274,15 +274,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_generic_params(rust_id)?;
 
         // Add the trait clauses
-        let parent_clauses = bt_ctx.while_registering_trait_clauses(move |bt_ctx| {
-            // Add the self trait clause
-            bt_ctx.translate_trait_decl_self_trait_clause(rust_id)?;
+        // Add the self trait clause
+        bt_ctx.translate_trait_decl_self_trait_clause(rust_id)?;
 
-            // Translate the predicates.
-            bt_ctx.with_parent_trait_clauses(def_id, &mut |s| {
-                s.translate_predicates_of(None, rust_id)
-            })
-        })?;
+        // Translate the predicates.
+        let parent_clauses = bt_ctx
+            .with_parent_trait_clauses(def_id, &mut |s| s.translate_predicates_of(None, rust_id))?;
 
         // TODO: move this below (we don't need to perform this function call exactly here)
         let preds = bt_ctx.get_predicates();
@@ -442,16 +439,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // Translate the generics
         bt_ctx.translate_generic_params(rust_id)?;
 
-        // Add the trait self clauses
-        bt_ctx.while_registering_trait_clauses(move |bt_ctx| {
-            // Translate the predicates
-            bt_ctx.translate_predicates_of(None, rust_id)?;
+        // Translate the predicates
+        bt_ctx.translate_predicates_of(None, rust_id)?;
 
-            // Add the self trait clause
-            bt_ctx.translate_trait_impl_self_trait_clause(def_id)?;
-
-            Ok(())
-        })?;
+        // Add the self trait clause
+        bt_ctx.translate_trait_impl_self_trait_clause(def_id)?;
 
         // Retrieve the information about the implemented trait.
         let (

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -739,7 +739,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_generic_params(rust_id)?;
 
         // Translate the predicates
-        bt_ctx.translate_predicates_of(None, rust_id)?;
+        bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnType)?;
 
         // Translate the meta information
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -739,7 +739,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_generic_params(rust_id)?;
 
         // Translate the predicates
-        bt_ctx.translate_predicates_solve_trait_obligations_of(None, rust_id)?;
+        bt_ctx.translate_predicates_of(None, rust_id)?;
 
         // Translate the meta information
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::prelude::{CommandCargoExt, OutputAssertExt};
 use itertools::Itertools;
+use macros::EnumAsGetters;
 use std::collections::HashMap;
 use std::{error::Error, fs::File, io::BufReader, process::Command};
 
@@ -75,6 +76,7 @@ fn trait_name(crate_data: &CrateData, trait_id: TraitDeclId) -> &str {
     trait_name
 }
 
+#[derive(EnumAsGetters)]
 enum ItemKind<'c> {
     Fun(&'c FunDecl),
     Global(&'c GlobalDecl),
@@ -316,6 +318,17 @@ fn predicate_origins() -> Result<(), Box<dyn Error>> {
             assert_eq!(&clause.origin, expected_origin, "failed for {item_name}");
         }
     }
+
+    let my_trait = items_by_name
+        .get("test_crate::Trait")
+        .unwrap()
+        .kind
+        .as_trait_decl();
+    let item_clauses = &(my_trait.types[0].1).0;
+    assert_eq!(
+        item_clauses[0].origin,
+        TraitItem(TraitItemName("AssocType".into()))
+    );
     Ok(())
 }
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -142,7 +142,7 @@ trait core::ops::function::FnMut<Self, Args>
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
 where
     [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
-    (parents(Unsolved(core::ops::function::FnMut<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>::Item)>))::[@TraitClause0])::Output = Acc,
+    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>#2}<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
 
@@ -212,34 +212,34 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::fold<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>, @2: B, @3: F) -> B
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = B,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>) (context: core::slice::iter::{impl#181}::fold)))::[@TraitClause0])::Output = B,
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::for_each<'a, T, F>(@1: core::slice::iter::Iter<'a, T>, @2: F)
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = (),
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#181}::for_each)))::[@TraitClause0])::Output = (),
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::all<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#181}::all)))::[@TraitClause0])::Output = bool,
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::any<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#181}::any)))::[@TraitClause0])::Output = bool,
 
 Unknown decl: 38
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::find_map<'a, '_1, T, B, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> core::option::Option<B>
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = core::option::Option<B>,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#181}::find_map)))::[@TraitClause0])::Output = core::option::Option<B>,
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::position<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause0]: core::ops::function::FnMut<P, (&'_ (T))>,
-    (parents(Unsolved(core::ops::function::FnMut<P, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item)>))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#181}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, (&'_ (T))>) (context: core::slice::iter::{impl#181}::position)))::[@TraitClause0])::Output = bool,
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
@@ -261,10 +261,10 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
-    [@TraitClause0]: core::ops::function::FnMut<P, ((parents(Unsolved(core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'a, T>>))::[@TraitClause0])::Item)>,
+    [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl5<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#181}::rposition)))::[@TraitClause0])::Item)>,
     [@TraitClause1]: core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'_, T>>,
     [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>>,
-    (parents(Unsolved(core::ops::function::FnMut<P, ((parents(Unsolved(core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'a, T>>))::[@TraitClause0])::Item)>))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl5<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl5<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#181}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl5<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl6<@Adt2<'_, T>>) (context: core::slice::iter::{impl#181}::rposition)))::[@TraitClause0])::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl5<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#181}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl5<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl6<@Adt2<'_, T>>) (context: core::slice::iter::{impl#181}::rposition)))::[@TraitClause0])::Output = bool,
 
 unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#181}<'_, T>::Item
 


### PR DESCRIPTION
This lays some groundwork towards #127. There's a few tweaks but mainly this PR:
- Removes some more leftover code from trait solving;
- Tracks for each `TraitClause` where it came from (function generics, associated type, etc).