### PR TITLE
Fix an issue with inline_local_panic_functions

### DIFF
--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -125,8 +125,6 @@ enum test_crate::CList<T> =
 |  CNil()
 
 
-Unknown decl: 13
-
 fn test_crate::list_nth<'a, T>(@1: &'a (test_crate::CList<T>), @2: u32) -> &'a (T)
 {
     let @0: &'_ (T); // return
@@ -175,8 +173,6 @@ fn test_crate::list_nth<'a, T>(@1: &'a (test_crate::CList<T>), @2: u32) -> &'a (
     drop x@3
     return
 }
-
-Unknown decl: 14
 
 fn test_crate::list_nth_mut<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) -> &'a mut (T)
 {
@@ -241,8 +237,6 @@ fn test_crate::list_nth_mut<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) 
     drop @3
     return
 }
-
-Unknown decl: 15
 
 fn test_crate::list_nth_mut1<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) -> &'a mut (T)
 {

--- a/charon/tests/ui/diverging.out
+++ b/charon/tests/ui/diverging.out
@@ -1,7 +1,5 @@
 # Final LLBC before serialization:
 
-Unknown decl: 3
-
 fn test_crate::my_panic(@1: u32) -> !
 {
     let @0: !; // return

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -1778,8 +1778,6 @@ enum test_crate::List<T> =
 |  Nil()
 
 
-Unknown decl: 96
-
 fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usize) -> &'_0 mut (usize)
 {
     let @0: &'_ mut (usize); // return
@@ -1835,8 +1833,6 @@ fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usi
     }
     panic(core::panicking::panic_explicit)
 }
-
-Unknown decl: 97
 
 fn test_crate::list_nth_mut_loop_with_id<'_0, T>(@1: &'_0 mut (test_crate::List<T>), @2: u32) -> &'_0 mut (T)
 {

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -382,8 +382,6 @@ fn test_crate::is_cons<'_0, T>(@1: &'_0 (test_crate::List<T>)) -> bool
     return
 }
 
-Unknown decl: 30
-
 fn test_crate::split_list<T>(@1: test_crate::List<T>) -> (T, test_crate::List<T>)
 {
     let @0: (T, test_crate::List<T>); // return

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -1,7 +1,5 @@
 # Final LLBC before serialization:
 
-Unknown decl: 9
-
 fn test_crate::panic1()
 {
     let @0: (); // return


### PR DESCRIPTION
The micro-pass which inlines the panic functions did not filter those functions from the declaration groups.