### PR TITLE
Add `DeclarationGroup::Mixed`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.14"
+let supported_charon_version = "0.1.15"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -9,6 +9,14 @@ module TraitDeclId = Types.TraitDeclId
 module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
 
+type any_decl_id =
+  | IdFun of FunDeclId.id
+  | IdGlobal of GlobalDeclId.id
+  | IdType of TypeDeclId.id
+  | IdTraitDecl of TraitDeclId.id
+  | IdTraitImpl of TraitImplId.id
+[@@deriving show, ord]
+
 type fun_decl_id = FunDeclId.id [@@deriving show, ord]
 type assumed_fun_id = Expressions.assumed_fun_id [@@deriving show, ord]
 type fun_id = Expressions.fun_id [@@deriving show, ord]
@@ -187,6 +195,8 @@ type fun_declaration_group = FunDeclId.id g_declaration_group [@@deriving show]
 type trait_declaration_group = TraitDeclId.id g_declaration_group
 [@@deriving show]
 
+type mixed_declaration_group = any_decl_id g_declaration_group [@@deriving show]
+
 (** Module declaration. Globals cannot be mutually recursive. *)
 type declaration_group =
   | TypeGroup of type_declaration_group
@@ -194,6 +204,7 @@ type declaration_group =
   | GlobalGroup of GlobalDeclId.id
   | TraitDeclGroup of trait_declaration_group
   | TraitImplGroup of TraitImplId.id
+  | MixedGroup of mixed_declaration_group
 [@@deriving show]
 
 type 'body gglobal_decl = {

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1345,6 +1345,31 @@ let trait_implementation_group_of_json (js : json) :
      | NonRecGroup id -> Ok id
      | RecGroup _ -> Error "got mutually dependent trait impls")
 
+let any_decl_id_of_json (js : json) : (any_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Fun", id) ] ->
+        let* id = FunDeclId.id_of_json id in
+        Ok (IdFun id)
+    | `Assoc [ ("Global", id) ] ->
+        let* id = GlobalDeclId.id_of_json id in
+        Ok (IdGlobal id)
+    | `Assoc [ ("Type", id) ] ->
+        let* id = TypeDeclId.id_of_json id in
+        Ok (IdType id)
+    | `Assoc [ ("TraitDecl", id) ] ->
+        let* id = TraitDeclId.id_of_json id in
+        Ok (IdTraitDecl id)
+    | `Assoc [ ("TraitImpl", id) ] ->
+        let* id = TraitImplId.id_of_json id in
+        Ok (IdTraitImpl id)
+    | _ -> Error "")
+
+let mixed_group_of_json (js : json) :
+    (any_decl_id g_declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (g_declaration_group_of_json any_decl_id_of_json js)
+
 let declaration_group_of_json (js : json) : (declaration_group, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1363,6 +1388,9 @@ let declaration_group_of_json (js : json) : (declaration_group, string) result =
     | `Assoc [ ("TraitImpl", decl) ] ->
         let* id = trait_implementation_group_of_json decl in
         Ok (TraitImplGroup id)
+    | `Assoc [ ("Mixed", decl) ] ->
+        let* id = mixed_group_of_json decl in
+        Ok (MixedGroup id)
     | _ -> Error "")
 
 let length_of_json_list (js : json) : (int, string) result =

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -82,5 +82,9 @@ let compute_fun_decl_groups_map (c : crate) : FunDeclId.Set.t FunDeclId.Map.t =
                 Some (List.map (fun id -> (id, idset)) ids)
             | TypeGroup _ | GlobalGroup _ | TraitDeclGroup _ | TraitImplGroup _
               ->
-                None)
+                None
+            | MixedGroup _ ->
+                raise
+                  (Failure
+                     "Mixed declaration groups cannot be indexed by declaration"))
           c.declarations))

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -7,6 +7,14 @@ open PrintUtils
 open PrintTypes
 open PrintExpressions
 
+let any_decl_id_to_string (id : any_decl_id) : string =
+  match id with
+  | IdFun id -> FunDeclId.to_string id
+  | IdGlobal id -> GlobalDeclId.to_string id
+  | IdType id -> TypeDeclId.to_string id
+  | IdTraitDecl id -> TraitDeclId.to_string id
+  | IdTraitImpl id -> TraitImplId.to_string id
+
 let fn_operand_to_string (env : ('a, 'b) fmt_env) (op : fn_operand) : string =
   match op with
   | FnOpRegular func -> fn_ptr_to_string env func

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -130,6 +130,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for DeclarationGroup {
             Global(g) => format!("Global decls group: {}", g.fmt_with_ctx(ctx)),
             TraitDecl(g) => format!("Trait decls group: {}", g.fmt_with_ctx(ctx)),
             TraitImpl(g) => format!("Trait impls group: {}", g.fmt_with_ctx(ctx)),
+            Mixed(g) => format!("Mixed group: {}", g.fmt_with_ctx(ctx)),
         }
     }
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -4,7 +4,7 @@ use crate::ids::Vector;
 use crate::llbc_ast;
 use crate::llbc_ast::*;
 use crate::pretty::{fmt_with_ctx, FmtWithCtx};
-use crate::translate_ctx::TranslatedCrate;
+use crate::translate_ctx::{AnyTransId, TranslatedCrate};
 use crate::types::*;
 use crate::ullbc_ast;
 use crate::ullbc_ast as ast;
@@ -174,6 +174,7 @@ pub trait AstFormatter = Formatter<TypeVarId>
     + Formatter<BodyId>
     + Formatter<TraitDeclId>
     + Formatter<TraitImplId>
+    + Formatter<AnyTransId>
     + Formatter<TraitClauseId>
     + Formatter<(DeBruijnId, RegionId)>
     + Formatter<VarId>
@@ -212,6 +213,16 @@ impl<'a> FmtCtx<'a> {
             type_vars: None,
             const_generic_vars: None,
             locals: None,
+        }
+    }
+
+    pub fn format_decl_id(&self, id: AnyTransId) -> String {
+        match id {
+            AnyTransId::Type(id) => self.format_decl(id),
+            AnyTransId::Fun(id) => self.format_decl(id),
+            AnyTransId::Global(id) => self.format_decl(id),
+            AnyTransId::TraitDecl(id) => self.format_decl(id),
+            AnyTransId::TraitImpl(id) => self.format_decl(id),
         }
     }
 }
@@ -290,6 +301,18 @@ impl<'a> Formatter<ast::TraitImplId> for FmtCtx<'a> {
                 None => id.to_pretty_string(),
                 Some(d) => d.name.fmt_with_ctx(self),
             },
+        }
+    }
+}
+
+impl<'a> Formatter<AnyTransId> for FmtCtx<'a> {
+    fn format_object(&self, id: AnyTransId) -> String {
+        match id {
+            AnyTransId::Type(x) => self.format_object(x),
+            AnyTransId::Fun(x) => self.format_object(x),
+            AnyTransId::Global(x) => self.format_object(x),
+            AnyTransId::TraitDecl(x) => self.format_object(x),
+            AnyTransId::TraitImpl(x) => self.format_object(x),
         }
     }
 }

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -38,6 +38,8 @@ pub enum DeclarationGroup {
     TraitDecl(GDeclarationGroup<TraitDeclId>),
     ///
     TraitImpl(GDeclarationGroup<TraitImplId>),
+    /// Anything that doesn't fit into these categories.
+    Mixed(GDeclarationGroup<AnyTransId>),
 }
 
 impl<Id: Copy> GDeclarationGroup<Id> {
@@ -78,6 +80,7 @@ impl DeclarationGroup {
             Global(gr) => gr.get_any_trans_ids(),
             TraitDecl(gr) => gr.get_any_trans_ids(),
             TraitImpl(gr) => gr.get_any_trans_ids(),
+            Mixed(gr) => gr.get_any_trans_ids(),
         }
     }
 }
@@ -114,6 +117,7 @@ impl Display for DeclarationGroup {
             DeclarationGroup::Global(decl) => write!(f, "{{ Global(s): {decl} }}"),
             DeclarationGroup::TraitDecl(decl) => write!(f, "{{ Trait decls(s): {decl} }}"),
             DeclarationGroup::TraitImpl(decl) => write!(f, "{{ Trait impl(s): {decl} }}"),
+            DeclarationGroup::Mixed(decl) => write!(f, "{{ Mixed items: {decl} }}"),
         }
     }
 }
@@ -409,7 +413,7 @@ fn compute_declarations_graph<'tcx, 'ctx>(ctx: &'tcx TransformCtx<'ctx>) -> Deps
 }
 
 fn group_declarations_from_scc(
-    ctx: &TransformCtx,
+    _ctx: &TransformCtx,
     graph: Deps<'_, '_>,
     reordered_sccs: SCCs<AnyTransId>,
 ) -> DeclarationsGroups {
@@ -425,19 +429,11 @@ fn group_declarations_from_scc(
         let id0 = *it.next().unwrap();
         let decl = graph.graph.get(&id0).unwrap();
 
-        // The group should consist of only functions, only types or only one global.
-        for id in scc {
-            assert!(
-                id0.variant_index_arity() == id.variant_index_arity(),
-                "Invalid scc:\n{}",
-                scc.iter()
-                    .map(|x| x.fmt_with_ctx(ctx))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            );
-        }
         if let AnyTransId::Global(_) = id0 {
-            assert!(scc.len() == 1);
+            assert!(
+                scc.len() == 1,
+                "Error: this constant recursively depends on itself, what is happening"
+            );
         }
 
         // If an SCC has length one, the declaration may be simply recursive:
@@ -445,13 +441,16 @@ fn group_declarations_from_scc(
         // its own set of dependencies.
         let is_mutually_recursive = scc.len() > 1;
         let is_simply_recursive = !is_mutually_recursive && decl.contains(&id0);
-
-        // Add the declaration.
-        // Note that we clone the vectors: it is not optimal, but they should
-        // be pretty small.
         let is_rec = is_mutually_recursive || is_simply_recursive;
+
+        let all_same_kind = scc
+            .iter()
+            .all(|id| id0.variant_index_arity() == id.variant_index_arity());
         let ids = scc.iter().copied();
         let group: DeclarationGroup = match id0 {
+            _ if !all_same_kind => {
+                DeclarationGroup::Mixed(GDeclarationGroup::make_group(is_rec, ids))
+            }
             AnyTransId::Type(_) => {
                 DeclarationGroup::Type(GDeclarationGroup::make_group(is_rec, ids))
             }


### PR DESCRIPTION
This is in preparation for #180 which will reveal some heterogeneous declaration groups such as:
```rust
trait Iterator {
    fn peekable(self) -> Peekable<Self>;
}
pub struct Peekable<I: Iterator> {
    iter: I,
    peeked: Option<Option<I::Item>>,
}
```