### PR TITLE
Add partial support for `dyn Trait`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.17"
+let supported_charon_version = "0.1.18"

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -149,6 +149,7 @@ class ['self] map_constant_expr_base =
 type cast_kind =
   | CastScalar of literal_type * literal_type
   | CastFnPtr of ty * ty
+  | CastUnsize of ty * ty
 
 (* Remark: no `ArrayToSlice` variant: it gets eliminated in a micro-pass. *)
 and unop =

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -764,6 +764,10 @@ let cast_kind_of_json (js : json) : (cast_kind, string) result =
         let* src_ty = ty_of_json src_ty in
         let* tgt_ty = ty_of_json tgt_ty in
         Ok (CastFnPtr (src_ty, tgt_ty))
+    | `Assoc [ ("Unsize", `List [ src_ty; tgt_ty ]) ] ->
+        let* src_ty = ty_of_json src_ty in
+        let* tgt_ty = ty_of_json tgt_ty in
+        Ok (CastUnsize (src_ty, tgt_ty))
     | _ -> Error "")
 
 let unop_of_json (js : json) : (unop, string) result =

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -372,6 +372,7 @@ let rec ty_of_json (js : json) : (ty, string) result =
         let* inputs = list_of_json ty_of_json inputs in
         let* output = ty_of_json output in
         Ok (TArrow (regions, inputs, output))
+    | `Assoc [ ("DynTrait", `Null) ] -> Ok (TDynTrait ())
     | `String "Never" -> Ok TNever
     | _ -> Error "")
 
@@ -450,6 +451,9 @@ and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
         let* fid = FunDeclId.id_of_json fid in
         let* generics = generic_args_of_json generics in
         Ok (Closure (fid, generics))
+    | `Assoc [ ("Dyn", id) ] ->
+        let* id = TraitDeclId.id_of_json id in
+        Ok (Dyn id)
     | `Assoc [ ("Unsolved", `List [ decl_id; generics ]) ] ->
         let* decl_id = TraitDeclId.id_of_json decl_id in
         let* generics = generic_args_of_json generics in

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -866,6 +866,7 @@ and ty_to_pattern_aux (ctx : ctx) (c : to_pat_config) (m : constraints)
       EArrow (inputs, out)
   | TRawPtr (ty, RMut) -> ERawPtr (Mut, ty_to_pattern_aux ctx c m ty)
   | TRawPtr (ty, RShared) -> ERawPtr (Not, ty_to_pattern_aux ctx c m ty)
+  | TDynTrait _ -> raise (Failure "Unimplemented: DynTrait")
   | TNever -> raise (Failure "Unimplemented: Never")
 
 and trait_ref_item_with_generics_to_pattern (ctx : ctx) (c : to_pat_config)

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -59,6 +59,8 @@ let cast_kind_to_string (env : ('a, 'b) fmt_env) (cast : cast_kind) : string =
       ^ ">"
   | CastFnPtr (src, tgt) ->
       "cast<" ^ ty_to_string env src ^ "," ^ ty_to_string env tgt ^ ">"
+  | CastUnsize (src, tgt) ->
+      "unsize<" ^ ty_to_string env src ^ "," ^ ty_to_string env tgt ^ ">"
 
 let unop_to_string (env : ('a, 'b) fmt_env) (unop : unop) : string =
   match unop with

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -167,6 +167,7 @@ and ty_to_string (env : ('a, 'b) fmt_env) (ty : ty) : string =
         "(" ^ String.concat ", " (List.map (ty_to_string env) inputs) ^ ") -> "
       in
       inputs ^ ty_to_string env output
+  | TDynTrait _ -> "dyn (TODO)"
 
 and params_to_string (env : ('a, 'b) fmt_env) (is_tuple : bool)
     (generics : generic_args) : string =
@@ -239,6 +240,7 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       ^ fun_decl_id_to_string env fid
       ^ generic_args_to_string env generics
       ^ ")"
+  | Dyn id -> "dyn(" ^ trait_decl_id_to_string env id ^ ")"
   | Unsolved (decl_id, generics) ->
       "unsolved("
       ^ trait_decl_id_to_string env decl_id

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -288,6 +288,7 @@ and ty =
   | TTraitType of trait_ref * string
       (** The string is for the name of the associated type *)
   | TArrow of region_var list * ty list * ty
+  | TDynTrait of unit
 
 and trait_ref = {
   trait_id : trait_instance_id;
@@ -331,6 +332,7 @@ and trait_instance_id =
        *)
   | FnPointer of ty
   | Closure of fun_decl_id * generic_args
+  | Dyn of trait_decl_id
   | Unsolved of trait_decl_id * generic_args
   | UnknownTrait of string
       (** Not present in the Rust version of Charon.

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -156,6 +156,12 @@ pub enum CastKind {
     /// Remark: for now we don't support conversions with Char.
     Scalar(LiteralTy, LiteralTy),
     FnPtr(Ty, Ty),
+    /// [Unsize coercion](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html). This is
+    /// either `[T; N]` -> `[T]` or `T: Trait` -> `dyn Trait` coercions, behind a pointer
+    /// (reference, `Box`, or other type that implements `CoerceUnsized`).
+    ///
+    /// The special case of `&[T; N]` -> `&[T]` coercion is caught by `UnOp::ArrayToSlice`.
+    Unsize(Ty, Ty),
 }
 
 /// Binary operations.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -275,25 +275,6 @@ impl Ty {
     }
 }
 
-impl Ty {
-    // TODO: reimplement this with visitors
-    pub fn contains_never(&self) -> bool {
-        match self {
-            Ty::Never => true,
-            Ty::Adt(_, args) => {
-                // For the trait type case: we are checking the projected type,
-                // so we don't need to explore the trait ref
-                args.types.iter().any(|ty| ty.contains_never())
-            }
-            Ty::TraitType(..) | Ty::TypeVar(_) | Ty::Literal(_) => false,
-            Ty::Ref(_, ty, _) | Ty::RawPtr(ty, _) => ty.contains_never(),
-            Ty::Arrow(_, inputs, box output) => {
-                inputs.iter().any(|ty| ty.contains_never()) || output.contains_never()
-            }
-        }
-    }
-}
-
 pub struct TySubst {
     pub ignore_regions: bool,
     /// This map is from regions to regions, not from region ids to regions.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -209,10 +209,6 @@ impl IntegerTy {
     }
 }
 
-pub fn bound_region_var_to_pretty_string(grid: DeBruijnId, rid: RegionId) -> String {
-    format!("'_{}_{}", grid.index, rid.to_string())
-}
-
 impl Ty {
     /// Return true if it is actually unit (i.e.: 0-tuple)
     pub fn is_unit(&self) -> bool {

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -11,10 +11,12 @@
 //! we reconstructed the control-flow to have `if ... then ... else ...`,
 //! loops, etc. instead of `GOTO`s).
 
+#![expect(incomplete_features)]
 #![feature(rustc_private)]
-#![feature(box_patterns)]
 // For rustdoc: prevents overflows
 #![recursion_limit = "256"]
+#![feature(box_patterns)]
+#![feature(deref_patterns)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_array_chunks)]

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -135,6 +135,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for DeclarationGroup {
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for ExistentialPredicate {
+    fn fmt_with_ctx(&self, _ctx: &C) -> String {
+        format!("exists(TODO)")
+    }
+}
+
 impl<C: AstFormatter> FmtWithCtx<C> for Field {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match &self.name {
@@ -1234,7 +1240,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitInstanceId {
             }
             TraitInstanceId::TraitImpl(id) => ctx.format_object(*id),
             TraitInstanceId::Clause(id) => ctx.format_object(*id),
-            TraitInstanceId::BuiltinOrAuto(id) => ctx.format_object(*id),
+            TraitInstanceId::BuiltinOrAuto(id) | TraitInstanceId::Dyn(id) => ctx.format_object(*id),
             TraitInstanceId::Unknown(msg) => format!("UNKNOWN({msg})"),
         }
     }
@@ -1289,6 +1295,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
             Ty::TraitType(trait_ref, name) => {
                 format!("{}::{name}", trait_ref.fmt_with_ctx(ctx),)
             }
+            Ty::DynTrait(pred) => format!("dyn ({})", pred.with_ctx(ctx)),
             Ty::Arrow(regions, inputs, box output) => {
                 // Update the bound regions
                 let ctx = &ctx.push_bound_regions(regions);

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -97,9 +97,16 @@ impl<C: AstFormatter> FmtWithCtx<C> for gast::Body {
 impl<C: AstFormatter> FmtWithCtx<C> for CastKind {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match self {
-            CastKind::Scalar(src, tgt) => format!("cast<{src},{tgt}>"),
+            CastKind::Scalar(src, tgt) => format!("cast<{src}, {tgt}>"),
             CastKind::FnPtr(src, tgt) => {
-                format!("cast<{},{}>", src.fmt_with_ctx(ctx), tgt.fmt_with_ctx(ctx))
+                format!("cast<{}, {}>", src.fmt_with_ctx(ctx), tgt.fmt_with_ctx(ctx))
+            }
+            CastKind::Unsize(src, tgt) => {
+                format!(
+                    "unsize_cast<{}, {}>",
+                    src.fmt_with_ctx(ctx),
+                    tgt.fmt_with_ctx(ctx)
+                )
             }
         }
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -313,7 +313,7 @@ impl GenericParams {
         let generics = self;
         let mut params = Vec::new();
         for x in &generics.regions {
-            params.push(x.to_string());
+            params.push(ctx.format_object(x));
         }
         for x in &generics.types {
             params.push(x.to_string());
@@ -403,7 +403,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for GenericParams {
                 trait_type_constraints: _,
             } = self;
             for x in regions {
-                params.push(x.to_string());
+                params.push(ctx.format_object(x));
             }
             for x in types {
                 params.push(x.to_string());
@@ -1300,7 +1300,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                         "<{}>",
                         regions
                             .iter()
-                            .map(|r| r.to_string())
+                            .map(|r| ctx.format_object(r))
                             .collect::<Vec<String>>()
                             .join(", ")
                     )
@@ -1570,15 +1570,6 @@ impl std::string::ToString for ConstGenericVar {
 impl std::string::ToString for Field {
     fn to_string(&self) -> String {
         self.fmt_with_ctx(&FmtCtx::new())
-    }
-}
-
-impl std::string::ToString for RegionVar {
-    fn to_string(&self) -> String {
-        match &self.name {
-            Some(name) => name.to_string(),
-            None => format!("'_{}", self.index),
-        }
     }
 }
 

--- a/charon/src/translate/translate_predicates.rs
+++ b/charon/src/translate/translate_predicates.rs
@@ -663,6 +663,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let trait_decl_id = self.register_trait_decl_id(span, def_id)?.unwrap();
 
                 // Retrieve the arguments
+                assert!(nested.is_empty());
                 let generics = self.translate_substs_and_trait_refs(
                     span,
                     erase_regions,
@@ -670,7 +671,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     &trait_ref.generic_args,
                     nested,
                 )?;
-                assert!(generics.trait_refs.is_empty());
 
                 // If we are refering to a trait clause, we need to find the
                 // relevant one.
@@ -734,9 +734,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     trait_decl_ref,
                 }
             }
-            ImplExprAtom::Dyn { .. } => {
-                error_or_panic!(self, span, "Unsupported trait impl source kind: object")
-            }
+            ImplExprAtom::Dyn => TraitRef {
+                trait_id: TraitInstanceId::Dyn(trait_decl_ref.trait_id),
+                generics: GenericArgs::empty(),
+                trait_decl_ref,
+            },
             ImplExprAtom::Builtin { r#trait: trait_ref } => {
                 let def_id = DefId::from(&trait_ref.def_id);
                 // Remark: we already filtered the marker traits when translating

--- a/charon/src/translate/translate_types.rs
+++ b/charon/src/translate/translate_types.rs
@@ -337,9 +337,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 error_or_panic!(self, span, "Unsupported type: infer type")
             }
 
-            hax::Ty::Dynamic(_, _, _) => {
+            hax::Ty::Dynamic(_existential_preds, _region, _) => {
+                // TODO: we don't translate the predicates yet because our machinery can't handle
+                // it.
                 trace!("Dynamic");
-                error_or_panic!(self, span, "Dynamic types are not supported yet")
+                Ok(Ty::DynTrait(ExistentialPredicate))
             }
 
             hax::Ty::Coroutine(..) => {

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -141,7 +141,7 @@ fn test_crate::test_closure_u32(@1: u32) -> u32
     let @5: u32; // anonymous local
 
     @3 := {test_crate::test_closure_u32::closure} {}
-    f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(move (@3))
+    f@2 := cast<fn(u32) -> u32, fn(u32) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
     @4 := copy (f@2)
@@ -174,7 +174,7 @@ fn test_crate::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
     let @6: &'_ (u32); // anonymous local
 
     @3 := {test_crate::test_closure_ref_u32::closure} {}
-    f@2 := cast<fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32),fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32)>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32), fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32)>(move (@3))
     drop @3
     @fake_read(f@2)
     @5 := copy (f@2)
@@ -209,7 +209,7 @@ fn test_crate::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
     let @6: &'_ (T); // anonymous local
 
     @3 := {test_crate::test_closure_ref_param::closure<T>} {}
-    f@2 := cast<fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T),fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T)>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T), fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T)>(move (@3))
     drop @3
     @fake_read(f@2)
     @5 := copy (f@2)
@@ -246,7 +246,7 @@ fn test_crate::test_map_option2(@1: core::option::Option<u32>) -> core::option::
     let @5: fn(u32) -> u32; // anonymous local
 
     @3 := {test_crate::test_map_option2::closure} {}
-    f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(move (@3))
+    f@2 := cast<fn(u32) -> u32, fn(u32) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
     @4 := copy (x@1)
@@ -337,7 +337,7 @@ fn test_crate::test_id_clone(@1: u32) -> u32
     let @3: fn(u32) -> u32; // anonymous local
     let @4: u32; // anonymous local
 
-    f@2 := cast<fn(u32) -> u32,fn(u32) -> u32>(const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
+    f@2 := cast<fn(u32) -> u32, fn(u32) -> u32>(const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
     @fake_read(f@2)
     @3 := copy (f@2)
     @4 := copy (x@1)
@@ -358,7 +358,7 @@ where
     let @3: fn(T) -> T; // anonymous local
     let @4: T; // anonymous local
 
-    f@2 := cast<fn(T) -> T,fn(T) -> T>(const (test_crate::id_clone<T>[@TraitClause0]))
+    f@2 := cast<fn(T) -> T, fn(T) -> T>(const (test_crate::id_clone<T>[@TraitClause0]))
     @fake_read(f@2)
     @3 := copy (f@2)
     @4 := move (x@1)
@@ -431,7 +431,7 @@ fn test_crate::test_regions<'a>(@1: &'a (u32)) -> u32
     let @6: &'_ (&'_ (u32)); // anonymous local
 
     @3 := {test_crate::test_regions::closure} {}
-    f@2 := cast<fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32,fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32, fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
     @4 := copy (f@2)

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -78,14 +78,14 @@ where
     return
 }
 
-fn test_crate::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>), @2: fn<'_0>(&'_0 (T)) -> T) -> core::option::Option<T>
+fn test_crate::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>), @2: fn<'_1_0>(&'_1_0 (T)) -> T) -> core::option::Option<T>
 {
     let @0: core::option::Option<T>; // return
     let x@1: &'_ (core::option::Option<T>); // arg #1
-    let f@2: fn<'_0>(&'_0 (T)) -> T; // arg #2
+    let f@2: fn<'_1_0>(&'_1_0 (T)) -> T; // arg #2
     let x@3: &'_ (T); // local
     let @4: T; // anonymous local
-    let @5: fn<'_0>(&'_0 (T)) -> T; // anonymous local
+    let @5: fn<'_1_0>(&'_1_0 (T)) -> T; // anonymous local
     let @6: &'_ (T); // anonymous local
 
     @fake_read(x@1)
@@ -167,14 +167,14 @@ fn test_crate::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
 {
     let @0: &'_ (u32); // return
     let x@1: &'_ (u32); // arg #1
-    let f@2: fn<'_0>(&'_0 (u32)) -> &'_0 (u32); // local
-    let @3: fn<'_0>(&'_0 (u32)) -> &'_0 (u32); // anonymous local
+    let f@2: fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32); // local
+    let @3: fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32); // anonymous local
     let @4: &'_ (u32); // anonymous local
-    let @5: fn<'_0>(&'_0 (u32)) -> &'_0 (u32); // anonymous local
+    let @5: fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32); // anonymous local
     let @6: &'_ (u32); // anonymous local
 
     @3 := {test_crate::test_closure_ref_u32::closure} {}
-    f@2 := cast<fn<'_0>(&'_0 (u32)) -> &'_0 (u32),fn<'_0>(&'_0 (u32)) -> &'_0 (u32)>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32),fn<'_1_0>(&'_1_0 (u32)) -> &'_1_0 (u32)>(move (@3))
     drop @3
     @fake_read(f@2)
     @5 := copy (f@2)
@@ -202,14 +202,14 @@ fn test_crate::test_closure_ref_param<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
 {
     let @0: &'_ (T); // return
     let x@1: &'_ (T); // arg #1
-    let f@2: fn<'_0>(&'_0 (T)) -> &'_0 (T); // local
-    let @3: fn<'_0>(&'_0 (T)) -> &'_0 (T); // anonymous local
+    let f@2: fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T); // local
+    let @3: fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T); // anonymous local
     let @4: &'_ (T); // anonymous local
-    let @5: fn<'_0>(&'_0 (T)) -> &'_0 (T); // anonymous local
+    let @5: fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T); // anonymous local
     let @6: &'_ (T); // anonymous local
 
     @3 := {test_crate::test_closure_ref_param::closure<T>} {}
-    f@2 := cast<fn<'_0>(&'_0 (T)) -> &'_0 (T),fn<'_0>(&'_0 (T)) -> &'_0 (T)>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T),fn<'_1_0>(&'_1_0 (T)) -> &'_1_0 (T)>(move (@3))
     drop @3
     @fake_read(f@2)
     @5 := copy (f@2)
@@ -424,14 +424,14 @@ fn test_crate::test_regions<'a>(@1: &'a (u32)) -> u32
 {
     let @0: u32; // return
     let x@1: &'_ (u32); // arg #1
-    let f@2: fn<'_0>(&'_0 (&'_ (u32))) -> u32; // local
-    let @3: fn<'_0>(&'_0 (&'_ (u32))) -> u32; // anonymous local
-    let @4: fn<'_0>(&'_0 (&'_ (u32))) -> u32; // anonymous local
+    let f@2: fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32; // local
+    let @3: fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32; // anonymous local
+    let @4: fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32; // anonymous local
     let @5: &'_ (&'_ (u32)); // anonymous local
     let @6: &'_ (&'_ (u32)); // anonymous local
 
     @3 := {test_crate::test_regions::closure} {}
-    f@2 := cast<fn<'_0>(&'_0 (&'_ (u32))) -> u32,fn<'_0>(&'_0 (&'_ (u32))) -> u32>(move (@3))
+    f@2 := cast<fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32,fn<'_1_0>(&'_1_0 (&'_ (u32))) -> u32>(move (@3))
     drop @3
     @fake_read(f@2)
     @4 := copy (f@2)

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -1,0 +1,86 @@
+# Final LLBC before serialization:
+
+opaque type core::fmt::Formatter<'a>
+  where
+      'a : 'a,
+
+enum core::result::Result<T, E> =
+|  Ok(T)
+|  Err(E)
+
+
+struct core::fmt::Error = {}
+
+trait core::fmt::Display<Self>
+{
+    fn fmt : core::fmt::Display::fmt
+}
+
+fn test_crate::construct<T>(@1: T) -> alloc::boxed::Box<dyn (exists(TODO))>
+where
+    [@TraitClause0]: core::fmt::Display<T>,
+
+opaque type alloc::string::String
+
+trait alloc::string::ToString<Self>
+{
+    fn to_string : alloc::string::ToString::to_string
+}
+
+fn alloc::string::{impl alloc::string::ToString for T#32}::to_string<'_0, T>(@1: &'_0 (T)) -> alloc::string::String
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::fmt::Display<T>,
+
+impl<T> alloc::string::{impl alloc::string::ToString for T#32}<T> : alloc::string::ToString<T>
+where
+    [@TraitClause0]: core::fmt::Display<T>,
+{
+    fn to_string = alloc::string::{impl alloc::string::ToString for T#32}::to_string
+}
+
+fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::string::String
+
+fn test_crate::destruct<'_0>(@1: &'_0 (dyn (exists(TODO)))) -> alloc::string::String
+{
+    let @0: alloc::string::String; // return
+    let x@1: &'_ (dyn (exists(TODO))); // arg #1
+    let @2: &'_ (dyn (exists(TODO))); // anonymous local
+
+    @2 := &*(x@1)
+    @0 := alloc::string::{impl alloc::string::ToString for T#32}<dyn (exists(TODO))>[core::fmt::Display]::to_string(move (@2))
+    drop @2
+    return
+}
+
+fn test_crate::combine()
+
+fn test_crate::foo<'_0, '_1, T>(@1: &'_0 (dyn (exists(TODO))), @2: &'_1 (dyn (exists(TODO))))
+{
+    let @0: (); // return
+    let @1: &'_ (dyn (exists(TODO))); // arg #1
+    let @2: &'_ (dyn (exists(TODO))); // arg #2
+    let @3: (); // anonymous local
+
+    @3 := ()
+    @0 := move (@3)
+    @0 := ()
+    return
+}
+
+fn test_crate::bar<'_0>(@1: &'_0 (dyn (exists(TODO))))
+{
+    let @0: (); // return
+    let @1: &'_ (dyn (exists(TODO))); // arg #1
+    let @2: (); // anonymous local
+
+    @2 := ()
+    @0 := move (@2)
+    @0 := ()
+    return
+}
+
+fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+
+

--- a/charon/tests/ui/dyn-trait.rs
+++ b/charon/tests/ui/dyn-trait.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool)]
+#![register_tool(charon)]
+use std::fmt::Display;
+
+// Opaque because we don't support unsize coercions.
+#[charon::opaque]
+fn construct<T: Display>(x: T) -> Box<dyn Display> {
+    Box::new(x)
+}
+
+fn destruct(x: &dyn Display) -> String {
+    x.to_string()
+}
+
+// Opaque because we don't support unsize coercions.
+#[charon::opaque]
+fn combine() {
+    let x = String::new();
+    let _ = destruct(&*construct(x));
+}
+
+fn foo<T>(_: &(dyn (for<'a> Fn(&'a T) -> T) + 'static), _: &dyn PartialEq<Option<T>>) {}
+
+fn bar(_: &dyn (Fn(&dyn Display))) {}

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -101,7 +101,7 @@ fn core::convert::num::{impl core::convert::From<i32> for i64#83}::from(@1: i32)
     let @0: i64; // return
     let small@1: i32; // arg #1
 
-    @0 := cast<i32,i64>(copy (small@1))
+    @0 := cast<i32, i64>(copy (small@1))
     return
 }
 

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -118,7 +118,7 @@ fn test_crate::cast_u32_to_i32(@1: u32) -> i32
     let @2: u32; // anonymous local
 
     @2 := copy (x@1)
-    @0 := cast<u32,i32>(move (@2))
+    @0 := cast<u32, i32>(move (@2))
     drop @2
     return
 }
@@ -130,7 +130,7 @@ fn test_crate::cast_bool_to_i32(@1: bool) -> i32
     let @2: bool; // anonymous local
 
     @2 := copy (x@1)
-    @0 := cast<bool,i32>(move (@2))
+    @0 := cast<bool, i32>(move (@2))
     drop @2
     return
 }

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -1,0 +1,169 @@
+# Final LLBC before serialization:
+
+enum core::result::Result<T, E> =
+|  Ok(T)
+|  Err(E)
+
+
+enum core::fmt::rt::Alignment =
+|  Left()
+|  Right()
+|  Center()
+|  Unknown()
+
+
+enum core::option::Option<T> =
+|  None()
+|  Some(T)
+
+
+struct core::fmt::Formatter<'a>
+  where
+      'a : 'a,
+ =
+{
+  flags: u32,
+  fill: char,
+  align: core::fmt::rt::Alignment,
+  width: core::option::Option<usize>,
+  precision: core::option::Option<usize>,
+  buf: &'a mut (dyn (exists(TODO)))
+}
+
+struct core::fmt::Error = {}
+
+trait core::fmt::Debug<Self>
+{
+    fn fmt : core::fmt::Debug::fmt
+}
+
+fn core::result::unwrap_failed<'_0, '_1>(@1: &'_0 (Str), @2: &'_1 (dyn (exists(TODO)))) -> !
+
+fn core::result::{core::result::Result<T, E>}::unwrap<T, E>(@1: core::result::Result<T, E>) -> T
+where
+    [@TraitClause0]: core::fmt::Debug<E>,
+{
+    let t@0: T; // return
+    let self@1: core::result::Result<T, E>; // arg #1
+    let e@2: E; // local
+    let @3: !; // anonymous local
+    let @4: &'_ (dyn (exists(TODO))); // anonymous local
+    let @5: &'_ (E); // anonymous local
+
+    match self@1 {
+        0 => {
+            nop
+        },
+        1 => {
+            e@2 := move ((self@1 as variant @1).0)
+            @5 := &e@2
+            @4 := unsize_cast<&'_ (E), &'_ (dyn (exists(TODO)))>(move (@5))
+            drop @5
+            @3 := core::result::unwrap_failed(const ("called `Result::unwrap()` on an `Err` value"), move (@4))
+        }
+    }
+    t@0 := move ((self@1 as variant @0).0)
+    return
+}
+
+trait core::fmt::LowerHex<Self>
+{
+    fn fmt : core::fmt::LowerHex::fmt
+}
+
+fn core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+impl core::fmt::num::{impl core::fmt::LowerHex for u32#60} : core::fmt::LowerHex<u32>
+{
+    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt
+}
+
+fn core::fmt::LowerHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+trait core::fmt::Display<Self>
+{
+    fn fmt : core::fmt::Display::fmt
+}
+
+fn core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+impl core::fmt::num::imp::{impl core::fmt::Display for u32#5} : core::fmt::Display<u32>
+{
+    fn fmt = core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt
+}
+
+fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+trait core::fmt::UpperHex<Self>
+{
+    fn fmt : core::fmt::UpperHex::fmt
+}
+
+fn core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+impl core::fmt::num::{impl core::fmt::UpperHex for u32#61} : core::fmt::UpperHex<u32>
+{
+    fn fmt = core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt
+}
+
+fn core::fmt::UpperHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+fn core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+{
+    let @0: core::result::Result<(), core::fmt::Error>; // return
+    let self@1: &'_ (u32); // arg #1
+    let f@2: &'_ mut (core::fmt::Formatter<'_>); // arg #2
+    let @3: u32; // anonymous local
+    let @4: u32; // anonymous local
+    let @5: u32; // anonymous local
+    let @6: u32; // anonymous local
+
+    @4 := copy ((*(f@2)).flags)
+    @3 := move (@4) & const (16 : u32)
+    drop @4
+    switch move (@3) {
+        0 : u32 => {
+            drop @3
+            @6 := copy ((*(f@2)).flags)
+            @5 := move (@6) & const (32 : u32)
+            drop @6
+            switch move (@5) {
+                0 : u32 => {
+                    drop @5
+                    @0 := core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt(move (self@1), move (f@2))
+                },
+                _ => {
+                    drop @5
+                    @0 := core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt(move (self@1), move (f@2))
+                }
+            }
+        },
+        _ => {
+            drop @3
+            @0 := core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt(move (self@1), move (f@2))
+        }
+    }
+    return
+}
+
+impl core::fmt::num::{impl core::fmt::Debug for u32#86} : core::fmt::Debug<u32>
+{
+    fn fmt = core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt
+}
+
+fn test_crate::unwrap(@1: core::result::Result<u32, u32>) -> u32
+{
+    let @0: u32; // return
+    let res@1: core::result::Result<u32, u32>; // arg #1
+    let @2: core::result::Result<u32, u32>; // anonymous local
+
+    @2 := copy (res@1)
+    @0 := core::result::{core::result::Result<T, E>}::unwrap<u32, u32>[core::fmt::num::{impl core::fmt::Debug for u32#86}](move (@2))
+    drop @2
+    return
+}
+
+fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+
+

--- a/charon/tests/ui/result-unwrap.rs
+++ b/charon/tests/ui/result-unwrap.rs
@@ -1,8 +1,5 @@
-//@ known-failure
-//@ no-check-output
 //@ charon-args=--extract-opaque-bodies
 
-// Errors because dyn types are not supported.
 fn unwrap(res: Result<u32, u32>) -> u32 {
     res.unwrap()
 }

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -1,0 +1,28 @@
+# Final LLBC before serialization:
+
+trait test_crate::Trait<'a, Self>
+{
+    fn method : test_crate::Trait::method
+}
+
+fn test_crate::{impl test_crate::Trait<'a> for &'a (())}::method<'a, 'b>(@1: &'b (&'a (()))) -> &'b (())
+
+impl<'a> test_crate::{impl test_crate::Trait<'a> for &'a (())}<'a> : test_crate::Trait<'a, &'a (())>
+{
+    fn method = test_crate::{impl test_crate::Trait<'a> for &'a (())}::method
+}
+
+opaque type test_crate::Foo<'a>
+
+fn test_crate::{test_crate::Foo<'_0>#1}::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
+
+fn test_crate::foo<'_0>(@1: &'_0 (fn<'_0>(&'_0 (u32)) -> u32))
+
+fn test_crate::bar<'_0>(@1: &'_0 (fn<'_0>(&'_0 (fn<'_0>(&'_0 (u32)) -> u32))))
+
+fn test_crate::baz<'a>(@1: &'a (fn<'b>(&'a (u32), &'b (fn<'c>(&'a (u32), &'b (u32), &'c (u32)) -> u32))))
+
+fn test_crate::Trait::method<'a, 'b, Self>(@1: &'b (Self)) -> &'b (())
+
+
+

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -16,9 +16,9 @@ opaque type test_crate::Foo<'a>
 
 fn test_crate::{test_crate::Foo<'_0>#1}::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
 
-fn test_crate::foo<'_0>(@1: &'_0 (fn<'_0>(&'_0 (u32)) -> u32))
+fn test_crate::foo<'_0>(@1: &'_0 (fn<'_1_0>(&'_1_0 (u32)) -> u32))
 
-fn test_crate::bar<'_0>(@1: &'_0 (fn<'_0>(&'_0 (fn<'_0>(&'_0 (u32)) -> u32))))
+fn test_crate::bar<'_0>(@1: &'_0 (fn<'_1_0>(&'_1_0 (fn<'_2_0>(&'_2_0 (u32)) -> u32))))
 
 fn test_crate::baz<'a>(@1: &'a (fn<'b>(&'a (u32), &'b (fn<'c>(&'a (u32), &'b (u32), &'c (u32)) -> u32))))
 

--- a/charon/tests/ui/scopes.rs
+++ b/charon/tests/ui/scopes.rs
@@ -1,0 +1,33 @@
+#![feature(register_tool)]
+#![register_tool(charon)]
+//! Test that we scope things properly.
+
+trait Trait<'a> {
+    fn method<'b>(&'b self) -> &'b ();
+}
+
+impl<'a> Trait<'a> for &'a () {
+    #[charon::opaque]
+    fn method<'b>(&'b self) -> &'b () {
+        self
+    }
+}
+
+#[charon::opaque]
+struct Foo<'a>(&'a ());
+
+impl Foo<'_> {
+    #[charon::opaque]
+    fn bar(&self) -> &() {
+        self.0
+    }
+}
+
+#[charon::opaque]
+fn foo(_: &fn(&u32) -> u32) {}
+
+#[charon::opaque]
+fn bar(_: &fn(&fn(&u32) -> u32)) {}
+
+#[charon::opaque]
+fn baz<'a>(_: &'a for<'b> fn(&'a u32, &'b for<'c> fn(&'a u32, &'b u32, &'c u32) -> u32)) {}

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -1,0 +1,126 @@
+# Final LLBC before serialization:
+
+opaque type alloc::rc::Rc<T, A>
+
+struct alloc::alloc::Global = {}
+
+opaque type alloc::string::String
+
+fn alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<T>(@1: T) -> alloc::rc::Rc<T, alloc::alloc::Global>
+
+fn alloc::string::{alloc::string::String}::new() -> alloc::string::String
+
+trait core::clone::Clone<Self>
+{
+    fn clone : core::clone::Clone::clone
+    fn clone_from
+}
+
+fn alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone<'_0>(@1: &'_0 (alloc::string::String)) -> alloc::string::String
+
+fn alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone_from<'_0, '_1>(@1: &'_0 mut (alloc::string::String), @2: &'_1 (alloc::string::String))
+
+impl alloc::string::{impl core::clone::Clone for alloc::string::String#6} : core::clone::Clone<alloc::string::String>
+{
+    fn clone = alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone
+    fn clone_from = alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone_from
+}
+
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn test_crate::foo()
+{
+    let @0: (); // return
+    let array@1: Array<i32, 2 : usize>; // local
+    let @2: &'_ (Slice<i32>); // anonymous local
+    let @3: &'_ (Array<i32, 2 : usize>); // anonymous local
+    let @4: &'_ (Array<i32, 2 : usize>); // anonymous local
+    let @5: alloc::boxed::Box<Slice<i32>>; // anonymous local
+    let @6: alloc::boxed::Box<Array<i32, 2 : usize>>; // anonymous local
+    let @7: Array<i32, 2 : usize>; // anonymous local
+    let @8: alloc::rc::Rc<Slice<i32>, alloc::alloc::Global>; // anonymous local
+    let @9: alloc::rc::Rc<Array<i32, 2 : usize>, alloc::alloc::Global>; // anonymous local
+    let @10: Array<i32, 2 : usize>; // anonymous local
+    let string@11: alloc::string::String; // local
+    let @12: &'_ (dyn (exists(TODO))); // anonymous local
+    let @13: &'_ (alloc::string::String); // anonymous local
+    let @14: &'_ (alloc::string::String); // anonymous local
+    let @15: alloc::boxed::Box<dyn (exists(TODO))>; // anonymous local
+    let @16: alloc::boxed::Box<alloc::string::String>; // anonymous local
+    let @17: alloc::string::String; // anonymous local
+    let @18: &'_ (alloc::string::String); // anonymous local
+    let @19: alloc::rc::Rc<dyn (exists(TODO)), alloc::alloc::Global>; // anonymous local
+    let @20: alloc::rc::Rc<alloc::string::String, alloc::alloc::Global>; // anonymous local
+    let @21: alloc::string::String; // anonymous local
+    let @22: &'_ (alloc::string::String); // anonymous local
+    let @23: (); // anonymous local
+
+    array@1 := [const (0 : i32), const (0 : i32); 2 : usize]
+    @fake_read(array@1)
+    @4 := &array@1
+    @3 := &*(@4)
+    @2 := @ArrayToSliceShared<'_, i32, 2 : usize>(move (@3))
+    drop @3
+    @fake_read(@2)
+    drop @4
+    drop @2
+    @7 := copy (array@1)
+    @6 := @BoxNew<Array<i32, 2 : usize>>(move (@7))
+    @5 := unsize_cast<alloc::boxed::Box<Array<i32, 2 : usize>>, alloc::boxed::Box<Slice<i32>>>(move (@6))
+    drop @6
+    drop @7
+    drop @6
+    @fake_read(@5)
+    drop @5
+    drop @5
+    @10 := copy (array@1)
+    @9 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<Array<i32, 2 : usize>>(move (@10))
+    @8 := unsize_cast<alloc::rc::Rc<Array<i32, 2 : usize>, alloc::alloc::Global>, alloc::rc::Rc<Slice<i32>, alloc::alloc::Global>>(move (@9))
+    drop @9
+    drop @10
+    drop @9
+    @fake_read(@8)
+    drop @8
+    drop @8
+    string@11 := alloc::string::{alloc::string::String}::new()
+    @fake_read(string@11)
+    @14 := &string@11
+    @13 := &*(@14)
+    @12 := unsize_cast<&'_ (alloc::string::String), &'_ (dyn (exists(TODO)))>(move (@13))
+    drop @13
+    @fake_read(@12)
+    drop @14
+    drop @12
+    @18 := &string@11
+    @17 := alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone(move (@18))
+    drop @18
+    @16 := @BoxNew<alloc::string::String>(move (@17))
+    @15 := unsize_cast<alloc::boxed::Box<alloc::string::String>, alloc::boxed::Box<dyn (exists(TODO))>>(move (@16))
+    drop @16
+    drop @17
+    drop @16
+    @fake_read(@15)
+    drop @15
+    drop @15
+    @22 := &string@11
+    @21 := alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone(move (@22))
+    drop @22
+    @20 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<alloc::string::String>(move (@21))
+    @19 := unsize_cast<alloc::rc::Rc<alloc::string::String, alloc::alloc::Global>, alloc::rc::Rc<dyn (exists(TODO)), alloc::alloc::Global>>(move (@20))
+    drop @20
+    drop @21
+    drop @20
+    @fake_read(@19)
+    drop @19
+    drop @19
+    @23 := ()
+    @0 := move (@23)
+    drop string@11
+    drop string@11
+    drop array@1
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/unsize.rs
+++ b/charon/tests/ui/unsize.rs
@@ -1,0 +1,14 @@
+use std::fmt::Display;
+use std::rc::Rc;
+
+fn foo() {
+    let array: [_; 2] = [0, 0];
+    let _: &[_] = &array;
+    let _: Box<[_]> = Box::new(array);
+    let _: Rc<[_]> = Rc::new(array);
+
+    let string = String::new();
+    let _: &dyn Display = &string;
+    let _: Box<dyn Display> = Box::new(string.clone());
+    let _: Rc<dyn Display> = Rc::new(string.clone());
+}

--- a/charon/tests/ui/unsupported/gat.out
+++ b/charon/tests/ui/unsupported/gat.out
@@ -1,0 +1,9 @@
+disabled backtrace
+error[E9999]: Cannot handle error `FulfillmentError` selecting `Binder { value: <<Self as ArraySize>::ArrayType<T> as Foo>, bound_vars: [] }`
+  |
+  = note: ⚠️ This is a bug in Hax's frontend.
+          Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+
+error: aborting due to 1 previous error
+
+Error: Charon driver exited with code 101

--- a/charon/tests/ui/unsupported/gat.rs
+++ b/charon/tests/ui/unsupported/gat.rs
@@ -1,0 +1,7 @@
+//@ known-failure
+trait Foo {
+    type Item;
+}
+trait ArraySize {
+    type ArrayType<T>: Foo<Item = T>;
+}


### PR DESCRIPTION
Just enough to not crash when encountering it in the wild. To support it properly, we need https://github.com/hacspec/hax/pull/741 and a deep change to allow type binders (on top of the existing support for region binders).