### PR TITLE
Only use immutable data structures when it's useful

### DIFF
--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -2,7 +2,7 @@
 use crate::ids::Vector;
 use crate::types::*;
 use hax_frontend_exporter as hax;
-use im::HashMap;
+use std::collections::HashMap;
 use std::iter::Iterator;
 
 impl DeBruijnId {

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::common::TAB_INCR;
 use crate::gast;
 use crate::ids::Vector;
@@ -90,7 +92,7 @@ impl<'a, 'b> SetGenerics<'a> for FmtCtx<'b> {
         let locals = locals.as_deref();
         FmtCtx {
             translated,
-            region_vars: im::vector![generics.regions.clone()],
+            region_vars: [generics.regions.clone()].into(),
             type_vars: Some(&generics.types),
             const_generic_vars: Some(&generics.const_generics),
             locals,
@@ -196,10 +198,11 @@ pub trait AstFormatter = Formatter<TypeVarId>
 /// clone the generics, because we may dive into different contexts and may
 /// need to update those. We can think of a smarter way of doing this, but
 /// for now it is simple and efficient enough.
+#[derive(Default)]
 pub struct FmtCtx<'a> {
     pub translated: Option<&'a TranslatedCrate>,
     /// The region variables are not an option, because we need to be able to push/pop
-    pub region_vars: im::Vector<Vector<RegionId, RegionVar>>,
+    pub region_vars: VecDeque<Vector<RegionId, RegionVar>>,
     pub type_vars: Option<&'a Vector<TypeVarId, TypeVar>>,
     pub const_generic_vars: Option<&'a Vector<ConstGenericVarId, ConstGenericVar>>,
     pub locals: Option<&'a Vector<VarId, ast::Var>>,
@@ -207,13 +210,7 @@ pub struct FmtCtx<'a> {
 
 impl<'a> FmtCtx<'a> {
     pub fn new() -> Self {
-        FmtCtx {
-            translated: None,
-            region_vars: im::Vector::new(),
-            type_vars: None,
-            const_generic_vars: None,
-            locals: None,
-        }
+        FmtCtx::default()
     }
 
     pub fn format_decl_id(&self, id: AnyTransId) -> String {
@@ -224,12 +221,6 @@ impl<'a> FmtCtx<'a> {
             AnyTransId::TraitDecl(id) => self.format_decl(id),
             AnyTransId::TraitImpl(id) => self.format_decl(id),
         }
-    }
-}
-
-impl<'a> Default for FmtCtx<'a> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/charon/src/transform/graphs.rs
+++ b/charon/src/transform/graphs.rs
@@ -1,5 +1,5 @@
-use im::OrdSet;
 use linked_hash_set::LinkedHashSet;
+use std::collections::BTreeSet as OrdSet;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::vec::Vec;
@@ -149,8 +149,8 @@ pub fn reorder_sccs<Id: std::fmt::Debug + Copy + std::hash::Hash + Eq>(
     // Compute the map from the original SCC ids to the new SCC ids (after
     // reordering).
     let mut old_id_to_new_id: Vec<usize> = reordered_sccs_ids.iter().map(|_| 0).collect();
-    for new_id in 0..reordered_sccs_ids.len() {
-        old_id_to_new_id[reordered_sccs_ids[new_id]] = new_id;
+    for (new_id, dep) in reordered_sccs_ids.iter().enumerate() {
+        old_id_to_new_id[*dep] = new_id;
     }
 
     // Generate the reordered SCCs
@@ -161,10 +161,9 @@ pub fn reorder_sccs<Id: std::fmt::Debug + Copy + std::hash::Hash + Eq>(
 
     // Compute the dependencies with the new indices
     let mut tgt_deps: Vec<OrdSet<usize>> = reordered_sccs.iter().map(|_| OrdSet::new()).collect();
-    for old_id in 0..scc_deps.len() {
+    for (old_id, deps) in scc_deps.iter().enumerate() {
         let new_id = old_id_to_new_id[old_id];
-        tgt_deps[new_id] =
-            OrdSet::from_iter(scc_deps[old_id].iter().map(|old| old_id_to_new_id[*old]));
+        tgt_deps[new_id] = OrdSet::from_iter(deps.iter().map(|old| old_id_to_new_id[*old]));
     }
 
     SCCs {

--- a/charon/src/transform/remove_unused_locals.rs
+++ b/charon/src/transform/remove_unused_locals.rs
@@ -27,7 +27,7 @@ fn update_locals(
         used_locals.insert(VarId::new(i));
     }
     // Explore the body
-    let mut used_locals_cnt: im::HashMap<VarId, _> = im::HashMap::default();
+    let mut used_locals_cnt: HashMap<VarId, _> = HashMap::default();
     st.drive(&mut visitor_enter_fn(|vid: &VarId| {
         match used_locals_cnt.get_mut(vid) {
             None => {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -514,6 +514,7 @@ pub fn compute_reordered_decls(ctx: &TransformCtx) -> DeclarationsGroups {
 mod tests {
     #[test]
     fn test_reorder_sccs1() {
+        use std::collections::BTreeSet as OrdSet;
         let sccs = vec![vec![0], vec![1, 2], vec![3, 4, 5]];
         let ids = vec![0, 1, 2, 3, 4, 5];
 
@@ -525,8 +526,8 @@ mod tests {
         let reordered = crate::reorder_decls::reorder_sccs(get_deps, &ids, &sccs);
 
         assert!(reordered.sccs == vec![vec![3, 4, 5], vec![0], vec![1, 2],]);
-        assert!(reordered.scc_deps[0] == im::OrdSet::from(vec![]));
-        assert!(reordered.scc_deps[1] == im::OrdSet::from(vec![0]));
-        assert!(reordered.scc_deps[2] == im::OrdSet::from(vec![0, 1]));
+        assert!(reordered.scc_deps[0] == OrdSet::from([]));
+        assert!(reordered.scc_deps[1] == OrdSet::from([0]));
+        assert!(reordered.scc_deps[2] == OrdSet::from([0, 1]));
     }
 }


### PR DESCRIPTION
Cloning a vector of a few elements is cheaper than using an immutable data structure, and there were plenty of cases where normal data structures were totally sufficient. The only place I left them is control flow reconstruction, which makes real use of sharing and cheap clones.