### PR TITLE
Cleanup `ItemMeta` and attributes

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.15"
+let supported_charon_version = "0.1.16"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -146,8 +146,6 @@ type 'body gexpr_body = {
 type 'body gfun_decl = {
   def_id : FunDeclId.id;
   item_meta : item_meta;
-  is_local : bool;
-  name : name;
   signature : fun_sig;
   kind : item_kind;
   body : 'body gexpr_body option;
@@ -158,8 +156,6 @@ type 'body gfun_decl = {
 type trait_decl = {
   def_id : trait_decl_id;
   item_meta : item_meta;
-  is_local : bool;
-  name : name;
   generics : generic_params;
   parent_clauses : trait_clause list;
   consts : (trait_item_name * (ty * global_decl_id option)) list;
@@ -172,8 +168,6 @@ type trait_decl = {
 type trait_impl = {
   def_id : trait_impl_id;
   item_meta : item_meta;
-  is_local : bool;
-  name : name;
   impl_trait : trait_decl_ref;
   generics : generic_params;
   parent_trait_refs : trait_ref list;
@@ -210,8 +204,6 @@ type declaration_group =
 type 'body gglobal_decl = {
   def_id : GlobalDeclId.id;
   item_meta : item_meta;
-  is_local : bool;
-  name : name;
   generics : generic_params;
   ty : ty;
   kind : item_kind;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -125,6 +125,18 @@ let inline_attr_of_json (js : json) : (inline_attr, string) result =
     | `String "Always" -> Ok Always
     | _ -> Error "")
 
+let attribute_of_json (js : json) : (attribute, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Opaque" -> Ok AttrOpaque
+    | `Assoc [ ("Rename", rename) ] ->
+        let* rename = string_of_json rename in
+        Ok (AttrRename rename)
+    | `Assoc [ ("Unknown", unknown) ] ->
+        let* unknown = string_of_json unknown in
+        Ok (AttrUnknown unknown)
+    | _ -> Error "")
+
 let item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
     (item_meta, string) result =
   combine_error_msgs js __FUNCTION__
@@ -138,7 +150,7 @@ let item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
           ("rename", rename);
         ] ->
         let* span = span_of_json id_to_file span in
-        let* attributes = list_of_json string_of_json attributes in
+        let* attributes = list_of_json attribute_of_json attributes in
         let* inline = option_of_json inline_attr_of_json inline in
         let* public = bool_of_json public in
         let* rename = string_option_of_json rename in

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -153,18 +153,7 @@ let global_decl_of_json (bodies : expr_body option list)
   combine_error_msgs js __FUNCTION__
     ((* Deserialize the global declaration *)
      let* global = gglobal_decl_of_json bodies id_to_file js in
-     let {
-       def_id = global_id;
-       item_meta;
-       body;
-       is_local;
-       name;
-       generics;
-       ty;
-       kind;
-     } =
-       global
-     in
+     let { def_id = global_id; item_meta; body; generics; ty; kind } = global in
      (* Decompose into a global and a function *)
      let fun_id = global_to_fun_id gid_conv global.def_id in
      let signature : fun_sig =
@@ -180,23 +169,12 @@ let global_decl_of_json (bodies : expr_body option list)
        }
      in
      let global_decl : global_decl =
-       {
-         def_id = global_id;
-         item_meta;
-         body = fun_id;
-         is_local;
-         name;
-         generics;
-         ty;
-         kind;
-       }
+       { def_id = global_id; item_meta; body = fun_id; generics; ty; kind }
      in
      let fun_decl : fun_decl =
        {
          def_id = fun_id;
          item_meta;
-         is_local;
-         name;
          signature;
          kind = RegularKind;
          body;

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -61,5 +61,3 @@ type attr_info = {
   public : bool;
 }
 [@@deriving show, ord]
-
-type item_meta = { span : span; attr_info : attr_info } [@@deriving show, ord]

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -50,9 +50,13 @@ type inline_attr =
   | Always  (** `#[inline(always)]` **)
 [@@deriving show, ord]
 
+(** Attribute (`#[...]`). **)
+type attribute = AttrOpaque | AttrRename of string | AttrUnknown of string
+[@@deriving show, ord]
+
 type item_meta = {
   span : span;
-  attributes : string list;  (** Attributes (`#[...]`). **)
+  attributes : attribute list;
   inline : inline_attr option;
   public : bool;
   rename : string option;

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -54,11 +54,12 @@ type inline_attr =
 type attribute = AttrOpaque | AttrRename of string | AttrUnknown of string
 [@@deriving show, ord]
 
-type item_meta = {
-  span : span;
+type attr_info = {
   attributes : attribute list;
   inline : inline_attr option;
-  public : bool;
   rename : string option;
+  public : bool;
 }
 [@@deriving show, ord]
+
+type item_meta = { span : span; attr_info : attr_info } [@@deriving show, ord]

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -92,7 +92,7 @@ let gfun_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let sg = def.signature in
 
   (* Function name *)
-  let name = name_to_string env def.name in
+  let name = name_to_string env def.item_meta.name in
 
   (* We print the declaration differently if it is opaque (no body) or transparent
    * (we have access to a body) *)
@@ -140,7 +140,7 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let ty_to_string = ty_to_string env in
 
   (* Name *)
-  let name = name_to_string env def.name in
+  let name = name_to_string env def.item_meta.name in
 
   (* Generics and predicates *)
   let params, clauses =
@@ -228,7 +228,7 @@ let trait_impl_to_string (env : ('a, 'b) fmt_env) (indent : string)
   let ty_to_string = ty_to_string env in
 
   (* Name *)
-  let name = name_to_string env def.name in
+  let name = name_to_string env def.item_meta.name in
 
   (* Generics and predicates *)
   let params, clauses =

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -129,7 +129,7 @@ module Ast = struct
     in
 
     (* Global name *)
-    let name = name_to_string env def.name in
+    let name = name_to_string env def.item_meta.name in
 
     (* Type *)
     let ty = ty_to_string env def.ty in

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -109,28 +109,28 @@ and type_decl_id_to_string env def_id =
   (* We don't want the printing functions to crash if the crate is partial *)
   match TypeDeclId.Map.find_opt def_id env.type_decls with
   | None -> type_decl_id_to_pretty_string def_id
-  | Some def -> name_to_string env def.name
+  | Some def -> name_to_string env def.item_meta.name
 
 and fun_decl_id_to_string (env : ('a, 'b) fmt_env) (id : FunDeclId.id) : string
     =
   match FunDeclId.Map.find_opt id env.fun_decls with
   | None -> fun_decl_id_to_pretty_string id
-  | Some def -> name_to_string env def.name
+  | Some def -> name_to_string env def.item_meta.name
 
 and global_decl_id_to_string env def_id =
   match GlobalDeclId.Map.find_opt def_id env.global_decls with
   | None -> global_decl_id_to_pretty_string def_id
-  | Some def -> name_to_string env def.name
+  | Some def -> name_to_string env def.item_meta.name
 
 and trait_decl_id_to_string env id =
   match TraitDeclId.Map.find_opt id env.trait_decls with
   | None -> trait_decl_id_to_pretty_string id
-  | Some def -> name_to_string env def.name
+  | Some def -> name_to_string env def.item_meta.name
 
 and trait_impl_id_to_string env id =
   match TraitImplId.Map.find_opt id env.trait_impls with
   | None -> trait_impl_id_to_pretty_string id
-  | Some def -> name_to_string env def.name
+  | Some def -> name_to_string env def.item_meta.name
 
 and const_generic_to_string (env : ('a, 'b) fmt_env) (cg : const_generic) :
     string =
@@ -397,7 +397,7 @@ let type_decl_to_string (env : ('a, 'b) fmt_env) (def : type_decl) : string =
     predicates_and_trait_clauses_to_string env "" "  " None def.generics
   in
 
-  let name = name_to_string env def.name in
+  let name = name_to_string env def.item_meta.name in
   let params =
     if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
   in
@@ -431,7 +431,7 @@ let adt_variant_to_string (env : ('a, 'b) fmt_env) (def_id : TypeDeclId.id)
       | Struct _ | Alias _ | Opaque -> raise (Failure "Unreachable")
       | Enum variants ->
           let variant = VariantId.nth variants variant_id in
-          name_to_string env def.name ^ "::" ^ variant.variant_name)
+          name_to_string env def.item_meta.name ^ "::" ^ variant.variant_name)
 
 let adt_field_names (env : ('a, 'b) fmt_env) (def_id : TypeDeclId.id)
     (opt_variant_id : VariantId.id option) : string list option =

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -106,7 +106,7 @@ module Ast = struct
       if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
     in
 
-    let name = name_to_string env def.name in
+    let name = name_to_string env def.item_meta.name in
     let ty = ty_to_string env def.ty in
 
     (* We print the declaration differently if it is opaque (no body) or transparent

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -227,7 +227,7 @@ let type_decl_get_instantiated_variants_fields_types (def : type_decl)
         raise
           (Failure
              ("Can't retrieve the variants of an opaque or alias type: "
-            ^ show_name def.name))
+             ^ show_name def.item_meta.name))
   in
   List.map
     (fun (id, fields) ->

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -527,14 +527,16 @@ type region_var_group = (RegionVarId.id, RegionGroupId.id) g_region_group
 type region_var_groups = region_var_group list [@@deriving show]
 
 type field = {
-  item_meta : item_meta;
+  span : span;
+  attr_info : attr_info;
   field_name : string option;
   field_ty : ty;
 }
 [@@deriving show]
 
 type variant = {
-  item_meta : item_meta;
+  span : span;
+  attr_info : attr_info;
   variant_name : string;
   fields : field list;
       (** The fields can be indexed with {!FieldId.id}.

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -507,6 +507,15 @@ type path_elem = PeIdent of string * Disambiguator.id | PeImpl of impl_elem
 (** A name *)
 type name = path_elem list [@@deriving show, ord]
 
+(** Information about a generic item. *)
+type item_meta = {
+  span : span;
+  name : name;
+  attr_info : attr_info;
+  is_local : bool;
+}
+[@@deriving show, ord]
+
 (** A group of regions.
 
     Results from a lifetime analysis: we group the regions with the same
@@ -567,8 +576,6 @@ type type_decl_kind =
 type type_decl = {
   def_id : TypeDeclId.id;
   item_meta : item_meta;
-  is_local : bool;
-  name : name;
   generics : generic_params;
   kind : type_decl_kind;
 }

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -154,7 +154,7 @@ module PatternTest = struct
     else if (not test.success) && match_success then (
       log#error "Pattern %s matches function %s but shouldn't\n"
         (pattern_to_string env.print_config test.pattern)
-        (PrintTypes.name_to_string env.fmt_env decl.name);
+        (PrintTypes.name_to_string env.fmt_env decl.item_meta.name);
       false)
     else true
 end

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -184,7 +184,7 @@ let annotated_rust_tests test_file =
         let attrs =
           List.filter_map
             (function AttrUnknown attr -> Some attr | _ -> None)
-            decl.item_meta.attributes
+            decl.item_meta.attr_info.attributes
         in
         let tests = List.filter_map PatternTest.parse attrs in
         let test_results =

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -1,6 +1,7 @@
 open Charon
 open Charon.Expressions
 open Charon.LlbcAst
+open Charon.Meta
 open Logging
 open NameMatcher
 
@@ -180,9 +181,12 @@ let annotated_rust_tests test_file =
   let all_pass =
     T.FunDeclId.Map.for_all
       (fun _ (decl : fun_decl) ->
-        let tests =
-          List.filter_map PatternTest.parse decl.item_meta.attributes
+        let attrs =
+          List.filter_map
+            (function AttrUnknown attr -> Some attr | _ -> None)
+            decl.item_meta.attributes
         in
+        let tests = List.filter_map PatternTest.parse attrs in
         let test_results =
           List.map (PatternTest.check_fun_decl env decl) tests
         in

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -149,10 +149,6 @@ pub struct FunDecl {
     pub rust_id: rustc_hir::def_id::DefId,
     /// The meta data associated with the declaration.
     pub item_meta: ItemMeta,
-    /// [true] if the decl is a local decl, [false] if it comes from
-    /// an external crate.
-    pub is_local: bool,
-    pub name: Name,
     /// The signature contains the inputs/output types *with* non-erased regions.
     /// It also contains the list of region and type parameters.
     pub signature: FunSig,
@@ -175,10 +171,6 @@ pub struct GlobalDecl {
     pub rust_id: rustc_hir::def_id::DefId,
     /// The meta data associated with the declaration.
     pub item_meta: ItemMeta,
-    /// [true] if the decl is a local decl, [false] if it comes from
-    /// an external crate.
-    pub is_local: bool,
-    pub name: Name,
     pub generics: GenericParams,
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
@@ -228,11 +220,7 @@ pub struct TraitItemName(pub String);
 pub struct TraitDecl {
     #[drive(skip)]
     pub def_id: TraitDeclId,
-    /// [true] if the decl is a local decl, [false] if it comes from
-    /// an external crate.
-    pub is_local: bool,
     pub item_meta: ItemMeta,
-    pub name: Name,
     pub generics: GenericParams,
     /// The "parent" clauses: the supertraits.
     ///
@@ -290,10 +278,6 @@ pub struct TraitDecl {
 pub struct TraitImpl {
     #[drive(skip)]
     pub def_id: TraitImplId,
-    /// [true] if the decl is a local decl, [false] if it comes from
-    /// an external crate.
-    pub is_local: bool,
-    pub name: Name,
     pub item_meta: ItemMeta,
     /// The information about the implemented trait.
     /// Note that this contains the instantiation of the "parent"

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -130,14 +130,21 @@ pub enum Attribute {
     Unknown(String),
 }
 
-/// Meta information about an item (function, trait decl, trait impl, type decl, global).
+/// Information about the attributes and visibility of an item, field or variant..
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
-pub struct ItemMeta {
-    pub span: Span,
+pub struct AttrInfo {
     /// Attributes (`#[...]`).
     pub attributes: Vec<Attribute>,
     /// Inline hints (on functions only).
     pub inline: Option<InlineAttr>,
+    /// Attribute `charon::rename("...")` provide a custom name that can be used by consumers of
+    /// llbc. E.g. Aeneas uses this to rename definitions in the extracted code.
+    pub rename: Option<String>,
+    /// Whether there was a `#[charon::opaque]` annotation on this item. This is different from
+    /// other reasons this may be opaque.
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    pub opaque: bool,
     /// Whether this item is declared public. Impl blocks and closures don't have visibility
     /// modifiers; we arbitrarily set this to `false` for them.
     ///
@@ -157,12 +164,13 @@ pub struct ItemMeta {
     /// API (this is called "pub-in-priv" items). With or without the `pub use`, we set `public =
     /// true`; computing item reachability is harder.
     pub public: bool,
-    /// Attribute `charon::rename("...")` (and `aeneas::rename("...")`) to provide a custom
-    /// name that can be used for instance when extracting the code via Aeneas.
-    pub rename: Option<String>,
-    #[serde(skip_serializing)]
-    #[serde(default)]
-    pub opaque: bool,
+}
+
+/// Meta information about an item (function, trait decl, trait impl, type decl, global).
+#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+pub struct ItemMeta {
+    pub span: Span,
+    pub attr_info: AttrInfo,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -3,7 +3,7 @@
 pub use crate::meta_utils::*;
 use derive_visitor::{Drive, DriveMut};
 use hax_frontend_exporter::PathBuf;
-use macros::{EnumAsGetters, EnumIsA};
+use macros::{EnumAsGetters, EnumIsA, EnumToGetters};
 use serde::{Deserialize, Serialize};
 
 generate_index_type!(LocalFileId);
@@ -99,9 +99,6 @@ impl From<Span> for rustc_error_messages::MultiSpan {
     }
 }
 
-/// Attributes (`#[...]`). For now we store just the string representation.
-pub type Attribute = String;
-
 /// `#[inline]` built-in attribute.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub enum InlineAttr {
@@ -111,6 +108,26 @@ pub enum InlineAttr {
     Never,
     /// `#[inline(always)]`
     Always,
+}
+
+/// Attributes (`#[...]`).
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    EnumIsA,
+    EnumAsGetters,
+    EnumToGetters,
+    Serialize,
+    Deserialize,
+    Drive,
+    DriveMut,
+)]
+pub enum Attribute {
+    Opaque,
+    Rename(String),
+    Unknown(String),
 }
 
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -138,11 +138,12 @@ pub struct AttrInfo {
     pub attributes: Vec<Attribute>,
     /// Inline hints (on functions only).
     pub inline: Option<InlineAttr>,
-    /// Attribute `charon::rename("...")` provide a custom name that can be used by consumers of
-    /// llbc. E.g. Aeneas uses this to rename definitions in the extracted code.
+    /// The name specified with the `#[charon::rename("...")]` attribute, if any. This provides a
+    /// custom name that can be used by consumers of llbc. E.g. Aeneas uses this to rename
+    /// definitions in the extracted code.
     pub rename: Option<String>,
-    /// Whether there was a `#[charon::opaque]` annotation on this item. This is different from
-    /// other reasons this may be opaque.
+    /// Whether there was a `#[charon::opaque]` annotation on this item. An item may be opaque for
+    /// other reasons than this attribute, e.g. if specified on the command line.
     #[serde(skip_serializing)]
     #[serde(default)]
     pub opaque: bool,

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -1,6 +1,7 @@
 //! Meta-information about programs (spans, etc.).
 
 pub use crate::meta_utils::*;
+use crate::names::Name;
 use derive_visitor::{Drive, DriveMut};
 use hax_frontend_exporter::PathBuf;
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters};
@@ -170,7 +171,11 @@ pub struct AttrInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct ItemMeta {
     pub span: Span,
+    pub name: Name,
+    /// Attributes and visibility.
     pub attr_info: AttrInfo,
+    /// `true` if the type decl is a local type decl, `false` if it comes from an external crate.
+    pub is_local: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,7 +1,6 @@
 pub use crate::gast::{FunDeclId, TraitItemName};
 use crate::ids::Vector;
 use crate::meta::{AttrInfo, ItemMeta, Span};
-use crate::names::Name;
 pub use crate::types_utils::*;
 use crate::values::{Literal, ScalarValue};
 use derivative::Derivative;
@@ -415,10 +414,6 @@ pub struct TypeDecl {
     pub def_id: TypeDeclId,
     /// Meta information associated with the item.
     pub item_meta: ItemMeta,
-    /// [true] if the type decl is a local type decl, [false] if it comes from
-    /// an external crate.
-    pub is_local: bool,
-    pub name: Name,
     pub generics: GenericParams,
     /// The type kind: enum, struct, or opaque.
     pub kind: TypeDeclKind,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,6 +1,6 @@
 pub use crate::gast::{FunDeclId, TraitItemName};
 use crate::ids::Vector;
-use crate::meta::{ItemMeta, Span};
+use crate::meta::{AttrInfo, ItemMeta, Span};
 use crate::names::Name;
 pub use crate::types_utils::*;
 use crate::values::{Literal, ScalarValue};
@@ -413,7 +413,7 @@ pub enum PredicateOrigin {
 pub struct TypeDecl {
     #[drive(skip)]
     pub def_id: TypeDeclId,
-    /// Meta information associated with the type.
+    /// Meta information associated with the item.
     pub item_meta: ItemMeta,
     /// [true] if the type decl is a local type decl, [false] if it comes from
     /// an external crate.
@@ -442,7 +442,8 @@ pub enum TypeDeclKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Variant {
-    pub item_meta: ItemMeta,
+    pub span: Span,
+    pub attr_info: AttrInfo,
     pub name: String,
     pub fields: Vector<FieldId, Field>,
     /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
@@ -452,8 +453,8 @@ pub struct Variant {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Field {
-    /// FIXME: define a more appropriate container for attribute and visibility information.
-    pub item_meta: ItemMeta,
+    pub span: Span,
+    pub attr_info: AttrInfo,
     pub name: Option<String>,
     pub ty: Ty,
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -499,7 +499,7 @@ where
         };
 
         // Function name
-        let name = self.name.fmt_with_ctx(ctx);
+        let name = self.item_meta.name.fmt_with_ctx(ctx);
 
         // Generic parameters
         let (params, preds, _) = self.signature.generics.fmt_with_ctx_with_trait_clauses(
@@ -571,7 +571,7 @@ where
         };
 
         // Decl name
-        let name = self.name.fmt_with_ctx(ctx);
+        let name = self.item_meta.name.fmt_with_ctx(ctx);
 
         // Body
         let body = match self.body {
@@ -1073,7 +1073,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
         // Update the context
         let ctx = &ctx.set_generics(&self.generics);
 
-        let name = self.name.fmt_with_ctx(ctx);
+        let name = self.item_meta.name.fmt_with_ctx(ctx);
         let (generics, clauses, _) = self
             .generics
             .fmt_with_ctx_with_trait_clauses(ctx, "", &None);
@@ -1155,7 +1155,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
         // Update the context
         let ctx = &ctx.set_generics(&self.generics);
 
-        let name = self.name.fmt_with_ctx(ctx);
+        let name = self.item_meta.name.fmt_with_ctx(ctx);
         let (generics, clauses, _) = self
             .generics
             .fmt_with_ctx_with_trait_clauses(ctx, "", &None);
@@ -1345,12 +1345,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for TypeDecl {
                     let fields = fields.join(",");
                     format!(
                         "struct {}{params}{preds}{eq_space}=\n{{{fields}\n}}",
-                        self.name.fmt_with_ctx(ctx)
+                        self.item_meta.name.fmt_with_ctx(ctx)
                     )
                 } else {
                     format!(
                         "struct {}{params}{preds}{eq_space}= {{}}",
-                        self.name.fmt_with_ctx(ctx)
+                        self.item_meta.name.fmt_with_ctx(ctx)
                     )
                 }
             }
@@ -1362,23 +1362,26 @@ impl<C: AstFormatter> FmtWithCtx<C> for TypeDecl {
                 let variants = variants.join("\n");
                 format!(
                     "enum {}{params}{preds}{eq_space}=\n{variants}\n",
-                    self.name.fmt_with_ctx(ctx)
+                    self.item_meta.name.fmt_with_ctx(ctx)
                 )
             }
             TypeDeclKind::Alias(ty) => {
                 format!(
                     "type {}{params}{preds} = {}",
-                    self.name.fmt_with_ctx(ctx),
+                    self.item_meta.name.fmt_with_ctx(ctx),
                     ty.fmt_with_ctx(ctx),
                 )
             }
             TypeDeclKind::Opaque => {
-                format!("opaque type {}{params}{preds}", self.name.fmt_with_ctx(ctx))
+                format!(
+                    "opaque type {}{params}{preds}",
+                    self.item_meta.name.fmt_with_ctx(ctx)
+                )
             }
             TypeDeclKind::Error(msg) => {
                 format!(
                     "opaque type {}{params}{preds} = ERROR({msg})",
-                    self.name.fmt_with_ctx(ctx),
+                    self.item_meta.name.fmt_with_ctx(ctx),
                 )
             }
         }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -239,7 +239,7 @@ impl<'a> Formatter<TypeDeclId> for FmtCtx<'a> {
             None => id.to_pretty_string(),
             Some(translated) => match translated.type_decls.get(id) {
                 None => id.to_pretty_string(),
-                Some(d) => d.name.fmt_with_ctx(self),
+                Some(d) => d.item_meta.name.fmt_with_ctx(self),
             },
         }
     }
@@ -251,7 +251,7 @@ impl<'a> Formatter<GlobalDeclId> for FmtCtx<'a> {
             None => id.to_pretty_string(),
             Some(translated) => match translated.global_decls.get(id) {
                 None => id.to_pretty_string(),
-                Some(d) => d.name.fmt_with_ctx(self),
+                Some(d) => d.item_meta.name.fmt_with_ctx(self),
             },
         }
     }
@@ -263,7 +263,7 @@ impl<'a> Formatter<ast::FunDeclId> for FmtCtx<'a> {
             None => id.to_pretty_string(),
             Some(translated) => match translated.fun_decls.get(id) {
                 None => id.to_pretty_string(),
-                Some(d) => d.name.fmt_with_ctx(self),
+                Some(d) => d.item_meta.name.fmt_with_ctx(self),
             },
         }
     }
@@ -287,7 +287,7 @@ impl<'a> Formatter<ast::TraitDeclId> for FmtCtx<'a> {
             None => id.to_pretty_string(),
             Some(translated) => match translated.trait_decls.get(id) {
                 None => id.to_pretty_string(),
-                Some(d) => d.name.fmt_with_ctx(self),
+                Some(d) => d.item_meta.name.fmt_with_ctx(self),
             },
         }
     }
@@ -299,7 +299,7 @@ impl<'a> Formatter<ast::TraitImplId> for FmtCtx<'a> {
             None => id.to_pretty_string(),
             Some(translated) => match translated.trait_impls.get(id) {
                 None => id.to_pretty_string(),
-                Some(d) => d.name.fmt_with_ctx(self),
+                Some(d) => d.item_meta.name.fmt_with_ctx(self),
             },
         }
     }
@@ -380,7 +380,7 @@ impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
                     ),
                     Some(def) => {
                         let variants = def.kind.as_enum();
-                        let mut name = def.name.fmt_with_ctx(self);
+                        let mut name = def.item_meta.name.fmt_with_ctx(self);
                         let variant_name = &variants.get(variant_id).unwrap().name;
                         name.push_str("::");
                         name.push_str(variant_name);

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -54,12 +54,12 @@ pub trait UllbcPass: Sync {
     fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
         ctx.for_each_fun_decl(|ctx, decl, body| {
             let body = body.map(|body| body.as_unstructured_mut().unwrap());
-            self.log_before_body(ctx, &decl.name, body.as_deref());
+            self.log_before_body(ctx, &decl.item_meta.name, body.as_deref());
             self.transform_function(ctx, decl, body);
         });
         ctx.for_each_global_decl(|ctx, decl, body| {
             let body = body.map(|body| body.as_unstructured_mut().unwrap());
-            self.log_before_body(ctx, &decl.name, body.as_deref());
+            self.log_before_body(ctx, &decl.item_meta.name, body.as_deref());
             self.transform_global(ctx, decl, body);
         });
     }
@@ -125,12 +125,12 @@ pub trait LlbcPass: Sync {
     fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
         ctx.for_each_fun_decl(|ctx, decl, body| {
             let body = body.map(|body| body.as_structured_mut().unwrap());
-            self.log_before_body(ctx, &decl.name, body.as_deref());
+            self.log_before_body(ctx, &decl.item_meta.name, body.as_deref());
             self.transform_function(ctx, decl, body);
         });
         ctx.for_each_global_decl(|ctx, decl, body| {
             let body = body.map(|body| body.as_structured_mut().unwrap());
-            self.log_before_body(ctx, &decl.name, body.as_deref());
+            self.log_before_body(ctx, &decl.item_meta.name, body.as_deref());
             self.transform_global(ctx, decl, body);
         });
     }

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -488,10 +488,20 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     /// Compute the meta information for a Rust item identified by its id.
-    pub(crate) fn translate_item_meta_from_rid(&mut self, def_id: DefId) -> ItemMeta {
+    pub(crate) fn translate_item_meta_from_rid(
+        &mut self,
+        def_id: DefId,
+    ) -> Result<ItemMeta, Error> {
         let span = self.translate_span_from_rid(def_id);
+        let name = self.def_id_to_name(def_id)?;
         let attr_info = self.translate_attr_info_from_rid(def_id, span);
-        ItemMeta { span, attr_info }
+        let is_local = def_id.is_local();
+        Ok(ItemMeta {
+            span,
+            attr_info,
+            name,
+            is_local,
+        })
     }
 
     pub fn translate_span(&mut self, rspan: hax::Span) -> meta::RawSpan {

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1767,13 +1767,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let def_span = self.tcx.def_span(rust_id);
 
         // Compute the meta information
-        let item_meta = self.translate_item_meta_from_rid(rust_id);
+        let item_meta = self.translate_item_meta_from_rid(rust_id)?;
 
         // Initialize the body translation context
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
-
-        // Translate the function name
-        let name = bt_ctx.t_ctx.def_id_to_name(rust_id)?;
 
         // Check whether this function is a method declaration for a trait definition.
         // If this is the case, it shouldn't contain a body.
@@ -1810,8 +1807,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             def_id,
             rust_id,
             item_meta,
-            is_local: rust_id.is_local(),
-            name,
             signature,
             kind,
             body: body_id,
@@ -1828,7 +1823,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let span = self.tcx.def_span(rust_id);
 
         // Compute the meta information
-        let item_meta = self.translate_item_meta_from_rid(rust_id);
+        let item_meta = self.translate_item_meta_from_rid(rust_id)?;
 
         // Initialize the body translation context
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
@@ -1844,9 +1839,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnFn)?;
 
         let hax_state = &bt_ctx.hax_state;
-
-        // Translate the global name
-        let name = bt_ctx.t_ctx.def_id_to_name(rust_id)?;
 
         trace!("Translating global type");
         let mir_ty = bt_ctx.t_ctx.tcx.type_of(rust_id).instantiate_identity();
@@ -1875,8 +1867,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             def_id,
             rust_id,
             item_meta,
-            is_local: rust_id.is_local(),
-            name,
             generics,
             ty,
             kind,

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1453,7 +1453,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     ) -> Result<Result<Body, Opaque>, Error> {
         let tcx = self.t_ctx.tcx;
 
-        if item_meta.opaque {
+        if item_meta.attr_info.opaque {
             return Ok(Err(Opaque));
         }
         if !self.t_ctx.id_is_transparent(rust_id)? {

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -384,7 +384,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trait_pred: &hax::TraitPredicate,
         origin: PredicateOrigin,
     ) -> Result<Option<TraitClauseId>, Error> {
-        // FIXME: once `clause` can't be `None`, use |Vector::reserve_slot` to be sure we don't use
+        // FIXME: once `clause` can't be `None`, use `Vector::reserve_slot` to be sure we don't use
         // the same id twice.
         let (clause_id, instance_id) = self.clause_translation_context.generate_instance_id();
         let clause = self.translate_trait_clause_aux(hspan, trait_pred, instance_id, origin)?;

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -389,7 +389,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 generic_clauses
             );
         }
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);
+        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
         if item_meta.attr_info.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
@@ -407,8 +407,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // check those, and lookup the relevant values.
         Ok(ast::TraitDecl {
             def_id,
-            is_local: rust_id.is_local(),
-            name,
             item_meta,
             generics,
             parent_clauses,
@@ -431,7 +429,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let span = tcx.def_span(rust_id);
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
-        let name = bt_ctx.t_ctx.def_id_to_name(rust_id)?;
         let erase_regions = false;
 
         // Translate the generics
@@ -599,7 +596,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 }
             }
         }
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);
+        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
         if item_meta.attr_info.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
@@ -608,15 +605,13 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     "The `aeneas::opaque` or `charon::opaque` attribute currently \
                     has no effect on trait implementations and will be ignored.\
                     \nImplementation name: {}\n",
-                    name.fmt_with_ctx(&ctx)
+                    item_meta.name.fmt_with_ctx(&ctx)
                 ),
             )
         }
 
         Ok(ast::TraitImpl {
             def_id,
-            is_local: rust_id.is_local(),
-            name,
             item_meta,
             impl_trait: implemented_trait,
             generics: bt_ctx.get_generics(),

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -390,7 +390,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             );
         }
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);
-        if item_meta.opaque {
+        if item_meta.attr_info.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,
@@ -600,7 +600,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
         }
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);
-        if item_meta.opaque {
+        if item_meta.attr_info.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -746,7 +746,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnType)?;
 
         // Translate the meta information
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id);
+        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
 
         // Check if the type has been explicitely marked as opaque.
         // If yes, ignore it, otherwise, dive into the body. Note that for
@@ -765,14 +765,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         };
 
         // Register the type
-        let name = bt_ctx.t_ctx.def_id_to_name(rust_id)?;
         let generics = bt_ctx.get_generics();
 
         let type_def = TypeDecl {
             def_id: trans_id,
             item_meta,
-            is_local: rust_id.is_local(),
-            name,
             generics,
             kind,
         };

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -581,12 +581,13 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             let mut have_names: Option<bool> = None;
             for (j, field_def) in var_def.fields.into_iter().enumerate() {
                 trace!("variant {i}: field {j}: {field_def:?}");
-                let field_span = field_def.span.rust_span_data.unwrap().span();
-                let field_meta = self
-                    .t_ctx
-                    .translate_item_meta_from_rid(DefId::from(&field_def.did));
+                let field_span = self.t_ctx.translate_span_from_rspan(field_def.span);
+                let field_rspan = field_span.span.rust_span_data.span();
                 // Translate the field type
-                let ty = self.translate_ty(field_span, erase_regions, &field_def.ty)?;
+                let ty = self.translate_ty(field_rspan, erase_regions, &field_def.ty)?;
+                let field_attrs = self
+                    .t_ctx
+                    .translate_attr_info_from_rid(DefId::from(&field_def.did), field_span);
 
                 // Retrieve the field name.
                 let field_name = field_def.name;
@@ -599,25 +600,28 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         }
                     }
                     Some(b) => {
-                        error_assert!(self, field_span, *b == field_name.is_some());
+                        error_assert!(self, field_rspan, *b == field_name.is_some());
                     }
                 };
 
                 // Store the field
                 let field = Field {
-                    item_meta: field_meta,
+                    span: field_span,
+                    attr_info: field_attrs,
                     name: field_name.clone(),
                     ty,
                 };
                 fields.push(field);
             }
 
-            let variant_meta = self
-                .t_ctx
-                .translate_item_meta_from_rid(DefId::from(&var_def.def_id));
+            let variant_span = self.t_ctx.translate_span_from_rspan(var_def.span);
             let variant_name = var_def.name;
+            let variant_attrs = self
+                .t_ctx
+                .translate_attr_info_from_rid(DefId::from(&var_def.def_id), variant_span);
             variants.push(Variant {
-                item_meta: variant_meta,
+                span: variant_span,
+                attr_info: variant_attrs,
                 name: variant_name,
                 fields,
                 discriminant,
@@ -751,7 +755,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // For instance, because `core::option::Option` is public, we can
         // manipulate its variants. If we encounter this type, we must retrieve
         // its definition.
-        let kind = if !is_transparent || item_meta.opaque {
+        let kind = if !is_transparent || item_meta.attr_info.opaque {
             TypeDeclKind::Opaque
         } else {
             match bt_ctx.translate_type_body(trans_id, rust_id) {

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -331,6 +331,7 @@ fn attributes() -> Result<(), Box<dyn Error>> {
     // Use the `clippy::` prefix because it's ignored by rustc.
     let unknown_attrs = |item_meta: &ItemMeta| {
         item_meta
+            .attr_info
             .attributes
             .iter()
             .filter(|a| a.is_unknown())
@@ -394,7 +395,7 @@ fn attributes() -> Result<(), Box<dyn Error>> {
         vec!["inline(never)"]
     );
     assert_eq!(
-        crate_data.functions[0].item_meta.inline,
+        crate_data.functions[0].item_meta.attr_info.inline,
         Some(InlineAttr::Never)
     );
     Ok(())
@@ -416,19 +417,19 @@ fn visibility() -> Result<(), Box<dyn Error>> {
         repr_name(&crate_data, &crate_data.types[0].name),
         "test_crate::Pub"
     );
-    assert!(crate_data.types[0].item_meta.public);
+    assert!(crate_data.types[0].item_meta.attr_info.public);
     assert_eq!(
         repr_name(&crate_data, &crate_data.types[1].name),
         "test_crate::Priv"
     );
-    assert!(!crate_data.types[1].item_meta.public);
+    assert!(!crate_data.types[1].item_meta.attr_info.public);
     // Note how we think `PubInPriv` is public. It kind of is but there is no path to it. This is
     // probably fine.
     assert_eq!(
         repr_name(&crate_data, &crate_data.types[2].name),
         "test_crate::private::PubInPriv"
     );
-    assert!(crate_data.types[2].item_meta.public);
+    assert!(crate_data.types[2].item_meta.attr_info.public);
     Ok(())
 }
 
@@ -520,66 +521,86 @@ fn rename_attribute() -> Result<(), Box<dyn Error>> {
     )?;
 
     assert_eq!(
-        crate_data.trait_decls[0].item_meta.rename.as_deref(),
+        crate_data.trait_decls[0]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
         Some("BoolTest")
     );
 
     assert_eq!(
-        crate_data.functions[2].item_meta.rename.as_deref(),
+        crate_data.functions[2]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
         Some("getTest")
     );
 
     assert_eq!(
-        crate_data.functions[3].item_meta.rename.as_deref(),
+        crate_data.functions[3]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
         Some("retTest")
     );
 
     assert_eq!(
-        crate_data.trait_impls[0].item_meta.rename.as_deref(),
+        crate_data.trait_impls[0]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
         Some("BoolImpl")
     );
 
     assert_eq!(
-        crate_data.functions[1].item_meta.rename.as_deref(),
+        crate_data.functions[1]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
         Some("BoolFn")
     );
 
     assert_eq!(
-        crate_data.types[0].item_meta.rename.as_deref(),
+        crate_data.types[0].item_meta.attr_info.rename.as_deref(),
         Some("TypeTest")
     );
 
     assert_eq!(
-        crate_data.types[1].item_meta.rename.as_deref(),
+        crate_data.types[1].item_meta.attr_info.rename.as_deref(),
         Some("VariantsTest")
     );
 
     assert_eq!(
         crate_data.types[1].kind.as_enum()[0]
-            .item_meta
+            .attr_info
             .rename
             .as_deref(),
         Some("Variant1")
     );
 
     assert_eq!(
-        crate_data.types[2].item_meta.rename.as_deref(),
+        crate_data.types[2].item_meta.attr_info.rename.as_deref(),
         Some("StructTest")
     );
 
     assert_eq!(
-        crate_data.globals[0].item_meta.rename.as_deref(),
+        crate_data.globals[0].item_meta.attr_info.rename.as_deref(),
         Some("Const_Test")
     );
 
     assert_eq!(
-        crate_data.types[3].item_meta.rename.as_deref(),
+        crate_data.types[3].item_meta.attr_info.rename.as_deref(),
         Some("_TypeAeneas36")
     );
 
     assert_eq!(
         crate_data.types[2].kind.as_struct()[0]
-            .item_meta
+            .attr_info
             .rename
             .as_deref(),
         Some("FieldTest")

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -329,6 +329,15 @@ fn predicate_origins() -> Result<(), Box<dyn Error>> {
 #[test]
 fn attributes() -> Result<(), Box<dyn Error>> {
     // Use the `clippy::` prefix because it's ignored by rustc.
+    let unknown_attrs = |item_meta: &ItemMeta| {
+        item_meta
+            .attributes
+            .iter()
+            .filter(|a| a.is_unknown())
+            .map(|a| a.as_unknown())
+            .cloned()
+            .collect_vec()
+    };
     let crate_data = translate(
         r#"
         #[clippy::foo]
@@ -356,31 +365,32 @@ fn attributes() -> Result<(), Box<dyn Error>> {
         "#,
     )?;
     assert_eq!(
-        crate_data.types[0].item_meta.attributes,
+        unknown_attrs(&crate_data.types[0].item_meta),
         vec!["clippy::foo", "clippy::foo(arg)", "clippy::foo = \"arg\""]
     );
     assert_eq!(
-        crate_data.types[1].item_meta.attributes,
+        unknown_attrs(&crate_data.types[1].item_meta),
         vec!["non_exhaustive"]
     );
     assert_eq!(
-        crate_data.trait_decls[0].item_meta.attributes,
+        unknown_attrs(&crate_data.trait_decls[0].item_meta),
         vec!["clippy::foo"]
     );
     assert_eq!(
-        crate_data.trait_impls[0].item_meta.attributes,
+        unknown_attrs(&crate_data.trait_impls[0].item_meta),
         vec!["clippy::foo"]
     );
     assert_eq!(
-        crate_data.globals[0].item_meta.attributes,
+        unknown_attrs(&crate_data.globals[0].item_meta),
         vec!["clippy::foo"]
     );
     assert_eq!(
-        crate_data.globals[1].item_meta.attributes,
+        unknown_attrs(&crate_data.globals[1].item_meta),
         vec!["clippy::foo"]
     );
+    // We don't parse that attribute ourselves, we let rustc do it.
     assert_eq!(
-        crate_data.functions[0].item_meta.attributes,
+        unknown_attrs(&crate_data.functions[0].item_meta),
         vec!["inline(never)"]
     );
     assert_eq!(

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -70,7 +70,7 @@ fn repr_span(span: Span) -> String {
 
 fn trait_name(crate_data: &CrateData, trait_id: TraitDeclId) -> &str {
     let tr = &crate_data.trait_decls[trait_id.index()];
-    let PathElem::Ident(trait_name, _) = tr.name.name.last().unwrap() else {
+    let PathElem::Ident(trait_name, _) = tr.item_meta.name.name.last().unwrap() else {
         panic!()
     };
     trait_name
@@ -102,29 +102,29 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
         .functions
         .iter()
         .map(|x| Item {
-            name: &x.name,
-            name_str: repr_name(crate_data, &x.name),
+            name: &x.item_meta.name,
+            name_str: repr_name(crate_data, &x.item_meta.name),
             item_meta: &x.item_meta,
             generics: x.signature.generics.clone(),
             kind: ItemKind::Fun(x),
         })
         .chain(crate_data.globals.iter().map(|x| Item {
-            name: &x.name,
-            name_str: repr_name(crate_data, &x.name),
+            name: &x.item_meta.name,
+            name_str: repr_name(crate_data, &x.item_meta.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
             kind: ItemKind::Global(x),
         }))
         .chain(crate_data.types.iter().map(|x| Item {
-            name: &x.name,
-            name_str: repr_name(crate_data, &x.name),
+            name: &x.item_meta.name,
+            name_str: repr_name(crate_data, &x.item_meta.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
             kind: ItemKind::Type(x),
         }))
         .chain(crate_data.trait_impls.iter().map(|x| Item {
-            name: &x.name,
-            name_str: repr_name(crate_data, &x.name),
+            name: &x.item_meta.name,
+            name_str: repr_name(crate_data, &x.item_meta.name),
             item_meta: &x.item_meta,
             generics: x.generics.clone(),
             kind: ItemKind::TraitImpl(x),
@@ -135,8 +135,8 @@ fn items_by_name<'c>(crate_data: &'c CrateData) -> HashMap<String, Item<'c>> {
             assert!(generics.trait_clauses.is_empty());
             generics.trait_clauses = x.parent_clauses.clone();
             Item {
-                name: &x.name,
-                name_str: repr_name(crate_data, &x.name),
+                name: &x.item_meta.name,
+                name_str: repr_name(crate_data, &x.item_meta.name),
                 item_meta: &x.item_meta,
                 generics,
                 kind: ItemKind::TraitDecl(x),
@@ -155,7 +155,7 @@ fn type_decl() -> Result<(), Box<dyn Error>> {
         ",
     )?;
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[0].name),
+        repr_name(&crate_data, &crate_data.types[0].item_meta.name),
         "test_crate::Struct"
     );
     Ok(())
@@ -169,11 +169,11 @@ fn file_name() -> Result<(), Box<dyn Error>> {
         ",
     )?;
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[0].name),
+        repr_name(&crate_data, &crate_data.types[0].item_meta.name),
         "test_crate::Foo"
     );
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[1].name),
+        repr_name(&crate_data, &crate_data.types[1].item_meta.name),
         "core::option::Option"
     );
     let file_id = crate_data.types[1].item_meta.span.span.file_id;
@@ -414,19 +414,19 @@ fn visibility() -> Result<(), Box<dyn Error>> {
         "#,
     )?;
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[0].name),
+        repr_name(&crate_data, &crate_data.types[0].item_meta.name),
         "test_crate::Pub"
     );
     assert!(crate_data.types[0].item_meta.attr_info.public);
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[1].name),
+        repr_name(&crate_data, &crate_data.types[1].item_meta.name),
         "test_crate::Priv"
     );
     assert!(!crate_data.types[1].item_meta.attr_info.public);
     // Note how we think `PubInPriv` is public. It kind of is but there is no path to it. This is
     // probably fine.
     assert_eq!(
-        repr_name(&crate_data, &crate_data.types[2].name),
+        repr_name(&crate_data, &crate_data.types[2].item_meta.name),
         "test_crate::private::PubInPriv"
     );
     assert!(crate_data.types[2].item_meta.attr_info.public);

--- a/charon/tests/ui/rename_attribute_failure.out
+++ b/charon/tests/ui/rename_attribute_failure.out
@@ -1,28 +1,40 @@
-error: Attribute `{charon,aeneas}::rename` should not contain an empty string
- --> tests/ui/rename_attribute_failure.rs:8:1
+error: Error parsing attribute: attribute `rename` should not be empty
+ --> tests/ui/rename_attribute_failure.rs:6:1
   |
-8 | type TestEmpty = i32;
-  | ^^^^^^^^^^^^^^
+6 | #[charon::rename("")]
+  | ^^^^^^^^^^^^^^^^^^^^^
 
-error: Attribute `rename` should only contain alphanumeric characters and `_`, and should start with a letter or '_': "Test!976?" is not a valid name
+error: Error parsing attribute: attribute `rename` should contain a valid identifier
+ --> tests/ui/rename_attribute_failure.rs:9:1
+  |
+9 | #[charon::rename("Test!976?")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Error parsing attribute: attribute `rename` should contain a valid identifier
   --> tests/ui/rename_attribute_failure.rs:12:1
    |
-12 | type TestNonAlphanumeric = i32;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+12 | #[charon::rename("75Test")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Attribute `rename` should only contain alphanumeric characters and `_`, and should start with a letter or '_': "75Test" is not a valid name
-  --> tests/ui/rename_attribute_failure.rs:16:1
+error: Error parsing attribute: the new name should be between quotes: `rename("aaaa")`.
+  --> tests/ui/rename_attribute_failure.rs:15:1
    |
-16 | type TestNotStartingWithLetter = i32;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Attribute `{charon,aeneas}::rename` should be of the shape `{charon,aeneas}::rename("...")`: `charon::rename()` is not valid
-  --> tests/ui/rename_attribute_failure.rs:20:1
-   |
-20 | type TestNotProperShape = i32;
+15 | #[charon::rename(aaaa)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: There should be at most one `charon::rename("...")` or `aeneas::rename("...")` attribute per declaration
+  --> tests/ui/rename_attribute_failure.rs:20:1
+   |
+20 | type TestMultiple = ();
+   | ^^^^^^^^^^^^^^^^^
 
-[ ERROR charon_driver:231] The extraction encountered 4 errors
+error: Error parsing attribute: Unrecognized attribute: `something_else("_Type36")`
+  --> tests/ui/rename_attribute_failure.rs:22:1
+   |
+22 | #[charon::something_else("_Type36")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+[ ERROR charon_driver:231] The extraction encountered 6 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/rename_attribute_failure.rs
+++ b/charon/tests/ui/rename_attribute_failure.rs
@@ -3,18 +3,21 @@
 #![register_tool(charon)]
 #![register_tool(aeneas)]
 
-// Errors because rename attribute should not be empty
 #[charon::rename("")]
-type TestEmpty = i32;
+type TestEmpty = ();
 
-// Errors because rename attribute should only contain alphanumeric or '_' characters
 #[charon::rename("Test!976?")]
-type TestNonAlphanumeric = i32;
+type TestNonAlphanumeric = ();
 
-// Errors because rename attribute should begin with a letter
 #[charon::rename("75Test")]
-type TestNotStartingWithLetter = i32;
+type TestNotStartingWithLetter = ();
 
-// Errors because rename attribute is not of the proper shape (lacks "")
-#[charon::rename()]
-type TestNotProperShape = i32;
+#[charon::rename(aaaa)]
+type TestNotQuoted = ();
+
+#[charon::rename("_Type36")]
+#[aeneas::rename("_Type37")]
+type TestMultiple = ();
+
+#[charon::something_else("_Type36")]
+type TestUnrecognizedArg = ();


### PR DESCRIPTION
https://github.com/AeneasVerif/charon/pull/237 introduced a new attribute and reused `ItemMeta` in fields and variants. This Pr splits off `ItemMeta` so that fields and variants can have attribute information and items can have item-specific information in `ItemMeta`. I then move some shared item fields to `ItemMeta`. This also parses attributes into a high-level representation.