### PR TITLE
Lift clauses on associated types to be clauses on the whole trait

### DIFF
--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -159,7 +159,7 @@ type trait_decl = {
   generics : generic_params;
   parent_clauses : trait_clause list;
   consts : (trait_item_name * (ty * global_decl_id option)) list;
-  types : (trait_item_name * (trait_clause list * ty option)) list;
+  types : (trait_item_name * ty option) list;
   required_methods : (trait_item_name * fun_decl_id) list;
   provided_methods : (trait_item_name * fun_decl_id option) list;
 }
@@ -172,7 +172,7 @@ type trait_impl = {
   generics : generic_params;
   parent_trait_refs : trait_ref list;
   consts : (trait_item_name * (ty * global_decl_id)) list;
-  types : (trait_item_name * (trait_ref list * ty)) list;
+  types : (trait_item_name * ty) list;
   required_methods : (trait_item_name * fun_decl_id) list;
   provided_methods : (trait_item_name * fun_decl_id) list;
 }

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -459,12 +459,6 @@ and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
         let* x1 = trait_decl_id_of_json x1 in
         let* x2 = trait_clause_id_of_json x2 in
         Ok (ParentClause (x0, x1, x2))
-    | `Assoc [ ("ItemClause", `List [ x0; x1; x2; x3 ]) ] ->
-        let* x0 = trait_instance_id_of_json x0 in
-        let* x1 = trait_decl_id_of_json x1 in
-        let* x2 = trait_item_name_of_json x2 in
-        let* x3 = trait_clause_id_of_json x3 in
-        Ok (ItemClause (x0, x1, x2, x3))
     | `String "SelfId" -> Ok Self
     | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
         let* builtin_or_auto = trait_decl_ref_of_json builtin_or_auto in
@@ -1241,6 +1235,7 @@ let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
         Ok global
     | _ -> Error "")
 
+(* Defined by hand because we discard the empty list of item clauses *)
 and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_decl, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1279,6 +1274,7 @@ and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
                   (option_of_json ty_of_json)))
             types
         in
+        let types = List.map (fun (name, (_, ty)) -> (name, ty)) types in
         let* required_methods =
           list_of_json
             (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
@@ -1303,6 +1299,7 @@ and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
           }
     | _ -> Error "")
 
+(* Defined by hand because we discard the empty list of item clauses *)
 and trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_impl, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1339,6 +1336,7 @@ and trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
                (pair_of_json (list_of_json trait_ref_of_json) ty_of_json))
             types
         in
+        let types = List.map (fun (name, (_, ty)) -> (name, ty)) types in
         let* required_methods =
           list_of_json
             (pair_of_json trait_item_name_of_json fun_decl_id_of_json)

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -176,14 +176,10 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     in
     let types =
       List.map
-        (fun (name, (clauses, opt_ty)) ->
-          let clauses = List.map (trait_clause_to_string env) clauses in
-          let clauses = clauses_to_string indent1 indent_incr 0 clauses in
+        (fun (name, opt_ty) ->
           match opt_ty with
-          | None -> indent1 ^ "type " ^ name ^ clauses ^ "\n"
-          | Some ty ->
-              indent1 ^ "type " ^ name ^ " = " ^ ty_to_string ty ^ clauses
-              ^ "\n")
+          | None -> indent1 ^ "type " ^ name ^ "\n"
+          | Some ty -> indent1 ^ "type " ^ name ^ " = " ^ ty_to_string ty ^ "\n")
         def.types
     in
     let required_methods =
@@ -261,16 +257,8 @@ let trait_impl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     in
     let types =
       List.map
-        (fun (name, (trait_refs, ty)) ->
-          let trait_refs =
-            if trait_refs <> [] then
-              " where ["
-              ^ String.concat ", "
-                  (List.map (trait_ref_to_string env) trait_refs)
-              ^ "]"
-            else ""
-          in
-          indent1 ^ "type " ^ name ^ " = " ^ ty_to_string ty ^ trait_refs ^ "\n")
+        (fun (name, ty) ->
+          indent1 ^ "type " ^ name ^ " = " ^ ty_to_string ty ^ "\n")
         def.types
     in
     let env_method (name, f) =

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -230,10 +230,6 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       let inst_id = trait_instance_id_to_string env inst_id in
       let clause_id = trait_clause_id_to_string env clause_id in
       "parent(" ^ inst_id ^ ")::" ^ clause_id
-  | ItemClause (inst_id, _decl_id, item_name, clause_id) ->
-      let inst_id = trait_instance_id_to_string env inst_id in
-      let clause_id = trait_clause_id_to_string env clause_id in
-      "(" ^ inst_id ^ ")::" ^ item_name ^ "::[" ^ clause_id ^ "]"
   | FnPointer ty -> "fn_ptr(" ^ ty_to_string env ty ^ ")"
   | Closure (fid, generics) ->
       "closure("

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -318,8 +318,6 @@ and trait_instance_id =
   | BuiltinOrAuto of trait_decl_ref
   | Clause of trait_clause_id
   | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
-  | ItemClause of
-      trait_instance_id * trait_decl_id * trait_item_name * trait_clause_id
   | FnPointer of ty
   | Closure of fun_decl_id * generic_args
   | Dyn of trait_decl_ref

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -238,7 +238,10 @@ pub struct TraitDecl {
     ///
     /// The optional id is for the default value.
     pub consts: Vec<(TraitItemName, (Ty, Option<GlobalDeclId>))>,
-    /// The associated types declared in the trait.
+    /// The associated types declared in the trait. The `Vector` is a list of trait clauses that
+    /// apply to this item. This is used during translation, but the `lift_associated_item_clauses`
+    /// pass moves them to be parent clauses later. Hence this is empty after that pass.
+    /// TODO: Do this as we translate to avoid the need to store this vector.
     pub types: Vec<(
         TraitItemName,
         (Vector<TraitClauseId, TraitClause>, Option<Ty>),
@@ -287,7 +290,9 @@ pub struct TraitImpl {
     pub parent_trait_refs: Vector<TraitClauseId, TraitRef>,
     /// The associated constants declared in the trait.
     pub consts: Vec<(TraitItemName, (Ty, GlobalDeclId))>,
-    /// The associated types declared in the trait.
+    /// The associated types declared in the trait. The `Vec` corresponds to the same `Vector` in
+    /// `TraitDecl.types`. In the same way, this is empty after the `lift_associated_item_clauses`
+    /// pass.
     pub types: Vec<(TraitItemName, (Vec<TraitRef>, Ty))>,
     /// The implemented required methods
     pub required_methods: Vec<(TraitItemName, FunDeclId)>,

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -78,22 +78,29 @@ pub enum AnyTransItem<'ctx> {
 }
 
 /// The data of a translated crate.
-#[derive(Default)]
+#[derive(Default, Drive, DriveMut)]
 pub struct TranslatedCrate {
     /// The name of the crate.
     pub crate_name: String,
 
     /// File names to ids and vice-versa
+    #[drive(skip)]
     pub file_to_id: HashMap<FileName, FileId>,
+    #[drive(skip)]
     pub id_to_file: HashMap<FileId, FileName>,
+    #[drive(skip)]
     pub real_file_counter: Generator<LocalFileId>,
+    #[drive(skip)]
     pub virtual_file_counter: Generator<VirtualFileId>,
 
     /// All the ids, in the order in which we encountered them
+    #[drive(skip)]
     pub all_ids: LinkedHashSet<AnyTransId>,
     /// The map from rustc id to translated id.
+    #[drive(skip)]
     pub id_map: HashMap<DefId, AnyTransId>,
     /// The reverse map of ids.
+    #[drive(skip)]
     pub reverse_id_map: HashMap<AnyTransId, DefId>,
 
     /// The translated type definitions
@@ -109,6 +116,7 @@ pub struct TranslatedCrate {
     /// The translated trait declarations
     pub trait_impls: Vector<TraitImplId, TraitImpl>,
     /// The re-ordered groups of declarations, initialized as empty.
+    #[drive(skip)]
     pub ordered_decls: Option<DeclarationsGroups>,
 }
 
@@ -126,7 +134,6 @@ impl TranslatedCrate {
     pub fn all_items(&self) -> impl Iterator<Item = AnyTransItem<'_>> {
         self.all_items_with_ids().map(|(_, item)| item)
     }
-
     pub fn all_items_with_ids(&self) -> impl Iterator<Item = (AnyTransId, AnyTransItem<'_>)> {
         self.all_ids
             .iter()

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -177,8 +177,8 @@ pub enum TraitRefKind {
     /// ```
     ParentClause(Box<TraitRefKind>, TraitDeclId, TraitClauseId),
 
-    /// A clause bound in a trait item (typically a trait clause in an
-    /// associated type).
+    /// A clause defined on an associated type. This variant is only used during translation; after
+    /// the `lift_associated_item_clauses` pass, clauses on items become `ParentClause`s.
     ///
     /// Remark: the [TraitDeclId] gives the trait declaration which is
     /// implemented by the trait implementation from which we take the item
@@ -202,8 +202,7 @@ pub enum TraitRefKind {
     ///                local clause 0 implements Foo
     /// }
     /// ```
-    ///
-    ///
+    #[charon::opaque]
     ItemClause(Box<TraitRefKind>, TraitDeclId, TraitItemName, TraitClauseId),
 
     /// Self, in case of trait declarations/implementations.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -103,6 +103,7 @@ impl GenericArgs {
     }
 
     /// Check whether this matches the given `GenericParams`.
+    /// TODO: check more things, e.g. that the trait refs use the correct trait and generics.
     pub fn matches(&self, params: &GenericParams) -> bool {
         params.regions.len() == self.regions.len()
             && params.types.len() == self.types.len()

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -251,6 +251,7 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
 
     // Run the micro-passes that clean up bodies.
     for pass in ULLBC_PASSES.iter() {
+        trace!("# Starting pass {}", pass.name());
         pass.transform_ctx(&mut ctx)
     }
 
@@ -269,6 +270,7 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
 
         // Run the micro-passes that clean up bodies.
         for pass in LLBC_PASSES.iter() {
+            trace!("# Starting pass {}", pass.name());
             pass.transform_ctx(&mut ctx)
         }
 

--- a/charon/src/bin/generate-ml/GAstOfJson.template.ml
+++ b/charon/src/bin/generate-ml/GAstOfJson.template.ml
@@ -261,6 +261,132 @@ let gglobal_decl_of_json (bodies : 'body gexpr_body option list)
         Ok global
     | _ -> Error "")
 
+(* Defined by hand because we discard the empty list of item clauses *)
+and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
+    (trait_decl, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("def_id", def_id);
+          ("item_meta", item_meta);
+          ("generics", generics);
+          ("parent_clauses", parent_clauses);
+          ("consts", consts);
+          ("types", types);
+          ("required_methods", required_methods);
+          ("provided_methods", provided_methods);
+        ] ->
+        let* def_id = trait_decl_id_of_json def_id in
+        let* item_meta = item_meta_of_json id_to_file item_meta in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* parent_clauses =
+          vector_of_json trait_clause_id_of_json
+            (trait_clause_of_json id_to_file)
+            parent_clauses
+        in
+        let* consts =
+          list_of_json
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json ty_of_json (option_of_json global_decl_id_of_json)))
+            consts
+        in
+        let* types =
+          list_of_json
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json
+                  (vector_of_json trait_clause_id_of_json
+                     (trait_clause_of_json id_to_file))
+                  (option_of_json ty_of_json)))
+            types
+        in
+        let types = List.map (fun (name, (_, ty)) -> (name, ty)) types in
+        let* required_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            required_methods
+        in
+        let* provided_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json
+               (option_of_json fun_decl_id_of_json))
+            provided_methods
+        in
+        Ok
+          {
+            def_id;
+            item_meta;
+            generics;
+            parent_clauses;
+            consts;
+            types;
+            required_methods;
+            provided_methods;
+          }
+    | _ -> Error "")
+
+(* Defined by hand because we discard the empty list of item clauses *)
+and trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
+    (trait_impl, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("def_id", def_id);
+          ("item_meta", item_meta);
+          ("impl_trait", impl_trait);
+          ("generics", generics);
+          ("parent_trait_refs", parent_trait_refs);
+          ("consts", consts);
+          ("types", types);
+          ("required_methods", required_methods);
+          ("provided_methods", provided_methods);
+        ] ->
+        let* def_id = trait_impl_id_of_json def_id in
+        let* item_meta = item_meta_of_json id_to_file item_meta in
+        let* impl_trait = trait_decl_ref_of_json impl_trait in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* parent_trait_refs =
+          vector_of_json trait_clause_id_of_json trait_ref_of_json
+            parent_trait_refs
+        in
+        let* consts =
+          list_of_json
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json ty_of_json global_decl_id_of_json))
+            consts
+        in
+        let* types =
+          list_of_json
+            (pair_of_json trait_item_name_of_json
+               (pair_of_json (list_of_json trait_ref_of_json) ty_of_json))
+            types
+        in
+        let types = List.map (fun (name, (_, ty)) -> (name, ty)) types in
+        let* required_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            required_methods
+        in
+        let* provided_methods =
+          list_of_json
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            provided_methods
+        in
+        Ok
+          {
+            def_id;
+            item_meta;
+            impl_trait;
+            generics;
+            parent_trait_refs;
+            consts;
+            types;
+            required_methods;
+            provided_methods;
+          }
+    | _ -> Error "")
+
 (* __REPLACE5__ *)
 
 let type_declaration_group_of_json (js : json) :

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -451,7 +451,7 @@ fn main() -> Result<()> {
             "GExprBody",
             "ItemKind",
         ],
-        &["TraitDecl", "TraitImpl", "GDeclarationGroup"],
+        &["GDeclarationGroup"],
     ];
     let template_path = dir.join("GAstOfJson.template.ml");
     let mut template = fs::read_to_string(&template_path)

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1176,15 +1176,19 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
                     )
                 }))
                 .chain(self.types.iter().map(|(name, (trait_refs, ty))| {
-                    let trait_refs = trait_refs
-                        .iter()
-                        .map(|x| x.fmt_with_ctx(ctx))
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                    let trait_refs = if trait_refs.is_empty() {
+                        ""
+                    } else {
+                        let trait_refs = trait_refs
+                            .iter()
+                            .map(|x| x.fmt_with_ctx(ctx))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        &format!(" with [{trait_refs}]")
+                    };
                     format!(
-                        "{TAB_INCR}type {name} = {} with [{}]\n",
+                        "{TAB_INCR}type {name} = {}{trait_refs}\n",
                         ty.fmt_with_ctx(ctx),
-                        trait_refs
                     )
                 }))
                 .chain(

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -1,0 +1,63 @@
+//! Move clauses on associated types to be parent clauses. The distinction is not semantically
+//! meaningful. We should ideally to this directly when translating but this is currently
+//! difficult; instead we do this as a post-processing pass.
+use std::collections::HashMap;
+use std::mem;
+
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
+
+use crate::{ast::*, ids::Vector};
+
+use super::{ctx::UllbcPass, TransformCtx};
+
+pub struct Transform;
+impl UllbcPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
+        // For each trait, we move the item-local clauses to be top-level parent clauses, and
+        // record the mapping from the old to the new ids.
+        let trait_item_clause_ids: Vector<
+            TraitDeclId,
+            HashMap<TraitItemName, Vector<TraitClauseId, TraitClauseId>>,
+        > = ctx.translated.trait_decls.map_ref_mut(|decl| {
+            decl.types
+                .iter_mut()
+                .map(|(name, (clauses, _))| {
+                    let id_map = mem::take(clauses).map(|mut clause| {
+                        decl.parent_clauses.push_with(|id| {
+                            clause.clause_id = id;
+                            clause
+                        })
+                    });
+                    (name.clone(), id_map)
+                })
+                .collect()
+        });
+
+        // Move the item-local trait refs to match what we did in the trait declarations.
+        for timpl in ctx.translated.trait_impls.iter_mut() {
+            for (_, (refs, _)) in timpl.types.iter_mut() {
+                for trait_ref in mem::take(refs) {
+                    // Note: this assumes that we listed the types in the same order as in the trait
+                    // decl, which we do.
+                    timpl.parent_trait_refs.push(trait_ref);
+                }
+            }
+        }
+
+        // Update trait refs.
+        ctx.translated
+            .drive_mut(&mut visitor_enter_fn_mut(|trkind: &mut TraitRefKind| {
+                use TraitRefKind::*;
+                if let ItemClause(..) = trkind {
+                    take_mut::take(trkind, |trkind| {
+                        let ItemClause(trait_ref, trait_decl, item_name, item_clause_id) = trkind
+                        else {
+                            unreachable!()
+                        };
+                        let new_id = trait_item_clause_ids[trait_decl][&item_name][item_clause_id];
+                        ParentClause(trait_ref, trait_decl, new_id)
+                    })
+                }
+            }));
+    }
+}

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -11,6 +11,8 @@ pub mod inline_local_panic_functions;
 #[charon::opaque]
 pub mod insert_assign_return_unit;
 #[charon::opaque]
+pub mod lift_associated_item_clauses;
+#[charon::opaque]
 pub mod ops_to_function_calls;
 #[charon::opaque]
 pub mod reconstruct_asserts;
@@ -37,6 +39,8 @@ pub mod update_closure_signatures;
 pub use ctx::TransformCtx;
 
 pub static ULLBC_PASSES: &[&dyn ctx::UllbcPass] = &[
+    // Move clauses on associated types to be parent clauses
+    &lift_associated_item_clauses::Transform,
     // # Micro-pass: Remove overflow/div-by-zero/bounds checks since they are already part of the
     // arithmetic/array operation in the semantics of (U)LLBC.
     // **WARNING**: this pass uses the fact that the dynamic checks introduced by Rustc use a

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -249,7 +249,7 @@ impl<T, I> core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T,
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
-    type Output = @TraitClause0::Output with []
+    type Output = @TraitClause0::Output
     fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
 }
 
@@ -270,7 +270,7 @@ fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::
 impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>, Slice<T>>
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>#1}
-    type Output = Slice<T> with []
+    type Output = Slice<T>
     fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get
     fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_mut
     fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_unchecked
@@ -399,7 +399,7 @@ impl<T, I, const N : usize> core::array::{impl core::ops::index::Index<I> for Ar
 where
     [@TraitClause0]: core::ops::index::Index<Slice<T>, I>,
 {
-    type Output = @TraitClause0::Output with []
+    type Output = @TraitClause0::Output
     fn index = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}::index
 }
 

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -16,9 +16,8 @@ where
     Self::Item : 'a,
 {
     parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
+    parent_clause_1 : [@TraitClause1]: core::clone::Clone<Self::Item>
     type Item
-        where
-            [@TraitClause0]: core::clone::Clone<Self::Item>,
     fn use_item : test_crate::Foo::use_item
 }
 
@@ -60,7 +59,8 @@ where
 impl<'a, T> test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T)>
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)#4}<'_, T>
-    type Item = core::option::Option<&'a (T)> with [core::option::{impl core::clone::Clone for core::option::Option<T>#5}<&'_ (T)>[core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>]]
+    parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>#5}<&'_ (T)>[core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>]
+    type Item = core::option::Option<&'a (T)>
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
@@ -74,7 +74,7 @@ where
     let @2: &'_ (@TraitClause0::Item); // anonymous local
 
     @2 := &x@1
-    @0 := (@TraitClause0::Item::[@TraitClause0])::clone(move (@2))
+    @0 := (parents(@TraitClause0)::[@TraitClause1])::clone(move (@2))
     drop @2
     drop x@1
     return

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -36,10 +36,9 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
     parent_clause_1 : [@TraitClause1]: core::num::nonzero::private::Sealed<Self>
+    parent_clause_2 : [@TraitClause2]: core::marker::Copy<Self::NonZeroInner>
+    parent_clause_3 : [@TraitClause3]: core::clone::Clone<Self::NonZeroInner>
     type NonZeroInner
-        where
-            [@TraitClause0]: core::marker::Copy<Self::NonZeroInner>,
-            [@TraitClause1]: core::clone::Clone<Self::NonZeroInner>,
 }
 
 opaque type core::num::nonzero::NonZero<T>
@@ -78,7 +77,9 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for u32#41}
     parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32#19}
-    type NonZeroInner = core::num::nonzero::private::NonZeroU32Inner with [core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner#12}, core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}]
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner#12}
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}
+    type NonZeroInner = core::num::nonzero::private::NonZeroU32Inner
 }
 
 enum core::option::Option<T> =

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -76,10 +76,9 @@ where
 
 trait test_crate::Trait<Self>
 {
+    parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self::Ty>
+    parent_clause_1 : [@TraitClause1]: core::clone::Clone<Self::Ty>
     type Ty
-        where
-            [@TraitClause0]: core::marker::Copy<Self::Ty>,
-            [@TraitClause1]: core::clone::Clone<Self::Ty>,
 }
 
 fn test_crate::copy_assoc_ty<T>(@1: @TraitClause0::Ty)

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -28,7 +28,7 @@ impl<T, U> core::convert::{impl core::convert::TryInto<U> for T#6}<T, U> : core:
 where
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 {
-    type Error = @TraitClause0::Error with []
+    type Error = @TraitClause0::Error
     fn try_into = core::convert::{impl core::convert::TryInto<U> for T#6}::try_into
 }
 
@@ -52,7 +52,7 @@ impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Sl
 where
     [@TraitClause0]: core::marker::Copy<T>,
 {
-    type Error = core::array::TryFromSliceError with []
+    type Error = core::array::TryFromSliceError
     fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from
 }
 

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -28,7 +28,7 @@ impl<T, U> core::convert::{impl core::convert::TryInto<U> for T#6}<T, U> : core:
 where
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 {
-    type Error = @TraitClause0::Error with []
+    type Error = @TraitClause0::Error
     fn try_into = core::convert::{impl core::convert::TryInto<U> for T#6}::try_into
 }
 
@@ -52,7 +52,7 @@ impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Sl
 where
     [@TraitClause0]: core::marker::Copy<T>,
 {
-    type Error = core::array::TryFromSliceError with []
+    type Error = core::array::TryFromSliceError
     fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from
 }
 

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -145,12 +145,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
 {
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
-        where
-            [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>,
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
@@ -163,8 +162,9 @@ impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIter
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
-    type Item = @TraitClause0::Item with []
-    type IntoIter = I with [@TraitClause0]
+    parent_clause0 = @TraitClause0
+    type Item = @TraitClause0::Item
+    type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
 }
 
@@ -285,10 +285,9 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
     parent_clause_1 : [@TraitClause1]: core::num::nonzero::private::Sealed<Self>
+    parent_clause_2 : [@TraitClause2]: core::marker::Copy<Self::NonZeroInner>
+    parent_clause_3 : [@TraitClause3]: core::clone::Clone<Self::NonZeroInner>
     type NonZeroInner
-        where
-            [@TraitClause0]: core::marker::Copy<Self::NonZeroInner>,
-            [@TraitClause1]: core::clone::Clone<Self::NonZeroInner>,
 }
 
 opaque type core::num::nonzero::NonZero<T>
@@ -327,7 +326,9 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#2
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
     parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner with [core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}, core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}]
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
@@ -352,7 +353,7 @@ impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core
 where
     [@TraitClause0]: core::iter::range::Step<A>,
 {
-    type Item = A with []
+    type Item = A
     fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next
     fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint
     fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -2,10 +2,9 @@
 
 trait test_crate::Trait1<Self>
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::Trait2<Self::T>
+    parent_clause_1 : [@TraitClause1]: test_crate::Trait1<Self::T>
     type T
-        where
-            [@TraitClause0]: test_crate::Trait2<Self::T>,
-            [@TraitClause1]: test_crate::Trait1<Self::T>,
 }
 
 trait test_crate::Trait2<Self>
@@ -25,17 +24,15 @@ trait test_crate::T2<Self, T>
 
 trait test_crate::T3<Self>
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::T5<Self::T>
     type T
-        where
-            [@TraitClause0]: test_crate::T5<Self::T>,
 }
 
 trait test_crate::T5<Self>
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::T4<Self::T>
+    parent_clause_1 : [@TraitClause1]: test_crate::T3<Self::T>
     type T
-        where
-            [@TraitClause0]: test_crate::T4<Self::T>,
-            [@TraitClause1]: test_crate::T3<Self::T>,
 }
 
 trait test_crate::T4<Self>

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -874,12 +874,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
 {
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
-        where
-            [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>,
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
@@ -892,8 +891,9 @@ impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIter
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
-    type Item = @TraitClause0::Item with []
-    type IntoIter = I with [@TraitClause0]
+    parent_clause0 = @TraitClause0
+    type Item = @TraitClause0::Item
+    type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
 }
 
@@ -1014,10 +1014,9 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
     parent_clause_1 : [@TraitClause1]: core::num::nonzero::private::Sealed<Self>
+    parent_clause_2 : [@TraitClause2]: core::marker::Copy<Self::NonZeroInner>
+    parent_clause_3 : [@TraitClause3]: core::clone::Clone<Self::NonZeroInner>
     type NonZeroInner
-        where
-            [@TraitClause0]: core::marker::Copy<Self::NonZeroInner>,
-            [@TraitClause1]: core::clone::Clone<Self::NonZeroInner>,
 }
 
 opaque type core::num::nonzero::NonZero<T>
@@ -1056,7 +1055,9 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#2
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
     parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner with [core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}, core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}]
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
@@ -1081,7 +1082,7 @@ impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core
 where
     [@TraitClause0]: core::iter::range::Step<A>,
 {
-    type Item = A with []
+    type Item = A
     fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next
     fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint
     fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count
@@ -1671,7 +1672,7 @@ impl<T, I, A> alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
-    type Output = @TraitClause0::Output with []
+    type Output = @TraitClause0::Output
     fn index = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}::index
 }
 
@@ -1705,7 +1706,7 @@ fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#
 impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}<T> : core::slice::index::SliceIndex<usize, Slice<T>>
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize}
-    type Output = T with []
+    type Output = T
     fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get
     fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_mut
     fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_unchecked

--- a/charon/tests/ui/name-matcher-tests.out
+++ b/charon/tests/ui/name-matcher-tests.out
@@ -89,7 +89,7 @@ impl<T, I> core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T,
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
-    type Output = @TraitClause0::Output with []
+    type Output = @TraitClause0::Output
     fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
 }
 
@@ -110,7 +110,7 @@ fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::
 impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}<T> : core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, Slice<T>>
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>#3}
-    type Output = Slice<T> with []
+    type Output = Slice<T>
     fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get
     fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_mut
     fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -268,7 +268,7 @@ fn alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}::der
 
 impl<T, A> alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}<T, A> : core::ops::deref::Deref<alloc::boxed::Box<T>>
 {
-    type Target = T with []
+    type Target = T
     fn deref = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}::deref
 }
 

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -49,9 +49,8 @@ trait core::hash::Hash<Self>
 
 trait core::hash::BuildHasher<Self>
 {
+    parent_clause_0 : [@TraitClause0]: core::hash::Hasher<Self::Hasher>
     type Hasher
-        where
-            [@TraitClause0]: core::hash::Hasher<Self::Hasher>,
     fn build_hasher : core::hash::BuildHasher::build_hasher
     fn hash_one
 }
@@ -125,7 +124,8 @@ fn std::hash::random::{impl core::hash::BuildHasher for std::hash::random::Rando
 
 impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1} : core::hash::BuildHasher<std::hash::random::RandomState>
 {
-    type Hasher = std::hash::random::DefaultHasher with [std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}]
+    parent_clause0 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}
+    type Hasher = std::hash::random::DefaultHasher
     fn build_hasher = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}::build_hasher
 }
 
@@ -160,7 +160,7 @@ where
     [@TraitClause4]: core::hash::Hash<Q>,
     [@TraitClause5]: core::hash::BuildHasher<S>,
 {
-    type Output = V with []
+    type Output = V
     fn index = std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>#9}::index
 }
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -116,12 +116,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
 {
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
-        where
-            [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>,
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
@@ -172,10 +171,9 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::marker::Copy<Self>
     parent_clause_1 : [@TraitClause1]: core::num::nonzero::private::Sealed<Self>
+    parent_clause_2 : [@TraitClause2]: core::marker::Copy<Self::NonZeroInner>
+    parent_clause_3 : [@TraitClause3]: core::clone::Clone<Self::NonZeroInner>
     type NonZeroInner
-        where
-            [@TraitClause0]: core::marker::Copy<Self::NonZeroInner>,
-            [@TraitClause1]: core::clone::Clone<Self::NonZeroInner>,
 }
 
 opaque type core::num::nonzero::NonZero<T>
@@ -214,7 +212,9 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#2
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
     parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner with [core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}, core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}]
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::advance_by<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
@@ -223,7 +223,7 @@ unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for co
 
 impl<T, const N : usize> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize> : core::iter::traits::iterator::Iterator<core::array::iter::IntoIter<T, const N : usize>>
 {
-    type Item = T with []
+    type Item = T
     fn next = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::next
     fn size_hint = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::size_hint
     fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::fold
@@ -237,8 +237,9 @@ fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<
 
 impl<T, const N : usize> core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize> : core::iter::traits::collect::IntoIterator<Array<T, const N : usize>>
 {
-    type Item = T with []
-    type IntoIter = core::array::iter::IntoIter<T, const N : usize> with [core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>]
+    parent_clause0 = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>
+    type Item = T
+    type IntoIter = core::array::iter::IntoIter<T, const N : usize>
     fn into_iter = core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter
 }
 
@@ -253,8 +254,9 @@ impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIter
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
-    type Item = @TraitClause0::Item with []
-    type IntoIter = I with [@TraitClause0]
+    parent_clause0 = @TraitClause0
+    type Item = @TraitClause0::Item
+    type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
 }
 
@@ -337,7 +339,7 @@ Unknown decl: 44
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
 {
-    type Item = &'a (T) with []
+    type Item = &'a (T)
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::count
@@ -386,7 +388,7 @@ unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for co
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Chunks<'a, T>>
 {
-    type Item = &'a (Slice<T>) with []
+    type Item = &'a (Slice<T>)
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::count
@@ -411,7 +413,7 @@ unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for co
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::ChunksExact<'a, T>>
 {
-    type Item = &'a (Slice<T>) with []
+    type Item = &'a (Slice<T>)
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::count

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -454,12 +454,11 @@ global test_crate::WithConstTy::LEN2<Self, const LEN : usize>  {
 
 trait test_crate::WithConstTy<Self, const LEN : usize>
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::ToU64<Self::W>
     const LEN1 : usize
     const LEN2 : usize = test_crate::WithConstTy::LEN2
     type V
     type W
-        where
-            [@TraitClause0]: test_crate::ToU64<Self::W>,
     fn f : test_crate::WithConstTy::f
 }
 
@@ -485,10 +484,11 @@ fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::f<'_0, '_1
 
 impl test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8} : test_crate::WithConstTy<bool, 32 : usize>
 {
+    parent_clause0 = test_crate::{impl test_crate::ToU64 for u64#2}
     const LEN1 : usize = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::LEN1
     const LEN2 : usize = test_crate::WithConstTy::LEN2
-    type V = u8 with []
-    type W = u64 with [test_crate::{impl test_crate::ToU64 for u64#2}]
+    type V = u8
+    type W = u64
     fn f = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::f
 }
 
@@ -526,7 +526,7 @@ where
     let @2: @TraitClause0::W; // anonymous local
 
     @2 := move (x@1)
-    @0 := (@TraitClause0::W::[@TraitClause0])::to_u64(move (@2))
+    @0 := (parents(@TraitClause0)::[@TraitClause0])::to_u64(move (@2))
     drop @2
     drop x@1
     return
@@ -644,12 +644,11 @@ trait test_crate::Iterator<Self>
 
 trait test_crate::IntoIterator<Self>
 where
-    (Self::IntoIter::[@TraitClause0])::Item = Self::Item,
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::Iterator<Self::IntoIter>
     type Item
     type IntoIter
-        where
-            [@TraitClause0]: test_crate::Iterator<Self::IntoIter>,
     fn into_iter : test_crate::IntoIterator::into_iter
 }
 
@@ -668,9 +667,8 @@ trait test_crate::WithTarget<Self>
 
 trait test_crate::ParentTrait2<Self>
 {
+    parent_clause_0 : [@TraitClause0]: test_crate::WithTarget<Self::U>
     type U
-        where
-            [@TraitClause0]: test_crate::WithTarget<Self::U>,
 }
 
 trait test_crate::ChildTrait2<Self>
@@ -681,12 +679,13 @@ trait test_crate::ChildTrait2<Self>
 
 impl test_crate::{impl test_crate::WithTarget for u32#11} : test_crate::WithTarget<u32>
 {
-    type Target = u32 with []
+    type Target = u32
 }
 
 impl test_crate::{impl test_crate::ParentTrait2 for u32#12} : test_crate::ParentTrait2<u32>
 {
-    type U = u32 with [test_crate::{impl test_crate::WithTarget for u32#11}]
+    parent_clause0 = test_crate::{impl test_crate::WithTarget for u32#11}
+    type U = u32
 }
 
 fn test_crate::{impl test_crate::ChildTrait2 for u32#13}::convert(@1: u32) -> u32
@@ -837,7 +836,7 @@ fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(@1: &'_0 mut (S
 
 fn test_crate::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
-fn test_crate::ChildTrait2::convert<Self>(@1: (parents(Self)::[@TraitClause0])::U) -> ((parents(Self)::[@TraitClause0])::U::[@TraitClause0])::Target
+fn test_crate::ChildTrait2::convert<Self>(@1: (parents(Self)::[@TraitClause0])::U) -> (parents((parents(Self)::[@TraitClause0]))::[@TraitClause0])::Target
 
 fn test_crate::CFnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -25,7 +25,7 @@ fn test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from<'_0, '_1>(@1:
 
 impl<'_0> test_crate::{impl test_crate::From<&'_0 (bool)> for bool}<'_0> : test_crate::From<bool, &'_0 (bool)>
 {
-    type Error = () with []
+    type Error = ()
     fn from = test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from
 }
 

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -17,9 +17,8 @@ trait core::borrow::Borrow<Self, Borrowed>
 
 trait alloc::borrow::ToOwned<Self>
 {
+    parent_clause_0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
     type Owned
-        where
-            [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>,
     fn to_owned : alloc::borrow::ToOwned::to_owned
     fn clone_into
 }
@@ -59,7 +58,8 @@ impl<T> alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}<T> : alloc::b
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
-    type Owned = alloc::vec::Vec<T, alloc::alloc::Global> with [alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}<T, alloc::alloc::Global>]
+    parent_clause0 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}<T, alloc::alloc::Global>
+    type Owned = alloc::vec::Vec<T, alloc::alloc::Global>
     fn to_owned = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::to_owned
     fn clone_into = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::clone_into
 }


### PR DESCRIPTION
Dinstinguishing trait clauses defined on an associated type versus those defined as a where clause on the whole trait does not seem useful. What's meaningful is distinguishing clauses that are required to mention the trait versus clauses that are implied by the trait. We already make this distinction: required clauses are in the `TraitDecl.generics` field, implied clauses are in `TraitDecl.parent_clauses`.

This PR moves all the `type Item: Trait` clauses to be `where Self::Item: Trait` parent clauses on the trait to simplify clause management. This is done as a post-processing pass. I would have liked to to this when we translate clauses, but I'll leave that for later when generics are easier to follow.