### PR TITLE
Catch more panics

### DIFF
--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -215,10 +215,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                         .instantiate_identity()
                         .sinto(&bt_ctx.hax_state);
 
-                    bt_ctx.translate_generic_params(id).unwrap();
-                    bt_ctx
-                        .translate_predicates_of(None, id, PredicateOrigin::WhereClauseOnImpl)
-                        .unwrap();
+                    bt_ctx.translate_generic_params(id)?;
+                    bt_ctx.translate_predicates_of(None, id, PredicateOrigin::WhereClauseOnImpl)?;
                     let erase_regions = false;
                     // Two cases, depending on whether the impl block is
                     // a "regular" impl block (`impl Foo { ... }`) or a trait
@@ -226,7 +224,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     let kind = match bt_ctx.t_ctx.tcx.impl_trait_ref(id) {
                         None => {
                             // Inherent impl ("regular" impl)
-                            let ty = bt_ctx.translate_ty(span, erase_regions, &ty).unwrap();
+                            let ty = bt_ctx.translate_ty(span, erase_regions, &ty)?;
                             ImplElemKind::Ty(ty)
                         }
                         Some(trait_ref) => {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -391,8 +391,9 @@ fn compute_declarations_graph<'tcx, 'ctx>(ctx: &'tcx TransformCtx<'ctx>) -> Deps
                         //   fn f(x : Trait::X);
                         // }
                         // ```
-                        let decl = ctx.translated.fun_decls.get(id).unwrap();
-                        decl.signature.drive(&mut graph);
+                        if let Some(decl) = ctx.translated.fun_decls.get(id) {
+                            decl.signature.drive(&mut graph);
+                        }
                     }
                 } else {
                     // There may have been errors

--- a/charon/tests/ui/unsupported/gat.out
+++ b/charon/tests/ui/unsupported/gat.out
@@ -4,6 +4,19 @@ error[E9999]: Cannot handle error `FulfillmentError` selecting `Binder { value: 
   = note: ⚠️ This is a bug in Hax's frontend.
           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-error: aborting due to 1 previous error
+error: Thread panicked when extracting item {rust_id}.
+ --> tests/ui/unsupported/gat.rs:5:1
+  |
+5 | trait ArraySize {
+  | ^^^^^^^^^^^^^^^
 
-Error: Charon driver exited with code 101
+error: Ignoring the following item due to an error: test_crate::ArraySize
+ --> tests/ui/unsupported/gat.rs:5:1
+  |
+5 | trait ArraySize {
+  | ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+[ERROR charon_driver:230] The extraction encountered 2 errors
+Error: Charon driver exited with code 1


### PR DESCRIPTION
There a still many unsupported rust features that make us panic. I added a `catch_unwind` to catch as many of these as we can, so we can keep making progress.