### PR TITLE
Factor out opacity computations

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.16"
+let supported_charon_version = "0.1.17"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -667,6 +667,7 @@ let item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
           ("name", name);
           ("attr_info", attr_info);
           ("is_local", is_local);
+          ("opacity", _);
         ] ->
         let* span = span_of_json id_to_file span in
         let* name = name_of_json id_to_file name in

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -163,6 +163,39 @@ pub struct AttrInfo {
     pub public: bool,
 }
 
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Drive,
+    DriveMut,
+    EnumIsA,
+)]
+pub enum ItemOpacity {
+    /// Translate the item name and signature, but not its contents. For function and globals, this
+    /// means we don't translate the body (the code); for ADTs, this means we don't translate the
+    /// fields/variants. For traits and trait impls, this doesn't change anything. For modules,
+    /// this means we don't explore its contents (we still translate any of its items mentioned
+    /// from somewhere else).
+    ///
+    /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
+    /// declared opaque via a command-line argument.
+    Opaque,
+    /// Translate the item depending on the normal rust visibility of its contents: for types, we
+    /// translate fully if it is a struct with public fields or an enum; for functions and globals
+    /// this is equivalent to `Opaque`; for trait decls and impls this is equivalent to
+    /// `Transparent`.
+    Foreign,
+    /// Translate the item fully.
+    Transparent,
+}
+
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct ItemMeta {
@@ -179,9 +212,7 @@ pub struct ItemMeta {
     ///
     /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
     /// declared opaque via a command-line argument.
-    #[serde(skip_serializing)]
-    #[serde(default)]
-    pub opaque: bool,
+    pub opacity: ItemOpacity,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -142,11 +142,6 @@ pub struct AttrInfo {
     /// custom name that can be used by consumers of llbc. E.g. Aeneas uses this to rename
     /// definitions in the extracted code.
     pub rename: Option<String>,
-    /// Whether there was a `#[charon::opaque]` annotation on this item. An item may be opaque for
-    /// other reasons than this attribute, e.g. if specified on the command line.
-    #[serde(skip_serializing)]
-    #[serde(default)]
-    pub opaque: bool,
     /// Whether this item is declared public. Impl blocks and closures don't have visibility
     /// modifiers; we arbitrarily set this to `false` for them.
     ///
@@ -177,6 +172,16 @@ pub struct ItemMeta {
     pub attr_info: AttrInfo,
     /// `true` if the type decl is a local type decl, `false` if it comes from an external crate.
     pub is_local: bool,
+    /// Whether this item is considered opaque. For function and globals, this means we don't
+    /// translate the body (the code); for ADTs, this means we don't translate the fields/variants.
+    /// For traits and trait impls, this doesn't change anything. For modules, this means we don't
+    /// explore its contents (we still translate any of its items mentioned from somewhere else).
+    ///
+    /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
+    /// declared opaque via a command-line argument.
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    pub opaque: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/meta_utils.rs
+++ b/charon/src/ast/meta_utils.rs
@@ -229,3 +229,19 @@ impl Attribute {
         }
     }
 }
+
+impl ItemOpacity {
+    pub(crate) fn with_content_visibility(self, contents_are_public: bool) -> Self {
+        use ItemOpacity::*;
+        match self {
+            Transparent => Transparent,
+            Foreign if contents_are_public => Transparent,
+            Foreign => Opaque,
+            Opaque => Opaque,
+        }
+    }
+
+    pub(crate) fn with_private_contents(self) -> Self {
+        self.with_content_visibility(false)
+    }
+}

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -273,25 +273,28 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         rust_id: DefId,
         trans_id: AnyTransId,
     ) -> Result<(), Error> {
+        // Translate the meta information
+        let item_meta = self.translate_item_meta_from_rid(rust_id)?;
+
         match trans_id {
             AnyTransId::Type(id) => {
-                let ty = self.translate_type(id, rust_id)?;
+                let ty = self.translate_type(id, rust_id, item_meta)?;
                 self.translated.type_decls.set_slot(id, ty);
             }
             AnyTransId::Fun(id) => {
-                let fun_decl = self.translate_function(id, rust_id)?;
+                let fun_decl = self.translate_function(id, rust_id, item_meta)?;
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             AnyTransId::Global(id) => {
-                let global_decl = self.translate_global(id, rust_id)?;
+                let global_decl = self.translate_global(id, rust_id, item_meta)?;
                 self.translated.global_decls.set_slot(id, global_decl);
             }
             AnyTransId::TraitDecl(id) => {
-                let trait_decl = self.translate_trait_decl(id, rust_id)?;
+                let trait_decl = self.translate_trait_decl(id, rust_id, item_meta)?;
                 self.translated.trait_decls.set_slot(id, trait_decl);
             }
             AnyTransId::TraitImpl(id) => {
-                let trait_impl = self.translate_trait_impl(id, rust_id)?;
+                let trait_impl = self.translate_trait_impl(id, rust_id, item_meta)?;
                 self.translated.trait_impls.set_slot(id, trait_impl);
             }
         }

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -234,15 +234,34 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         }
     }
 
-    pub(crate) fn translate_item(&mut self, ord_id: OrdRustId, trans_id: AnyTransId) {
-        let rust_id = ord_id.get_id();
+    pub(crate) fn translate_item(&mut self, rust_id: DefId, trans_id: AnyTransId) {
+        if self.errors.ignored_failed_decls.contains(&rust_id) || self.get_item(trans_id).is_some()
+        {
+            return;
+        }
         self.with_def_id(rust_id, |ctx| {
-            let res = ctx.translate_item_aux(rust_id, trans_id);
-            if res.is_err() {
-                let span = ctx.tcx.def_span(rust_id);
+            let span = ctx.tcx.def_span(rust_id);
+            // Catch cycles
+            let res = if ctx.translate_stack.contains(&trans_id) {
                 ctx.span_err(
                     span,
-                    &format!("Ignoring the following item due to an error: {:?}", rust_id),
+                    &format!(
+                        "Cycle detected while translating {rust_id:?}! Stack: {:?}",
+                        &ctx.translate_stack
+                    ),
+                );
+                Err(())
+            } else {
+                ctx.translate_stack.push(trans_id);
+                let res = ctx.translate_item_aux(rust_id, trans_id);
+                ctx.translate_stack.pop();
+                res.map_err(|_| ())
+            };
+
+            if res.is_err() {
+                ctx.span_err(
+                    span,
+                    &format!("Ignoring the following item due to an error: {rust_id:?}"),
                 );
                 ctx.errors.ignore_failed_decl(rust_id);
             }
@@ -277,6 +296,43 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
         }
         Ok(())
+    }
+
+    fn get_item(&mut self, trans_id: AnyTransId) -> Option<AnyTransItem<'_>> {
+        match trans_id {
+            AnyTransId::Type(id) => self.translated.type_decls.get(id).map(AnyTransItem::Type),
+            AnyTransId::Fun(id) => self.translated.fun_decls.get(id).map(AnyTransItem::Fun),
+            AnyTransId::Global(id) => self
+                .translated
+                .global_decls
+                .get(id)
+                .map(AnyTransItem::Global),
+            AnyTransId::TraitDecl(id) => self
+                .translated
+                .trait_decls
+                .get(id)
+                .map(AnyTransItem::TraitDecl),
+            AnyTransId::TraitImpl(id) => self
+                .translated
+                .trait_impls
+                .get(id)
+                .map(AnyTransItem::TraitImpl),
+        }
+    }
+
+    /// While translating an item you may need the contents of another. Use this to retreive the
+    /// translated version of this item.
+    #[allow(dead_code)]
+    pub(crate) fn get_or_translate(&mut self, id: AnyTransId) -> Result<AnyTransItem<'_>, Error> {
+        let rust_id = *self.translated.reverse_id_map.get(&id).unwrap();
+        // Translate if not already translated.
+        self.translate_item(rust_id, id);
+
+        if self.errors.ignored_failed_decls.contains(&rust_id) {
+            let span = self.tcx.def_span(rust_id);
+            error_or_panic!(self, span, format!("Failed to translate item {id:?}."))
+        }
+        Ok(self.get_item(id).unwrap())
     }
 }
 
@@ -318,6 +374,7 @@ pub fn translate<'tcx, 'ctx>(
             ..TranslatedCrate::default()
         },
         priority_queue: Default::default(),
+        translate_stack: Default::default(),
     };
 
     // First push all the items in the stack of items to translate.
@@ -362,7 +419,7 @@ pub fn translate<'tcx, 'ctx>(
     // from Rust ids to translated ids.
     while let Some((ord_id, trans_id)) = ctx.priority_queue.pop_first() {
         trace!("About to translate id: {:?}", ord_id);
-        ctx.translate_item(ord_id, trans_id);
+        ctx.translate_item(ord_id.get_id(), trans_id);
     }
 
     // Return the context, dropping the hax state and rustc `tcx`.

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -186,8 +186,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 // to check that all the opaque modules given as arguments actually
                 // exist
                 trace!("{:?}", def_id);
-                let opaque = self.id_is_opaque(def_id)?;
-                if opaque {
+                let item_meta = self.translate_item_meta_from_rid(def_id)?;
+                if item_meta.opaque {
                     // Ignore
                     trace!("Ignoring module [{:?}] because marked as opaque", def_id);
                 } else {

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -187,7 +187,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 // exist
                 trace!("{:?}", def_id);
                 let item_meta = self.translate_item_meta_from_rid(def_id)?;
-                if item_meta.opaque {
+                if item_meta.opacity.is_opaque() {
                     // Ignore
                     trace!("Ignoring module [{:?}] because marked as opaque", def_id);
                 } else {
@@ -275,7 +275,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     ) -> Result<(), Error> {
         // Translate the meta information
         let item_meta = self.translate_item_meta_from_rid(rust_id)?;
-
         match trans_id {
             AnyTransId::Type(id) => {
                 let ty = self.translate_type(id, rust_id, item_meta)?;

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -137,6 +137,16 @@ wrap_unwrap_enum!(AnyTransId::Type(TypeDeclId));
 wrap_unwrap_enum!(AnyTransId::TraitDecl(TraitDeclId));
 wrap_unwrap_enum!(AnyTransId::TraitImpl(TraitImplId));
 
+/// A translated item.
+#[derive(Debug, Clone, Copy, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity)]
+pub enum AnyTransItem<'ctx> {
+    Type(&'ctx TypeDecl),
+    Fun(&'ctx FunDecl),
+    Global(&'ctx GlobalDecl),
+    TraitDecl(&'ctx TraitDecl),
+    TraitImpl(&'ctx TraitImpl),
+}
+
 /// We use a special type to store the Rust identifiers in the stack, to
 /// make sure we translate them in a specific order (top-level constants
 /// before constant functions before functions...). This allows us to
@@ -272,6 +282,9 @@ pub struct TranslateCtx<'tcx, 'ctx> {
     /// We use an ordered map to make sure we translate them in a specific
     /// order (this avoids stealing issues when querying the MIR bodies).
     pub priority_queue: BTreeMap<OrdRustId, AnyTransId>,
+    /// Stack of the translations currently happening. Used to avoid cycles where items need to
+    /// translate themselves transitively.
+    pub translate_stack: Vec<AnyTransId>,
 }
 
 /// A translation context for type/global/function bodies.

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1759,12 +1759,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         &mut self,
         def_id: FunDeclId,
         rust_id: DefId,
+        item_meta: ItemMeta,
     ) -> Result<FunDecl, Error> {
         trace!("About to translate function:\n{:?}", rust_id);
         let def_span = self.tcx.def_span(rust_id);
-
-        // Compute the meta information
-        let item_meta = self.translate_item_meta_from_rid(rust_id)?;
 
         // Initialize the body translation context
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
@@ -1815,12 +1813,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         &mut self,
         def_id: GlobalDeclId,
         rust_id: DefId,
+        item_meta: ItemMeta,
     ) -> Result<GlobalDecl, Error> {
         trace!("About to translate global:\n{:?}", rust_id);
         let span = self.tcx.def_span(rust_id);
-
-        // Compute the meta information
-        let item_meta = self.translate_item_meta_from_rid(rust_id)?;
 
         // Initialize the body translation context
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1453,11 +1453,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     ) -> Result<Result<Body, Opaque>, Error> {
         let tcx = self.t_ctx.tcx;
 
-        if item_meta.opaque {
-            return Ok(Err(Opaque));
-        }
-        if !rust_id.is_local() && !self.t_ctx.options.extract_opaque_bodies {
-            // We only extract non-local bodies if the `extract_opaque_bodies` option is set.
+        if item_meta.opacity.with_private_contents().is_opaque() {
+            // The bodies of foreign functions are opaque by default.
             return Ok(Err(Opaque));
         }
 

--- a/charon/src/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/translate/translate_functions_to_ullbc.rs
@@ -1453,10 +1453,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     ) -> Result<Result<Body, Opaque>, Error> {
         let tcx = self.t_ctx.tcx;
 
-        if item_meta.attr_info.opaque {
-            return Ok(Err(Opaque));
-        }
-        if !self.t_ctx.id_is_transparent(rust_id)? {
+        if item_meta.opaque {
             return Ok(Err(Opaque));
         }
         if !rust_id.is_local() && !self.t_ctx.options.extract_opaque_bodies {

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -391,7 +391,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 generic_clauses
             );
         }
-        if item_meta.opaque {
+        if item_meta.opacity.is_opaque() {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,
@@ -596,7 +596,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 }
             }
         }
-        if item_meta.opaque {
+        if item_meta.opacity.is_opaque() {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -390,14 +390,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             );
         }
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
-        if item_meta.attr_info.opaque {
+        if item_meta.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,
                 format!(
-                    "The `aeneas::opaque` or `charon::opaque` attribute currently \
-                    has no effect on trait declarations and will be ignored.\
-                    \nDeclaration name: {}\n",
+                    "Trait declarations cannot be \"opaque\"; the trait `{}` will be translated as normal.",
                     name.fmt_with_ctx(&ctx)
                 ),
             )
@@ -597,14 +595,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
         }
         let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
-        if item_meta.attr_info.opaque {
+        if item_meta.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
                 item_meta.span,
                 format!(
-                    "The `aeneas::opaque` or `charon::opaque` attribute currently \
-                    has no effect on trait implementations and will be ignored.\
-                    \nImplementation name: {}\n",
+                    "Trait implementations cannot be \"opaque\"; the impl `{}` will be translated as normal.",
                     item_meta.name.fmt_with_ctx(&ctx)
                 ),
             )

--- a/charon/src/translate/translate_traits.rs
+++ b/charon/src/translate/translate_traits.rs
@@ -2,6 +2,7 @@ use crate::common::*;
 use crate::formatter::IntoFormatter;
 use crate::gast::*;
 use crate::ids::Vector;
+use crate::meta::ItemMeta;
 use crate::pretty::FmtWithCtx;
 use crate::translate_ctx::*;
 use crate::types::*;
@@ -263,6 +264,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         &mut self,
         def_id: TraitDeclId,
         rust_id: DefId,
+        item_meta: ItemMeta,
     ) -> Result<TraitDecl, Error> {
         trace!("About to translate trait decl:\n{:?}", rust_id);
         trace!("Trait decl id:\n{:?}", def_id);
@@ -389,7 +391,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 generic_clauses
             );
         }
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
         if item_meta.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(
@@ -419,6 +420,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         &mut self,
         def_id: TraitImplId,
         rust_id: DefId,
+        item_meta: ItemMeta,
     ) -> Result<TraitImpl, Error> {
         trace!("About to translate trait impl:\n{:?}", rust_id);
         trace!("Trait impl id:\n{:?}", def_id);
@@ -594,7 +596,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 }
             }
         }
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
         if item_meta.opaque {
             let ctx = bt_ctx.into_fmt();
             bt_ctx.t_ctx.errors.session.span_warn(

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -3,6 +3,7 @@ use crate::common::*;
 use crate::formatter::IntoFormatter;
 use crate::gast::*;
 use crate::ids::Vector;
+use crate::meta::ItemMeta;
 use crate::pretty::FmtWithCtx;
 use crate::translate_ctx::*;
 use crate::types::*;
@@ -734,6 +735,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         &mut self,
         trans_id: TypeDeclId,
         rust_id: DefId,
+        item_meta: ItemMeta,
     ) -> Result<TypeDecl, Error> {
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
@@ -742,9 +744,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
 
         // Translate the predicates
         bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnType)?;
-
-        // Translate the meta information
-        let item_meta = bt_ctx.t_ctx.translate_item_meta_from_rid(rust_id)?;
 
         // Check if the type has been explicitely marked as opaque.
         // If yes, ignore it, otherwise, dive into the body. Note that for

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -735,7 +735,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         trans_id: TypeDeclId,
         rust_id: DefId,
     ) -> Result<TypeDecl, Error> {
-        let is_transparent = self.id_is_transparent(rust_id)?;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
         // Check and translate the generics
@@ -754,7 +753,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // For instance, because `core::option::Option` is public, we can
         // manipulate its variants. If we encounter this type, we must retrieve
         // its definition.
-        let kind = if !is_transparent || item_meta.attr_info.opaque {
+        let kind = if item_meta.opaque {
             TypeDeclKind::Opaque
         } else {
             match bt_ctx.translate_type_body(trans_id, rust_id) {

--- a/charon/tests/ui/opaque_attribute.out
+++ b/charon/tests/ui/opaque_attribute.out
@@ -56,14 +56,6 @@ fn test_crate::call_fn_in_opaque_module()
     return
 }
 
-fn test_crate::opaque::other_fn_in_opaque_module() -> u32
-{
-    let @0: u32; // return
-
-    @0 := const (42 : u32)
-    return
-}
-
 fn test_crate::BoolTrait::get_bool<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 fn test_crate::BoolTrait::ret_true<'_0, Self>(@1: &'_0 (Self)) -> bool

--- a/charon/tests/ui/opaque_attribute.out
+++ b/charon/tests/ui/opaque_attribute.out
@@ -33,6 +33,37 @@ global test_crate::SIX_SIX_SIX
 
 opaque type test_crate::Test2
 
+fn test_crate::opaque::fn_in_opaque_module() -> u32
+{
+    let @0: u32; // return
+
+    @0 := const (42 : u32)
+    return
+}
+
+fn test_crate::call_fn_in_opaque_module()
+{
+    let @0: (); // return
+    let @1: u32; // anonymous local
+    let @2: (); // anonymous local
+
+    @1 := test_crate::opaque::fn_in_opaque_module()
+    @fake_read(@1)
+    drop @1
+    @2 := ()
+    @0 := move (@2)
+    @0 := ()
+    return
+}
+
+fn test_crate::opaque::other_fn_in_opaque_module() -> u32
+{
+    let @0: u32; // return
+
+    @0 := const (42 : u32)
+    return
+}
+
 fn test_crate::BoolTrait::get_bool<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 fn test_crate::BoolTrait::ret_true<'_0, Self>(@1: &'_0 (Self)) -> bool

--- a/charon/tests/ui/opaque_attribute.rs
+++ b/charon/tests/ui/opaque_attribute.rs
@@ -35,3 +35,19 @@ const SIX_SIX_SIX: u32 = 600 + 60 + 6;
 
 #[aeneas::opaque]
 type Test2 = u32;
+
+fn call_fn_in_opaque_module() {
+    let _ = opaque::fn_in_opaque_module();
+}
+
+#[charon::opaque]
+mod opaque {
+    // This one will be translated because it is called.
+    pub fn fn_in_opaque_module() -> u32 {
+        42
+    }
+    // This one will be skipped because the module is opaque hence not traversed.
+    pub fn other_fn_in_opaque_module() -> u32 {
+        42
+    }
+}


### PR DESCRIPTION
This PR factors out the various places where we computed the opacity of an item. It's now computed once when building the `ItemMeta`. As a bonus, `#[charon::opaque]` now works on modules too.

This PR also includes an API to query another item while translating. This is unrelated but I had been carrying around that commit for a while and I wanted to include it somewhere. I'll have a use for it soon.