### PR TITLE
Run `reorder_decls` after the micro-passes

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -241,14 +241,6 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
         trace!("# ULLBC after translation from MIR:\n\n{ctx}\n");
     }
 
-    // # Reorder the graph of dependencies and compute the strictly
-    // connex components to:
-    // - compute the order in which to extract the definitions
-    // - find the recursive definitions
-    // - group the mutually recursive definitions
-    let reordered_decls = compute_reordered_decls(&mut ctx);
-    ctx.translated.ordered_decls = Some(reordered_decls);
-
     //
     // =================
     // **Micro-passes**:
@@ -279,6 +271,14 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
         for pass in LLBC_PASSES.iter() {
             pass.transform_ctx(&mut ctx)
         }
+
+        // # Reorder the graph of dependencies and compute the strictly
+        // connex components to:
+        // - compute the order in which to extract the definitions
+        // - find the recursive definitions
+        // - group the mutually recursive definitions
+        let reordered_decls = compute_reordered_decls(&mut ctx);
+        ctx.translated.ordered_decls = Some(reordered_decls);
 
         if options.print_llbc {
             println!("# Final LLBC before serialization:\n\n{ctx}\n");

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -62,30 +62,8 @@ impl LlbcPass for Transform {
         });
 
         // Remove these functions from the context.
-        // We first remove them from the translated definitions.
         for id in &panic_fns {
             ctx.translated.fun_decls.remove(*id);
         }
-
-        // We also filter the declaration groups.
-        ctx.translated.ordered_decls = if let Some(groups) = &mut ctx.translated.ordered_decls {
-            Some(
-                groups
-                    .iter()
-                    .filter_map(|gr| {
-                        use crate::reorder_decls::DeclarationGroup::*;
-                        use crate::reorder_decls::GDeclarationGroup::*;
-                        // The panic functions should only appear in singleton groups
-                        // (they are not mutually recursive with any other definition).
-                        match gr {
-                            Fun(NonRec(id)) if panic_fns.contains(id) => Option::None,
-                            _ => Option::Some(gr.clone()),
-                        }
-                    })
-                    .collect(),
-            )
-        } else {
-            None
-        };
     }
 }

--- a/charon/src/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/translate/translate_crate_to_ullbc.rs
@@ -231,7 +231,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     pub(crate) fn translate_item(&mut self, rust_id: DefId, trans_id: AnyTransId) {
-        if self.errors.ignored_failed_decls.contains(&rust_id) || self.get_item(trans_id).is_some()
+        if self.errors.ignored_failed_decls.contains(&rust_id)
+            || self.translated.get_item(trans_id).is_some()
         {
             return;
         }
@@ -317,28 +318,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         Ok(())
     }
 
-    fn get_item(&mut self, trans_id: AnyTransId) -> Option<AnyTransItem<'_>> {
-        match trans_id {
-            AnyTransId::Type(id) => self.translated.type_decls.get(id).map(AnyTransItem::Type),
-            AnyTransId::Fun(id) => self.translated.fun_decls.get(id).map(AnyTransItem::Fun),
-            AnyTransId::Global(id) => self
-                .translated
-                .global_decls
-                .get(id)
-                .map(AnyTransItem::Global),
-            AnyTransId::TraitDecl(id) => self
-                .translated
-                .trait_decls
-                .get(id)
-                .map(AnyTransItem::TraitDecl),
-            AnyTransId::TraitImpl(id) => self
-                .translated
-                .trait_impls
-                .get(id)
-                .map(AnyTransItem::TraitImpl),
-        }
-    }
-
     /// While translating an item you may need the contents of another. Use this to retreive the
     /// translated version of this item.
     #[allow(dead_code)]
@@ -351,7 +330,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             let span = self.tcx.def_span(rust_id);
             error_or_panic!(self, span, format!("Failed to translate item {id:?}."))
         }
-        Ok(self.get_item(id).unwrap())
+        Ok(self.translated.get_item(id).unwrap())
     }
 }
 

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -442,6 +442,18 @@ impl ErrorCtx<'_> {
     }
 }
 
+impl TranslatedCrate {
+    pub fn get_item(&self, trans_id: AnyTransId) -> Option<AnyTransItem<'_>> {
+        match trans_id {
+            AnyTransId::Type(id) => self.type_decls.get(id).map(AnyTransItem::Type),
+            AnyTransId::Fun(id) => self.fun_decls.get(id).map(AnyTransItem::Fun),
+            AnyTransId::Global(id) => self.global_decls.get(id).map(AnyTransItem::Global),
+            AnyTransId::TraitDecl(id) => self.trait_decls.get(id).map(AnyTransItem::TraitDecl),
+            AnyTransId::TraitImpl(id) => self.trait_impls.get(id).map(AnyTransItem::TraitImpl),
+        }
+    }
+}
+
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     pub fn continue_on_failure(&self) -> bool {
         self.errors.continue_on_failure()

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -29,6 +29,7 @@ fn translate(code: impl std::fmt::Display) -> Result<CrateData, Box<dyn Error>> 
     let output_path = tmp_dir.path().join("test_crate.llbc");
     Command::cargo_bin("charon")?
         .arg("--no-cargo")
+        .arg("--rustc-flag=--edition=2021")
         .arg("--input")
         .arg(input_path)
         .arg("--dest-file")
@@ -606,5 +607,22 @@ fn rename_attribute() -> Result<(), Box<dyn Error>> {
             .as_deref(),
         Some("FieldTest")
     );
+    Ok(())
+}
+
+#[test]
+fn declaration_groups() -> Result<(), Box<dyn Error>> {
+    let crate_data = translate(
+        r#"
+        fn foo() {
+            panic!()
+        }
+        "#,
+    )?;
+
+    assert_eq!(crate_data.functions.len(), 1);
+    assert_eq!(crate_data.declarations.len(), 1);
+    assert!(crate_data.declarations[0].as_fun().is_non_rec());
+
     Ok(())
 }

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -66,20 +66,6 @@ where
     return
 }
 
-trait core::fmt::LowerHex<Self>
-{
-    fn fmt : core::fmt::LowerHex::fmt
-}
-
-fn core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
-
-impl core::fmt::num::{impl core::fmt::LowerHex for u32#60} : core::fmt::LowerHex<u32>
-{
-    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt
-}
-
-fn core::fmt::LowerHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
-
 trait core::fmt::Display<Self>
 {
     fn fmt : core::fmt::Display::fmt
@@ -107,6 +93,20 @@ impl core::fmt::num::{impl core::fmt::UpperHex for u32#61} : core::fmt::UpperHex
 }
 
 fn core::fmt::UpperHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+trait core::fmt::LowerHex<Self>
+{
+    fn fmt : core::fmt::LowerHex::fmt
+}
+
+fn core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+
+impl core::fmt::num::{impl core::fmt::LowerHex for u32#60} : core::fmt::LowerHex<u32>
+{
+    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt
+}
+
+fn core::fmt::LowerHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
 fn core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 {


### PR DESCRIPTION
This makes `reorder_decls` more robust to missing items, which makes it possible to run after our micro-passes. This makes our graph computation reflect more accurately the final structure of the code. This removes the need for post-hoc alterations of the declaration groups like in https://github.com/AeneasVerif/charon/pull/277.