### PR TITLE
Generate `GAstOfJson.ml` from the rust definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ charon-tests:
 charon-ml-tests: build-charon-ml charon-tests
 	cd charon-ml && make tests
 
+# Generate some of the ml code automatically from the rust definitions.
+.PHONY: generate-ml
+generate-ml:
+	cd charon && cargo test --test generate-ml -- --ignored
+	cd charon-ml && make format 2> /dev/null
+
 # Run Charon on rustc's ui test suite
 .PHONY: rustc-tests
 rustc-tests:

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.18"
+let supported_charon_version = "0.1.19"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -132,6 +132,9 @@ let attribute_of_json (js : json) : (attribute, string) result =
     | `Assoc [ ("Rename", rename) ] ->
         let* rename = string_of_json rename in
         Ok (AttrRename rename)
+    | `Assoc [ ("VariantsPrefix", prefix) ] ->
+        let* prefix = string_of_json prefix in
+        Ok (AttrVariantsPrefix prefix)
     | `Assoc [ ("Unknown", unknown) ] ->
         let* unknown = string_of_json unknown in
         Ok (AttrUnknown unknown)

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1,3 +1,10 @@
+(** WARNING: this file is partially auto-generated. `GAstOfJson.template.ml`
+    contains the manual definitions and some `(* __REPLACEn__ *)` comments.
+    These comments are replaced by auto-generated definitions by the
+    `generate-ml` rust test. That test is ignored by default. To re-generate
+    the files, call `make generate-ml` in the crate root. Do not edit
+    `GAstOfJson` by hand. *)
+
 (** Functions to load (U)LLBC ASTs from json.
 
     Initially, we used [ppx_derive_yojson] to automate this.
@@ -45,26 +52,49 @@ module IdToFile = Collections.MakeMap (OrderedIdToFile)
 
 type id_to_file_map = file_name IdToFile.t
 
-let file_id_of_json (js : json) : (file_id, string) result =
+let de_bruijn_id_of_json = int_of_json
+let path_buf_of_json = string_of_json
+let trait_item_name_of_json = string_of_json
+let vector_of_json _ = list_of_json
+let const_generic_var_id_of_json = ConstGenericVarId.id_of_json
+let disambiguator_of_json = Disambiguator.id_of_json
+let field_id_of_json = FieldId.id_of_json
+let fun_decl_id_of_json = FunDeclId.id_of_json
+let global_decl_id_of_json = GlobalDeclId.id_of_json
+let local_file_id_of_json = LocalFileId.id_of_json
+let region_id_of_json = RegionVarId.id_of_json
+let trait_clause_id_of_json = TraitClauseId.id_of_json
+let trait_decl_id_of_json = TraitDeclId.id_of_json
+let trait_impl_id_of_json = TraitImplId.id_of_json
+let type_decl_id_of_json = TypeDeclId.id_of_json
+let type_var_id_of_json = TypeVarId.id_of_json
+let variant_id_of_json = VariantId.id_of_json
+let var_id_of_json = VarId.id_of_json
+let virtual_file_id_of_json = VirtualFileId.id_of_json
+
+(* Start of the `and` chain *)
+let __ = ()
+
+and file_id_of_json (js : json) : (file_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("LocalId", id) ] ->
-        let* id = LocalFileId.id_of_json id in
-        Ok (LocalId id)
-    | `Assoc [ ("VirtualId", id) ] ->
-        let* id = VirtualFileId.id_of_json id in
-        Ok (VirtualId id)
+    | `Assoc [ ("LocalId", local_id) ] ->
+        let* local_id = local_file_id_of_json local_id in
+        Ok (LocalId local_id)
+    | `Assoc [ ("VirtualId", virtual_id) ] ->
+        let* virtual_id = virtual_file_id_of_json virtual_id in
+        Ok (VirtualId virtual_id)
     | _ -> Error "")
 
-let file_name_of_json (js : json) : (file_name, string) result =
+and file_name_of_json (js : json) : (file_name, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Virtual", name) ] ->
-        let* name = string_of_json name in
-        Ok (Virtual name)
-    | `Assoc [ ("Local", name) ] ->
-        let* name = string_of_json name in
-        Ok (Local name)
+    | `Assoc [ ("Virtual", virtual_) ] ->
+        let* virtual_ = path_buf_of_json virtual_ in
+        Ok (Virtual virtual_)
+    | `Assoc [ ("Local", local) ] ->
+        let* local = path_buf_of_json local in
+        Ok (Local local)
     | _ -> Error "")
 
 (** Deserialize a map from file id to file name.
@@ -84,7 +114,7 @@ let id_to_file_of_json (js : json) : (id_to_file_map, string) result =
      in
      Ok (IdToFile.of_list key_values))
 
-let loc_of_json (js : json) : (loc, string) result =
+and loc_of_json (js : json) : (loc, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("line", line); ("col", col) ] ->
@@ -93,7 +123,8 @@ let loc_of_json (js : json) : (loc, string) result =
         Ok { line; col }
     | _ -> Error "")
 
-let raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
+(* This is written by hand because it accessed `id_to_file`. *)
+let rec raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
     (raw_span, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -105,7 +136,7 @@ let raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
         Ok { file; beg_loc; end_loc }
     | _ -> Error "")
 
-let span_of_json (id_to_file : id_to_file_map) (js : json) :
+and span_of_json (id_to_file : id_to_file_map) (js : json) :
     (span, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -117,7 +148,7 @@ let span_of_json (id_to_file : id_to_file_map) (js : json) :
         Ok { span; generated_from_span }
     | _ -> Error "")
 
-let inline_attr_of_json (js : json) : (inline_attr, string) result =
+and inline_attr_of_json (js : json) : (inline_attr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Hint" -> Ok Hint
@@ -125,22 +156,25 @@ let inline_attr_of_json (js : json) : (inline_attr, string) result =
     | `String "Always" -> Ok Always
     | _ -> Error "")
 
-let attribute_of_json (js : json) : (attribute, string) result =
+and attribute_of_json (js : json) : (attribute, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Opaque" -> Ok AttrOpaque
     | `Assoc [ ("Rename", rename) ] ->
         let* rename = string_of_json rename in
         Ok (AttrRename rename)
-    | `Assoc [ ("VariantsPrefix", prefix) ] ->
-        let* prefix = string_of_json prefix in
-        Ok (AttrVariantsPrefix prefix)
+    | `Assoc [ ("VariantsPrefix", variants_prefix) ] ->
+        let* variants_prefix = string_of_json variants_prefix in
+        Ok (AttrVariantsPrefix variants_prefix)
+    | `Assoc [ ("VariantsSuffix", variants_suffix) ] ->
+        let* variants_suffix = string_of_json variants_suffix in
+        Ok (AttrVariantsSuffix variants_suffix)
     | `Assoc [ ("Unknown", unknown) ] ->
         let* unknown = string_of_json unknown in
         Ok (AttrUnknown unknown)
     | _ -> Error "")
 
-let attr_info_of_json (js : json) : (attr_info, string) result =
+and attr_info_of_json (js : json) : (attr_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -152,83 +186,85 @@ let attr_info_of_json (js : json) : (attr_info, string) result =
         ] ->
         let* attributes = list_of_json attribute_of_json attributes in
         let* inline = option_of_json inline_attr_of_json inline in
+        let* rename = option_of_json string_of_json rename in
         let* public = bool_of_json public in
-        let* rename = string_option_of_json rename in
-        Ok { attributes; inline; public; rename }
+        Ok { attributes; inline; rename; public }
     | _ -> Error "")
 
-let type_var_of_json (js : json) : (type_var, string) result =
+and type_var_of_json (js : json) : (type_var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = TypeVarId.id_of_json index in
+        let* index = type_var_id_of_json index in
         let* name = string_of_json name in
         Ok { index; name }
     | _ -> Error "")
 
-let region_var_of_json (js : json) : (region_var, string) result =
+and region_var_of_json (js : json) : (region_var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = RegionVarId.id_of_json index in
-        let* name = string_option_of_json name in
+        let* index = region_id_of_json index in
+        let* name = option_of_json string_of_json name in
         Ok { index; name }
     | _ -> Error "")
 
-let region_of_json (js : json) : (region, string) result =
+and region_of_json (js : json) : (region, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Static" -> Ok RStatic
+    | `Assoc [ ("BVar", `List [ x0; x1 ]) ] ->
+        let* x0 = de_bruijn_id_of_json x0 in
+        let* x1 = region_id_of_json x1 in
+        Ok (RBVar (x0, x1))
     | `String "Erased" -> Ok RErased
-    | `Assoc [ ("BVar", `List [ dbid; rid ]) ] ->
-        let* dbid = int_of_json dbid in
-        let* rid = RegionVarId.id_of_json rid in
-        Ok (RBVar (dbid, rid) : region)
     | _ -> Error "")
 
-let integer_type_of_json (js : json) : (integer_type, string) result =
-  match js with
-  | `String "Isize" -> Ok Isize
-  | `String "I8" -> Ok I8
-  | `String "I16" -> Ok I16
-  | `String "I32" -> Ok I32
-  | `String "I64" -> Ok I64
-  | `String "I128" -> Ok I128
-  | `String "Usize" -> Ok Usize
-  | `String "U8" -> Ok U8
-  | `String "U16" -> Ok U16
-  | `String "U32" -> Ok U32
-  | `String "U64" -> Ok U64
-  | `String "U128" -> Ok U128
-  | _ -> Error ("integer_type_of_json failed on: " ^ show js)
-
-let literal_type_of_json (js : json) : (literal_type, string) result =
+and integer_type_of_json (js : json) : (integer_type, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Integer", int_ty) ] ->
-        let* int_ty = integer_type_of_json int_ty in
-        Ok (TInteger int_ty)
+    | `String "Isize" -> Ok Isize
+    | `String "I8" -> Ok I8
+    | `String "I16" -> Ok I16
+    | `String "I32" -> Ok I32
+    | `String "I64" -> Ok I64
+    | `String "I128" -> Ok I128
+    | `String "Usize" -> Ok Usize
+    | `String "U8" -> Ok U8
+    | `String "U16" -> Ok U16
+    | `String "U32" -> Ok U32
+    | `String "U64" -> Ok U64
+    | `String "U128" -> Ok U128
+    | _ -> Error "")
+
+and literal_type_of_json (js : json) : (literal_type, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Integer", integer) ] ->
+        let* integer = integer_type_of_json integer in
+        Ok (TInteger integer)
     | `String "Bool" -> Ok TBool
     | `String "Char" -> Ok TChar
     | _ -> Error "")
 
-let const_generic_var_of_json (js : json) : (const_generic_var, string) result =
+and const_generic_var_of_json (js : json) : (const_generic_var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = ConstGenericVarId.id_of_json index in
+        let* index = const_generic_var_id_of_json index in
         let* name = string_of_json name in
         let* ty = literal_type_of_json ty in
         Ok { index; name; ty }
     | _ -> Error "")
 
-let ref_kind_of_json (js : json) : (ref_kind, string) result =
-  match js with
-  | `String "Mut" -> Ok RMut
-  | `String "Shared" -> Ok RShared
-  | _ -> Error ("ref_kind_of_json failed on: " ^ show js)
+and ref_kind_of_json (js : json) : (ref_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Mut" -> Ok RMut
+    | `String "Shared" -> Ok RShared
+    | _ -> Error "")
 
-let assumed_ty_of_json (js : json) : (assumed_ty, string) result =
+and assumed_ty_of_json (js : json) : (assumed_ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Box" -> Ok TBox
@@ -237,16 +273,16 @@ let assumed_ty_of_json (js : json) : (assumed_ty, string) result =
     | `String "Str" -> Ok TStr
     | _ -> Error "")
 
-let type_id_of_json (js : json) : (type_id, string) result =
+and type_id_of_json (js : json) : (type_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Adt", id) ] ->
-        let* id = TypeDeclId.id_of_json id in
-        Ok (TAdtId id)
+    | `Assoc [ ("Adt", adt) ] ->
+        let* adt = type_decl_id_of_json adt in
+        Ok (TAdtId adt)
     | `String "Tuple" -> Ok TTuple
-    | `Assoc [ ("Assumed", aty) ] ->
-        let* aty = assumed_ty_of_json aty in
-        Ok (TAssumed aty)
+    | `Assoc [ ("Assumed", assumed) ] ->
+        let* assumed = assumed_ty_of_json assumed in
+        Ok (TAssumed assumed)
     | _ -> Error "")
 
 let big_int_of_json (js : json) : (big_int, string) result =
@@ -261,8 +297,10 @@ let big_int_of_json (js : json) : (big_int, string) result =
     Note that in practice we also check that the values are in range
     in the interpreter functions. Still, it doesn't cost much to be
     a bit conservative.
- *)
-let scalar_value_of_json (js : json) : (scalar_value, string) result =
+
+    This is written by hand because it does not match the structure of the
+    corresponding rust type. *)
+let rec scalar_value_of_json (js : json) : (scalar_value, string) result =
   let res =
     combine_error_msgs js __FUNCTION__
       (match js with
@@ -312,72 +350,61 @@ let scalar_value_of_json (js : json) : (scalar_value, string) result =
         raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv)));
       res
 
-let literal_of_json (js : json) : (literal, string) result =
+and const_generic_of_json (js : json) : (const_generic, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Scalar", v) ] ->
-        let* v = scalar_value_of_json v in
-        Ok (VScalar v)
-    | `Assoc [ ("Bool", v) ] ->
-        let* v = bool_of_json v in
-        Ok (VBool v)
-    | `Assoc [ ("Char", v) ] ->
-        let* v = char_of_json v in
-        Ok (VChar v)
+    | `Assoc [ ("Global", global) ] ->
+        let* global = global_decl_id_of_json global in
+        Ok (CgGlobal global)
+    | `Assoc [ ("Var", var) ] ->
+        let* var = const_generic_var_id_of_json var in
+        Ok (CgVar var)
+    | `Assoc [ ("Value", value) ] ->
+        let* value = literal_of_json value in
+        Ok (CgValue value)
     | _ -> Error "")
 
-let const_generic_of_json (js : json) : (const_generic, string) result =
+and ty_of_json (js : json) : (ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Global", id) ] ->
-        let* id = GlobalDeclId.id_of_json id in
-        Ok (CgGlobal id)
-    | `Assoc [ ("Var", id) ] ->
-        let* id = ConstGenericVarId.id_of_json id in
-        Ok (CgVar id)
-    | `Assoc [ ("Value", lit) ] ->
-        let* lit = literal_of_json lit in
-        Ok (CgValue lit)
-    | _ -> Error "")
-
-let rec ty_of_json (js : json) : (ty, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Adt", `List [ id; generics ]) ] ->
-        let* id = type_id_of_json id in
-        let* generics = generic_args_of_json generics in
-        (* Sanity check *)
-        (match id with
-        | TTuple -> assert (generics.regions = [] && generics.trait_refs = [])
-        | _ -> ());
-        Ok (TAdt (id, generics))
-    | `Assoc [ ("TypeVar", id) ] ->
-        let* id = TypeVarId.id_of_json id in
-        Ok (TVar id)
-    | `Assoc [ ("Literal", ty) ] ->
-        let* ty = literal_type_of_json ty in
-        Ok (TLiteral ty)
-    | `Assoc [ ("Ref", `List [ region; ty; ref_kind ]) ] ->
-        let* region = region_of_json region in
-        let* ty = ty_of_json ty in
-        let* ref_kind = ref_kind_of_json ref_kind in
-        Ok (TRef (region, ty, ref_kind))
-    | `Assoc [ ("RawPtr", `List [ ty; ref_kind ]) ] ->
-        let* ty = ty_of_json ty in
-        let* ref_kind = ref_kind_of_json ref_kind in
-        Ok (TRawPtr (ty, ref_kind))
-    | `Assoc [ ("TraitType", `List [ trait_ref; item_name ]) ] ->
-        let* trait_ref = trait_ref_of_json trait_ref in
-        let* item_name = string_of_json item_name in
-        Ok (TTraitType (trait_ref, item_name))
-    | `Assoc [ ("Arrow", `List [ regions; inputs; output ]) ] ->
-        let* regions = list_of_json region_var_of_json regions in
-        let* inputs = list_of_json ty_of_json inputs in
-        let* output = ty_of_json output in
-        Ok (TArrow (regions, inputs, output))
-    | `Assoc [ ("DynTrait", `Null) ] -> Ok (TDynTrait ())
+    | `Assoc [ ("Adt", `List [ x0; x1 ]) ] ->
+        let* x0 = type_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (TAdt (x0, x1))
+    | `Assoc [ ("TypeVar", type_var) ] ->
+        let* type_var = type_var_id_of_json type_var in
+        Ok (TVar type_var)
+    | `Assoc [ ("Literal", literal) ] ->
+        let* literal = literal_type_of_json literal in
+        Ok (TLiteral literal)
     | `String "Never" -> Ok TNever
+    | `Assoc [ ("Ref", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = region_of_json x0 in
+        let* x1 = ty_of_json x1 in
+        let* x2 = ref_kind_of_json x2 in
+        Ok (TRef (x0, x1, x2))
+    | `Assoc [ ("RawPtr", `List [ x0; x1 ]) ] ->
+        let* x0 = ty_of_json x0 in
+        let* x1 = ref_kind_of_json x1 in
+        Ok (TRawPtr (x0, x1))
+    | `Assoc [ ("TraitType", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_ref_of_json x0 in
+        let* x1 = trait_item_name_of_json x1 in
+        Ok (TTraitType (x0, x1))
+    | `Assoc [ ("DynTrait", dyn_trait) ] ->
+        let* dyn_trait = existential_predicate_of_json dyn_trait in
+        Ok (TDynTrait dyn_trait)
+    | `Assoc [ ("Arrow", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = vector_of_json region_id_of_json region_var_of_json x0 in
+        let* x1 = list_of_json ty_of_json x1 in
+        let* x2 = ty_of_json x2 in
+        Ok (TArrow (x0, x1, x2))
     | _ -> Error "")
+
+and existential_predicate_of_json (js : json) :
+    (existential_predicate, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with `Null -> Ok () | _ -> Error "")
 
 and trait_ref_of_json (js : json) : (trait_ref, string) result =
   combine_error_msgs js __FUNCTION__
@@ -391,16 +418,16 @@ and trait_ref_of_json (js : json) : (trait_ref, string) result =
         let* trait_id = trait_instance_id_of_json trait_id in
         let* generics = generic_args_of_json generics in
         let* trait_decl_ref = trait_decl_ref_of_json trait_decl_ref in
-        Ok ({ trait_id; generics; trait_decl_ref } : trait_ref)
+        Ok { trait_id; generics; trait_decl_ref }
     | _ -> Error "")
 
 and trait_decl_ref_of_json (js : json) : (trait_decl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("trait_id", trait_id); ("generics", generics) ] ->
-        let* trait_decl_id = TraitDeclId.id_of_json trait_id in
+        let* trait_decl_id = trait_decl_id_of_json trait_id in
         let* decl_generics = generic_args_of_json generics in
-        Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
+        Ok { trait_decl_id; decl_generics }
     | _ -> Error "")
 
 and generic_args_of_json (js : json) : (generic_args, string) result =
@@ -425,48 +452,36 @@ and generic_args_of_json (js : json) : (generic_args, string) result =
 and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
+    | `Assoc [ ("TraitImpl", trait_impl) ] ->
+        let* trait_impl = trait_impl_id_of_json trait_impl in
+        Ok (TraitImpl trait_impl)
+    | `Assoc [ ("Clause", clause) ] ->
+        let* clause = trait_clause_id_of_json clause in
+        Ok (Clause clause)
+    | `Assoc [ ("ParentClause", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = trait_instance_id_of_json x0 in
+        let* x1 = trait_decl_id_of_json x1 in
+        let* x2 = trait_clause_id_of_json x2 in
+        Ok (ParentClause (x0, x1, x2))
+    | `Assoc [ ("ItemClause", `List [ x0; x1; x2; x3 ]) ] ->
+        let* x0 = trait_instance_id_of_json x0 in
+        let* x1 = trait_decl_id_of_json x1 in
+        let* x2 = trait_item_name_of_json x2 in
+        let* x3 = trait_clause_id_of_json x3 in
+        Ok (ItemClause (x0, x1, x2, x3))
     | `String "SelfId" -> Ok Self
-    | `Assoc [ ("TraitImpl", id) ] ->
-        let* id = TraitImplId.id_of_json id in
-        Ok (TraitImpl id)
-    | `Assoc [ ("BuiltinOrAuto", id) ] ->
-        let* id = TraitDeclId.id_of_json id in
-        Ok (BuiltinOrAuto id)
-    | `Assoc [ ("Clause", id) ] ->
-        let* id = TraitClauseId.id_of_json id in
-        Ok (Clause id)
-    | `Assoc [ ("ParentClause", `List [ inst_id; decl_id; clause_id ]) ] ->
-        let* inst_id = trait_instance_id_of_json inst_id in
-        let* decl_id = TraitDeclId.id_of_json decl_id in
-        let* clause_id = TraitClauseId.id_of_json clause_id in
-        Ok (ParentClause (inst_id, decl_id, clause_id))
-    | `Assoc
-        [ ("ItemClause", `List [ inst_id; decl_id; item_name; clause_id ]) ] ->
-        let* inst_id = trait_instance_id_of_json inst_id in
-        let* decl_id = TraitDeclId.id_of_json decl_id in
-        let* item_name = string_of_json item_name in
-        let* clause_id = TraitClauseId.id_of_json clause_id in
-        Ok (ItemClause (inst_id, decl_id, item_name, clause_id))
-    | `Assoc [ ("FnPointer", ty) ] ->
-        let* ty = ty_of_json ty in
-        Ok (FnPointer ty)
-    | `Assoc [ ("Closure", `List [ fid; generics ]) ] ->
-        let* fid = FunDeclId.id_of_json fid in
-        let* generics = generic_args_of_json generics in
-        Ok (Closure (fid, generics))
-    | `Assoc [ ("Dyn", id) ] ->
-        let* id = TraitDeclId.id_of_json id in
-        Ok (Dyn id)
-    | `Assoc [ ("Unsolved", `List [ decl_id; generics ]) ] ->
-        let* decl_id = TraitDeclId.id_of_json decl_id in
-        let* generics = generic_args_of_json generics in
-        Ok (Unsolved (decl_id, generics))
-    | `Assoc [ ("Unknown", str) ] ->
-        let* str = string_of_json str in
-        Ok (UnknownTrait str)
+    | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
+        let* builtin_or_auto = trait_decl_id_of_json builtin_or_auto in
+        Ok (BuiltinOrAuto builtin_or_auto)
+    | `Assoc [ ("Dyn", dyn) ] ->
+        let* dyn = trait_decl_id_of_json dyn in
+        Ok (Dyn dyn)
+    | `Assoc [ ("Unknown", unknown) ] ->
+        let* unknown = string_of_json unknown in
+        Ok (UnknownTrait unknown)
     | _ -> Error "")
 
-let field_of_json (id_to_file : id_to_file_map) (js : json) :
+and field_of_json (id_to_file : id_to_file_map) (js : json) :
     (field, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -475,12 +490,12 @@ let field_of_json (id_to_file : id_to_file_map) (js : json) :
       ->
         let* span = span_of_json id_to_file span in
         let* attr_info = attr_info_of_json attr_info in
-        let* name = option_of_json string_of_json name in
-        let* ty = ty_of_json ty in
-        Ok { span; attr_info; field_name = name; field_ty = ty }
+        let* field_name = option_of_json string_of_json name in
+        let* field_ty = ty_of_json ty in
+        Ok { span; attr_info; field_name; field_ty }
     | _ -> Error "")
 
-let variant_of_json (id_to_file : id_to_file_map) (js : json) :
+and variant_of_json (id_to_file : id_to_file_map) (js : json) :
     (variant, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -494,29 +509,36 @@ let variant_of_json (id_to_file : id_to_file_map) (js : json) :
         ] ->
         let* span = span_of_json id_to_file span in
         let* attr_info = attr_info_of_json attr_info in
-        let* name = string_of_json name in
-        let* fields = list_of_json (field_of_json id_to_file) fields in
+        let* variant_name = string_of_json name in
+        let* fields =
+          vector_of_json field_id_of_json (field_of_json id_to_file) fields
+        in
         let* discriminant = scalar_value_of_json discriminant in
-        Ok { span; attr_info; variant_name = name; fields; discriminant }
+        Ok { span; attr_info; variant_name; fields; discriminant }
     | _ -> Error "")
 
-let type_decl_kind_of_json (id_to_file : id_to_file_map) (js : json) :
+and type_decl_kind_of_json (id_to_file : id_to_file_map) (js : json) :
     (type_decl_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Struct", fields) ] ->
-        let* fields = list_of_json (field_of_json id_to_file) fields in
-        Ok (Struct fields)
-    | `Assoc [ ("Enum", variants) ] ->
-        let* variants = list_of_json (variant_of_json id_to_file) variants in
-        Ok (Enum variants)
-    | `Assoc [ ("Alias", ty) ] ->
-        let* ty = ty_of_json ty in
-        Ok (Alias ty)
+    | `Assoc [ ("Struct", struct_) ] ->
+        let* struct_ =
+          vector_of_json field_id_of_json (field_of_json id_to_file) struct_
+        in
+        Ok (Struct struct_)
+    | `Assoc [ ("Enum", enum) ] ->
+        let* enum =
+          vector_of_json variant_id_of_json (variant_of_json id_to_file) enum
+        in
+        Ok (Enum enum)
     | `String "Opaque" -> Ok Opaque
+    | `Assoc [ ("Alias", alias) ] ->
+        let* alias = ty_of_json alias in
+        Ok (Alias alias)
     | _ -> Error "")
 
-let region_var_group_of_json (js : json) : (region_var_group, string) result =
+(* This is written by hand because the corresponding rust type does not exist. *)
+and region_var_group_of_json (js : json) : (region_var_group, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("regions", regions); ("parents", parents) ] ->
@@ -526,10 +548,10 @@ let region_var_group_of_json (js : json) : (region_var_group, string) result =
         Ok { id; regions; parents }
     | _ -> Error "")
 
-let region_var_groups_of_json (js : json) : (region_var_groups, string) result =
+and region_var_groups_of_json (js : json) : (region_var_groups, string) result =
   combine_error_msgs js __FUNCTION__ (list_of_json region_var_group_of_json js)
 
-let trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
+and trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_clause, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -541,44 +563,53 @@ let trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
           ("trait_id", trait_id);
           ("generics", generics);
         ] ->
-        let* clause_id = TraitClauseId.id_of_json clause_id in
+        let* clause_id = trait_clause_id_of_json clause_id in
         let* span = option_of_json (span_of_json id_to_file) span in
-        let* trait_id = TraitDeclId.id_of_json trait_id in
+        let* trait_id = trait_decl_id_of_json trait_id in
         let* clause_generics = generic_args_of_json generics in
-        Ok ({ clause_id; span; trait_id; clause_generics } : trait_clause)
+        Ok { clause_id; span; trait_id; clause_generics }
     | _ -> Error "")
 
-let region_outlives_of_json (js : json) : (region_outlives, string) result =
+and outlives_pred_of_json :
+      'a0 'a1.
+      (json -> ('a0, string) result) ->
+      (json -> ('a1, string) result) ->
+      json ->
+      (('a0, 'a1) outlives_pred, string) result =
+ fun arg0_of_json arg1_of_json js ->
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `List [ r0; r1 ] ->
-        let* r0 = region_of_json r0 in
-        let* r1 = region_of_json r1 in
-        Ok (r0, r1)
+    | `List [ x0; x1 ] ->
+        let* x0 = arg0_of_json x0 in
+        let* x1 = arg1_of_json x1 in
+        Ok (x0, x1)
     | _ -> Error "")
 
-let type_outlives_of_json (js : json) : (type_outlives, string) result =
+and region_outlives_of_json (js : json) : (region_outlives, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `List [ ty; r ] ->
-        let* ty = ty_of_json ty in
-        let* r = region_of_json r in
-        Ok (ty, r)
+    | x -> outlives_pred_of_json region_of_json region_of_json x
     | _ -> Error "")
 
-let trait_type_constraint_of_json (js : json) :
+and type_outlives_of_json (js : json) : (type_outlives, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> outlives_pred_of_json ty_of_json region_of_json x
+    | _ -> Error "")
+
+and trait_type_constraint_of_json (js : json) :
     (trait_type_constraint, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("trait_ref", trait_ref); ("type_name", type_name); ("ty", ty) ]
       ->
         let* trait_ref = trait_ref_of_json trait_ref in
-        let* type_name = string_of_json type_name in
+        let* type_name = trait_item_name_of_json type_name in
         let* ty = ty_of_json ty in
-        Ok ({ trait_ref; type_name; ty } : trait_type_constraint)
+        Ok { trait_ref; type_name; ty }
     | _ -> Error "")
 
-let generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
+and generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
     (generic_params, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -592,18 +623,31 @@ let generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
           ("types_outlive", types_outlive);
           ("trait_type_constraints", trait_type_constraints);
         ] ->
-        let* regions = list_of_json region_var_of_json regions in
-        let* types = list_of_json type_var_of_json types in
+        let* regions =
+          vector_of_json region_id_of_json region_var_of_json regions
+        in
+        let* types =
+          vector_of_json type_var_id_of_json type_var_of_json types
+        in
         let* const_generics =
-          list_of_json const_generic_var_of_json const_generics
+          vector_of_json const_generic_var_id_of_json const_generic_var_of_json
+            const_generics
         in
         let* trait_clauses =
-          list_of_json (trait_clause_of_json id_to_file) trait_clauses
+          vector_of_json trait_clause_id_of_json
+            (trait_clause_of_json id_to_file)
+            trait_clauses
         in
         let* regions_outlive =
-          list_of_json region_outlives_of_json regions_outlive
+          list_of_json
+            (outlives_pred_of_json region_of_json region_of_json)
+            regions_outlive
         in
-        let* types_outlive = list_of_json type_outlives_of_json types_outlive in
+        let* types_outlive =
+          list_of_json
+            (outlives_pred_of_json ty_of_json region_of_json)
+            types_outlive
+        in
         let* trait_type_constraints =
           list_of_json trait_type_constraint_of_json trait_type_constraints
         in
@@ -619,18 +663,18 @@ let generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
           }
     | _ -> Error "")
 
-let impl_elem_kind_of_json (js : json) : (impl_elem_kind, string) result =
+and impl_elem_kind_of_json (js : json) : (impl_elem_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Ty", ty) ] ->
         let* ty = ty_of_json ty in
         Ok (ImplElemTy ty)
-    | `Assoc [ ("Trait", tr) ] ->
-        let* tr = trait_decl_ref_of_json tr in
-        Ok (ImplElemTrait tr)
+    | `Assoc [ ("Trait", trait) ] ->
+        let* trait = trait_decl_ref_of_json trait in
+        Ok (ImplElemTrait trait)
     | _ -> Error "")
 
-let impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
+and impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
     (impl_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -640,31 +684,33 @@ let impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
           ("generics", generics);
           ("kind", kind);
         ] ->
-        let* disambiguator = Disambiguator.id_of_json disambiguator in
+        let* disambiguator = disambiguator_of_json disambiguator in
         let* generics = generic_params_of_json id_to_file generics in
         let* kind = impl_elem_kind_of_json kind in
         Ok { disambiguator; generics; kind }
     | _ -> Error "")
 
-let path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
+and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
     (path_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Ident", `List [ name; d ]) ] ->
-        let* name = string_of_json name in
-        let* d = Disambiguator.id_of_json d in
-        Ok (PeIdent (name, d))
+    | `Assoc [ ("Ident", `List [ x0; x1 ]) ] ->
+        let* x0 = string_of_json x0 in
+        let* x1 = disambiguator_of_json x1 in
+        Ok (PeIdent (x0, x1))
     | `Assoc [ ("Impl", impl) ] ->
-        let* d = impl_elem_of_json id_to_file impl in
-        Ok (PeImpl d)
+        let* impl = impl_elem_of_json id_to_file impl in
+        Ok (PeImpl impl)
     | _ -> Error "")
 
-let name_of_json (id_to_file : id_to_file_map) (js : json) :
+and name_of_json (id_to_file : id_to_file_map) (js : json) :
     (name, string) result =
   combine_error_msgs js __FUNCTION__
-    (list_of_json (path_elem_of_json id_to_file) js)
+    (match js with
+    | x -> list_of_json (path_elem_of_json id_to_file) x
+    | _ -> Error "")
 
-let item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
+and item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
     (item_meta, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -683,7 +729,7 @@ let item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
         Ok { span; name; attr_info; is_local }
     | _ -> Error "")
 
-let type_decl_of_json (id_to_file : id_to_file_map) (js : json) :
+and type_decl_of_json (id_to_file : id_to_file_map) (js : json) :
     (type_decl, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -694,177 +740,181 @@ let type_decl_of_json (id_to_file : id_to_file_map) (js : json) :
           ("generics", generics);
           ("kind", kind);
         ] ->
-        let* def_id = TypeDeclId.id_of_json def_id in
+        let* def_id = type_decl_id_of_json def_id in
         let* item_meta = item_meta_of_json id_to_file item_meta in
         let* generics = generic_params_of_json id_to_file generics in
         let* kind = type_decl_kind_of_json id_to_file kind in
         Ok { def_id; item_meta; generics; kind }
     | _ -> Error "")
 
-let var_of_json (js : json) : (var, string) result =
+and var_of_json (js : json) : (var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = VarId.id_of_json index in
-        let* name = string_option_of_json name in
+        let* index = var_id_of_json index in
+        let* name = option_of_json string_of_json name in
         let* var_ty = ty_of_json ty in
         Ok { index; name; var_ty }
     | _ -> Error "")
 
-let field_proj_kind_of_json (js : json) : (field_proj_kind, string) result =
+and field_proj_kind_of_json (js : json) : (field_proj_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("ProjAdt", `List [ def_id; opt_variant_id ]) ] ->
-        let* def_id = TypeDeclId.id_of_json def_id in
-        let* opt_variant_id =
-          option_of_json VariantId.id_of_json opt_variant_id
-        in
-        Ok (ProjAdt (def_id, opt_variant_id))
-    | `Assoc [ ("ProjTuple", i) ] ->
-        let* i = int_of_json i in
-        Ok (ProjTuple i)
+    | `Assoc [ ("Adt", `List [ x0; x1 ]) ] ->
+        let* x0 = type_decl_id_of_json x0 in
+        let* x1 = option_of_json variant_id_of_json x1 in
+        Ok (ProjAdt (x0, x1))
+    | `Assoc [ ("Tuple", tuple) ] ->
+        let* tuple = int_of_json tuple in
+        Ok (ProjTuple tuple)
     | _ -> Error "")
 
-let projection_elem_of_json (js : json) : (projection_elem, string) result =
+and projection_elem_of_json (js : json) : (projection_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Deref" -> Ok Deref
     | `String "DerefBox" -> Ok DerefBox
-    | `Assoc [ ("Field", `List [ proj_kind; field_id ]) ] ->
-        let* proj_kind = field_proj_kind_of_json proj_kind in
-        let* field_id = FieldId.id_of_json field_id in
-        Ok (Field (proj_kind, field_id))
-    | _ -> Error ("projection_elem_of_json failed on:" ^ show js))
+    | `Assoc [ ("Field", `List [ x0; x1 ]) ] ->
+        let* x0 = field_proj_kind_of_json x0 in
+        let* x1 = field_id_of_json x1 in
+        Ok (Field (x0, x1))
+    | _ -> Error "")
 
-let projection_of_json (js : json) : (projection, string) result =
-  combine_error_msgs js __FUNCTION__ (list_of_json projection_elem_of_json js)
+and projection_of_json (js : json) : (projection, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> list_of_json projection_elem_of_json x
+    | _ -> Error "")
 
-let place_of_json (js : json) : (place, string) result =
+and place_of_json (js : json) : (place, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("var_id", var_id); ("projection", projection) ] ->
-        let* var_id = VarId.id_of_json var_id in
-        let* projection = projection_of_json projection in
+        let* var_id = var_id_of_json var_id in
+        let* projection = list_of_json projection_elem_of_json projection in
         Ok { var_id; projection }
     | _ -> Error "")
 
-let borrow_kind_of_json (js : json) : (borrow_kind, string) result =
-  match js with
-  | `String "Shared" -> Ok BShared
-  | `String "Mut" -> Ok BMut
-  | `String "TwoPhaseMut" -> Ok BTwoPhaseMut
-  | `String "Shallow" -> Ok BShallow
-  | _ -> Error ("borrow_kind_of_json failed on:" ^ show js)
-
-let cast_kind_of_json (js : json) : (cast_kind, string) result =
+and borrow_kind_of_json (js : json) : (borrow_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Scalar", `List [ src_ty; tgt_ty ]) ] ->
-        let* src_ty = literal_type_of_json src_ty in
-        let* tgt_ty = literal_type_of_json tgt_ty in
-        Ok (CastScalar (src_ty, tgt_ty))
-    | `Assoc [ ("FnPtr", `List [ src_ty; tgt_ty ]) ] ->
-        let* src_ty = ty_of_json src_ty in
-        let* tgt_ty = ty_of_json tgt_ty in
-        Ok (CastFnPtr (src_ty, tgt_ty))
-    | `Assoc [ ("Unsize", `List [ src_ty; tgt_ty ]) ] ->
-        let* src_ty = ty_of_json src_ty in
-        let* tgt_ty = ty_of_json tgt_ty in
-        Ok (CastUnsize (src_ty, tgt_ty))
+    | `String "Shared" -> Ok BShared
+    | `String "Mut" -> Ok BMut
+    | `String "TwoPhaseMut" -> Ok BTwoPhaseMut
+    | `String "Shallow" -> Ok BShallow
     | _ -> Error "")
 
-let unop_of_json (js : json) : (unop, string) result =
+and cast_kind_of_json (js : json) : (cast_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Scalar", `List [ x0; x1 ]) ] ->
+        let* x0 = literal_type_of_json x0 in
+        let* x1 = literal_type_of_json x1 in
+        Ok (CastScalar (x0, x1))
+    | `Assoc [ ("FnPtr", `List [ x0; x1 ]) ] ->
+        let* x0 = ty_of_json x0 in
+        let* x1 = ty_of_json x1 in
+        Ok (CastFnPtr (x0, x1))
+    | `Assoc [ ("Unsize", `List [ x0; x1 ]) ] ->
+        let* x0 = ty_of_json x0 in
+        let* x1 = ty_of_json x1 in
+        Ok (CastUnsize (x0, x1))
+    | _ -> Error "")
+
+and unop_of_json (js : json) : (unop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Not" -> Ok Not
     | `String "Neg" -> Ok Neg
-    | `Assoc [ ("Cast", cast_kind) ] ->
-        let* cast_kind = cast_kind_of_json cast_kind in
-        Ok (Cast cast_kind)
+    | `Assoc [ ("Cast", cast) ] ->
+        let* cast = cast_kind_of_json cast in
+        Ok (Cast cast)
     | _ -> Error "")
 
-let binop_of_json (js : json) : (binop, string) result =
-  match js with
-  | `String "BitXor" -> Ok BitXor
-  | `String "BitAnd" -> Ok BitAnd
-  | `String "BitOr" -> Ok BitOr
-  | `String "Eq" -> Ok Eq
-  | `String "Lt" -> Ok Lt
-  | `String "Le" -> Ok Le
-  | `String "Ne" -> Ok Ne
-  | `String "Ge" -> Ok Ge
-  | `String "Gt" -> Ok Gt
-  | `String "Div" -> Ok Div
-  | `String "Rem" -> Ok Rem
-  | `String "Add" -> Ok Add
-  | `String "Sub" -> Ok Sub
-  | `String "Mul" -> Ok Mul
-  | `String "CheckedAdd" -> Ok CheckedAdd
-  | `String "CheckedSub" -> Ok CheckedSub
-  | `String "CheckedMul" -> Ok CheckedMul
-  | `String "Shl" -> Ok Shl
-  | `String "Shr" -> Ok Shr
-  | _ -> Error ("binop_of_json failed on:" ^ show js)
-
-let literal_of_json (js : json) : (literal, string) result =
+and binop_of_json (js : json) : (binop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Scalar", scalar_value) ] ->
-        let* scalar_value = scalar_value_of_json scalar_value in
-        Ok (VScalar scalar_value)
-    | `Assoc [ ("Bool", v) ] ->
-        let* v = bool_of_json v in
-        Ok (VBool v)
-    | `Assoc [ ("Char", v) ] ->
-        let* v = char_of_json v in
-        Ok (VChar v)
-    | `Assoc [ ("Str", v) ] ->
-        let* v = string_of_json v in
-        Ok (VStr v)
-    | `Assoc [ ("ByteStr", v) ] ->
-        let* v = list_of_json int_of_json v in
-        Ok (VByteStr v)
+    | `String "BitXor" -> Ok BitXor
+    | `String "BitAnd" -> Ok BitAnd
+    | `String "BitOr" -> Ok BitOr
+    | `String "Eq" -> Ok Eq
+    | `String "Lt" -> Ok Lt
+    | `String "Le" -> Ok Le
+    | `String "Ne" -> Ok Ne
+    | `String "Ge" -> Ok Ge
+    | `String "Gt" -> Ok Gt
+    | `String "Div" -> Ok Div
+    | `String "Rem" -> Ok Rem
+    | `String "Add" -> Ok Add
+    | `String "Sub" -> Ok Sub
+    | `String "Mul" -> Ok Mul
+    | `String "CheckedAdd" -> Ok CheckedAdd
+    | `String "CheckedSub" -> Ok CheckedSub
+    | `String "CheckedMul" -> Ok CheckedMul
+    | `String "Shl" -> Ok Shl
+    | `String "Shr" -> Ok Shr
     | _ -> Error "")
 
-let assumed_fun_id_of_json (js : json) : (assumed_fun_id, string) result =
-  match js with
-  | `String "BoxNew" -> Ok BoxNew
-  | `String "BoxFree" -> Ok BoxFree
-  | `String "ArrayIndexShared" -> Ok ArrayIndexShared
-  | `String "ArrayIndexMut" -> Ok ArrayIndexMut
-  | `String "ArrayToSliceShared" -> Ok ArrayToSliceShared
-  | `String "ArrayToSliceMut" -> Ok ArrayToSliceMut
-  | `String "ArrayRepeat" -> Ok ArrayRepeat
-  | `String "SliceIndexShared" -> Ok SliceIndexShared
-  | `String "SliceIndexMut" -> Ok SliceIndexMut
-  | _ -> Error ("assumed_fun_id_of_json failed on:" ^ show js)
-
-let fun_id_of_json (js : json) : (fun_id, string) result =
+and literal_of_json (js : json) : (literal, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Regular", id) ] ->
-        let* id = FunDeclId.id_of_json id in
-        Ok (FRegular id)
-    | `Assoc [ ("Assumed", fid) ] ->
-        let* fid = assumed_fun_id_of_json fid in
-        Ok (FAssumed fid)
+    | `Assoc [ ("Scalar", scalar) ] ->
+        let* scalar = scalar_value_of_json scalar in
+        Ok (VScalar scalar)
+    | `Assoc [ ("Bool", bool_) ] ->
+        let* bool_ = bool_of_json bool_ in
+        Ok (VBool bool_)
+    | `Assoc [ ("Char", char_) ] ->
+        let* char_ = char_of_json char_ in
+        Ok (VChar char_)
+    | `Assoc [ ("ByteStr", byte_str) ] ->
+        let* byte_str = list_of_json int_of_json byte_str in
+        Ok (VByteStr byte_str)
+    | `Assoc [ ("Str", str) ] ->
+        let* str = string_of_json str in
+        Ok (VStr str)
     | _ -> Error "")
 
-let fun_id_or_trait_method_ref_of_json (js : json) :
+and assumed_fun_id_of_json (js : json) : (assumed_fun_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "BoxNew" -> Ok BoxNew
+    | `String "BoxFree" -> Ok BoxFree
+    | `String "ArrayIndexShared" -> Ok ArrayIndexShared
+    | `String "ArrayIndexMut" -> Ok ArrayIndexMut
+    | `String "ArrayToSliceShared" -> Ok ArrayToSliceShared
+    | `String "ArrayToSliceMut" -> Ok ArrayToSliceMut
+    | `String "ArrayRepeat" -> Ok ArrayRepeat
+    | `String "SliceIndexShared" -> Ok SliceIndexShared
+    | `String "SliceIndexMut" -> Ok SliceIndexMut
+    | _ -> Error "")
+
+and fun_id_of_json (js : json) : (fun_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Regular", regular) ] ->
+        let* regular = fun_decl_id_of_json regular in
+        Ok (FRegular regular)
+    | `Assoc [ ("Assumed", assumed) ] ->
+        let* assumed = assumed_fun_id_of_json assumed in
+        Ok (FAssumed assumed)
+    | _ -> Error "")
+
+and fun_id_or_trait_method_ref_of_json (js : json) :
     (fun_id_or_trait_method_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Fun", id) ] ->
-        let* id = fun_id_of_json id in
-        Ok (FunId id)
-    | `Assoc [ ("Trait", `List [ trait_ref; method_name; fun_decl_id ]) ] ->
-        let* trait_ref = trait_ref_of_json trait_ref in
-        let* method_name = string_of_json method_name in
-        let* fun_decl_id = FunDeclId.id_of_json fun_decl_id in
-        Ok (TraitMethod (trait_ref, method_name, fun_decl_id))
+    | `Assoc [ ("Fun", fun_) ] ->
+        let* fun_ = fun_id_of_json fun_ in
+        Ok (FunId fun_)
+    | `Assoc [ ("Trait", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = trait_ref_of_json x0 in
+        let* x1 = trait_item_name_of_json x1 in
+        let* x2 = fun_decl_id_of_json x2 in
+        Ok (TraitMethod (x0, x1, x2))
     | _ -> Error "")
 
-let fn_ptr_of_json (js : json) : (fn_ptr, string) result =
+and fn_ptr_of_json (js : json) : (fn_ptr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("func", func); ("generics", generics) ] ->
@@ -873,18 +923,18 @@ let fn_ptr_of_json (js : json) : (fn_ptr, string) result =
         Ok { func; generics }
     | _ -> Error "")
 
-let fn_operand_of_json (js : json) : (fn_operand, string) result =
+and fn_operand_of_json (js : json) : (fn_operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Regular", func) ] ->
-        let* func = fn_ptr_of_json func in
-        Ok (FnOpRegular func)
-    | `Assoc [ ("Move", p) ] ->
-        let* p = place_of_json p in
-        Ok (FnOpMove p)
+    | `Assoc [ ("Regular", regular) ] ->
+        let* regular = fn_ptr_of_json regular in
+        Ok (FnOpRegular regular)
+    | `Assoc [ ("Move", move) ] ->
+        let* move = place_of_json move in
+        Ok (FnOpMove move)
     | _ -> Error "")
 
-let rec constant_expr_of_json (js : json) : (constant_expr, string) result =
+and constant_expr_of_json (js : json) : (constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("value", value); ("ty", ty) ] ->
@@ -896,96 +946,92 @@ let rec constant_expr_of_json (js : json) : (constant_expr, string) result =
 and raw_constant_expr_of_json (js : json) : (raw_constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Literal", lit) ] ->
-        let* lit = literal_of_json lit in
-        Ok (CLiteral lit)
-    | `Assoc [ ("Var", vid) ] ->
-        let* vid = ConstGenericVarId.id_of_json vid in
-        Ok (CVar vid)
-    | `Assoc [ ("TraitConst", `List [ trait_ref; const_name ]) ] ->
-        let* trait_ref = trait_ref_of_json trait_ref in
-        let* const_name = string_of_json const_name in
-        Ok (CTraitConst (trait_ref, const_name))
+    | `Assoc [ ("Literal", literal) ] ->
+        let* literal = literal_of_json literal in
+        Ok (CLiteral literal)
+    | `Assoc [ ("TraitConst", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_ref_of_json x0 in
+        let* x1 = trait_item_name_of_json x1 in
+        Ok (CTraitConst (x0, x1))
+    | `Assoc [ ("Var", var) ] ->
+        let* var = const_generic_var_id_of_json var in
+        Ok (CVar var)
     | `Assoc [ ("FnPtr", fn_ptr) ] ->
         let* fn_ptr = fn_ptr_of_json fn_ptr in
         Ok (CFnPtr fn_ptr)
     | _ -> Error "")
 
-let operand_of_json (js : json) : (operand, string) result =
+and operand_of_json (js : json) : (operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Copy", place) ] ->
-        let* place = place_of_json place in
-        Ok (Copy place)
-    | `Assoc [ ("Move", place) ] ->
-        let* place = place_of_json place in
-        Ok (Move place)
-    | `Assoc [ ("Const", cv) ] ->
-        let* cv = constant_expr_of_json cv in
-        Ok (Constant cv)
+    | `Assoc [ ("Copy", copy) ] ->
+        let* copy = place_of_json copy in
+        Ok (Copy copy)
+    | `Assoc [ ("Move", move) ] ->
+        let* move = place_of_json move in
+        Ok (Move move)
+    | `Assoc [ ("Const", const) ] ->
+        let* const = constant_expr_of_json const in
+        Ok (Constant const)
     | _ -> Error "")
 
-let aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
+and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Adt", `List [ id; opt_variant_id; generics ]) ] ->
-        let* id = type_id_of_json id in
-        let* opt_variant_id =
-          option_of_json VariantId.id_of_json opt_variant_id
-        in
-        let* generics = generic_args_of_json generics in
-        Ok (AggregatedAdt (id, opt_variant_id, generics))
-    | `Assoc [ ("Array", `List [ ty; cg ]) ] ->
-        let* ty = ty_of_json ty in
-        let* cg = const_generic_of_json cg in
-        Ok (AggregatedArray (ty, cg))
-    | `Assoc [ ("Closure", `List [ fid; generics ]) ] ->
-        let* fid = FunDeclId.id_of_json fid in
-        let* generics = generic_args_of_json generics in
-        Ok (AggregatedClosure (fid, generics))
+    | `Assoc [ ("Adt", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = type_id_of_json x0 in
+        let* x1 = option_of_json variant_id_of_json x1 in
+        let* x2 = generic_args_of_json x2 in
+        Ok (AggregatedAdt (x0, x1, x2))
+    | `Assoc [ ("Array", `List [ x0; x1 ]) ] ->
+        let* x0 = ty_of_json x0 in
+        let* x1 = const_generic_of_json x1 in
+        Ok (AggregatedArray (x0, x1))
+    | `Assoc [ ("Closure", `List [ x0; x1 ]) ] ->
+        let* x0 = fun_decl_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (AggregatedClosure (x0, x1))
     | _ -> Error "")
 
-let rvalue_of_json (js : json) : (rvalue, string) result =
+and rvalue_of_json (js : json) : (rvalue, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Use", op) ] ->
-        let* op = operand_of_json op in
-        Ok (Use op)
-    | `Assoc [ ("Ref", `List [ place; borrow_kind ]) ] ->
-        let* place = place_of_json place in
-        let* borrow_kind = borrow_kind_of_json borrow_kind in
-        Ok (RvRef (place, borrow_kind))
-    | `Assoc [ ("UnaryOp", `List [ unop; op ]) ] ->
-        let* unop = unop_of_json unop in
-        let* op = operand_of_json op in
-        Ok (UnaryOp (unop, op))
-    | `Assoc [ ("BinaryOp", `List [ binop; op1; op2 ]) ] ->
-        let* binop = binop_of_json binop in
-        let* op1 = operand_of_json op1 in
-        let* op2 = operand_of_json op2 in
-        Ok (BinaryOp (binop, op1, op2))
-    | `Assoc [ ("Discriminant", `List [ place; adt_id ]) ] ->
-        let* place = place_of_json place in
-        let* adt_id = TypeDeclId.id_of_json adt_id in
-        Ok (Discriminant (place, adt_id))
-    | `Assoc [ ("Global", `List [ gid; generics ]) ] ->
-        let* gid = GlobalDeclId.id_of_json gid in
-        let* generics = generic_args_of_json generics in
-        Ok (Global (gid, generics) : rvalue)
-    | `Assoc [ ("Len", `List [ place; ty; const_generics ]) ] ->
-        let* place = place_of_json place in
-        let* ty = ty_of_json ty in
-        let* const_generics =
-          option_of_json const_generic_of_json const_generics
-        in
-        Ok (Len (place, ty, const_generics) : rvalue)
-    | `Assoc [ ("Aggregate", `List [ aggregate_kind; ops ]) ] ->
-        let* aggregate_kind = aggregate_kind_of_json aggregate_kind in
-        let* ops = list_of_json operand_of_json ops in
-        Ok (Aggregate (aggregate_kind, ops))
+    | `Assoc [ ("Use", use) ] ->
+        let* use = operand_of_json use in
+        Ok (Use use)
+    | `Assoc [ ("Ref", `List [ x0; x1 ]) ] ->
+        let* x0 = place_of_json x0 in
+        let* x1 = borrow_kind_of_json x1 in
+        Ok (RvRef (x0, x1))
+    | `Assoc [ ("UnaryOp", `List [ x0; x1 ]) ] ->
+        let* x0 = unop_of_json x0 in
+        let* x1 = operand_of_json x1 in
+        Ok (UnaryOp (x0, x1))
+    | `Assoc [ ("BinaryOp", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = binop_of_json x0 in
+        let* x1 = operand_of_json x1 in
+        let* x2 = operand_of_json x2 in
+        Ok (BinaryOp (x0, x1, x2))
+    | `Assoc [ ("Discriminant", `List [ x0; x1 ]) ] ->
+        let* x0 = place_of_json x0 in
+        let* x1 = type_decl_id_of_json x1 in
+        Ok (Discriminant (x0, x1))
+    | `Assoc [ ("Aggregate", `List [ x0; x1 ]) ] ->
+        let* x0 = aggregate_kind_of_json x0 in
+        let* x1 = list_of_json operand_of_json x1 in
+        Ok (Aggregate (x0, x1))
+    | `Assoc [ ("Global", `List [ x0; x1 ]) ] ->
+        let* x0 = global_decl_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (Global (x0, x1))
+    | `Assoc [ ("Len", `List [ x0; x1; x2 ]) ] ->
+        let* x0 = place_of_json x0 in
+        let* x1 = ty_of_json x1 in
+        let* x2 = option_of_json const_generic_of_json x2 in
+        Ok (Len (x0, x1, x2))
     | _ -> Error "")
 
-let params_info_of_json (js : json) : (params_info, string) result =
+and params_info_of_json (js : json) : (params_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -1019,7 +1065,7 @@ let params_info_of_json (js : json) : (params_info, string) result =
           }
     | _ -> Error "")
 
-let closure_kind_of_json (js : json) : (closure_kind, string) result =
+and closure_kind_of_json (js : json) : (closure_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Fn" -> Ok Fn
@@ -1027,7 +1073,7 @@ let closure_kind_of_json (js : json) : (closure_kind, string) result =
     | `String "FnOnce" -> Ok FnOnce
     | _ -> Error "")
 
-let closure_info_of_json (js : json) : (closure_info, string) result =
+and closure_info_of_json (js : json) : (closure_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("kind", kind); ("state", state) ] ->
@@ -1036,7 +1082,7 @@ let closure_info_of_json (js : json) : (closure_info, string) result =
         Ok { kind; state }
     | _ -> Error "")
 
-let fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
+and fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
     (fun_sig, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1053,7 +1099,6 @@ let fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
         let* is_unsafe = bool_of_json is_unsafe in
         let* is_closure = bool_of_json is_closure in
         let* closure_info = option_of_json closure_info_of_json closure_info in
-
         let* generics = generic_params_of_json id_to_file generics in
         let* parent_params_info =
           option_of_json params_info_of_json parent_params_info
@@ -1072,7 +1117,7 @@ let fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
           }
     | _ -> Error "")
 
-let call_of_json (js : json) : (call, string) result =
+and call_of_json (js : json) : (call, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("func", func); ("args", args); ("dest", dest) ] ->
@@ -1082,9 +1127,13 @@ let call_of_json (js : json) : (call, string) result =
         Ok { func; args; dest }
     | _ -> Error "")
 
-let gexpr_body_of_json (body_of_json : json -> ('body, string) result)
-    (id_to_file : id_to_file_map) (js : json) :
-    ('body gexpr_body, string) result =
+and gexpr_body_of_json :
+      'a0.
+      (json -> ('a0, string) result) ->
+      id_to_file_map ->
+      json ->
+      ('a0 gexpr_body, string) result =
+ fun arg0_of_json id_to_file js ->
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -1096,12 +1145,12 @@ let gexpr_body_of_json (body_of_json : json -> ('body, string) result)
         ] ->
         let* span = span_of_json id_to_file span in
         let* arg_count = int_of_json arg_count in
-        let* locals = list_of_json var_of_json locals in
-        let* body = body_of_json body in
+        let* locals = vector_of_json var_id_of_json var_of_json locals in
+        let* body = arg0_of_json body in
         Ok { span; arg_count; locals; body }
     | _ -> Error "")
 
-let item_kind_of_json (js : json) : (item_kind, string) result =
+and item_kind_of_json (js : json) : (item_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Regular" -> Ok RegularKind
@@ -1112,23 +1161,23 @@ let item_kind_of_json (js : json) : (item_kind, string) result =
               [
                 ("impl_id", impl_id);
                 ("trait_id", trait_id);
-                ("item_name", method_name);
+                ("item_name", item_name);
                 ("provided", provided);
               ] );
         ] ->
-        let* impl_id = TraitImplId.id_of_json impl_id in
-        let* trait_id = TraitDeclId.id_of_json trait_id in
-        let* method_name = string_of_json method_name in
+        let* impl_id = trait_impl_id_of_json impl_id in
+        let* trait_id = trait_decl_id_of_json trait_id in
+        let* item_name = trait_item_name_of_json item_name in
         let* provided = bool_of_json provided in
-        Ok (TraitItemImpl (impl_id, trait_id, method_name, provided))
-    | `Assoc [ ("TraitItemDecl", `List [ trait_id; item_name ]) ] ->
-        let* trait_id = TraitDeclId.id_of_json trait_id in
-        let* item_name = string_of_json item_name in
-        Ok (TraitItemDecl (trait_id, item_name))
-    | `Assoc [ ("TraitItemProvided", `List [ trait_id; item_name ]) ] ->
-        let* trait_id = TraitDeclId.id_of_json trait_id in
-        let* item_name = string_of_json item_name in
-        Ok (TraitItemProvided (trait_id, item_name))
+        Ok (TraitItemImpl (impl_id, trait_id, item_name, provided))
+    | `Assoc [ ("TraitItemDecl", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_decl_id_of_json x0 in
+        let* x1 = trait_item_name_of_json x1 in
+        Ok (TraitItemDecl (x0, x1))
+    | `Assoc [ ("TraitItemProvided", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_decl_id_of_json x0 in
+        let* x1 = trait_item_name_of_json x1 in
+        Ok (TraitItemProvided (x0, x1))
     | _ -> Error "")
 
 let maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
@@ -1142,6 +1191,7 @@ let maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
     | `Assoc [ ("Err", `Null) ] -> Ok None
     | _ -> Error "")
 
+(* This is written by hand because the corresponding rust type is not type-generic. *)
 let gfun_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) : ('body gfun_decl, string) result
     =
@@ -1197,7 +1247,7 @@ let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
         Ok global
     | _ -> Error "")
 
-let trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
+and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_decl, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1212,35 +1262,38 @@ let trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
           ("required_methods", required_methods);
           ("provided_methods", provided_methods);
         ] ->
-        let* def_id = TraitDeclId.id_of_json def_id in
+        let* def_id = trait_decl_id_of_json def_id in
         let* item_meta = item_meta_of_json id_to_file item_meta in
         let* generics = generic_params_of_json id_to_file generics in
         let* parent_clauses =
-          list_of_json (trait_clause_of_json id_to_file) parent_clauses
+          vector_of_json trait_clause_id_of_json
+            (trait_clause_of_json id_to_file)
+            parent_clauses
         in
         let* consts =
           list_of_json
-            (pair_of_json string_of_json
-               (pair_of_json ty_of_json
-                  (option_of_json GlobalDeclId.id_of_json)))
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json ty_of_json (option_of_json global_decl_id_of_json)))
             consts
         in
         let* types =
           list_of_json
-            (pair_of_json string_of_json
+            (pair_of_json trait_item_name_of_json
                (pair_of_json
-                  (list_of_json (trait_clause_of_json id_to_file))
+                  (vector_of_json trait_clause_id_of_json
+                     (trait_clause_of_json id_to_file))
                   (option_of_json ty_of_json)))
             types
         in
         let* required_methods =
           list_of_json
-            (pair_of_json string_of_json FunDeclId.id_of_json)
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
             required_methods
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json string_of_json (option_of_json FunDeclId.id_of_json))
+            (pair_of_json trait_item_name_of_json
+               (option_of_json fun_decl_id_of_json))
             provided_methods
         in
         Ok
@@ -1256,7 +1309,7 @@ let trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
           }
     | _ -> Error "")
 
-let trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
+and trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_impl, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1272,55 +1325,64 @@ let trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
           ("required_methods", required_methods);
           ("provided_methods", provided_methods);
         ] ->
-        let* def_id = TraitImplId.id_of_json def_id in
+        let* def_id = trait_impl_id_of_json def_id in
         let* item_meta = item_meta_of_json id_to_file item_meta in
         let* impl_trait = trait_decl_ref_of_json impl_trait in
         let* generics = generic_params_of_json id_to_file generics in
         let* parent_trait_refs =
-          list_of_json trait_ref_of_json parent_trait_refs
+          vector_of_json trait_clause_id_of_json trait_ref_of_json
+            parent_trait_refs
         in
         let* consts =
           list_of_json
-            (pair_of_json string_of_json
-               (pair_of_json ty_of_json GlobalDeclId.id_of_json))
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json ty_of_json global_decl_id_of_json))
             consts
         in
         let* types =
           list_of_json
-            (pair_of_json string_of_json
+            (pair_of_json trait_item_name_of_json
                (pair_of_json (list_of_json trait_ref_of_json) ty_of_json))
             types
         in
-        let methods_of_json =
-          list_of_json (pair_of_json string_of_json FunDeclId.id_of_json)
+        let* required_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            required_methods
         in
-        let* required_methods = methods_of_json required_methods in
-        let* provided_methods = methods_of_json provided_methods in
+        let* provided_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            provided_methods
+        in
         Ok
-          ({
-             def_id;
-             item_meta;
-             impl_trait;
-             generics;
-             parent_trait_refs;
-             consts;
-             types;
-             required_methods;
-             provided_methods;
-           }
-            : trait_impl)
+          {
+            def_id;
+            item_meta;
+            impl_trait;
+            generics;
+            parent_trait_refs;
+            consts;
+            types;
+            required_methods;
+            provided_methods;
+          }
     | _ -> Error "")
 
-let g_declaration_group_of_json (id_of_json : json -> ('id, string) result)
-    (js : json) : ('id g_declaration_group, string) result =
+and g_declaration_group_of_json :
+      'a0.
+      (json -> ('a0, string) result) ->
+      json ->
+      ('a0 g_declaration_group, string) result =
+ fun arg0_of_json js ->
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("NonRec", id) ] ->
-        let* id = id_of_json id in
-        Ok (NonRecGroup id)
-    | `Assoc [ ("Rec", ids) ] ->
-        let* ids = list_of_json id_of_json ids in
-        Ok (RecGroup ids)
+    | `Assoc [ ("NonRec", non_rec) ] ->
+        let* non_rec = arg0_of_json non_rec in
+        Ok (NonRecGroup non_rec)
+    | `Assoc [ ("Rec", rec_) ] ->
+        let* rec_ = list_of_json arg0_of_json rec_ in
+        Ok (RecGroup rec_)
     | _ -> Error "")
 
 let type_declaration_group_of_json (js : json) :
@@ -1333,6 +1395,7 @@ let fun_declaration_group_of_json (js : json) :
   combine_error_msgs js __FUNCTION__
     (g_declaration_group_of_json FunDeclId.id_of_json js)
 
+(* This is written by hand because we assert non-recursivity. *)
 let global_declaration_group_of_json (js : json) :
     (GlobalDeclId.id, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1401,9 +1464,3 @@ let declaration_group_of_json (js : json) : (declaration_group, string) result =
         let* id = mixed_group_of_json decl in
         Ok (MixedGroup id)
     | _ -> Error "")
-
-let length_of_json_list (js : json) : (int, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `List jsl -> Ok (List.length jsl)
-    | _ -> Error ("not a list: " ^ show js))

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -56,6 +56,7 @@ type attribute =
   | AttrRename of string
   | AttrUnknown of string
   | AttrVariantsPrefix of string
+  | AttrVariantsSuffix of string
 [@@deriving show, ord]
 
 type attr_info = {

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -51,7 +51,11 @@ type inline_attr =
 [@@deriving show, ord]
 
 (** Attribute (`#[...]`). **)
-type attribute = AttrOpaque | AttrRename of string | AttrUnknown of string
+type attribute =
+  | AttrOpaque
+  | AttrRename of string
+  | AttrUnknown of string
+  | AttrVariantsPrefix of string
 [@@deriving show, ord]
 
 type attr_info = {

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -17,6 +17,8 @@ module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
 module BodyId = IdGen ()
 
+type ('a, 'b) outlives_pred = 'a * 'b
+
 (** We define this type to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
@@ -199,6 +201,7 @@ type const_generic =
       }]
 
 type trait_item_name = string [@@deriving show, ord]
+type existential_predicate = unit [@@deriving show, ord]
 
 (** Ancestor for iter visitor for {!type: Types.ty} *)
 class ['self] iter_ty_base =

--- a/charon-ml/src/dune
+++ b/charon-ml/src/dune
@@ -44,19 +44,11 @@
  (package charon))
 
 (env
- (dev
+ (_
   (flags
    :standard
    -safe-string
    -g
    ;-dsource
-   -warn-error
-   -5@8-11-14-33-20-21-26-27-39))
- (release
-  (flags
-   :standard
-   -safe-string
-   -g
-   ;-dsource
-   -warn-error
+   -w
    -5@8-11-14-33-20-21-26-27-39)))

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "convert_case 0.6.0",
  "derivative",
  "derive-visitor",
  "env_logger",
@@ -241,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,7 +301,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427b39a85fecafea16b1a5f3f50437151022e35eb4fe038107f08adbf7f8def6"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
@@ -1254,6 +1264,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -55,6 +55,7 @@ macros = { path = "./macros" }
 
 [dev-dependencies]
 assert_cmd = "2.0"
+convert_case = "0.6.0"
 ignore = "0.4"
 indoc = "2"
 libtest-mimic = "0.7"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/Charon.toml
+++ b/charon/Charon.toml
@@ -1,0 +1,10 @@
+[charon]
+opaque_modules = [
+    "cli_options",
+    "common",
+    "deps_errors",
+    "ids",
+    "logger",
+    "pretty",
+    "translate",
+]

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -1,6 +1,5 @@
 //! This file groups everything which is linked to implementations about [crate::expressions]
 use crate::expressions::*;
-use crate::values::*;
 use std::vec::Vec;
 
 impl Place {

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -39,6 +39,7 @@ pub struct Var {
     /// through desugaring.
     pub name: Option<String>,
     /// The variable type
+    #[charon::rename("var_ty")]
     pub ty: Ty,
 }
 
@@ -50,6 +51,7 @@ pub struct Opaque;
 /// TODO: arg_count should be stored in GFunDecl below. But then,
 ///       the print is obfuscated and Aeneas may need some refactoring.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[charon::rename("GexprBody")]
 pub struct GExprBody<T> {
     pub span: Span,
     /// The number of local variables used for the input arguments.
@@ -119,6 +121,7 @@ pub enum Body {
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut, PartialEq, Eq)]
 pub enum ItemKind {
     /// A "normal" function
+    #[charon::rename("RegularKind")]
     Regular,
     /// Trait item implementation
     TraitItemImpl {
@@ -300,6 +303,7 @@ pub struct TraitImpl {
 /// It either designates a top-level function, or a place in case
 /// we are using function pointers stored in local variables.
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[charon::variants_prefix("FnOp")]
 pub enum FnOperand {
     /// Regular case: call to a top-level function, trait method, etc.
     Regular(FnPtr),

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -5,7 +5,6 @@ use crate::ids::Vector;
 use crate::llbc_ast;
 use crate::types::*;
 use crate::ullbc_ast;
-use crate::values::*;
 
 /// Makes a lambda that generates a new variable id, pushes a new variable in
 /// the body locals with the given type and returns its id.

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -126,8 +126,18 @@ pub enum InlineAttr {
     DriveMut,
 )]
 pub enum Attribute {
+    /// Do not translate the body of this item.
+    /// Written `#[charon::opaque]`
     Opaque,
+    /// Provide a new name that consumers of the llbc can use.
+    /// Written `#[charon::rename("new_name")]`
     Rename(String),
+    /// For enums only: rename the variants by pre-pending their names with the given prefix.
+    /// Written `#[charon::variants_prefix("prefix_")]`.
+    VariantsPrefix(String),
+    /// Same as `VariantsPrefix`, but appends to the name instead of pre-pending.
+    VariantsSuffix(String),
+    /// A non-charon-specific attribute.
     Unknown(String),
 }
 
@@ -138,9 +148,9 @@ pub struct AttrInfo {
     pub attributes: Vec<Attribute>,
     /// Inline hints (on functions only).
     pub inline: Option<InlineAttr>,
-    /// The name specified with the `#[charon::rename("...")]` attribute, if any. This provides a
-    /// custom name that can be used by consumers of llbc. E.g. Aeneas uses this to rename
-    /// definitions in the extracted code.
+    /// The name computed from `charon::rename` and `charon::variants_prefix` attributes, if any.
+    /// This provides a custom name that can be used by consumers of llbc. E.g. Aeneas uses this to
+    /// rename definitions in the extracted code.
     pub rename: Option<String>,
     /// Whether this item is declared public. Impl blocks and closures don't have visibility
     /// modifiers; we arbitrarily set this to `false` for them.

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -125,6 +125,7 @@ pub enum InlineAttr {
     Drive,
     DriveMut,
 )]
+#[charon::variants_prefix("Attr")]
 pub enum Attribute {
     /// Do not translate the body of this item.
     /// Written `#[charon::opaque]`
@@ -222,6 +223,7 @@ pub struct ItemMeta {
     ///
     /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
     /// declared opaque via a command-line argument.
+    #[charon::opaque]
     pub opacity: ItemOpacity,
 }
 
@@ -240,5 +242,6 @@ pub enum FileName {
     #[drive(skip)] // drive is not implemented for `PathBuf`
     Local(PathBuf),
     /// A "not real" file name (macro, query, etc.)
+    #[charon::opaque]
     NotReal(String),
 }

--- a/charon/src/ast/meta_utils.rs
+++ b/charon/src/ast/meta_utils.rs
@@ -1,5 +1,6 @@
 //! This file groups everything which is linked to implementations about [crate::meta]
 use crate::meta::*;
+use crate::names::{Disambiguator, Name, PathElem};
 use hax_frontend_exporter as hax;
 use rustc_ast::{AttrArgs, NormalAttr};
 use rustc_hir::def_id::DefId;
@@ -287,5 +288,15 @@ impl ItemOpacity {
 
     pub(crate) fn with_private_contents(self) -> Self {
         self.with_content_visibility(false)
+    }
+}
+
+impl ItemMeta {
+    pub fn renamed_name(&self) -> Name {
+        let mut name = self.name.clone();
+        if let Some(rename) = self.attr_info.rename.clone() {
+            *name.name.last_mut().unwrap() = PathElem::Ident(rename, Disambiguator::new(0));
+        }
+        name
     }
 }

--- a/charon/src/ast/meta_utils.rs
+++ b/charon/src/ast/meta_utils.rs
@@ -238,6 +238,32 @@ impl Attribute {
 
                 Ok(Self::Rename(attr.to_string()))
             }
+            // `#[charon::variants_prefix("T")]`
+            "variants_prefix" if let Some(attr) = args => {
+                let Some(attr) = attr
+                    .strip_prefix("\"")
+                    .and_then(|attr| attr.strip_suffix("\""))
+                else {
+                    return Err(format!(
+                        "the name should be between quotes: `variants_prefix(\"{attr}\")`."
+                    ));
+                };
+
+                Ok(Self::VariantsPrefix(attr.to_string()))
+            }
+            // `#[charon::variants_suffix("T")]`
+            "variants_suffix" if let Some(attr) = args => {
+                let Some(attr) = attr
+                    .strip_prefix("\"")
+                    .and_then(|attr| attr.strip_suffix("\""))
+                else {
+                    return Err(format!(
+                        "the name should be between quotes: `variants_suffix(\"{attr}\")`."
+                    ));
+                };
+
+                Ok(Self::VariantsSuffix(attr.to_string()))
+            }
             _ => {
                 let full_attr = rustc_ast_pretty::pprust::State::to_string(|s| {
                     s.print_attr_item(&normal_attr.item, span)

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -1,17 +1,26 @@
+#[charon::opaque]
 pub mod assumed;
 pub mod expressions;
+#[charon::opaque]
 pub mod expressions_utils;
 pub mod gast;
+#[charon::opaque]
 pub mod gast_utils;
 pub mod llbc_ast;
+#[charon::opaque]
 pub mod llbc_ast_utils;
 pub mod meta;
+#[charon::opaque]
 pub mod meta_utils;
 pub mod names;
+#[charon::opaque]
 pub mod names_utils;
 pub mod types;
+#[charon::opaque]
 pub mod types_utils;
 pub mod ullbc_ast;
+#[charon::opaque]
 pub mod ullbc_ast_utils;
 pub mod values;
+#[charon::opaque]
 pub mod values_utils;

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -10,6 +10,7 @@ generate_index_type!(Disambiguator);
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut, EnumIsA, EnumAsGetters,
 )]
+#[charon::variants_prefix("Pe")]
 pub enum PathElem {
     Ident(String, Disambiguator),
     Impl(ImplElem),
@@ -33,6 +34,7 @@ pub struct ImplElem {
 ///   ```
 /// We distinguish the two.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[charon::variants_prefix("ImplElem")]
 pub enum ImplElemKind {
     Ty(Ty),
     /// Remark: the first type argument in the trait ref gives the type for

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -91,6 +91,7 @@ pub struct DeBruijnId {
     Drive,
     DriveMut,
 )]
+#[charon::variants_prefix("R")]
 pub enum Region {
     /// Static region
     Static,
@@ -120,6 +121,7 @@ pub enum Region {
     /// Erased region
     Erased,
     /// For error reporting.
+    #[charon::opaque]
     Unknown,
 }
 
@@ -215,6 +217,7 @@ pub enum TraitInstanceId {
     /// we start with the other clauses (in particular, the local clauses). It
     /// is useful to give priority to the local clauses when solving the trait
     /// obligations which are fullfilled by the trait parameters.
+    #[charon::rename("Self")]
     SelfId,
 
     /// A specific builtin trait implementation like [core::marker::Sized] or
@@ -225,6 +228,7 @@ pub enum TraitInstanceId {
     Dyn(TraitDeclId),
 
     /// For error reporting.
+    #[charon::rename("UnknownTrait")]
     Unknown(String),
 }
 
@@ -248,7 +252,9 @@ pub struct TraitRef {
 /// The substitution is: `[String, bool]`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitDeclRef {
+    #[charon::rename("trait_decl_id")]
     pub trait_id: TraitDeclId,
+    #[charon::rename("decl_generics")]
     pub generics: GenericArgs,
 }
 
@@ -344,11 +350,13 @@ pub struct TraitClause {
     pub span: Option<Span>,
     /// Where the predicate was written, relative to the item that requires it.
     #[derivative(PartialEq = "ignore")]
+    #[charon::opaque]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.
     pub trait_id: TraitDeclId,
     /// The generics applied to the trait. Note: this includes the `Self` type.
     /// Remark: the trait refs list in the [generics] field should be empty.
+    #[charon::rename("clause_generics")]
     pub generics: GenericArgs,
 }
 
@@ -435,6 +443,7 @@ pub enum TypeDeclKind {
     Alias(Ty),
     /// Used if an error happened during the extraction, and we don't panic
     /// on error.
+    #[charon::opaque]
     Error(String),
 }
 
@@ -442,6 +451,7 @@ pub enum TypeDeclKind {
 pub struct Variant {
     pub span: Span,
     pub attr_info: AttrInfo,
+    #[charon::rename("variant_name")]
     pub name: String,
     pub fields: Vector<FieldId, Field>,
     /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
@@ -453,7 +463,9 @@ pub struct Variant {
 pub struct Field {
     pub span: Span,
     pub attr_info: AttrInfo,
+    #[charon::rename("field_name")]
     pub name: Option<String>,
+    #[charon::rename("field_ty")]
     pub ty: Ty,
 }
 
@@ -473,6 +485,7 @@ pub struct Field {
     Ord,
     PartialOrd,
 )]
+#[charon::rename("IntegerType")]
 pub enum IntegerTy {
     Isize,
     I8,
@@ -504,6 +517,7 @@ pub enum IntegerTy {
     Ord,
     PartialOrd,
 )]
+#[charon::variants_prefix("R")]
 pub enum RefKind {
     Mut,
     Shared,
@@ -529,11 +543,13 @@ pub enum RefKind {
     Ord,
     PartialOrd,
 )]
+#[charon::variants_prefix("T")]
 pub enum TypeId {
     /// A "regular" ADT type.
     ///
     /// Includes transparent ADTs and opaque ADTs (local ADTs marked as opaque,
     /// and external ADTs).
+    #[charon::rename("TAdtId")]
     Adt(TypeDeclId),
     Tuple,
     /// Assumed type. Either a primitive type like array or slice, or a
@@ -565,6 +581,8 @@ pub enum TypeId {
     Ord,
     PartialOrd,
 )]
+#[charon::rename("LiteralType")]
+#[charon::variants_prefix("T")]
 pub enum LiteralTy {
     Integer(IntegerTy),
     Bool,
@@ -589,6 +607,7 @@ pub enum LiteralTy {
     Ord,
     PartialOrd,
 )]
+#[charon::variants_prefix("Cg")]
 pub enum ConstGeneric {
     /// A global constant
     Global(GlobalDeclId),
@@ -615,6 +634,7 @@ pub enum ConstGeneric {
     Drive,
     DriveMut,
 )]
+#[charon::variants_prefix("T")]
 pub enum Ty {
     /// An ADT.
     /// Note that here ADTs are very general. They can be:
@@ -624,6 +644,7 @@ pub enum Ty {
     /// The information on the nature of the ADT is stored in (`TypeId`)[TypeId].
     /// The last list is used encode const generics, e.g., the size of an array
     Adt(TypeId, GenericArgs),
+    #[charon::rename("TVar")]
     TypeVar(TypeVarId),
     Literal(LiteralTy),
     /// The never type, for computations which don't return. It is sometimes
@@ -697,13 +718,16 @@ pub enum Ty {
     Ord,
     PartialOrd,
 )]
+#[charon::variants_prefix("T")]
 pub enum AssumedTy {
     /// Boxes have a special treatment: we translate them as identity.
     Box,
     /// Comes from the standard library. See the comments for [Ty::RawPtr]
     /// as to why we have this here.
+    #[charon::opaque]
     PtrUnique,
     /// Same comments as for [AssumedTy::PtrUnique]
+    #[charon::opaque]
     PtrNonNull,
     /// Primitive type
     Array,

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -441,3 +441,37 @@ impl TySubst {
         Ok(s)
     }
 }
+
+impl Field {
+    /// The new name for this field, as suggested by the `#[charon::rename]` attribute.
+    pub fn renamed_name(&self) -> Option<&str> {
+        self.attr_info.rename.as_deref().or(self.name.as_deref())
+    }
+
+    /// Whether this field has a `#[charon::opaque]` annotation.
+    pub fn is_opaque(&self) -> bool {
+        self.attr_info
+            .attributes
+            .iter()
+            .any(|attr| attr.is_opaque())
+    }
+}
+
+impl Variant {
+    /// The new name for this variant, as suggested by the `#[charon::rename]` and
+    /// `#[charon::variants_prefix]` attributes.
+    pub fn renamed_name(&self) -> &str {
+        self.attr_info
+            .rename
+            .as_deref()
+            .unwrap_or(self.name.as_ref())
+    }
+
+    /// Whether this variant has a `#[charon::opaque]` annotation.
+    pub fn is_opaque(&self) -> bool {
+        self.attr_info
+            .attributes
+            .iter()
+            .any(|attr| attr.is_opaque())
+    }
+}

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -33,6 +33,7 @@ generate_index_type!(VarId, "");
     PartialOrd,
     Ord,
 )]
+#[charon::variants_prefix("V")]
 pub enum Literal {
     Scalar(ScalarValue),
     Bool(bool),

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -224,10 +224,8 @@ fn main() {
             // Standard rust panic error code.
             std::process::exit(101);
         }
-        Err(CharonFailure::RustcError(_) | CharonFailure::Serialize) => {
-            assert!(!errors_as_warnings);
-            let msg = format!("The extraction encountered {} errors", error_count);
-            log::error!("{}", msg);
+        Err(err @ (CharonFailure::RustcError(_) | CharonFailure::Serialize)) => {
+            log::error!("{err}");
             std::process::exit(1);
         }
     }

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -36,6 +36,7 @@ pub struct CrateData {
 }
 
 impl CrateData {
+    #[charon::opaque]
     pub fn new(ctx: &TransformCtx) -> Self {
         // Transform the map file id -> file into a vector.
         // Sort the vector to make the serialized file as stable as possible.
@@ -71,6 +72,7 @@ impl CrateData {
 
     /// Export the translated definitions to a JSON file.
     #[allow(clippy::result_unit_err)]
+    #[charon::opaque]
     pub fn serialize_to_file(&self, target_filename: &Path) -> Result<(), ()> {
         // Create the directory, if necessary (note that if the target directory
         // is not specified, there is no need to create it: otherwise we

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -87,7 +87,7 @@ where
     }
 
     /// Iter over the nonempty slots.
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> impl Iterator<Item = &T> + Clone {
         self.vector.iter().flat_map(|opt| opt.as_ref())
     }
 

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -24,6 +24,9 @@
 #![feature(let_chains)]
 #![feature(lint_reasons)]
 #![feature(trait_alias)]
+#![feature(register_tool)]
+// For when we use charon on itself :3
+#![register_tool(charon)]
 
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -393,7 +393,7 @@ impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
                         def_id.to_pretty_string(),
                         variant_id.to_pretty_string()
                     ),
-                    Some(def) => {
+                    Some(def) if def.kind.is_enum() => {
                         let variants = def.kind.as_enum();
                         let mut name = def.item_meta.name.fmt_with_ctx(self);
                         let variant_name = &variants.get(variant_id).unwrap().name;
@@ -401,6 +401,7 @@ impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
                         name.push_str(variant_name);
                         name
                     }
+                    _ => format!("__unknown_variant"),
                 }
             }
         }
@@ -463,7 +464,7 @@ impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
                                 None => field_id.to_string(),
                             }
                         }
-                        _ => unreachable!(),
+                        _ => format!("__unknown_field"),
                     },
                 }
             }

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -8,7 +8,6 @@ use crate::expressions::*;
 use crate::llbc_ast::{ExprBody, FunDecl, GlobalDecl, Opaque, RawStatement, Statement};
 use crate::transform::TransformCtx;
 use crate::types::*;
-use crate::values::*;
 
 use super::ctx::LlbcPass;
 

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -1,19 +1,35 @@
+#[charon::opaque]
 pub mod ctx;
+#[charon::opaque]
 pub mod graphs;
+#[charon::opaque]
 pub mod index_to_function_calls;
+#[charon::opaque]
 pub mod inline_local_panic_functions;
+#[charon::opaque]
 pub mod insert_assign_return_unit;
+#[charon::opaque]
 pub mod ops_to_function_calls;
+#[charon::opaque]
 pub mod reconstruct_asserts;
+#[charon::opaque]
 pub mod remove_arithmetic_overflow_checks;
+#[charon::opaque]
 pub mod remove_drop_never;
+#[charon::opaque]
 pub mod remove_dynamic_checks;
+#[charon::opaque]
 pub mod remove_nops;
+#[charon::opaque]
 pub mod remove_read_discriminant;
+#[charon::opaque]
 pub mod remove_unused_locals;
 pub mod reorder_decls;
+#[charon::opaque]
 pub mod simplify_constants;
+#[charon::opaque]
 pub mod ullbc_to_llbc;
+#[charon::opaque]
 pub mod update_closure_signatures;
 
 pub use ctx::TransformCtx;

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -21,6 +21,7 @@ use std::vec::Vec;
 #[derive(
     Debug, Clone, VariantIndexArity, VariantName, EnumAsGetters, EnumIsA, Serialize, Deserialize,
 )]
+#[charon::variants_suffix("Group")]
 pub enum GDeclarationGroup<Id> {
     /// A non-recursive declaration
     NonRec(Id),
@@ -32,6 +33,7 @@ pub enum GDeclarationGroup<Id> {
 #[derive(
     Debug, Clone, VariantIndexArity, VariantName, EnumAsGetters, EnumIsA, Serialize, Deserialize,
 )]
+#[charon::variants_suffix("Group")]
 pub enum DeclarationGroup {
     /// A type declaration group
     Type(GDeclarationGroup<TypeDeclId>),

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -638,23 +638,14 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// encodes them as attributes). For now we use `String`s for `Attributes`.
     pub(crate) fn translate_attribute(&mut self, attr: &rustc_ast::Attribute) -> Option<Attribute> {
         use rustc_ast::ast::AttrKind;
-        use rustc_ast_pretty::pprust;
         match &attr.kind {
-            AttrKind::Normal(normal_attr) => {
-                // Use `pprust` to render the attribute somewhat like it is written in the source.
-                // WARNING: this can change whitespace, and soetimes even adds newlines. Maybe we
-                // should use spans and SourceMap info instead.
-                use pprust::PrintState;
-                let s =
-                    pprust::State::to_string(|s| s.print_attr_item(&normal_attr.item, attr.span));
-                match Attribute::parse(s) {
-                    Ok(a) => Some(a),
-                    Err(msg) => {
-                        self.span_err(attr.span, &format!("Error parsing attribute: {msg}"));
-                        None
-                    }
+            AttrKind::Normal(normal_attr) => match Attribute::parse(&normal_attr, attr.span) {
+                Ok(a) => Some(a),
+                Err(msg) => {
+                    self.span_err(attr.span, &format!("Error parsing attribute: {msg}"));
+                    None
                 }
-            }
+            },
             AttrKind::DocComment(..) => None,
         }
     }

--- a/charon/src/translate/translate_ctx.rs
+++ b/charon/src/translate/translate_ctx.rs
@@ -121,6 +121,8 @@ impl DepSource {
     Drive,
     DriveMut,
 )]
+#[charon::rename("AnyDeclId")]
+#[charon::variants_prefix("Id")]
 pub enum AnyTransId {
     Type(TypeDeclId),
     Fun(FunDeclId),

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -501,6 +501,8 @@ fn rename_attribute() -> Result<(), Box<dyn Error>> {
         type Test = i32;
 
         #[charon::rename("VariantsTest")]
+        #[charon::variants_prefix("Simple")]
+        #[charon::variants_suffix("_")]
         enum SimpleEnum {
             #[charon::rename("Variant1")]
             FirstVariant,
@@ -578,11 +580,12 @@ fn rename_attribute() -> Result<(), Box<dyn Error>> {
     );
 
     assert_eq!(
-        crate_data.types[1].kind.as_enum()[0]
-            .attr_info
-            .rename
-            .as_deref(),
-        Some("Variant1")
+        crate_data.types[1].kind.as_enum()[0].renamed_name(),
+        "Variant1"
+    );
+    assert_eq!(
+        crate_data.types[1].kind.as_enum()[1].renamed_name(),
+        "SimpleSecondVariant_"
     );
 
     assert_eq!(

--- a/charon/tests/generate-ml.rs
+++ b/charon/tests/generate-ml.rs
@@ -1,0 +1,467 @@
+#![cfg(test)]
+//! Generate ocaml deserialization code for our types.
+//!
+//! This test runs charon on itself and generates the appropriate `<type>_of_json` functions for
+//! our types. The generated functions are inserted into `./generated-ml/GAstOfJson.template.ml` to
+//! construct the final `GAstOfJson.ml`.
+//!
+//! Note: this test is ignored by default because running charon on itself is slow. To run it, call
+//! `cargo test --test generate-ml -- --ignored`. It is also run by `make generate-ml` in the crate
+//! root. Don't forget to format the output code after regenerating.
+use anyhow::{bail, Result};
+use assert_cmd::cargo::CommandCargoExt;
+use charon_lib::export::CrateData;
+use charon_lib::meta::ItemMeta;
+use charon_lib::names::{Name, PathElem};
+use charon_lib::types::{
+    AssumedTy, Field, LiteralTy, Ty, TypeDecl, TypeDeclId, TypeDeclKind, TypeId,
+};
+use convert_case::{Case, Casing};
+use derive_visitor::Drive;
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::fs;
+use std::fs::File;
+use std::io::BufReader;
+use std::process::Command;
+
+/// `Name` is a complex datastructure; to inspect it we serialize it a little bit.
+fn repr_name(_crate_data: &CrateData, n: &Name) -> String {
+    n.name
+        .iter()
+        .map(|path_elem| match path_elem {
+            PathElem::Ident(i, _) => i.clone(),
+            PathElem::Impl(_) => "<impl>".to_string(),
+        })
+        .join("::")
+}
+
+fn make_ocaml_ident(name: &str) -> String {
+    let mut name = name.to_case(Case::Snake);
+    if matches!(
+        &*name,
+        "virtual" | "bool" | "char" | "struct" | "type" | "let" | "fun" | "open" | "rec"
+    ) {
+        name += "_";
+    }
+    name
+}
+fn type_name_to_ocaml_ident(item_meta: &ItemMeta) -> String {
+    let name = item_meta
+        .attr_info
+        .rename
+        .as_ref()
+        .unwrap_or(item_meta.name.name.last().unwrap().as_ident().0);
+    make_ocaml_ident(name)
+}
+
+/// Traverse all types to figure out which ones transitively contain the given id.
+fn contains_id(crate_data: &CrateData, haystack: TypeDeclId) -> HashMap<TypeDeclId, bool> {
+    enum ContainsRawSpan {
+        Yes,
+        No,
+        Processing,
+    }
+    use ContainsRawSpan::*;
+    fn traverse_ty(
+        crate_data: &CrateData,
+        ty: &TypeDecl,
+        map: &mut HashMap<TypeDeclId, ContainsRawSpan>,
+    ) -> bool {
+        match map.get(&ty.def_id) {
+            Some(Yes) => return true,
+            Some(No | Processing) => return false,
+            None => {}
+        }
+        map.insert(ty.def_id, Processing);
+        let mut contains = false;
+        ty.drive(&mut derive_visitor::visitor_enter_fn(|id: &TypeDeclId| {
+            if let Some(ty) = crate_data.types.iter().find(|ty| ty.def_id == *id) {
+                if traverse_ty(crate_data, ty, map) {
+                    contains = true;
+                }
+            }
+        }));
+        map.insert(ty.def_id, if contains { Yes } else { No });
+        contains
+    }
+    let mut map = HashMap::new();
+    map.insert(haystack, Yes);
+    for ty in &crate_data.types {
+        traverse_ty(crate_data, ty, &mut map);
+    }
+    map.into_iter()
+        .map(|(id, x)| (id, matches!(x, Yes)))
+        .collect()
+}
+
+struct GenerateCtx {
+    crate_data: CrateData,
+    contains_raw_span: HashMap<TypeDeclId, bool>,
+}
+
+/// Converts a type to the appropriate `*_of_json` call. In case of generics, this combines several
+/// functions, e.g. `list_of_json bool_of_json`.
+fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
+    match ty {
+        Ty::Literal(LiteralTy::Bool) => "bool_of_json".to_string(),
+        Ty::Literal(LiteralTy::Char) => "char_of_json".to_string(),
+        Ty::Literal(LiteralTy::Integer(_)) => "int_of_json".to_string(),
+        Ty::Adt(adt_kind, generics) => {
+            let mut expr = Vec::new();
+            let mut types = generics.types.as_slice();
+            match adt_kind {
+                TypeId::Adt(id) => {
+                    let adt: &TypeDecl = &ctx.crate_data.types[id.index()];
+                    let mut first = type_name_to_ocaml_ident(&adt.item_meta);
+                    if first == "vec" {
+                        first = "list".to_string();
+                        types = &types[0..1]; // Remove the allocator generic param
+                    }
+                    expr.push(first + "_of_json");
+                }
+                TypeId::Assumed(AssumedTy::Box) => {
+                    types = &types[0..1]; // Remove the allocator generic param
+                }
+                TypeId::Tuple => {
+                    let name = match types.len() {
+                        2 => "pair_of_json".to_string(),
+                        3 => "triple_of_json".to_string(),
+                        len => format!("tuple_{len}_of_json"),
+                    };
+                    expr.push(name);
+                }
+                _ => unimplemented!("{ty:?}"),
+            }
+            for ty in types {
+                expr.push(type_to_ocaml_call(ctx, ty))
+            }
+            if let TypeId::Adt(id) = adt_kind {
+                if *ctx.contains_raw_span.get(&id).unwrap() {
+                    expr.push("id_to_file".to_string())
+                }
+            }
+            expr.into_iter().map(|f| format!("({f})")).join(" ")
+        }
+        Ty::TypeVar(var_id) => format!("arg{}_of_json", var_id.index()),
+        // Ty::Ref(_, _, _) => todo!(),
+        _ => unimplemented!("{ty:?}"),
+    }
+}
+
+fn convert_vars<'a>(ctx: &GenerateCtx, fields: impl IntoIterator<Item = &'a Field>) -> String {
+    fields
+        .into_iter()
+        .filter(|f| !f.is_opaque())
+        .map(|f| {
+            let name = f.name.as_deref().unwrap();
+            let rename = f.renamed_name().unwrap();
+            let convert = type_to_ocaml_call(ctx, &f.ty);
+            format!("let* {rename} = {convert} {name} in")
+        })
+        .join("\n")
+}
+
+fn build_branch<'a>(
+    ctx: &GenerateCtx,
+    pat: &str,
+    fields: impl IntoIterator<Item = &'a Field>,
+    construct: &str,
+) -> String {
+    let convert = convert_vars(ctx, fields);
+    format!("| {pat} -> {convert} Ok ({construct})")
+}
+
+fn build_function(ctx: &GenerateCtx, decl: &TypeDecl, branches: &str) -> String {
+    let ty_name = type_name_to_ocaml_ident(&decl.item_meta);
+    let contains_raw_span = *ctx.contains_raw_span.get(&decl.def_id).unwrap();
+    let signature = if decl.generics.types.is_empty() {
+        let id_to_file = if contains_raw_span {
+            "(id_to_file : id_to_file_map) "
+        } else {
+            ""
+        };
+        format!("{ty_name}_of_json {id_to_file}(js : json) : ({ty_name}, string) result =")
+    } else {
+        let types = &decl.generics.types;
+        let gen_vars_space = types
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("'a{i}"))
+            .join(" ");
+        let gen_vars_comma = types
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("'a{i}"))
+            .join(", ");
+
+        let mut args = Vec::new();
+        let mut ty_args = Vec::new();
+        for (i, _) in types.iter().enumerate() {
+            args.push(format!("arg{i}_of_json"));
+            ty_args.push(format!("(json -> ('a{i}, string) result)"));
+        }
+        if contains_raw_span {
+            args.push("id_to_file".to_string());
+            ty_args.push("id_to_file_map".to_string());
+        }
+        args.push("js".to_string());
+        ty_args.push("json".to_string());
+
+        let ty_args = ty_args.into_iter().join(" -> ");
+        let args = args.into_iter().join(" ");
+        let fun_ty =
+            format!("{gen_vars_space}. {ty_args} -> (({gen_vars_comma}) {ty_name}, string) result");
+        format!("{ty_name}_of_json : {fun_ty} = fun {args} ->")
+    };
+    format!(
+        r#"
+        and {signature}
+          combine_error_msgs js __FUNCTION__
+            (match js with{branches} | _ -> Error "")
+        "#
+    )
+}
+
+fn type_decl_to_json_deserializer(ctx: &GenerateCtx, decl: &TypeDecl) -> String {
+    let branches = match &decl.kind {
+        TypeDeclKind::Struct(fields) if fields.is_empty() => {
+            build_branch(ctx, "`Null", fields, "()")
+        }
+        TypeDeclKind::Struct(fields)
+            if fields.len() == 1
+                && decl
+                    .item_meta
+                    .attr_info
+                    .attributes
+                    .iter()
+                    .any(|a| a.is_unknown() && a.as_unknown() == "serde(transparent)") =>
+        {
+            let ty = &fields[0].ty;
+            let call = type_to_ocaml_call(ctx, ty);
+            format!("| x -> {call} x")
+        }
+        TypeDeclKind::Alias(ty) => {
+            let call = type_to_ocaml_call(ctx, ty);
+            format!("| x -> {call} x")
+        }
+        TypeDeclKind::Struct(fields) if fields.iter().all(|f| f.name.is_none()) => {
+            let mut fields = fields.clone();
+            for (i, f) in fields.iter_mut().enumerate() {
+                f.name = Some(format!("x{i}"));
+            }
+            let pat: String = fields.iter().map(|f| f.name.as_deref().unwrap()).join(";");
+            let pat = format!("`List [ {pat} ]");
+            let construct = fields.iter().map(|f| f.renamed_name().unwrap()).join(", ");
+            let construct = format!("( {construct} )");
+            build_branch(ctx, &pat, &fields, &construct)
+        }
+        TypeDeclKind::Struct(fields) => {
+            let pat: String = fields
+                .iter()
+                .map(|f| {
+                    let name = f.name.as_ref().unwrap();
+                    let var = if f.is_opaque() { "_" } else { name };
+                    format!("(\"{name}\", {var});")
+                })
+                .join("\n");
+            let pat = format!("`Assoc [ {pat} ]");
+            let construct = fields
+                .iter()
+                .filter(|f| !f.is_opaque())
+                .map(|f| f.renamed_name().unwrap())
+                .join("; ");
+            let construct = format!("{{ {construct} }}");
+            build_branch(ctx, &pat, fields, &construct)
+        }
+        TypeDeclKind::Enum(variants) => {
+            variants
+                .iter()
+                .filter(|v| !v.is_opaque())
+                .map(|variant| {
+                    let name = &variant.name;
+                    let rename = variant.renamed_name();
+                    if variant.fields.is_empty() {
+                        // Unit variant
+                        let pat = format!("`String \"{name}\"");
+                        build_branch(ctx, &pat, &variant.fields, rename)
+                    } else {
+                        let mut fields = variant.fields.clone();
+                        let inner_pat = if fields.iter().all(|f| f.name.is_none()) {
+                            // Tuple variant
+                            if variant.fields.len() == 1 {
+                                let var = make_ocaml_ident(&variant.name);
+                                fields[0].name = Some(var.clone());
+                                var
+                            } else {
+                                for (i, f) in fields.iter_mut().enumerate() {
+                                    f.name = Some(format!("x{i}"));
+                                }
+                                let pat =
+                                    fields.iter().map(|f| f.name.as_ref().unwrap()).join("; ");
+                                format!("`List [ {pat} ]")
+                            }
+                        } else {
+                            // Struct variant
+                            let pat = fields
+                                .iter()
+                                .map(|f| {
+                                    let name = f.name.as_ref().unwrap();
+                                    let var = if f.is_opaque() { "_" } else { name };
+                                    format!("(\"{name}\", {var});")
+                                })
+                                .join(" ");
+                            format!("`Assoc [ {pat} ]")
+                        };
+                        let pat = format!("`Assoc [ (\"{name}\", {inner_pat}) ]");
+                        let construct_fields =
+                            fields.iter().map(|f| f.name.as_ref().unwrap()).join(", ");
+                        let construct = format!("{rename} ({construct_fields})");
+                        build_branch(ctx, &pat, &fields, &construct)
+                    }
+                })
+                .join("\n")
+        }
+        TypeDeclKind::Opaque => todo!(),
+        TypeDeclKind::Error(_) => todo!(),
+    };
+    build_function(ctx, decl, &branches)
+}
+
+#[test]
+// Test is ignored by default. See the top for how to run it.
+#[ignore]
+fn generate_ml() -> Result<()> {
+    let charon_llbc = "tests/generated-ml/charon-itself.llbc";
+    const RUN_CHARON: bool = true;
+    if RUN_CHARON {
+        // Call charon on itself
+        let mut cmd = Command::cargo_bin("charon")?;
+        cmd.arg("--cargo-arg=--lib");
+        cmd.arg("--errors-as-warnings");
+        cmd.arg("--dest-file");
+        cmd.arg(charon_llbc);
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8(output.stderr.clone())?;
+            bail!("Compilation failed: {stderr}")
+        }
+    }
+
+    let crate_data: CrateData = {
+        let file = File::open(charon_llbc)?;
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader)?
+    };
+
+    let mut ctx = GenerateCtx {
+        crate_data,
+        contains_raw_span: Default::default(),
+    };
+
+    let mut name_to_type: HashMap<String, &TypeDecl> = Default::default();
+    for ty in &ctx.crate_data.types {
+        let long_name = repr_name(&ctx.crate_data, &ty.item_meta.name);
+        if long_name.starts_with("charon_lib") {
+            let short_name = ty.item_meta.name.name.last().unwrap().as_ident().0.clone();
+            name_to_type.insert(short_name, ty);
+        }
+        name_to_type.insert(long_name, ty);
+    }
+    let raw_span = name_to_type.get("RawSpan").unwrap();
+    ctx.contains_raw_span = contains_id(&ctx.crate_data, raw_span.def_id);
+
+    let names: &[&[&str]] = &[
+        &[
+            "Span",
+            "InlineAttr",
+            "Attribute",
+            "AttrInfo",
+            "TypeVar",
+            "RegionVar",
+            "Region",
+            "IntegerTy",
+            "LiteralTy",
+            "ConstGenericVar",
+            "RefKind",
+            "AssumedTy",
+            "TypeId",
+        ],
+        &[
+            "ConstGeneric",
+            "Ty",
+            "ExistentialPredicate",
+            "TraitRef",
+            "TraitDeclRef",
+            "GenericArgs",
+            "TraitInstanceId",
+            "Field",
+            "Variant",
+            "TypeDeclKind",
+        ],
+        &["Loc"],
+        &["FileId", "FileName"],
+        &[
+            "TraitClause",
+            "OutlivesPred",
+            "RegionOutlives",
+            "TypeOutlives",
+            "TraitTypeConstraint",
+            "GenericParams",
+            "ImplElemKind",
+            "ImplElem",
+            "PathElem",
+            "Name",
+            "ItemMeta",
+            "TypeDecl",
+            "Var",
+            "FieldProjKind",
+            "ProjectionElem",
+            "Projection",
+            "Place",
+            "BorrowKind",
+            "CastKind",
+            "UnOp",
+            "BinOp",
+            "Literal",
+            "AssumedFunId",
+            "FunId",
+            "FunIdOrTraitMethodRef",
+            "FnPtr",
+            "FnOperand",
+            "ConstantExpr",
+            "RawConstantExpr",
+            "Operand",
+            "AggregateKind",
+            "Rvalue",
+            "ParamsInfo",
+            "ClosureKind",
+            "ClosureInfo",
+            "FunSig",
+            "Call",
+            "GExprBody",
+            "ItemKind",
+        ],
+        &["TraitDecl", "TraitImpl", "GDeclarationGroup"],
+    ];
+    let mut template = fs::read_to_string("./tests/generated-ml/GAstOfJson.template.ml")?;
+    for (i, names) in names.iter().enumerate() {
+        let generated = names
+            .iter()
+            .map(|name| {
+                type_decl_to_json_deserializer(
+                    &ctx,
+                    name_to_type
+                        .get(*name)
+                        .expect(&format!("Name not found: `{name}`")),
+                )
+            })
+            .join("\n");
+        let placeholder = format!("(* __REPLACE{i}__ *)");
+        template = template.replace(&placeholder, &generated);
+    }
+
+    fs::write("./tests/generated-ml/GAstOfJson.ml", template)?;
+    Ok(())
+}

--- a/charon/tests/generated-ml/GAstOfJson.ml
+++ b/charon/tests/generated-ml/GAstOfJson.ml
@@ -1,0 +1,1 @@
+../../../charon-ml/src/GAstOfJson.ml

--- a/charon/tests/generated-ml/GAstOfJson.template.ml
+++ b/charon/tests/generated-ml/GAstOfJson.template.ml
@@ -1,0 +1,343 @@
+(** WARNING: this file is partially auto-generated. `GAstOfJson.template.ml`
+    contains the manual definitions and some `(* __REPLACEn__ *)` comments.
+    These comments are replaced by auto-generated definitions by the
+    `generate-ml` rust test. That test is ignored by default. To re-generate
+    the files, call `make generate-ml` in the crate root. Do not edit
+    `GAstOfJson` by hand. *)
+
+(** Functions to load (U)LLBC ASTs from json.
+
+    Initially, we used [ppx_derive_yojson] to automate this.
+    However, [ppx_derive_yojson] expects formatting to be slightly
+    different from what [serde_rs] generates (because it uses [Yojson.Safe.t]
+    and not [Yojson.Basic.t]).
+
+    TODO: we should check all that the integer values are in the proper range
+ *)
+
+open Yojson.Basic
+open OfJsonBasic
+open Identifiers
+open Meta
+open Values
+open Types
+open Scalars
+open Expressions
+open GAst
+module LocalFileId = IdGen ()
+module VirtualFileId = IdGen ()
+
+(** The default logger *)
+let log = Logging.llbc_of_json_logger
+
+(** A file identifier *)
+type file_id = LocalId of LocalFileId.id | VirtualId of VirtualFileId.id
+[@@deriving show, ord]
+
+module OrderedIdToFile : Collections.OrderedType with type t = file_id = struct
+  type t = file_id
+
+  let compare fid0 fid1 = compare_file_id fid0 fid1
+
+  let to_string id =
+    match id with
+    | LocalId id -> "Local " ^ LocalFileId.to_string id
+    | VirtualId id -> "Virtual " ^ VirtualFileId.to_string id
+
+  let pp_t fmt x = Format.pp_print_string fmt (to_string x)
+  let show_t x = to_string x
+end
+
+module IdToFile = Collections.MakeMap (OrderedIdToFile)
+
+type id_to_file_map = file_name IdToFile.t
+
+let de_bruijn_id_of_json = int_of_json
+let path_buf_of_json = string_of_json
+let trait_item_name_of_json = string_of_json
+let vector_of_json _ = list_of_json
+
+let const_generic_var_id_of_json = ConstGenericVarId.id_of_json
+let disambiguator_of_json = Disambiguator.id_of_json
+let field_id_of_json = FieldId.id_of_json
+let fun_decl_id_of_json = FunDeclId.id_of_json
+let global_decl_id_of_json = GlobalDeclId.id_of_json
+let local_file_id_of_json = LocalFileId.id_of_json
+let region_id_of_json = RegionVarId.id_of_json
+let trait_clause_id_of_json = TraitClauseId.id_of_json
+let trait_decl_id_of_json = TraitDeclId.id_of_json
+let trait_impl_id_of_json = TraitImplId.id_of_json
+let type_decl_id_of_json = TypeDeclId.id_of_json
+let type_var_id_of_json = TypeVarId.id_of_json
+let variant_id_of_json = VariantId.id_of_json
+let var_id_of_json = VarId.id_of_json
+let virtual_file_id_of_json = VirtualFileId.id_of_json
+
+(* Start of the `and` chain *)
+let __ = ()
+(* __REPLACE3__ *)
+
+(** Deserialize a map from file id to file name.
+
+    In the serialized LLBC, the files in the loc spans are refered to by their
+    ids, in order to save space. In a functional language like OCaml this is
+    not necessary: we thus replace the file ids by the file name themselves in
+    the AST.
+    The "id to file" map is thus only used in the deserialization process.
+  *)
+let id_to_file_of_json (js : json) : (id_to_file_map, string) result =
+  combine_error_msgs js __FUNCTION__
+    ((* The map is stored as a list of pairs (key, value): we deserialize
+      * this list then convert it to a map *)
+     let* key_values =
+       list_of_json (pair_of_json file_id_of_json file_name_of_json) js
+     in
+     Ok (IdToFile.of_list key_values))
+
+(* __REPLACE2__ *)
+
+(* This is written by hand because it accessed `id_to_file`. *)
+let rec raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
+    (raw_span, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("file_id", file_id); ("beg", beg_loc); ("end", end_loc) ] ->
+        let* file_id = file_id_of_json file_id in
+        let file = IdToFile.find file_id id_to_file in
+        let* beg_loc = loc_of_json beg_loc in
+        let* end_loc = loc_of_json end_loc in
+        Ok { file; beg_loc; end_loc }
+    | _ -> Error "")
+
+(* __REPLACE0__ *)
+let big_int_of_json (js : json) : (big_int, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Int i -> Ok (Z.of_int i)
+    | `String is -> Ok (Z.of_string is)
+    | _ -> Error "")
+
+(** Deserialize a {!Values.scalar_value} from JSON and **check the ranges**.
+
+    Note that in practice we also check that the values are in range
+    in the interpreter functions. Still, it doesn't cost much to be
+    a bit conservative.
+
+    This is written by hand because it does not match the structure of the
+    corresponding rust type. *)
+let rec scalar_value_of_json (js : json) : (scalar_value, string) result =
+  let res =
+    combine_error_msgs js __FUNCTION__
+      (match js with
+      | `Assoc [ ("Isize", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = Isize }
+      | `Assoc [ ("I8", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = I8 }
+      | `Assoc [ ("I16", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = I16 }
+      | `Assoc [ ("I32", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = I32 }
+      | `Assoc [ ("I64", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = I64 }
+      | `Assoc [ ("I128", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = I128 }
+      | `Assoc [ ("Usize", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = Usize }
+      | `Assoc [ ("U8", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = U8 }
+      | `Assoc [ ("U16", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = U16 }
+      | `Assoc [ ("U32", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = U32 }
+      | `Assoc [ ("U64", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = U64 }
+      | `Assoc [ ("U128", bi) ] ->
+          let* bi = big_int_of_json bi in
+          Ok { value = bi; int_ty = U128 }
+      | _ -> Error "")
+  in
+  match res with
+  | Error _ -> res
+  | Ok sv ->
+      if not (check_scalar_value_in_range sv) then (
+        log#serror ("Scalar value not in range: " ^ show_scalar_value sv);
+        raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv)));
+      res
+
+(* __REPLACE1__ *)
+
+(* This is written by hand because the corresponding rust type does not exist. *)
+and region_var_group_of_json (js : json) : (region_var_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("id", id); ("regions", regions); ("parents", parents) ] ->
+        let* id = RegionGroupId.id_of_json id in
+        let* regions = list_of_json RegionVarId.id_of_json regions in
+        let* parents = list_of_json RegionGroupId.id_of_json parents in
+        Ok { id; regions; parents }
+    | _ -> Error "")
+
+and region_var_groups_of_json (js : json) : (region_var_groups, string) result =
+  combine_error_msgs js __FUNCTION__ (list_of_json region_var_group_of_json js)
+
+(* __REPLACE4__ *)
+
+let maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
+    (js : json) : ('body gexpr_body option, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Ok", body) ] ->
+        let* body_id = BodyId.id_of_json body in
+        let body = List.nth bodies (BodyId.to_int body_id) in
+        Ok body
+    | `Assoc [ ("Err", `Null) ] -> Ok None
+    | _ -> Error "")
+
+(* This is written by hand because the corresponding rust type is not type-generic. *)
+let gfun_decl_of_json (bodies : 'body gexpr_body option list)
+    (id_to_file : id_to_file_map) (js : json) : ('body gfun_decl, string) result
+    =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("def_id", def_id);
+          ("item_meta", item_meta);
+          ("signature", signature);
+          ("kind", kind);
+          ("body", body);
+        ] ->
+        let* def_id = FunDeclId.id_of_json def_id in
+        let* item_meta = item_meta_of_json id_to_file item_meta in
+        let* signature = fun_sig_of_json id_to_file signature in
+        let* kind = item_kind_of_json kind in
+        let* body = maybe_opaque_body_of_json bodies body in
+        Ok
+          {
+            def_id;
+            item_meta;
+            signature;
+            kind;
+            body;
+            is_global_decl_body = false;
+          }
+    | _ -> Error "")
+
+let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
+    (id_to_file : id_to_file_map) (js : json) :
+    ('body gexpr_body option gglobal_decl, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("def_id", def_id);
+          ("item_meta", item_meta);
+          ("generics", generics);
+          ("ty", ty);
+          ("kind", kind);
+          ("body", body);
+        ] ->
+        let* global_id = GlobalDeclId.id_of_json def_id in
+        let* item_meta = item_meta_of_json id_to_file item_meta in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* ty = ty_of_json ty in
+        let* kind = item_kind_of_json kind in
+        let* body = maybe_opaque_body_of_json bodies body in
+        let global =
+          { def_id = global_id; item_meta; body; generics; ty; kind }
+        in
+        Ok global
+    | _ -> Error "")
+
+(* __REPLACE5__ *)
+
+let type_declaration_group_of_json (js : json) :
+    (type_declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (g_declaration_group_of_json TypeDeclId.id_of_json js)
+
+let fun_declaration_group_of_json (js : json) :
+    (fun_declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (g_declaration_group_of_json FunDeclId.id_of_json js)
+
+(* This is written by hand because we assert non-recursivity. *)
+let global_declaration_group_of_json (js : json) :
+    (GlobalDeclId.id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (let* decl = g_declaration_group_of_json GlobalDeclId.id_of_json js in
+     match decl with
+     | NonRecGroup id -> Ok id
+     | RecGroup _ -> Error "got mutually dependent globals")
+
+let trait_declaration_group_of_json (js : json) :
+    (trait_declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (g_declaration_group_of_json TraitDeclId.id_of_json js)
+
+let trait_implementation_group_of_json (js : json) :
+    (TraitImplId.id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (let* decl = g_declaration_group_of_json TraitImplId.id_of_json js in
+     match decl with
+     | NonRecGroup id -> Ok id
+     | RecGroup _ -> Error "got mutually dependent trait impls")
+
+let any_decl_id_of_json (js : json) : (any_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Fun", id) ] ->
+        let* id = FunDeclId.id_of_json id in
+        Ok (IdFun id)
+    | `Assoc [ ("Global", id) ] ->
+        let* id = GlobalDeclId.id_of_json id in
+        Ok (IdGlobal id)
+    | `Assoc [ ("Type", id) ] ->
+        let* id = TypeDeclId.id_of_json id in
+        Ok (IdType id)
+    | `Assoc [ ("TraitDecl", id) ] ->
+        let* id = TraitDeclId.id_of_json id in
+        Ok (IdTraitDecl id)
+    | `Assoc [ ("TraitImpl", id) ] ->
+        let* id = TraitImplId.id_of_json id in
+        Ok (IdTraitImpl id)
+    | _ -> Error "")
+
+let mixed_group_of_json (js : json) :
+    (any_decl_id g_declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (g_declaration_group_of_json any_decl_id_of_json js)
+
+let declaration_group_of_json (js : json) : (declaration_group, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Type", decl) ] ->
+        let* decl = type_declaration_group_of_json decl in
+        Ok (TypeGroup decl)
+    | `Assoc [ ("Fun", decl) ] ->
+        let* decl = fun_declaration_group_of_json decl in
+        Ok (FunGroup decl)
+    | `Assoc [ ("Global", decl) ] ->
+        let* id = global_declaration_group_of_json decl in
+        Ok (GlobalGroup id)
+    | `Assoc [ ("TraitDecl", decl) ] ->
+        let* id = trait_declaration_group_of_json decl in
+        Ok (TraitDeclGroup id)
+    | `Assoc [ ("TraitImpl", decl) ] ->
+        let* id = trait_implementation_group_of_json decl in
+        Ok (TraitImplGroup id)
+    | `Assoc [ ("Mixed", decl) ] ->
+        let* id = mixed_group_of_json decl in
+        Ok (MixedGroup id)
+    | _ -> Error "")

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -6,5 +6,5 @@ error: Unsupported statement kind: intrinsic
 
 error: aborting due to 1 previous error
 
-[ERROR charon_driver:230] The extraction encountered 1 errors
+[ERROR charon_driver:228] Compilation encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/rename_attribute_failure.out
+++ b/charon/tests/ui/rename_attribute_failure.out
@@ -28,7 +28,7 @@ error: There should be at most one `charon::rename("...")` or `aeneas::rename(".
 20 | type TestMultiple = ();
    | ^^^^^^^^^^^^^^^^^
 
-error: Error parsing attribute: Unrecognized attribute: `something_else("_Type36")`
+error: Error parsing attribute: Unrecognized attribute: `charon::something_else("_Type36")`
   --> tests/ui/rename_attribute_failure.rs:22:1
    |
 22 | #[charon::something_else("_Type36")]

--- a/charon/tests/ui/rename_attribute_failure.out
+++ b/charon/tests/ui/rename_attribute_failure.out
@@ -36,5 +36,5 @@ error: Error parsing attribute: Unrecognized attribute: `charon::something_else(
 
 error: aborting due to 6 previous errors
 
-[ERROR charon_driver:230] The extraction encountered 6 errors
+[ERROR charon_driver:228] Compilation encountered 6 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/gat.out
+++ b/charon/tests/ui/unsupported/gat.out
@@ -18,5 +18,5 @@ error: Ignoring the following item due to an error: test_crate::ArraySize
 
 error: aborting due to 3 previous errors
 
-[ERROR charon_driver:230] The extraction encountered 2 errors
+[ERROR charon_driver:228] Compilation encountered 2 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/issue-165-vec-macro.out
+++ b/charon/tests/ui/unsupported/issue-165-vec-macro.out
@@ -8,5 +8,5 @@ error: Nullary operations are not supported
 
 error: aborting due to 1 previous error
 
-[ERROR charon_driver:230] The extraction encountered 1 errors
+[ERROR charon_driver:228] Compilation encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/projection-index-from-end.out
+++ b/charon/tests/ui/unsupported/projection-index-from-end.out
@@ -6,5 +6,5 @@ error: Unexpected ProjectionElem::ConstantIndex
 
 error: aborting due to 1 previous error
 
-[ERROR charon_driver:230] The extraction encountered 1 errors
+[ERROR charon_driver:228] Compilation encountered 1 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/unbound-lifetime.out
+++ b/charon/tests/ui/unsupported/unbound-lifetime.out
@@ -27,5 +27,5 @@ error: Ignoring the following item due to an error: test_crate::get
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0261`.
-[ERROR charon_driver:230] The extraction encountered 2 errors
+[ERROR charon_driver:228] Compilation encountered 2 errors
 Error: Charon driver exited with code 1

--- a/charon/tests/ui/unsupported/well-formedness-bound.out
+++ b/charon/tests/ui/unsupported/well-formedness-bound.out
@@ -14,5 +14,5 @@ error: Ignoring the following item due to an error: test_crate::get
 
 error: aborting due to 2 previous errors
 
-[ERROR charon_driver:230] The extraction encountered 2 errors
+[ERROR charon_driver:228] Compilation encountered 2 errors
 Error: Charon driver exited with code 1


### PR DESCRIPTION
This PR adds a rust test that runs charon on itself and uses the resulting llbc to generate most of the `*_of_json` functions in `GAstOfJson.ml`. Eventually we should also generate the other files, including the type definitions, but this is a good start. I aimed to make it change the existing file as little as possible.