### PR TITLE
Use upstream libcrux flake in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,27 +74,8 @@ jobs:
     if: needs.check_if_skip_duplicate_job.outputs.should_skip != 'true'
     runs-on: [self-hosted, linux, nix]
     steps:
-      - name: checkout libcrux
-        uses: actions/checkout@v4
-        with:
-          repository: cryspen/libcrux
-          ref: dev
-      # Kyber expects Eurydice's sources in `$EURYDICE_HOME`,
-      # not the install directory.
-      - name: checkout eurydice
-        uses: actions/checkout@v4
-        with:
-          repository: aeneasverif/eurydice
-          path: eurydice
-      - name: setup
-        run: |
-          nix build ./eurydice -o eurydice/result --override-input charon github:aeneasverif/charon/${{ github.sha }}
-          ln -s $(pwd)/eurydice/result/bin/eurydice $(pwd)/eurydice/eurydice
-          nix build github:hacl-star/hacl-nix#fstar -o fstar
-          nix build github:hacl-star/hacl-nix#karamel.home -o karamel
-          echo EURYDICE_HOME=$(pwd)/eurydice >> $GITHUB_ENV
-          echo FSTAR_HOME=$(pwd)/fstar >> $GITHUB_ENV
-          echo KRML_HOME=$(pwd)/karamel >> $GITHUB_ENV
-      - name: build kyber
-        run: |
-          nix develop 'github:aeneasverif/charon/${{ github.sha }}#kyber-ci' --command build-kyber
+      - run: |
+          nix build -L github:cryspen/libcrux/dev#ml-kem \
+              --override-input charon github:aeneasverif/charon/${{ github.sha }} \
+              --override-input charon/rust-overlay github:oxalica/rust-overlay/master \
+              --override-input eurydice github:aeneasverif/eurydice

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -101,16 +101,13 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 trace!("impl");
                 // Sanity checks
                 // TODO: make proper error messages
-                use rustc_hir::{Defaultness, ImplPolarity, Safety};
-                assert!(impl_block.safety == Safety::Safe);
+                use rustc_hir::{Defaultness, ImplPolarity};
                 // About polarity:
                 // [https://doc.rust-lang.org/beta/unstable-book/language-features/negative-impls.html]
                 // Not sure about what I should do about it. Should I do anything, actually?
                 // This seems useful to enforce some discipline on the user-side, but not
                 // necessary for analysis purposes.
                 assert!(impl_block.polarity == ImplPolarity::Positive);
-                // Not sure what this is about
-                assert!(impl_block.defaultness == Defaultness::Final);
 
                 // If this is a trait implementation, register it
                 if self.tcx.trait_id_of_impl(def_id).is_some() {

--- a/flake.nix
+++ b/flake.nix
@@ -159,31 +159,6 @@
             self.packages.${system}.charon-ml
           ];
         };
-        # The dev-shell we need to run kyber in CI. This doesn't really belong here but it's easier here.
-        devShells.kyber-ci =
-          let
-            build-kyber = pkgs.writeShellScriptBin "build-kyber" ''
-              export RUSTFLAGS="--cfg eurydice"
-              echo "Running charon (sha3) ..."
-              (cd libcrux-sha3 && charon)
-              echo "Running charon (ml-kem) ..."
-              cd libcrux-ml-kem
-              charon
-
-              mkdir -p c
-              cd c
-              echo "Running eurydice ..."
-              $EURYDICE_HOME/eurydice --config ../c.yaml ../../libcrux_ml_kem.llbc ../../libcrux_sha3.llbc
-            '';
-          in
-          pkgs.mkShell {
-            packages = [
-              charon
-              build-kyber
-              rustToolchain
-              pkgs.clang-tools # For clang-format
-            ];
-          };
         checks = { inherit charon-ml-tests charon-check-fmt charon-ml-check-fmt; };
 
         # Export this function so that users of charon can use it in nix. This


### PR DESCRIPTION
Now that libcrux has proper flake support, we can use their flake in CI instead of our outdated copy-paste of `c.sh`.