### PR TITLE
Merge `Predicates` into `GenericParams`

### DIFF
--- a/charon-ml/Makefile
+++ b/charon-ml/Makefile
@@ -11,7 +11,7 @@ build-dev:
 # You can use the environment variable "CHARON_LOG" to activate the log.
 # For instance: `CHARON_LOG=1 make tests`.
 .PHONY: tests
-tests: build copy-tests
+tests: copy-tests
 	dune test
 
 # Reformat the code

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.13"
+let supported_charon_version = "0.1.14"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -31,14 +31,14 @@ type var = {
 class ['self] iter_ast_base =
   object (_self : 'self)
     inherit [_] iter_rvalue
-    inherit! [_] iter_predicates
+    inherit! [_] iter_generic_params
   end
 
 (** Ancestor the AST map visitors *)
 class ['self] map_ast_base =
   object (_self : 'self)
     inherit [_] map_rvalue
-    inherit! [_] map_predicates
+    inherit! [_] map_generic_params
   end
 
 (* Below: the types need not be mutually recursive, but it makes it easier
@@ -98,7 +98,6 @@ type fun_sig = {
   is_closure : bool;
   closure_info : closure_info option;
   generics : generic_params;
-  preds : predicates;
   parent_params_info : params_info option;
   inputs : ty list;
   output : ty;
@@ -154,7 +153,6 @@ type trait_decl = {
   is_local : bool;
   name : name;
   generics : generic_params;
-  preds : predicates;
   parent_clauses : trait_clause list;
   consts : (trait_item_name * (ty * global_decl_id option)) list;
   types : (trait_item_name * (trait_clause list * ty option)) list;
@@ -170,7 +168,6 @@ type trait_impl = {
   name : name;
   impl_trait : trait_decl_ref;
   generics : generic_params;
-  preds : predicates;
   parent_trait_refs : trait_ref list;
   consts : (trait_item_name * (ty * global_decl_id)) list;
   types : (trait_item_name * (trait_ref list * ty)) list;
@@ -205,7 +202,6 @@ type 'body gglobal_decl = {
   is_local : bool;
   name : name;
   generics : generic_params;
-  preds : predicates;
   ty : ty;
   kind : item_kind;
   body : 'body;

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -160,7 +160,6 @@ let global_decl_of_json (bodies : expr_body option list)
        is_local;
        name;
        generics;
-       preds;
        ty;
        kind;
      } =
@@ -175,7 +174,6 @@ let global_decl_of_json (bodies : expr_body option list)
          is_closure = false;
          closure_info = None;
          generics;
-         preds;
          parent_params_info = None;
          inputs = [];
          output = ty;
@@ -189,7 +187,6 @@ let global_decl_of_json (bodies : expr_body option list)
          is_local;
          name;
          generics;
-         preds;
          ty;
          kind;
        }

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -210,11 +210,8 @@ let ctx_to_fmt_env (ctx : ctx) : PrintLlbcAst.fmt_env =
     global_decls = ctx.global_decls;
     trait_decls = ctx.trait_decls;
     trait_impls = ctx.trait_impls;
-    types = [];
     regions = [];
-    const_generics = [];
-    trait_clauses = [];
-    preds = TypesUtils.empty_predicates;
+    generics = TypesUtils.empty_generic_params;
     locals = [];
   }
 

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -36,10 +36,9 @@ let fun_sig_with_name_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let unsafe = if sg.is_unsafe then "unsafe " else "" in
 
   (* Generics and predicates *)
-  let params, trait_clauses = generic_params_to_strings env sg.generics in
-  let clauses =
+  let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr
-      sg.parent_params_info trait_clauses sg.preds
+      sg.parent_params_info sg.generics sg.preds
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
@@ -139,10 +138,9 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let name = name_to_string env def.name in
 
   (* Generics and predicates *)
-  let params, trait_clauses = generic_params_to_strings env def.generics in
-  let clauses =
+  let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr None
-      trait_clauses def.preds
+      def.generics def.preds
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
@@ -228,10 +226,9 @@ let trait_impl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let name = name_to_string env def.name in
 
   (* Generics and predicates *)
-  let params, trait_clauses = generic_params_to_strings env def.generics in
-  let clauses =
+  let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr None
-      trait_clauses def.preds
+      def.generics def.preds
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -38,7 +38,7 @@ let fun_sig_with_name_to_string (env : ('a, 'b) fmt_env) (indent : string)
   (* Generics and predicates *)
   let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr
-      sg.parent_params_info sg.generics sg.preds
+      sg.parent_params_info sg.generics
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
@@ -79,10 +79,7 @@ let gfun_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     (body_to_string : ('a, 'b) fmt_env -> string -> string -> 'body -> string)
     (def : 'body gfun_decl) : string =
   (* Locally update the environment *)
-  let env =
-    fmt_env_update_generics_and_preds env def.signature.generics
-      def.signature.preds
-  in
+  let env = fmt_env_update_generics_and_preds env def.signature.generics in
 
   let sg = def.signature in
 
@@ -130,7 +127,7 @@ let gfun_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
 let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     (indent_incr : string) (def : trait_decl) : string =
   (* Locally update the environment *)
-  let env = fmt_env_update_generics_and_preds env def.generics def.preds in
+  let env = fmt_env_update_generics_and_preds env def.generics in
 
   let ty_to_string = ty_to_string env in
 
@@ -140,7 +137,7 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   (* Generics and predicates *)
   let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr None
-      def.generics def.preds
+      def.generics
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
@@ -218,7 +215,7 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
 let trait_impl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     (indent_incr : string) (def : trait_impl) : string =
   (* Locally update the environment *)
-  let env = fmt_env_update_generics_and_preds env def.generics def.preds in
+  let env = fmt_env_update_generics_and_preds env def.generics in
 
   let ty_to_string = ty_to_string env in
 
@@ -228,7 +225,7 @@ let trait_impl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   (* Generics and predicates *)
   let params, clauses =
     predicates_and_trait_clauses_to_string env indent indent_incr None
-      def.generics def.preds
+      def.generics
   in
   let params =
     if params = [] then "" else "<" ^ String.concat ", " params ^ ">"

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -120,10 +120,9 @@ module Ast = struct
   let global_decl_to_string (env : fmt_env) (indent : string)
       (_indent_incr : string) (def : global_decl) : string =
     (* Locally update the generics and the predicates *)
-    let env = fmt_env_update_generics_and_preds env def.generics def.preds in
+    let env = fmt_env_update_generics_and_preds env def.generics in
     let params, clauses =
       predicates_and_trait_clauses_to_string env "" "  " None def.generics
-        def.preds
     in
     let params =
       if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
@@ -151,10 +150,7 @@ module Crate = struct
       trait_decls = m.trait_decls;
       trait_impls = m.trait_impls;
       regions = [];
-      types = [];
-      const_generics = [];
-      trait_clauses = [];
-      preds = empty_predicates;
+      generics = empty_generic_params;
       locals = [];
     }
 

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -121,9 +121,8 @@ module Ast = struct
       (_indent_incr : string) (def : global_decl) : string =
     (* Locally update the generics and the predicates *)
     let env = fmt_env_update_generics_and_preds env def.generics def.preds in
-    let params, trait_clauses = generic_params_to_strings env def.generics in
-    let clauses =
-      predicates_and_trait_clauses_to_string env "" "  " None trait_clauses
+    let params, clauses =
+      predicates_and_trait_clauses_to_string env "" "  " None def.generics
         def.preds
     in
     let params =

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -99,9 +99,8 @@ module Ast = struct
       (indent_incr : string) (def : global_decl) : string =
     (* Locally update the generics and the predicates *)
     let env = fmt_env_update_generics_and_preds env def.generics def.preds in
-    let params, trait_clauses = generic_params_to_strings env def.generics in
-    let clauses =
-      predicates_and_trait_clauses_to_string env "" "  " None trait_clauses
+    let params, clauses =
+      predicates_and_trait_clauses_to_string env "" "  " None def.generics
         def.preds
     in
     let params =

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -98,10 +98,9 @@ module Ast = struct
   let global_decl_to_string (env : fmt_env) (indent : string)
       (indent_incr : string) (def : global_decl) : string =
     (* Locally update the generics and the predicates *)
-    let env = fmt_env_update_generics_and_preds env def.generics def.preds in
+    let env = fmt_env_update_generics_and_preds env def.generics in
     let params, clauses =
       predicates_and_trait_clauses_to_string env "" "  " None def.generics
-        def.preds
     in
     let params =
       if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
@@ -135,10 +134,7 @@ module Crate = struct
         trait_decls = m.trait_decls;
         trait_impls = m.trait_impls;
         regions = [];
-        types = [];
-        const_generics = [];
-        trait_clauses = [];
-        preds = empty_predicates;
+        generics = empty_generic_params;
         locals = [];
       }
     in

--- a/charon-ml/src/PrintUtils.ml
+++ b/charon-ml/src/PrintUtils.ml
@@ -26,27 +26,16 @@ type ('fun_body, 'global_body) fmt_env = {
           indices, i.e., the region var of index 0 doesn't have to be at index 0,
           etc. We lookup the variables by checking their id, not their position.
       *)
-  types : type_var list;
-  const_generics : const_generic_var list;
-  trait_clauses : trait_clause list;
-  preds : predicates;
+  generics : generic_params;
+      (* We ignore `generics.regions` as they are tracked in `regions` already *)
   locals : (VarId.id * string option) list;
       (** The local variables don't need to be ordered (same as the generics) *)
 }
 
 let fmt_env_update_generics_and_preds (env : ('a, 'b) fmt_env)
-    (generics : generic_params) (preds : predicates) : ('a, 'b) fmt_env =
-  let { regions; types; const_generics; trait_clauses } : generic_params =
-    generics
-  in
-  {
-    env with
-    regions = regions :: env.regions;
-    types;
-    const_generics;
-    trait_clauses;
-    preds;
-  }
+    (generics : generic_params) : ('a, 'b) fmt_env =
+  let { regions; _ } : generic_params = generics in
+  { env with regions = regions :: env.regions; generics }
 
 let fmt_env_push_regions (env : ('a, 'b) fmt_env) (regions : region_var list) :
     ('a, 'b) fmt_env =

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -49,17 +49,7 @@ let st_substitute_visitor (subst : subst) =
       TArrow (regions, inputs, output)
 
     method! visit_TVar (subst : subst) id = subst.ty_subst id
-
-    method! visit_type_var_id _ _ =
-      (* We should never get here because we reimplemented [visit_TypeVar] *)
-      raise (Failure "Unexpected")
-
     method! visit_CgVar _ id = subst.cg_subst id
-
-    method! visit_const_generic_var_id _ _ =
-      (* We should never get here because we reimplemented [visit_Var] *)
-      raise (Failure "Unexpected")
-
     method! visit_Clause (subst : subst) id = subst.tr_subst id
     method! visit_Self (subst : subst) = subst.tr_self
   end
@@ -88,9 +78,10 @@ let generic_args_substitute (subst : subst) (g : generic_args) : generic_args =
   let visitor = st_substitute_visitor subst in
   visitor#visit_generic_args subst g
 
-let predicates_substitute (subst : subst) (p : predicates) : predicates =
+let generic_params_substitute (subst : subst) (p : generic_params) :
+    generic_params =
   let visitor = st_substitute_visitor subst in
-  visitor#visit_predicates subst p
+  visitor#visit_generic_params subst p
 
 let erase_regions_subst : subst =
   {

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -374,8 +374,8 @@ and region =
         polymorphic = false;
       }]
 
-(** Ancestor for iter visitor for {!type: Types.predicates} *)
-class ['self] iter_predicates_base =
+(** Ancestor for iter visitor for {!type: Types.generic_params} *)
+class ['self] iter_generic_params_base =
   object (self : 'self)
     inherit [_] iter_ty
     method visit_span : 'env -> span -> unit = fun _ _ -> ()
@@ -394,8 +394,8 @@ class ['self] iter_predicates_base =
         self#visit_literal_type env ty
   end
 
-(** Ancestor for map visitor for {!type: Types.ty} *)
-class virtual ['self] map_predicates_base =
+(** Ancestor for map visitor for {!type: Types.generic_params} *)
+class virtual ['self] map_generic_params_base =
   object (self : 'self)
     inherit [_] map_ty
     method visit_span : 'env -> span -> span = fun _ x -> x
@@ -449,6 +449,9 @@ and generic_params = {
           because of the way the clauses are resolved in hax (see the comments
           in Charon).
         *)
+  regions_outlive : region_outlives list;
+  types_outlive : type_outlives list;
+  trait_type_constraints : trait_type_constraint list;
 }
 
 (** ('long, 'short) means that 'long outlives 'short *)
@@ -462,29 +465,23 @@ and trait_type_constraint = {
   type_name : trait_item_name;
   ty : ty;
 }
-
-and predicates = {
-  regions_outlive : region_outlives list;
-  types_outlive : type_outlives list;
-  trait_type_constraints : trait_type_constraint list;
-}
 [@@deriving
   show,
     ord,
     visitors
       {
-        name = "iter_predicates";
+        name = "iter_generic_params";
         variety = "iter";
-        ancestors = [ "iter_predicates_base" ];
+        ancestors = [ "iter_generic_params_base" ];
         nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
         concrete = true;
         polymorphic = false;
       },
     visitors
       {
-        name = "map_predicates";
+        name = "map_generic_params";
         variety = "map";
-        ancestors = [ "map_predicates_base" ];
+        ancestors = [ "map_generic_params_base" ];
         nude = true (* Don't inherit {!VisitorsRuntime.map} *);
         concrete = false;
         polymorphic = false;
@@ -499,7 +496,6 @@ type impl_elem_kind = ImplElemTy of ty | ImplElemTrait of trait_decl_ref
 type impl_elem = {
   disambiguator : Disambiguator.id;
   generics : generic_params;
-  preds : predicates;
   kind : impl_elem_kind;
 }
 [@@deriving show, ord]
@@ -572,7 +568,6 @@ type type_decl = {
   is_local : bool;
   name : name;
   generics : generic_params;
-  preds : predicates;
   kind : type_decl_kind;
 }
 [@@deriving show]

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -97,10 +97,15 @@ let mk_generic_args_from_types (types : ty list) : generic_args =
   { regions = []; types; const_generics = []; trait_refs = [] }
 
 let empty_generic_params : generic_params =
-  { regions = []; types = []; const_generics = []; trait_clauses = [] }
-
-let empty_predicates : predicates =
-  { regions_outlive = []; types_outlive = []; trait_type_constraints = [] }
+  {
+    regions = [];
+    types = [];
+    const_generics = [];
+    trait_clauses = [];
+    regions_outlive = [];
+    types_outlive = [];
+    trait_type_constraints = [];
+  }
 
 let merge_generic_args (g1 : generic_args) (g2 : generic_args) : generic_args =
   let { regions = r1; types = tys1; const_generics = cgs1; trait_refs = tr1 } =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -180,7 +180,6 @@ pub struct GlobalDecl {
     pub is_local: bool,
     pub name: Name,
     pub generics: GenericParams,
-    pub preds: Predicates,
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
     pub kind: ItemKind,
@@ -235,7 +234,6 @@ pub struct TraitDecl {
     pub item_meta: ItemMeta,
     pub name: Name,
     pub generics: GenericParams,
-    pub preds: Predicates,
     /// The "parent" clauses: the supertraits.
     ///
     /// Supertraits are actually regular where clauses, but we decided to have
@@ -302,7 +300,6 @@ pub struct TraitImpl {
     /// clauses.
     pub impl_trait: TraitDeclRef,
     pub generics: GenericParams,
-    pub preds: Predicates,
     /// The trait references for the parent clauses (see [TraitDecl]).
     pub parent_trait_refs: Vector<TraitClauseId, TraitRef>,
     /// The associated constants declared in the trait.

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -20,7 +20,6 @@ pub enum PathElem {
 pub struct ImplElem {
     pub disambiguator: Disambiguator,
     pub generics: GenericParams,
-    pub preds: Predicates,
     pub kind: ImplElemKind,
 }
 

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -245,7 +245,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     name.push(PathElem::Impl(ImplElem {
                         disambiguator,
                         generics: bt_ctx.get_generics(),
-                        preds: bt_ctx.get_predicates(),
                         kind,
                     }));
                 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -293,17 +293,6 @@ pub struct TraitTypeConstraint {
     pub ty: Ty,
 }
 
-/// The predicates which apply to a definition
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Drive, DriveMut)]
-pub struct Predicates {
-    /// The first region in the pair outlives the second region
-    pub regions_outlive: Vec<RegionOutlives>,
-    /// The type outlives the region
-    pub types_outlive: Vec<TypeOutlives>,
-    /// Constraints over trait associated types
-    pub trait_type_constraints: Vec<TraitTypeConstraint>,
-}
-
 #[derive(
     Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Ord, PartialOrd, Drive, DriveMut,
 )]
@@ -322,13 +311,19 @@ pub struct GenericArgs {
 /// be filled. We group in a different place the predicates which are not
 /// trait clauses, because those enforce constraints but do not need to
 /// be filled with witnesses/instances.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct GenericParams {
     pub regions: Vector<RegionId, RegionVar>,
     pub types: Vector<TypeVarId, TypeVar>,
     pub const_generics: Vector<ConstGenericVarId, ConstGenericVar>,
     // TODO: rename to match [GenericArgs]?
     pub trait_clauses: Vector<TraitClauseId, TraitClause>,
+    /// The first region in the pair outlives the second region
+    pub regions_outlive: Vec<RegionOutlives>,
+    /// The type outlives the region
+    pub types_outlive: Vec<TypeOutlives>,
+    /// Constraints over trait associated types
+    pub trait_type_constraints: Vec<TraitTypeConstraint>,
 }
 
 generate_index_type!(TraitClauseId, "TraitClause");
@@ -425,7 +420,6 @@ pub struct TypeDecl {
     pub is_local: bool,
     pub name: Name,
     pub generics: GenericParams,
-    pub preds: Predicates,
     /// The type kind: enum, struct, or opaque.
     pub kind: TypeDeclKind,
 }
@@ -809,7 +803,6 @@ pub struct FunSig {
     /// Additional information if this is the signature of a closure.
     pub closure_info: Option<ClosureInfo>,
     pub generics: GenericParams,
-    pub preds: Predicates,
     /// Optional fields, for trait methods only (see the comments in [ParamsInfo]).
     pub parent_params_info: Option<ParamsInfo>,
     pub inputs: Vec<Ty>,

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -34,8 +34,17 @@ impl GenericParams {
             types,
             const_generics,
             trait_clauses,
+            regions_outlive,
+            types_outlive,
+            trait_type_constraints,
         } = self;
-        regions.len() + types.len() + const_generics.len() + trait_clauses.len()
+        regions.len()
+            + types.len()
+            + const_generics.len()
+            + trait_clauses.len()
+            + regions_outlive.len()
+            + types_outlive.len()
+            + trait_type_constraints.len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -43,23 +52,7 @@ impl GenericParams {
     }
 
     pub fn empty() -> Self {
-        GenericParams {
-            regions: Vector::new(),
-            types: Vector::new(),
-            const_generics: Vector::new(),
-            trait_clauses: Vector::new(),
-        }
-    }
-}
-
-impl Predicates {
-    pub fn is_empty(&self) -> bool {
-        let Predicates {
-            regions_outlive,
-            types_outlive,
-            trait_type_constraints,
-        } = self;
-        regions_outlive.is_empty() && types_outlive.is_empty() && trait_type_constraints.is_empty()
+        Self::default()
     }
 }
 

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -398,9 +398,6 @@ fn compute_declarations_graph<'tcx, 'ctx>(ctx: &'tcx TransformCtx<'ctx>) -> Deps
                     // Visit the traits referenced in the generics
                     d.generics.drive(&mut graph);
 
-                    // Visit the predicates
-                    d.preds.drive(&mut graph);
-
                     // Visit the parent clauses
                     d.parent_clauses.drive(&mut graph);
 

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -1008,6 +1008,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             types: self.type_vars.clone(),
             const_generics: self.const_generic_vars.clone(),
             trait_clauses: self.get_local_trait_clauses(),
+            regions_outlive: self.regions_outlive.clone(),
+            types_outlive: self.types_outlive.clone(),
+            trait_type_constraints: self.trait_type_constraints.clone(),
         }
     }
 
@@ -1024,14 +1027,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             .all(|(i, c)| c.clause_id.index() == i));
         // Return
         clauses.clone()
-    }
-
-    pub(crate) fn get_predicates(&self) -> Predicates {
-        Predicates {
-            regions_outlive: self.regions_outlive.clone(),
-            types_outlive: self.types_outlive.clone(),
-            trait_type_constraints: self.trait_type_constraints.clone(),
-        }
     }
 
     /// We use this when exploring the clauses of a predicate, to introduce

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1729,7 +1729,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
         Ok(FunSig {
             generics: self.get_generics(),
-            preds: self.get_predicates(),
             is_unsafe,
             is_closure,
             closure_info,
@@ -1860,7 +1859,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             .get_item_kind(&DepSource::make(rust_id, span), rust_id)?;
 
         let generics = bt_ctx.get_generics();
-        let preds = bt_ctx.get_predicates();
 
         // Translate its body like the body of a function. This returns `Opaque if we can't/decide
         // not to translate this body.
@@ -1880,7 +1878,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             is_local: rust_id.is_local(),
             name,
             generics,
-            preds,
             ty,
             kind,
             body: body_id,

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -282,9 +282,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             s.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnTrait)
         })?;
 
-        // TODO: move this below (we don't need to perform this function call exactly here)
-        let preds = bt_ctx.get_predicates();
-
         // Explore the associated items
         // We do something subtle here: TODO: explain
         let tcx = bt_ctx.t_ctx.tcx;
@@ -414,7 +411,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             name,
             item_meta,
             generics,
-            preds,
             parent_clauses,
             consts,
             types,
@@ -622,7 +618,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             item_meta,
             impl_trait: implemented_trait,
             generics: bt_ctx.get_generics(),
-            preds: bt_ctx.get_predicates(),
             parent_trait_refs,
             consts,
             types,

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -770,11 +770,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             is_local: rust_id.is_local(),
             name,
             generics,
-            preds: bt_ctx.get_predicates(),
             kind,
         };
-
-        trace!("translate_type: preds: {:?}", &type_def.preds);
 
         trace!(
             "{} -> {}",

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -93,7 +93,6 @@ struct Item<'c> {
     item_meta: &'c ItemMeta,
     // Not a ref because we do a little hack.
     generics: GenericParams,
-    preds: &'c Predicates,
     kind: ItemKind<'c>,
 }
 
@@ -107,7 +106,6 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
             name_str: repr_name(crate_data, &x.name),
             item_meta: &x.item_meta,
             generics: x.signature.generics.clone(),
-            preds: &x.signature.preds,
             kind: ItemKind::Fun(x),
         })
         .chain(crate_data.globals.iter().map(|x| Item {
@@ -115,7 +113,6 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
             name_str: repr_name(crate_data, &x.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
-            preds: &x.preds,
             kind: ItemKind::Global(x),
         }))
         .chain(crate_data.types.iter().map(|x| Item {
@@ -123,7 +120,6 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
             name_str: repr_name(crate_data, &x.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
-            preds: &x.preds,
             kind: ItemKind::Type(x),
         }))
         .chain(crate_data.trait_impls.iter().map(|x| Item {
@@ -131,7 +127,6 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
             name_str: repr_name(crate_data, &x.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
-            preds: &x.preds,
             kind: ItemKind::TraitImpl(x),
         }))
         .chain(crate_data.trait_decls.iter().map(|x| {
@@ -144,7 +139,6 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
                 name_str: repr_name(crate_data, &x.name),
                 item_meta: &x.item_meta,
                 generics,
-                preds: &x.preds,
                 kind: ItemKind::TraitDecl(x),
             }
         }))

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -144,6 +144,8 @@ trait core::iter::traits::iterator::Iterator<Self>
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
 {
     type Item
     type IntoIter

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -873,6 +873,8 @@ trait core::iter::traits::iterator::Iterator<Self>
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
 {
     type Item
     type IntoIter

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -115,6 +115,8 @@ trait core::iter::traits::iterator::Iterator<Self>
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
 {
     type Item
     type IntoIter

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -643,6 +643,8 @@ trait test_crate::Iterator<Self>
 }
 
 trait test_crate::IntoIterator<Self>
+where
+    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
 {
     type Item
     type IntoIter


### PR DESCRIPTION
This PR merges two structs together. This reduces code duplication, as these two always came together in the AST. This is correct to do because predicates can appear exactly in the same places that clauses can, so it makes sense to group them together. This is part of my attempts to clarify how we deal with generics in preparation of #127 and #67 among others.

I will now prepare the changes to aeneas aud eurydice.