### PR TITLE
Cleanup handling of trait generics

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.19"
+let supported_charon_version = "0.1.20"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -409,16 +409,10 @@ and existential_predicate_of_json (js : json) :
 and trait_ref_of_json (js : json) : (trait_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc
-        [
-          ("kind", kind);
-          ("generics", generics);
-          ("trait_decl_ref", trait_decl_ref);
-        ] ->
+    | `Assoc [ ("kind", kind); ("trait_decl_ref", trait_decl_ref) ] ->
         let* trait_id = trait_instance_id_of_json kind in
-        let* generics = generic_args_of_json generics in
         let* trait_decl_ref = trait_decl_ref_of_json trait_decl_ref in
-        Ok { trait_id; generics; trait_decl_ref }
+        Ok { trait_id; trait_decl_ref }
     | _ -> Error "")
 
 and trait_decl_ref_of_json (js : json) : (trait_decl_ref, string) result =
@@ -452,9 +446,10 @@ and generic_args_of_json (js : json) : (generic_args, string) result =
 and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("TraitImpl", trait_impl) ] ->
-        let* trait_impl = trait_impl_id_of_json trait_impl in
-        Ok (TraitImpl trait_impl)
+    | `Assoc [ ("TraitImpl", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_impl_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (TraitImpl (x0, x1))
     | `Assoc [ ("Clause", clause) ] ->
         let* clause = trait_clause_id_of_json clause in
         Ok (Clause clause)
@@ -470,12 +465,14 @@ and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
         let* x3 = trait_clause_id_of_json x3 in
         Ok (ItemClause (x0, x1, x2, x3))
     | `String "SelfId" -> Ok Self
-    | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
-        let* builtin_or_auto = trait_decl_id_of_json builtin_or_auto in
-        Ok (BuiltinOrAuto builtin_or_auto)
-    | `Assoc [ ("Dyn", dyn) ] ->
-        let* dyn = trait_decl_id_of_json dyn in
-        Ok (Dyn dyn)
+    | `Assoc [ ("BuiltinOrAuto", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_decl_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (BuiltinOrAuto (x0, x1))
+    | `Assoc [ ("Dyn", `List [ x0; x1 ]) ] ->
+        let* x0 = trait_decl_id_of_json x0 in
+        let* x1 = generic_args_of_json x1 in
+        Ok (Dyn (x0, x1))
     | `Assoc [ ("Unknown", unknown) ] ->
         let* unknown = string_of_json unknown in
         Ok (UnknownTrait unknown)

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -465,14 +465,12 @@ and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
         let* x3 = trait_clause_id_of_json x3 in
         Ok (ItemClause (x0, x1, x2, x3))
     | `String "SelfId" -> Ok Self
-    | `Assoc [ ("BuiltinOrAuto", `List [ x0; x1 ]) ] ->
-        let* x0 = trait_decl_id_of_json x0 in
-        let* x1 = generic_args_of_json x1 in
-        Ok (BuiltinOrAuto (x0, x1))
-    | `Assoc [ ("Dyn", `List [ x0; x1 ]) ] ->
-        let* x0 = trait_decl_id_of_json x0 in
-        let* x1 = generic_args_of_json x1 in
-        Ok (Dyn (x0, x1))
+    | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
+        let* builtin_or_auto = trait_decl_ref_of_json builtin_or_auto in
+        Ok (BuiltinOrAuto builtin_or_auto)
+    | `Assoc [ ("Dyn", dyn) ] ->
+        let* dyn = trait_decl_ref_of_json dyn in
+        Ok (Dyn dyn)
     | `Assoc [ ("Unknown", unknown) ] ->
         let* unknown = string_of_json unknown in
         Ok (UnknownTrait unknown)
@@ -557,14 +555,12 @@ and trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
           ("clause_id", clause_id);
           ("span", span);
           ("origin", _);
-          ("trait_id", trait_id);
-          ("generics", generics);
+          ("trait_", trait_);
         ] ->
         let* clause_id = trait_clause_id_of_json clause_id in
         let* span = option_of_json (span_of_json id_to_file) span in
-        let* trait_id = trait_decl_id_of_json trait_id in
-        let* clause_generics = generic_args_of_json generics in
-        Ok { clause_id; span; trait_id; clause_generics }
+        let* trait = trait_decl_ref_of_json trait_ in
+        Ok { clause_id; span; trait }
     | _ -> Error "")
 
 and outlives_pred_of_json :

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -411,11 +411,11 @@ and trait_ref_of_json (js : json) : (trait_ref, string) result =
     (match js with
     | `Assoc
         [
-          ("trait_id", trait_id);
+          ("kind", kind);
           ("generics", generics);
           ("trait_decl_ref", trait_decl_ref);
         ] ->
-        let* trait_id = trait_instance_id_of_json trait_id in
+        let* trait_id = trait_instance_id_of_json kind in
         let* generics = generic_args_of_json generics in
         let* trait_decl_ref = trait_decl_ref_of_json trait_decl_ref in
         Ok { trait_id; generics; trait_decl_ref }

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -224,10 +224,7 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       let impl = trait_impl_id_to_string env id in
       let generics = generic_args_to_string env generics in
       impl ^ generics
-  | BuiltinOrAuto (id, generics) ->
-      let decl = trait_decl_id_to_string env id in
-      let generics = generic_args_to_string env generics in
-      decl ^ generics
+  | BuiltinOrAuto trait -> trait_decl_ref_to_string env trait
   | Clause id -> trait_clause_id_to_string env id
   | ParentClause (inst_id, _decl_id, clause_id) ->
       let inst_id = trait_instance_id_to_string env inst_id in
@@ -244,10 +241,9 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       ^ fun_decl_id_to_string env fid
       ^ generic_args_to_string env generics
       ^ ")"
-  | Dyn (id, generics) ->
-      let decl = trait_decl_id_to_string env id in
-      let generics = generic_args_to_string env generics in
-      "dyn(" ^ decl ^ generics ^ ")"
+  | Dyn trait ->
+      let trait = trait_decl_ref_to_string env trait in
+      "dyn(" ^ trait ^ ")"
   | Unsolved (decl_id, generics) ->
       "unsolved("
       ^ trait_decl_id_to_string env decl_id
@@ -296,9 +292,8 @@ and name_to_string (env : ('a, 'b) fmt_env) (n : name) : string =
 let trait_clause_to_string (env : ('a, 'b) fmt_env) (clause : trait_clause) :
     string =
   let clause_id = trait_clause_id_to_string env clause.clause_id in
-  let trait_id = trait_decl_id_to_string env clause.trait_id in
-  let generics = generic_args_to_string env clause.clause_generics in
-  "[" ^ clause_id ^ "]: " ^ trait_id ^ generics
+  let trait = trait_decl_ref_to_string env clause.trait in
+  "[" ^ clause_id ^ "]: " ^ trait
 
 let generic_params_to_strings (env : ('a, 'b) fmt_env)
     (generics : generic_params) : string list * string list =

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -234,7 +234,6 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       let inst_id = trait_instance_id_to_string env inst_id in
       let clause_id = trait_clause_id_to_string env clause_id in
       "(" ^ inst_id ^ ")::" ^ item_name ^ "::[" ^ clause_id ^ "]"
-  | TraitRef tr -> trait_ref_to_string env tr
   | FnPointer ty -> "fn_ptr(" ^ ty_to_string env ty ^ ")"
   | Closure (fid, generics) ->
       "closure("

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -208,9 +208,7 @@ and generic_args_to_string (env : ('a, 'b) fmt_env) (generics : generic_args) :
   params ^ trait_refs
 
 and trait_ref_to_string (env : ('a, 'b) fmt_env) (tr : trait_ref) : string =
-  let trait_id = trait_instance_id_to_string env tr.trait_id in
-  let generics = generic_args_to_string env tr.generics in
-  trait_id ^ generics
+  trait_instance_id_to_string env tr.trait_id
 
 and trait_decl_ref_to_string (env : ('a, 'b) fmt_env) (tr : trait_decl_ref) :
     string =
@@ -222,8 +220,14 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
     (id : trait_instance_id) : string =
   match id with
   | Self -> "Self"
-  | TraitImpl id -> trait_impl_id_to_string env id
-  | BuiltinOrAuto id -> trait_decl_id_to_string env id
+  | TraitImpl (id, generics) ->
+      let impl = trait_impl_id_to_string env id in
+      let generics = generic_args_to_string env generics in
+      impl ^ generics
+  | BuiltinOrAuto (id, generics) ->
+      let decl = trait_decl_id_to_string env id in
+      let generics = generic_args_to_string env generics in
+      decl ^ generics
   | Clause id -> trait_clause_id_to_string env id
   | ParentClause (inst_id, _decl_id, clause_id) ->
       let inst_id = trait_instance_id_to_string env inst_id in
@@ -240,7 +244,10 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       ^ fun_decl_id_to_string env fid
       ^ generic_args_to_string env generics
       ^ ")"
-  | Dyn id -> "dyn(" ^ trait_decl_id_to_string env id ^ ")"
+  | Dyn (id, generics) ->
+      let decl = trait_decl_id_to_string env id in
+      let generics = generic_args_to_string env generics in
+      "dyn(" ^ decl ^ generics ^ ")"
   | Unsolved (decl_id, generics) ->
       "unsolved("
       ^ trait_decl_id_to_string env decl_id

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -213,7 +213,7 @@ let make_trait_subst (clause_ids : TraitClauseId.id list) (trs : trait_ref list)
   let ls = List.combine clause_ids trs in
   let mp =
     List.fold_left
-      (fun mp (k, v) -> TraitClauseId.Map.add k (TraitRef v) mp)
+      (fun mp (k, v) -> TraitClauseId.Map.add k v.trait_id mp)
       TraitClauseId.Map.empty ls
   in
   fun id -> TraitClauseId.Map.find id mp

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -320,18 +320,6 @@ and trait_instance_id =
   | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
   | ItemClause of
       trait_instance_id * trait_decl_id * trait_item_name * trait_clause_id
-  | TraitRef of trait_ref
-      (** Not present in the Rust version of Charon.
-
-          We need this case for instantiations: when calling a function which has
-          trait clauses, for instance, we substitute the clauses refernced in the
-          [Clause] and [Self] case with trait references.
-
-          Remark: something potentially confusing is that [trait_clause_id] is used for
-          different purposes. In the [Clause] case, a trait clause id identifies a local
-          trait clause (which can thus be substituted). In the other cases, it references
-          a sub-clause relative to a trait instance id.
-       *)
   | FnPointer of ty
   | Closure of fun_decl_id * generic_args
   | Dyn of trait_decl_ref

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -295,7 +295,6 @@ and ty =
 
 and trait_ref = {
   trait_id : trait_instance_id;
-  generics : generic_args;
   trait_decl_ref : trait_decl_ref;
 }
 
@@ -315,8 +314,8 @@ and generic_args = {
 and trait_instance_id =
   | Self
       (** Reference to *self*, in case of trait declarations/implementations *)
-  | TraitImpl of trait_impl_id  (** A specific implementation *)
-  | BuiltinOrAuto of trait_decl_id
+  | TraitImpl of trait_impl_id * generic_args  (** A specific implementation *)
+  | BuiltinOrAuto of trait_decl_id * generic_args
   | Clause of trait_clause_id
   | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
   | ItemClause of
@@ -335,7 +334,7 @@ and trait_instance_id =
        *)
   | FnPointer of ty
   | Closure of fun_decl_id * generic_args
-  | Dyn of trait_decl_id
+  | Dyn of trait_decl_id * generic_args
   | Unsolved of trait_decl_id * generic_args
   | UnknownTrait of string
       (** Not present in the Rust version of Charon.

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -315,7 +315,7 @@ and trait_instance_id =
   | Self
       (** Reference to *self*, in case of trait declarations/implementations *)
   | TraitImpl of trait_impl_id * generic_args  (** A specific implementation *)
-  | BuiltinOrAuto of trait_decl_id * generic_args
+  | BuiltinOrAuto of trait_decl_ref
   | Clause of trait_clause_id
   | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
   | ItemClause of
@@ -334,7 +334,7 @@ and trait_instance_id =
        *)
   | FnPointer of ty
   | Closure of fun_decl_id * generic_args
-  | Dyn of trait_decl_id * generic_args
+  | Dyn of trait_decl_ref
   | Unsolved of trait_decl_id * generic_args
   | UnknownTrait of string
       (** Not present in the Rust version of Charon.
@@ -430,8 +430,7 @@ and rty = ty
 and trait_clause = {
   clause_id : trait_clause_id;
   span : span option;
-  trait_id : trait_decl_id;
-  clause_generics : generic_args;
+  trait : trait_decl_ref;
 }
 
 and generic_params = {

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -82,8 +82,11 @@ let ty_as_literal (ty : ty) : literal_type =
 let const_generic_as_literal (cg : const_generic) : Values.literal =
   match cg with CgValue v -> v | _ -> raise (Failure "Unreachable")
 
-let trait_instance_id_as_trait_impl (id : trait_instance_id) : trait_impl_id =
-  match id with TraitImpl id -> id | _ -> raise (Failure "Unreachable")
+let trait_instance_id_as_trait_impl (id : trait_instance_id) :
+    trait_impl_id * generic_args =
+  match id with
+  | TraitImpl (impl_id, args) -> (impl_id, args)
+  | _ -> raise (Failure "Unreachable")
 
 let empty_generic_args : generic_args =
   { regions = []; types = []; const_generics = []; trait_refs = [] }

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -21,6 +21,16 @@ path = "src/bin/charon/main.rs"
 name = "charon-driver"
 path = "src/bin/charon-driver/main.rs"
 
+[[test]]
+name = "ui"
+path = "tests/ui.rs"
+harness = false
+
+[[test]]
+name = "cargo"
+path = "tests/cargo.rs"
+harness = false
+
 [dependencies]
 anyhow = "1.0.81"
 clap = { version = "4.0", features = ["derive", "env"] }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -236,7 +236,6 @@ pub struct TraitRef {
     pub trait_id: TraitInstanceId,
     pub generics: GenericArgs,
     /// Not necessary, but useful
-    #[drive(skip)]
     pub trait_decl_ref: TraitDeclRef,
 }
 

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -217,10 +217,10 @@ pub enum TraitRefKind {
 
     /// A specific builtin trait implementation like [core::marker::Sized] or
     /// auto trait implementation like [core::marker::Syn].
-    BuiltinOrAuto(TraitDeclId, GenericArgs),
+    BuiltinOrAuto(TraitDeclRef),
 
     /// The automatically-generated implementation for `dyn Trait`.
-    Dyn(TraitDeclId, GenericArgs),
+    Dyn(TraitDeclRef),
 
     /// For error reporting.
     #[charon::rename("UnknownTrait")]
@@ -347,11 +347,8 @@ pub struct TraitClause {
     #[charon::opaque]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.
-    pub trait_id: TraitDeclId,
-    /// The generics applied to the trait. Note: this includes the `Self` type.
-    /// Remark: the trait refs list in the [generics] field should be empty.
-    #[charon::rename("clause_generics")]
-    pub generics: GenericArgs,
+    #[charon::rename("trait")]
+    pub trait_: TraitDeclRef,
 }
 
 impl Eq for TraitClause {}

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -133,7 +133,8 @@ pub enum Region {
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd, Drive, DriveMut,
 )]
-pub enum TraitInstanceId {
+#[charon::rename("TraitInstanceId")]
+pub enum TraitRefKind {
     /// A specific top-level implementation item.
     TraitImpl(TraitImplId),
 
@@ -173,7 +174,7 @@ pub enum TraitInstanceId {
     ///              clause 0 implements Bar
     /// }
     /// ```
-    ParentClause(Box<TraitInstanceId>, TraitDeclId, TraitClauseId),
+    ParentClause(Box<TraitRefKind>, TraitDeclId, TraitClauseId),
 
     /// A clause bound in a trait item (typically a trait clause in an
     /// associated type).
@@ -202,12 +203,7 @@ pub enum TraitInstanceId {
     /// ```
     ///
     ///
-    ItemClause(
-        Box<TraitInstanceId>,
-        TraitDeclId,
-        TraitItemName,
-        TraitClauseId,
-    ),
+    ItemClause(Box<TraitRefKind>, TraitDeclId, TraitItemName, TraitClauseId),
 
     /// Self, in case of trait declarations/implementations.
     ///
@@ -233,7 +229,8 @@ pub enum TraitInstanceId {
 /// A reference to a trait
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitRef {
-    pub trait_id: TraitInstanceId,
+    #[charon::rename("trait_id")]
+    pub kind: TraitRefKind,
     pub generics: GenericArgs,
     /// Not necessary, but useful
     pub trait_decl_ref: TraitDeclRef,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -130,13 +130,11 @@ pub enum Region {
 /// definition. Note that every path designated by [TraitInstanceId] refers
 /// to a *trait instance*, which is why the [Clause] variant may seem redundant
 /// with some of the other variants.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd, Drive, DriveMut,
-)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 #[charon::rename("TraitInstanceId")]
 pub enum TraitRefKind {
     /// A specific top-level implementation item.
-    TraitImpl(TraitImplId),
+    TraitImpl(TraitImplId, GenericArgs),
 
     /// One of the local clauses.
     ///
@@ -153,6 +151,9 @@ pub enum TraitRefKind {
     /// Remark: the [TraitDeclId] gives the trait declaration which is
     /// implemented by the instance id from which we take the parent clause
     /// (see example below). It is not necessary and included for convenience.
+    ///
+    /// Remark: Ideally we should store a full `TraitRef` instead, but hax does not give us enough
+    /// information to get the right generic args.
     ///
     /// Example:
     /// ```text
@@ -216,10 +217,10 @@ pub enum TraitRefKind {
 
     /// A specific builtin trait implementation like [core::marker::Sized] or
     /// auto trait implementation like [core::marker::Syn].
-    BuiltinOrAuto(TraitDeclId),
+    BuiltinOrAuto(TraitDeclId, GenericArgs),
 
     /// The automatically-generated implementation for `dyn Trait`.
-    Dyn(TraitDeclId),
+    Dyn(TraitDeclId, GenericArgs),
 
     /// For error reporting.
     #[charon::rename("UnknownTrait")]
@@ -231,7 +232,6 @@ pub enum TraitRefKind {
 pub struct TraitRef {
     #[charon::rename("trait_id")]
     pub kind: TraitRefKind,
-    pub generics: GenericArgs,
     /// Not necessary, but useful
     pub trait_decl_ref: TraitDeclRef,
 }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -102,6 +102,14 @@ impl GenericArgs {
         }
     }
 
+    /// Check whether this matches the given `GenericParams`.
+    pub fn matches(&self, params: &GenericParams) -> bool {
+        params.regions.len() == self.regions.len()
+            && params.types.len() == self.types.len()
+            && params.const_generics.len() == self.const_generics.len()
+            && params.trait_clauses.len() == self.trait_refs.len()
+    }
+
     /// Return the same generics, but where we pop the first type arguments.
     /// This is useful for trait references (for pretty printing for instance),
     /// because the first type argument is the type for which the trait is

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -43,17 +43,15 @@ impl ClauseTransCtx {
             | ClauseTransCtx::Item(clauses, ..) => clauses,
         }
     }
-    pub(crate) fn generate_instance_id(&mut self) -> (TraitClauseId, TraitInstanceId) {
+    pub(crate) fn generate_instance_id(&mut self) -> (TraitClauseId, TraitRefKind) {
         let fresh_id = self.as_mut_clauses().next_id();
         let instance_id = match self {
-            ClauseTransCtx::Base { .. } => TraitInstanceId::Clause(fresh_id),
-            ClauseTransCtx::Parent(_, trait_decl_id) => TraitInstanceId::ParentClause(
-                Box::new(TraitInstanceId::SelfId),
-                *trait_decl_id,
-                fresh_id,
-            ),
-            ClauseTransCtx::Item(_, trait_decl_id, item_name) => TraitInstanceId::ItemClause(
-                Box::new(TraitInstanceId::SelfId),
+            ClauseTransCtx::Base { .. } => TraitRefKind::Clause(fresh_id),
+            ClauseTransCtx::Parent(_, trait_decl_id) => {
+                TraitRefKind::ParentClause(Box::new(TraitRefKind::SelfId), *trait_decl_id, fresh_id)
+            }
+            ClauseTransCtx::Item(_, trait_decl_id, item_name) => TraitRefKind::ItemClause(
+                Box::new(TraitRefKind::SelfId),
                 *trait_decl_id,
                 item_name.clone(),
                 fresh_id,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1209,11 +1209,11 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
     }
 }
 
-impl<C: AstFormatter> FmtWithCtx<C> for TraitInstanceId {
+impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match self {
-            TraitInstanceId::SelfId => "Self".to_string(),
-            TraitInstanceId::ParentClause(id, _decl_id, clause_id) => {
+            TraitRefKind::SelfId => "Self".to_string(),
+            TraitRefKind::ParentClause(id, _decl_id, clause_id) => {
                 let id = id.fmt_with_ctx(ctx);
                 // Using on purpose [to_pretty_string] instead of [format_object]:
                 // the clause is local to the associated type, so it should not
@@ -1221,7 +1221,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitInstanceId {
                 let clause = clause_id.to_pretty_string();
                 format!("(parents({id})::[{clause}])")
             }
-            TraitInstanceId::ItemClause(id, _decl_id, type_name, clause_id) => {
+            TraitRefKind::ItemClause(id, _decl_id, type_name, clause_id) => {
                 let id = id.fmt_with_ctx(ctx);
                 // Using on purpose [to_pretty_string] instead of [format_object]:
                 // the clause is local to the associated type, so it should not
@@ -1229,17 +1229,17 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitInstanceId {
                 let clause = clause_id.to_pretty_string();
                 format!("({id}::{type_name}::[{clause}])")
             }
-            TraitInstanceId::TraitImpl(id) => ctx.format_object(*id),
-            TraitInstanceId::Clause(id) => ctx.format_object(*id),
-            TraitInstanceId::BuiltinOrAuto(id) | TraitInstanceId::Dyn(id) => ctx.format_object(*id),
-            TraitInstanceId::Unknown(msg) => format!("UNKNOWN({msg})"),
+            TraitRefKind::TraitImpl(id) => ctx.format_object(*id),
+            TraitRefKind::Clause(id) => ctx.format_object(*id),
+            TraitRefKind::BuiltinOrAuto(id) | TraitRefKind::Dyn(id) => ctx.format_object(*id),
+            TraitRefKind::Unknown(msg) => format!("UNKNOWN({msg})"),
         }
     }
 }
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitRef {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        let trait_id = self.trait_id.fmt_with_ctx(ctx);
+        let trait_id = self.kind.fmt_with_ctx(ctx);
         let generics = self.generics.fmt_with_ctx_split_trait_refs(ctx);
         format!("{trait_id}{generics}")
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1059,9 +1059,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
 impl<C: AstFormatter> FmtWithCtx<C> for TraitClause {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         let clause_id = ctx.format_object(self.clause_id);
-        let trait_id = ctx.format_object(self.trait_id);
-        let generics = self.generics.fmt_with_ctx(ctx);
-        format!("[{clause_id}]: {trait_id}{generics}")
+        let trait_ = self.trait_.fmt_with_ctx(ctx);
+        format!("[{clause_id}]: {trait_}")
     }
 }
 
@@ -1235,11 +1234,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
                 format!("{impl_}{args}")
             }
             TraitRefKind::Clause(id) => ctx.format_object(*id),
-            TraitRefKind::BuiltinOrAuto(id, args) | TraitRefKind::Dyn(id, args) => {
-                let trait_ = ctx.format_object(*id);
-                let args = args.fmt_with_ctx_split_trait_refs(ctx);
-                format!("{trait_}{args}")
-            }
+            TraitRefKind::BuiltinOrAuto(tr) | TraitRefKind::Dyn(tr) => tr.fmt_with_ctx(ctx),
             TraitRefKind::Unknown(msg) => format!("UNKNOWN({msg})"),
         }
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1229,9 +1229,17 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
                 let clause = clause_id.to_pretty_string();
                 format!("({id}::{type_name}::[{clause}])")
             }
-            TraitRefKind::TraitImpl(id) => ctx.format_object(*id),
+            TraitRefKind::TraitImpl(id, args) => {
+                let impl_ = ctx.format_object(*id);
+                let args = args.fmt_with_ctx_split_trait_refs(ctx);
+                format!("{impl_}{args}")
+            }
             TraitRefKind::Clause(id) => ctx.format_object(*id),
-            TraitRefKind::BuiltinOrAuto(id) | TraitRefKind::Dyn(id) => ctx.format_object(*id),
+            TraitRefKind::BuiltinOrAuto(id, args) | TraitRefKind::Dyn(id, args) => {
+                let trait_ = ctx.format_object(*id);
+                let args = args.fmt_with_ctx_split_trait_refs(ctx);
+                format!("{trait_}{args}")
+            }
             TraitRefKind::Unknown(msg) => format!("UNKNOWN({msg})"),
         }
     }
@@ -1239,9 +1247,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitRef {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        let trait_id = self.kind.fmt_with_ctx(ctx);
-        let generics = self.generics.fmt_with_ctx_split_trait_refs(ctx);
-        format!("{trait_id}{generics}")
+        self.kind.fmt_with_ctx(ctx)
     }
 }
 

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -126,15 +126,15 @@ impl CheckGenericsVisitor<'_, '_> {
     }
     fn enter_trait_ref(&mut self, tref: &TraitRef) {
         let args = &tref.generics;
-        match tref.trait_id {
-            TraitInstanceId::TraitImpl(id) => self.generics_should_match_item(args, id),
-            TraitInstanceId::Clause(..)
-            | TraitInstanceId::ParentClause(..)
-            | TraitInstanceId::ItemClause(..)
-            | TraitInstanceId::SelfId
-            | TraitInstanceId::BuiltinOrAuto(_)
-            | TraitInstanceId::Dyn(_)
-            | TraitInstanceId::Unknown(_) => self.generics_should_be_empty(args),
+        match tref.kind {
+            TraitRefKind::TraitImpl(id) => self.generics_should_match_item(args, id),
+            TraitRefKind::Clause(..)
+            | TraitRefKind::ParentClause(..)
+            | TraitRefKind::ItemClause(..)
+            | TraitRefKind::SelfId
+            | TraitRefKind::BuiltinOrAuto(_)
+            | TraitRefKind::Dyn(_)
+            | TraitRefKind::Unknown(_) => self.generics_should_be_empty(args),
         }
     }
     fn enter_ty(&mut self, ty: &Ty) {

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -15,7 +15,6 @@ use super::{ctx::LlbcPass, TransformCtx};
     FnPtr(enter),
     RawConstantExpr(enter),
     Rvalue(enter),
-    TraitClause(enter),
     TraitDeclRef(enter),
     TraitRefKind(enter),
     Ty(enter)
@@ -105,19 +104,15 @@ impl CheckGenericsVisitor<'_, '_> {
             self.generics_should_match_item(args, *id);
         }
     }
-    fn enter_trait_clause(&mut self, clause: &TraitClause) {
-        self.generics_should_match_item(&clause.generics, clause.trait_id);
-    }
     fn enter_trait_decl_ref(&mut self, tref: &TraitDeclRef) {
         self.generics_should_match_item(&tref.generics, tref.trait_id);
     }
     fn enter_trait_ref_kind(&mut self, kind: &TraitRefKind) {
         match kind {
             TraitRefKind::TraitImpl(id, args) => self.generics_should_match_item(args, *id),
-            TraitRefKind::BuiltinOrAuto(id, args) | TraitRefKind::Dyn(id, args) => {
-                self.generics_should_match_item(args, *id)
-            }
-            TraitRefKind::Clause(..)
+            TraitRefKind::BuiltinOrAuto(..)
+            | TraitRefKind::Dyn(..)
+            | TraitRefKind::Clause(..)
             | TraitRefKind::ParentClause(..)
             | TraitRefKind::ItemClause(..)
             | TraitRefKind::SelfId

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -1,0 +1,189 @@
+//! Check that all supplied generic types match the corresponding generic parameters.
+use std::fmt::Display;
+
+use derive_visitor::Visitor;
+
+use crate::{ast::*, errors::ErrorCtx, register_error_or_panic};
+
+use super::{ctx::LlbcPass, TransformCtx};
+
+#[derive(Visitor)]
+#[visitor(
+    TraitImpl(enter),
+    GenericArgs(enter),
+    AggregateKind(enter),
+    FnPtr(enter),
+    RawConstantExpr(enter),
+    Rvalue(enter),
+    TraitClause(enter),
+    TraitDeclRef(enter),
+    TraitRef(enter),
+    Ty(enter)
+)]
+struct CheckGenericsVisitor<'a, 'ctx> {
+    translated: &'a TranslatedCrate,
+    error_ctx: &'a mut ErrorCtx<'ctx>,
+    // Count how many `GenericArgs` we handled. This is to make sure we don't miss one.
+    discharged_args: u32,
+    // Tracks an enclosing span to make errors useful.
+    item_span: Span,
+}
+
+impl CheckGenericsVisitor<'_, '_> {
+    fn error(&mut self, message: impl Display) {
+        let span = self.item_span;
+        let message = message.to_string();
+        register_error_or_panic!(self.error_ctx, span, message);
+    }
+
+    /// Count that we just discharged one instance of `GenericArgs`.
+    fn discharged_one_generics(&mut self) {
+        self.discharged_args += 1;
+    }
+
+    fn generics_should_be_empty(&mut self, args: &GenericArgs) {
+        self.discharged_one_generics();
+        if !args.is_empty() {
+            self.error("Mismatched generics: should be empty!")
+        }
+    }
+    fn check_generics(&mut self, args: &GenericArgs, params: &GenericParams) {
+        self.discharged_one_generics();
+        if !args.matches(params) {
+            self.error("Mismatched generics!")
+        }
+    }
+
+    fn generics_should_match_item(&mut self, args: &GenericArgs, item_id: impl Into<AnyTransId>) {
+        if let Some(item) = self.translated.get_item(item_id.into()) {
+            self.check_generics(args, item.generic_params())
+        } else {
+            // If the item is missing, we can't check anything but we must still count this.
+            self.discharged_one_generics();
+        }
+    }
+    fn check_typeid_generics(&mut self, args: &GenericArgs, ty_kind: &TypeId) {
+        match ty_kind {
+            TypeId::Adt(id) => self.generics_should_match_item(args, *id),
+            TypeId::Tuple => {
+                self.discharged_one_generics();
+                if !(args.regions.is_empty()
+                    && args.const_generics.is_empty()
+                    && args.trait_refs.is_empty())
+                {
+                    self.error("Mismatched generics: generics for a tuple should be only types")
+                }
+            }
+            TypeId::Assumed(..) => {
+                // TODO: check generics for built-in types
+                self.discharged_one_generics()
+            }
+        }
+    }
+}
+
+// Visitor functions
+impl CheckGenericsVisitor<'_, '_> {
+    fn enter_aggregate_kind(&mut self, agg: &AggregateKind) {
+        match agg {
+            AggregateKind::Adt(kind, _, args) => {
+                self.check_typeid_generics(args, kind);
+            }
+            AggregateKind::Closure(id, args) => {
+                self.generics_should_match_item(args, *id);
+            }
+            AggregateKind::Array(..) => {}
+        }
+    }
+    fn enter_fn_ptr(&mut self, fn_ptr: &FnPtr) {
+        let args = &fn_ptr.generics;
+        match &fn_ptr.func {
+            FunIdOrTraitMethodRef::Fun(FunId::Regular(id))
+            | FunIdOrTraitMethodRef::Trait(_, _, id) => {
+                self.generics_should_match_item(args, *id);
+            }
+            FunIdOrTraitMethodRef::Fun(FunId::Assumed(..)) => {
+                // TODO: check generics for built-in types
+                self.discharged_one_generics()
+            }
+        }
+    }
+    fn enter_raw_constant_expr(&mut self, cexpr: &RawConstantExpr) {
+        if let RawConstantExpr::Global(id, args) = cexpr {
+            self.generics_should_match_item(args, *id);
+        }
+    }
+    fn enter_rvalue(&mut self, rvalue: &Rvalue) {
+        if let Rvalue::Global(id, args) = rvalue {
+            self.generics_should_match_item(args, *id);
+        }
+    }
+    fn enter_trait_clause(&mut self, clause: &TraitClause) {
+        self.generics_should_match_item(&clause.generics, clause.trait_id);
+    }
+    fn enter_trait_decl_ref(&mut self, tref: &TraitDeclRef) {
+        self.generics_should_match_item(&tref.generics, tref.trait_id);
+    }
+    fn enter_trait_ref(&mut self, tref: &TraitRef) {
+        let args = &tref.generics;
+        match tref.trait_id {
+            TraitInstanceId::TraitImpl(id) => self.generics_should_match_item(args, id),
+            TraitInstanceId::Clause(..)
+            | TraitInstanceId::ParentClause(..)
+            | TraitInstanceId::ItemClause(..)
+            | TraitInstanceId::SelfId
+            | TraitInstanceId::BuiltinOrAuto(_)
+            | TraitInstanceId::Dyn(_)
+            | TraitInstanceId::Unknown(_) => self.generics_should_be_empty(args),
+        }
+    }
+    fn enter_ty(&mut self, ty: &Ty) {
+        if let Ty::Adt(kind, args) = ty {
+            self.check_typeid_generics(args, kind);
+        }
+    }
+
+    fn enter_generic_args(&mut self, args: &GenericArgs) {
+        if self.discharged_args == 0 {
+            // Ensure we counted all `GenericArgs`
+            panic!("Unexpected `GenericArgs` in the AST! {args:?}")
+        }
+        self.discharged_args -= 1;
+    }
+
+    // Special case that is not represented as a `GenericArgs`.
+    fn enter_trait_impl(&mut self, timpl: &TraitImpl) {
+        let Some(tdecl) = self.translated.trait_decls.get(timpl.impl_trait.trait_id) else {
+            return;
+        };
+        let args_match = timpl.parent_trait_refs.len() == tdecl.parent_clauses.len()
+            && timpl.types.len() == tdecl.types.len()
+            && timpl.consts.len() == tdecl.consts.len();
+        if !args_match {
+            self.error("The generics supplied by the trait impl don't match the trait decl.")
+        }
+        let methods = timpl.required_methods.len() == tdecl.required_methods.len();
+        if !methods {
+            self.error("The methods supplied by the trait impl don't match the trait decl.")
+        }
+    }
+}
+
+pub struct Check;
+impl LlbcPass for Check {
+    fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
+        for item in ctx.translated.all_items() {
+            let mut visitor = CheckGenericsVisitor {
+                translated: &ctx.translated,
+                error_ctx: &mut ctx.errors,
+                discharged_args: 0,
+                item_span: item.item_meta().span,
+            };
+            item.drive(&mut visitor);
+            assert_eq!(
+                visitor.discharged_args, 0,
+                "Got confused about `GenericArgs` locations"
+            );
+        }
+    }
+}

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -1,4 +1,6 @@
 #[charon::opaque]
+pub mod check_generics;
+#[charon::opaque]
 pub mod ctx;
 #[charon::opaque]
 pub mod graphs;
@@ -90,4 +92,6 @@ pub static LLBC_PASSES: &[&dyn ctx::LlbcPass] = &[
     // # Micro-pass (not necessary, but good for cleaning): remove the
     // useless no-ops.
     &remove_nops::Transform,
+    // Check that all supplied generic types match the corresponding generic parameters.
+    &check_generics::Check,
 ];

--- a/charon/tests/cargo.rs
+++ b/charon/tests/cargo.rs
@@ -48,8 +48,7 @@ fn perform_test(test_case: &Case, action: Action) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn cargo() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let action = if std::env::var("IN_CI").as_deref() == Ok("1") {
         Action::Verify
     } else {

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -309,7 +309,7 @@ fn predicate_origins() -> Result<(), Box<dyn Error>> {
         let clauses = &item.generics.trait_clauses;
         assert_eq!(origins.len(), clauses.len(), "failed for {item_name}");
         for (clause, (expected_origin, expected_trait_name)) in clauses.iter().zip(origins) {
-            let trait_name = trait_name(&crate_data, clause.trait_id);
+            let trait_name = trait_name(&crate_data, clause.trait_.trait_id);
             assert_eq!(trait_name, *expected_trait_name, "failed for {item_name}");
             assert_eq!(&clause.origin, expected_origin, "failed for {item_name}");
         }

--- a/charon/tests/generate-ml.rs
+++ b/charon/tests/generate-ml.rs
@@ -401,7 +401,7 @@ fn generate_ml() -> Result<()> {
             "TraitRef",
             "TraitDeclRef",
             "GenericArgs",
-            "TraitInstanceId",
+            "TraitRefKind",
             "Field",
             "Variant",
             "TypeDeclKind",

--- a/charon/tests/ui.rs
+++ b/charon/tests/ui.rs
@@ -242,8 +242,7 @@ fn perform_test(test_case: &Case, action: Action) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn ui() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let action = if std::env::var("IN_CI").as_deref() == Ok("1") {
         Action::Verify
     } else {

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -1,0 +1,125 @@
+# Final LLBC before serialization:
+
+trait core::clone::Clone<Self>
+{
+    fn clone : core::clone::Clone::clone
+    fn clone_from
+}
+
+trait core::marker::Copy<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
+}
+
+trait test_crate::Foo<'a, Self>
+where
+    Self::Item : 'a,
+{
+    parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
+    type Item
+        where
+            [@TraitClause0]: core::clone::Clone<Self::Item>,
+    fn use_item : test_crate::Foo::use_item
+}
+
+fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
+
+impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_0, T> : core::clone::Clone<&'_0 (T)>
+{
+    fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}::clone
+}
+
+impl<'_0, T> core::marker::{impl core::marker::Copy for &'_0 (T)#4}<'_0, T> : core::marker::Copy<&'_0 (T)>
+{
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>
+}
+
+enum core::option::Option<T> =
+|  None()
+|  Some(T)
+
+
+fn core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> core::option::Option<T>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::clone::Clone<T>,
+
+fn core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone_from<'_0, '_1, T>(@1: &'_0 mut (core::option::Option<T>), @2: &'_1 (core::option::Option<T>))
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::clone::Clone<T>,
+
+impl<T> core::option::{impl core::clone::Clone for core::option::Option<T>#5}<T> : core::clone::Clone<core::option::Option<T>>
+where
+    [@TraitClause0]: core::clone::Clone<T>,
+{
+    fn clone = core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone
+    fn clone_from = core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone_from
+}
+
+impl<'a, T> test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T)>
+{
+    parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)#4}<'_, T>
+    type Item = core::option::Option<&'a (T)> with [core::option::{impl core::clone::Clone for core::option::Option<T>#5}<&'_ (T)>[core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>]]
+}
+
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn test_crate::external_use_item<'a, T>(@1: @TraitClause0::Item) -> @TraitClause0::Item
+where
+    [@TraitClause0]: test_crate::Foo<'_, T>,
+{
+    let @0: @TraitClause0::Item; // return
+    let x@1: @TraitClause0::Item; // arg #1
+    let @2: &'_ (@TraitClause0::Item); // anonymous local
+
+    @2 := &x@1
+    @0 := (@TraitClause0::Item::[@TraitClause0])::clone(move (@2))
+    drop @2
+    drop x@1
+    return
+}
+
+fn test_crate::call_fn()
+{
+    let @0: (); // return
+    let @1: core::option::Option<&'_ (bool)>; // anonymous local
+    let @2: core::option::Option<&'_ (bool)>; // anonymous local
+    let @3: (); // anonymous local
+
+    @2 := core::option::Option::None {  }
+    @1 := test_crate::external_use_item<'_, &'_ (bool)>[test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'_, bool>](move (@2))
+    drop @2
+    @fake_read(@1)
+    drop @1
+    @3 := ()
+    @0 := move (@3)
+    @0 := ()
+    return
+}
+
+fn test_crate::type_equality<'a, I, J>(@1: @TraitClause0::Item) -> @TraitClause1::Item
+where
+    [@TraitClause0]: test_crate::Foo<'_, I>,
+    [@TraitClause1]: test_crate::Foo<'_, J>,
+    @TraitClause1::Item = @TraitClause0::Item,
+{
+    let @0: @TraitClause0::Item; // return
+    let x@1: @TraitClause0::Item; // arg #1
+
+    @0 := move (x@1)
+    drop x@1
+    return
+}
+
+fn test_crate::Foo::use_item<'a, '_1, Self>(@1: &'_1 (Self::Item)) -> &'_1 (Self::Item)
+{
+    let @0: &'_ (Self::Item); // return
+    let x@1: &'_ (Self::Item); // arg #1
+
+    @0 := copy (x@1)
+    return
+}
+
+
+

--- a/charon/tests/ui/associated-types.rs
+++ b/charon/tests/ui/associated-types.rs
@@ -1,0 +1,28 @@
+trait Foo<'a>: Copy {
+    // FIXME: the `+ 'a` appears to be completely ignored.
+    type Item: Clone + 'a;
+
+    fn use_item(x: &Self::Item) -> &Self::Item {
+        x
+    }
+}
+
+impl<'a, T> Foo<'a> for &'a T {
+    type Item = Option<&'a T>;
+}
+
+fn external_use_item<'a, T: Foo<'a>>(x: T::Item) -> T::Item {
+    x.clone()
+}
+
+fn call_fn() {
+    let _ = external_use_item::<&bool>(None);
+}
+
+fn type_equality<'a, I, J>(x: I::Item) -> J::Item
+where
+    I: Foo<'a>,
+    J: Foo<'a, Item = I::Item>,
+{
+    x
+}

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -48,7 +48,7 @@ fn test_crate::destruct<'_0>(@1: &'_0 (dyn (exists(TODO)))) -> alloc::string::St
     let @2: &'_ (dyn (exists(TODO))); // anonymous local
 
     @2 := &*(x@1)
-    @0 := alloc::string::{impl alloc::string::ToString for T#32}<dyn (exists(TODO))>[core::fmt::Display]::to_string(move (@2))
+    @0 := alloc::string::{impl alloc::string::ToString for T#32}<dyn (exists(TODO))>[core::fmt::Display<dyn (exists(TODO))>]::to_string(move (@2))
     drop @2
     return
 }

--- a/charon/tests/ui/generic-associated-types.out
+++ b/charon/tests/ui/generic-associated-types.out
@@ -1,0 +1,57 @@
+error: Could not find region: Region { kind: ReEarlyParam(EarlyParamRegion { index: 2, name: "'b" }) }
+       
+       Region vars map:
+       {Region { kind: ReEarlyParam(EarlyParamRegion { index: 0, name: "'a" }) }: 0}
+       
+       Bound region vars:
+       []
+  --> tests/ui/generic-associated-types.rs:11:5
+   |
+11 |     type Item<'b> = &'b T;
+   |     ^^^^^^^^^^^^^
+
+error: Ignoring the following item due to an error: test_crate::{impl#0}
+  --> tests/ui/generic-associated-types.rs:10:1
+   |
+10 | impl<'a, T> LendingIterator for Option<&'a T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+thread 'rustc' panicked at /rustc/6b0f4b5ec3aa707ecaa78230722117324a4ce23c/compiler/rustc_type_ir/src/binder.rs:785:9:
+const parameter `'a/#1` ('a/#1/1) out of range when instantiating args=[Self/#0]
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Thread panicked when extracting item {rust_id}.
+ --> tests/ui/generic-associated-types.rs:7:5
+  |
+7 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ignoring the following item due to an error: test_crate::LendingIterator::next
+ --> tests/ui/generic-associated-types.rs:7:5
+  |
+7 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Predicates with bound regions (i.e., `for<'a> ...`) are not supported yet
+  --> tests/ui/generic-associated-types.rs:24:54
+   |
+24 | fn for_each<I: LendingIterator>(mut iter: I, f: impl for<'a> FnMut(I::Item<'a>)) {
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ignoring the following item due to an error: test_crate::for_each
+  --> tests/ui/generic-associated-types.rs:24:1
+   |
+24 | fn for_each<I: LendingIterator>(mut iter: I, f: impl for<'a> FnMut(I::Item<'a>)) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused variable: `x`
+  --> tests/ui/generic-associated-types.rs:31:9
+   |
+31 |     let x = 42;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+error: aborting due to 6 previous errors; 1 warning emitted
+
+[ERROR charon_driver:249] Compilation encountered 6 errors
+Error: Charon driver exited with code 1

--- a/charon/tests/ui/generic-associated-types.rs
+++ b/charon/tests/ui/generic-associated-types.rs
@@ -1,0 +1,36 @@
+//@ known-failure
+trait LendingIterator {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+}
+
+impl<'a, T> LendingIterator for Option<&'a T> {
+    type Item<'b> = &'b T;
+
+    fn next<'b>(&'b mut self) -> Option<Self::Item<'b>> {
+        if let Some(item) = self {
+            *self = None;
+            let item = &**item;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
+fn for_each<I: LendingIterator>(mut iter: I, f: impl for<'a> FnMut(I::Item<'a>)) {
+    while let Some(item) = iter.next() {
+        f(item)
+    }
+}
+
+fn main() {
+    let x = 42;
+    let iter = Some(&42);
+    let mut sum = 0;
+    for_each(iter, |item| sum += *item);
+    assert_eq!(sum, 42);
+}


### PR DESCRIPTION
This PR cleanups our handling of generics somewhat:
- Adds a pass that ensures all `GenericArgs` match the corresponding `GenericParams`;
- Moves the generic arguments in `TraitRef` to be close to the id they apply to (also avoids creating empty `GenericArgs` in cases where non is needed);
- Uses `TraitDeclRef` anywhere a trait is referenced alongside generic arguments;
- The `trait_instance_id.TraitRef` variant on the ml side was a hack and is no longer needed.

In theory, all occurrences of `TraitDeclId` in the ast could come with appropriate generic arguments, but this is not yet needed and hax does not give us the necessary information yet (the tricky place is in nested trait references, e.g. parent clauses of a where-clause in scope).