### PR TITLE
Store `TraitImplId` in `Name` instead of reproducing generics by hand

### DIFF
--- a/charon-ml/.ocamlformat
+++ b/charon-ml/.ocamlformat
@@ -1,1 +1,2 @@
-doc-comments=before
+doc-comments = before
+exp-grouping = preserve

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.21"
+let supported_charon_version = "0.1.22"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -660,31 +660,17 @@ and generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
           }
     | _ -> Error "")
 
-and impl_elem_kind_of_json (js : json) : (impl_elem_kind, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Ty", ty) ] ->
-        let* ty = ty_of_json ty in
-        Ok (ImplElemTy ty)
-    | `Assoc [ ("Trait", trait) ] ->
-        let* trait = trait_decl_ref_of_json trait in
-        Ok (ImplElemTrait trait)
-    | _ -> Error "")
-
 and impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
     (impl_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc
-        [
-          ("disambiguator", disambiguator);
-          ("generics", generics);
-          ("kind", kind);
-        ] ->
-        let* disambiguator = disambiguator_of_json disambiguator in
-        let* generics = generic_params_of_json id_to_file generics in
-        let* kind = impl_elem_kind_of_json kind in
-        Ok { disambiguator; generics; kind }
+    | `Assoc [ ("Ty", `List [ x0; x1 ]) ] ->
+        let* x0 = generic_params_of_json id_to_file x0 in
+        let* x1 = ty_of_json x1 in
+        Ok (ImplElemTy (x0, x1))
+    | `Assoc [ ("Trait", trait) ] ->
+        let* trait = trait_impl_id_of_json trait in
+        Ok (ImplElemTrait trait)
     | _ -> Error "")
 
 and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
@@ -695,9 +681,10 @@ and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
         let* x0 = string_of_json x0 in
         let* x1 = disambiguator_of_json x1 in
         Ok (PeIdent (x0, x1))
-    | `Assoc [ ("Impl", impl) ] ->
-        let* impl = impl_elem_of_json id_to_file impl in
-        Ok (PeImpl impl)
+    | `Assoc [ ("Impl", `List [ x0; x1 ]) ] ->
+        let* x0 = impl_elem_of_json id_to_file x0 in
+        let* x1 = disambiguator_of_json x1 in
+        Ok (PeImpl (x0, x1))
     | _ -> Error "")
 
 and name_of_json (id_to_file : id_to_file_map) (js : json) :

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -252,30 +252,28 @@ and trait_instance_id_to_string (env : ('a, 'b) fmt_env)
       ^ ")"
   | UnknownTrait msg -> "UNKNOWN(" ^ msg ^ ")"
 
-and impl_elem_kind_to_string (env : ('a, 'b) fmt_env) (k : impl_elem_kind) :
-    string =
-  match k with
-  | ImplElemTy ty -> ty_to_string env ty
-  | ImplElemTrait tr ->
-      (* Put the first type argument aside (it gives the type for which we
-         implement the trait) *)
-      let { trait_decl_id; decl_generics } = tr in
-      let ty, types = Collections.List.pop decl_generics.types in
-      let decl_generics = { decl_generics with types } in
-      let ty = ty_to_string env ty in
-      let tr = { trait_decl_id; decl_generics } in
-      let tr = trait_decl_ref_to_string env tr in
-      "(" ^ tr ^ " for " ^ ty ^ ")"
-
-and impl_elem_to_string (env : ('a, 'b) fmt_env) (e : impl_elem) : string =
-  (* Locally replace the generics and the predicates *)
-  let env = fmt_env_update_generics_and_preds env e.generics in
-  let d =
-    if e.disambiguator = Disambiguator.zero then ""
-    else "#" ^ Disambiguator.to_string e.disambiguator
-  in
-  let kind = impl_elem_kind_to_string env e.kind in
-  "{" ^ kind ^ d ^ "}"
+and impl_elem_to_string (env : ('a, 'b) fmt_env) (elem : impl_elem) : string =
+  match elem with
+  | ImplElemTy (generics, ty) ->
+      (* Locally replace the generics and the predicates *)
+      let env = fmt_env_update_generics_and_preds env generics in
+      ty_to_string env ty
+  | ImplElemTrait impl_id -> begin
+      match TraitImplId.Map.find_opt impl_id env.trait_impls with
+      | None -> trait_impl_id_to_string env impl_id
+      | Some impl ->
+          (* Locally replace the generics and the predicates *)
+          let env = fmt_env_update_generics_and_preds env impl.generics in
+          (* Put the first type argument aside (it gives the type for which we
+             implement the trait) *)
+          let { trait_decl_id; decl_generics } = impl.impl_trait in
+          let ty, types = Collections.List.pop decl_generics.types in
+          let decl_generics = { decl_generics with types } in
+          let tr = { trait_decl_id; decl_generics } in
+          let ty = ty_to_string env ty in
+          let tr = trait_decl_ref_to_string env tr in
+          tr ^ " for " ^ ty
+    end
 
 and path_elem_to_string (env : ('a, 'b) fmt_env) (e : path_elem) : string =
   match e with
@@ -284,7 +282,11 @@ and path_elem_to_string (env : ('a, 'b) fmt_env) (e : path_elem) : string =
         if d = Disambiguator.zero then "" else "#" ^ Disambiguator.to_string d
       in
       s ^ d
-  | PeImpl impl -> impl_elem_to_string env impl
+  | PeImpl (impl, d) ->
+      let d =
+        if d = Disambiguator.zero then "" else "#" ^ Disambiguator.to_string d
+      in
+      "{" ^ impl_elem_to_string env impl ^ "}" ^ d
 
 and name_to_string (env : ('a, 'b) fmt_env) (n : name) : string =
   let name = List.map (path_elem_to_string env) n in

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -483,19 +483,15 @@ and trait_type_constraint = {
 
 (** In implementation path elements we distinguish inherent impls (impl blocks
     for types) from trait impls *)
-type impl_elem_kind = ImplElemTy of ty | ImplElemTrait of trait_decl_ref
-[@@deriving show, ord]
-
-(** An impl path element for [name] *)
-type impl_elem = {
-  disambiguator : Disambiguator.id;
-  generics : generic_params;
-  kind : impl_elem_kind;
-}
+type impl_elem =
+  | ImplElemTy of generic_params * ty
+  | ImplElemTrait of trait_impl_id
 [@@deriving show, ord]
 
 (** A path element for [name] *)
-type path_elem = PeIdent of string * Disambiguator.id | PeImpl of impl_elem
+type path_elem =
+  | PeIdent of string * Disambiguator.id
+  | PeImpl of impl_elem * Disambiguator.id
 [@@deriving show, ord]
 
 (** A name *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/src/ast/assumed.rs
+++ b/charon/src/ast/assumed.rs
@@ -87,34 +87,21 @@ impl BuiltinFun {
             // Box::new is peculiar because there is an impl block
             use PathElem::*;
             match name.name.as_slice() {
-                [Ident(alloc, _), Ident(boxed, _), Impl(impl_elem), Ident(new, _)] => {
-                    if alloc == "alloc" && boxed == "boxed" && new == "new" {
-                        match &impl_elem.kind {
-                            ImplElemKind::Ty(Ty::Adt(
-                                TypeId::Assumed(AssumedTy::Box),
-                                generics,
-                            )) => {
-                                let GenericArgs {
-                                    regions,
-                                    types,
-                                    const_generics,
-                                    trait_refs,
-                                } = generics;
-                                if regions.is_empty()
-                                    && types.len() == 1
-                                    && const_generics.is_empty()
-                                    && trait_refs.is_empty()
-                                {
-                                    match types.as_slice() {
-                                        [Ty::TypeVar(_)] => Some(BuiltinFun::BoxNew),
-                                        _ => None,
-                                    }
-                                } else {
-                                    None
-                                }
-                            }
-                            _ => None,
-                        }
+                [Ident(alloc, _), Ident(boxed, _), Impl(ImplElem::Ty(_, Ty::Adt(TypeId::Assumed(AssumedTy::Box), generics)), _), Ident(new, _)]
+                    if alloc == "alloc" && boxed == "boxed" && new == "new" =>
+                {
+                    let GenericArgs {
+                        regions,
+                        types,
+                        const_generics,
+                        trait_refs,
+                    } = generics;
+                    if regions.is_empty()
+                        && matches!(types.as_slice(), [Ty::TypeVar(_)])
+                        && const_generics.is_empty()
+                        && trait_refs.is_empty()
+                    {
+                        Some(BuiltinFun::BoxNew)
                     } else {
                         None
                     }

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -13,14 +13,7 @@ generate_index_type!(Disambiguator);
 #[charon::variants_prefix("Pe")]
 pub enum PathElem {
     Ident(String, Disambiguator),
-    Impl(ImplElem),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
-pub struct ImplElem {
-    pub disambiguator: Disambiguator,
-    pub generics: GenericParams,
-    pub kind: ImplElemKind,
+    Impl(ImplElem, Disambiguator),
 }
 
 /// There are two kinds of `impl` blocks:
@@ -35,13 +28,9 @@ pub struct ImplElem {
 /// We distinguish the two.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 #[charon::variants_prefix("ImplElem")]
-pub enum ImplElemKind {
-    Ty(Ty),
-    /// Remark: the first type argument in the trait ref gives the type for
-    /// which we implement the trait.
-    /// For instance: `PartialEq<List<T>>` means: the `PartialEq` instance
-    /// for `List<T>`.
-    Trait(TraitDeclRef),
+pub enum ImplElem {
+    Ty(GenericParams, Ty),
+    Trait(TraitImplId),
 }
 
 /// An item name/path

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -9,7 +9,7 @@ impl PathElem {
     fn equals_ident(&self, id: &str) -> bool {
         match self {
             PathElem::Ident(s, d) => s == id && d.is_zero(),
-            PathElem::Impl(_) => false,
+            PathElem::Impl(..) => false,
         }
     }
 }

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -30,7 +30,7 @@ fn repr_name(_crate_data: &CrateData, n: &Name) -> String {
         .iter()
         .map(|path_elem| match path_elem {
             PathElem::Ident(i, _) => i.clone(),
-            PathElem::Impl(_) => "<impl>".to_string(),
+            PathElem::Impl(..) => "<impl>".to_string(),
         })
         .join("::")
 }
@@ -418,7 +418,6 @@ fn main() -> Result<()> {
             "TypeOutlives",
             "TraitTypeConstraint",
             "GenericParams",
-            "ImplElemKind",
             "ImplElem",
             "PathElem",
             "Name",

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -608,35 +608,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for GlobalDeclRef {
 
 impl<C: AstFormatter> FmtWithCtx<C> for ImplElem {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        let d = if self.disambiguator.is_zero() {
-            "".to_string()
-        } else {
-            format!("#{}", self.disambiguator)
-        };
-        let ctx = ctx.set_generics(&self.generics);
-        // Just printing the generics (not the predicates)
-        format!("{{{}}}{d}", self.kind.fmt_with_ctx(&ctx),)
-    }
-}
-
-impl<C: AstFormatter> FmtWithCtx<C> for ImplElemKind {
-    fn fmt_with_ctx(&self, ctx: &C) -> String {
-        match self {
-            ImplElemKind::Ty(ty) => ty.fmt_with_ctx(ctx),
-            ImplElemKind::Trait(tr) => {
-                // We need to put the first type parameter aside: it is
-                // the type for which we implement the trait.
-                // This is not very clean because it's hard to move the
-                // first element out of a vector...
-                let TraitDeclRef { trait_id, generics } = tr;
-                let (ty, generics) = generics.pop_first_type_arg();
-                let tr = TraitDeclRef {
-                    trait_id: *trait_id,
-                    generics,
-                };
-                format!("impl {} for {}", tr.fmt_with_ctx(ctx), ty.fmt_with_ctx(ctx))
-            }
-        }
+        ctx.format_object(self)
     }
 }
 
@@ -672,7 +644,15 @@ impl<C: AstFormatter> FmtWithCtx<C> for PathElem {
                 };
                 format!("{s}{d}")
             }
-            PathElem::Impl(impl_elem) => impl_elem.fmt_with_ctx(ctx),
+            PathElem::Impl(impl_elem, d) => {
+                let impl_elem = impl_elem.fmt_with_ctx(ctx);
+                let d = if d.is_zero() {
+                    "".to_string()
+                } else {
+                    format!("#{}", d)
+                };
+                format!("{impl_elem}{d}")
+            }
         }
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -615,7 +615,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for ImplElem {
         };
         let ctx = ctx.set_generics(&self.generics);
         // Just printing the generics (not the predicates)
-        format!("{{{}{d}}}", self.kind.fmt_with_ctx(&ctx),)
+        format!("{{{}}}{d}", self.kind.fmt_with_ctx(&ctx),)
     }
 }
 

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -253,30 +253,30 @@ where
     fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
 }
 
-impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>#1} : core::slice::index::private_slice_index::Sealed<core::ops::range::Range<usize>>
+impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>}#1 : core::slice::index::private_slice_index::Sealed<core::ops::range::Range<usize>>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_mut<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_mut<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_unchecked<T>(@1: core::ops::range::Range<usize>, @2: *mut Slice<T>) -> *mut Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_unchecked<T>(@1: core::ops::range::Range<usize>, @2: *mut Slice<T>) -> *mut Slice<T>
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_unchecked_mut<T>(@1: core::ops::range::Range<usize>, @2: *const Slice<T>) -> *const Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_unchecked_mut<T>(@1: core::ops::range::Range<usize>, @2: *const Slice<T>) -> *const Slice<T>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::index<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::index<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::index_mut<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::index_mut<'_0, T>(@1: core::ops::range::Range<usize>, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
 
-impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>, Slice<T>>
+impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>, Slice<T>>
 {
-    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>#1}
+    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>}#1
     type Output = Slice<T>
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}::index_mut
+    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get
+    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_mut
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_unchecked
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::get_unchecked_mut
+    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::index
+    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4::index_mut
 }
 
 fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
@@ -300,7 +300,7 @@ fn test_crate::slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3:
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]::index(move (@6), move (@7))
+    @5 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]::index(move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)
@@ -316,17 +316,17 @@ trait core::ops::index::IndexMut<Self, Idx>
     fn index_mut : core::ops::index::IndexMut::index_mut
 }
 
-fn core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}::index_mut<'_0, T, I>(@1: &'_0 mut (Slice<T>), @2: I) -> &'_0 mut (@TraitClause0::Output)
+fn core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut<'_0, T, I>(@1: &'_0 mut (Slice<T>), @2: I) -> &'_0 mut (@TraitClause0::Output)
 where
     // Inherited clauses:
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 
-impl<T, I> core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}<T, I> : core::ops::index::IndexMut<Slice<T>, I>
+impl<T, I> core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<T, I> : core::ops::index::IndexMut<Slice<T>, I>
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     parent_clause0 = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I>[@TraitClause0]
-    fn index_mut = core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}::index_mut
+    fn index_mut = core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut
 }
 
 fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut ((parents(Self)::[@TraitClause0])::Output)
@@ -351,7 +351,7 @@ fn test_crate::slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3
     @8 := core::ops::range::Range { start: move (@9), end: move (@10) }
     drop @10
     drop @9
-    @6 := core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]::index_mut(move (@7), move (@8))
+    @6 := core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]::index_mut(move (@7), move (@8))
     drop @8
     drop @7
     @5 := &mut *(@6)
@@ -390,17 +390,17 @@ fn test_crate::array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>)) -
     return
 }
 
-fn core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<T, I, const N : usize>[@TraitClause0]::Output)
+fn core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0]::Output)
 where
     // Inherited clauses:
     [@TraitClause0]: core::ops::index::Index<Slice<T>, I>,
 
-impl<T, I, const N : usize> core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<T, I, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I>
+impl<T, I, const N : usize> core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I>
 where
     [@TraitClause0]: core::ops::index::Index<Slice<T>, I>,
 {
     type Output = @TraitClause0::Output
-    fn index = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}::index
+    fn index = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index
 }
 
 fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
@@ -422,7 +422,7 @@ fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]]::index(move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]]::index(move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)
@@ -432,17 +432,17 @@ fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2
     return
 }
 
-fn core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>#16}::index_mut<'_0, T, I, const N : usize>(@1: &'_0 mut (Array<T, const N : usize>), @2: I) -> &'_0 mut (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<T, I, const N : usize>[(parents(@TraitClause0)::[@TraitClause0])]::Output)
+fn core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_0, T, I, const N : usize>(@1: &'_0 mut (Array<T, const N : usize>), @2: I) -> &'_0 mut (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[(parents(@TraitClause0)::[@TraitClause0])]::Output)
 where
     // Inherited clauses:
     [@TraitClause0]: core::ops::index::IndexMut<Slice<T>, I>,
 
-impl<T, I, const N : usize> core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>#16}<T, I, const N : usize> : core::ops::index::IndexMut<Array<T, const N : usize>, I>
+impl<T, I, const N : usize> core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16<T, I, const N : usize> : core::ops::index::IndexMut<Array<T, const N : usize>, I>
 where
     [@TraitClause0]: core::ops::index::IndexMut<Slice<T>, I>,
 {
-    parent_clause0 = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<T, I, const N : usize>[(parents(@TraitClause0)::[@TraitClause0])]
-    fn index_mut = core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>#16}::index_mut
+    parent_clause0 = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[(parents(@TraitClause0)::[@TraitClause0])]
+    fn index_mut = core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut
 }
 
 fn test_crate::array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
@@ -465,7 +465,7 @@ fn test_crate::array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @
     @8 := core::ops::range::Range { start: move (@9), end: move (@10) }
     drop @10
     drop @9
-    @6 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>#16}<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]]::index_mut(move (@7), move (@8))
+    @6 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]]::index_mut(move (@7), move (@8))
     drop @8
     drop @7
     @5 := &mut *(@6)
@@ -1002,7 +1002,7 @@ fn test_crate::range_all()
     @fake_read(x@1)
     @6 := &mut x@1
     @7 := core::ops::range::Range { start: const (1 : usize), end: const (3 : usize) }
-    @5 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>#16}<u32, core::ops::range::Range<usize>, 4 : usize>[core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>#1}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]]::index_mut(move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16<u32, core::ops::range::Range<usize>, 4 : usize>[core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]]::index_mut(move (@6), move (@7))
     drop @7
     drop @6
     @4 := &mut *(@5)
@@ -1354,7 +1354,7 @@ fn test_crate::f4<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) 
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>#15}<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>#4}<u32>]]::index(move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<u32, core::ops::range::Range<usize>, 32 : usize>[core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>}#4<u32>]]::index(move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -215,6 +215,12 @@ struct core::ops::range::Range<Idx> =
   end: Idx
 }
 
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index : core::ops::index::Index::index
+}
+
 trait core::slice::index::private_slice_index::Sealed<Self>
 
 enum core::option::Option<T> =
@@ -232,12 +238,6 @@ trait core::slice::index::SliceIndex<Self, T>
     fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
     fn index : core::slice::index::SliceIndex::index
     fn index_mut : core::slice::index::SliceIndex::index_mut
-}
-
-trait core::ops::index::Index<Self, Idx>
-{
-    type Output
-    fn index : core::ops::index::Index::index
 }
 
 fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause0::Output)

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -17,28 +17,28 @@ trait test_crate::HasLen<Self>
     const LEN : usize
 }
 
-global test_crate::{impl test_crate::HasLen for Array<(), const N : usize>#1}::LEN<const N : usize>  {
+global test_crate::{impl test_crate::HasLen for Array<(), const N : usize>}#1::LEN<const N : usize>  {
     let @0: usize; // return
 
     @0 := const (const N : usize)
     return
 }
 
-impl<const N : usize> test_crate::{impl test_crate::HasLen for Array<(), const N : usize>#1}<const N : usize> : test_crate::HasLen<Array<(), const N : usize>>
+impl<const N : usize> test_crate::{impl test_crate::HasLen for Array<(), const N : usize>}#1<const N : usize> : test_crate::HasLen<Array<(), const N : usize>>
 {
-    const LEN = test_crate::{impl test_crate::HasLen for Array<(), const N : usize>#1}::LEN<const N : usize>
+    const LEN = test_crate::{impl test_crate::HasLen for Array<(), const N : usize>}#1::LEN<const N : usize>
 }
 
-global test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>#2}::LEN<const N : usize>  {
+global test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>}#2::LEN<const N : usize>  {
     let @0: usize; // return
 
     @0 := const (const N : usize) + const (1 : usize)
     return
 }
 
-impl<const N : usize> test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>#2}<const N : usize> : test_crate::HasLen<Array<bool, const N : usize>>
+impl<const N : usize> test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>}#2<const N : usize> : test_crate::HasLen<Array<bool, const N : usize>>
 {
-    const LEN = test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>#2}::LEN<const N : usize>
+    const LEN = test_crate::{impl test_crate::HasLen for Array<bool, const N : usize>}#2::LEN<const N : usize>
 }
 
 global test_crate::HasDefaultLen::LEN<Self, const M : usize>  {
@@ -53,17 +53,17 @@ trait test_crate::HasDefaultLen<Self, const M : usize>
     const LEN : usize
 }
 
-impl<const N : usize> test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<(), const N : usize>#3}<const N : usize> : test_crate::HasDefaultLen<Array<(), const N : usize>, const N : usize>
+impl<const N : usize> test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<(), const N : usize>}#3<const N : usize> : test_crate::HasDefaultLen<Array<(), const N : usize>, const N : usize>
 {
     const LEN = test_crate::HasDefaultLen::LEN<Array<(), const N : usize>, const N : usize>
 }
 
-impl<const N : usize> test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>#4}<const N : usize> : test_crate::HasDefaultLen<Array<bool, const N : usize>, const N : usize>
+impl<const N : usize> test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>}#4<const N : usize> : test_crate::HasDefaultLen<Array<bool, const N : usize>, const N : usize>
 {
-    const LEN = test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>#4}::LEN<const N : usize>
+    const LEN = test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>}#4::LEN<const N : usize>
 }
 
-global test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>#4}::LEN<const N : usize>  {
+global test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>}#4::LEN<const N : usize>  {
     let @0: usize; // return
     let @1: bool; // anonymous local
 
@@ -72,7 +72,7 @@ global test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bo
         @0 := const (const N : usize)
     }
     else {
-        @0 := const (test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>#4}<const N : usize>::LEN)
+        @0 := const (test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>}#4<const N : usize>::LEN)
     }
     drop @1
     return

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -21,16 +21,16 @@ where
     fn use_item : test_crate::Foo::use_item
 }
 
-fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
+fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
 
-impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_0, T> : core::clone::Clone<&'_0 (T)>
+impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T> : core::clone::Clone<&'_0 (T)>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone
 }
 
-impl<'_0, T> core::marker::{impl core::marker::Copy for &'_0 (T)#4}<'_0, T> : core::marker::Copy<&'_0 (T)>
+impl<'_0, T> core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_0, T> : core::marker::Copy<&'_0 (T)>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>
 }
 
 enum core::option::Option<T> =
@@ -38,28 +38,28 @@ enum core::option::Option<T> =
 |  Some(T)
 
 
-fn core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> core::option::Option<T>
+fn core::option::{impl core::clone::Clone for core::option::Option<T>}#5::clone<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> core::option::Option<T>
 where
     // Inherited clauses:
     [@TraitClause0]: core::clone::Clone<T>,
 
-fn core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone_from<'_0, '_1, T>(@1: &'_0 mut (core::option::Option<T>), @2: &'_1 (core::option::Option<T>))
+fn core::option::{impl core::clone::Clone for core::option::Option<T>}#5::clone_from<'_0, '_1, T>(@1: &'_0 mut (core::option::Option<T>), @2: &'_1 (core::option::Option<T>))
 where
     // Inherited clauses:
     [@TraitClause0]: core::clone::Clone<T>,
 
-impl<T> core::option::{impl core::clone::Clone for core::option::Option<T>#5}<T> : core::clone::Clone<core::option::Option<T>>
+impl<T> core::option::{impl core::clone::Clone for core::option::Option<T>}#5<T> : core::clone::Clone<core::option::Option<T>>
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
-    fn clone = core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone
-    fn clone_from = core::option::{impl core::clone::Clone for core::option::Option<T>#5}::clone_from
+    fn clone = core::option::{impl core::clone::Clone for core::option::Option<T>}#5::clone
+    fn clone_from = core::option::{impl core::clone::Clone for core::option::Option<T>}#5::clone_from
 }
 
 impl<'a, T> test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T)>
 {
-    parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)#4}<'_, T>
-    parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>#5}<&'_ (T)>[core::clone::impls::{impl core::clone::Clone for &'_0 (T)#3}<'_, T>]
+    parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_, T>
+    parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>}#5<&'_ (T)>[core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>]
     type Item = core::option::Option<&'a (T)>
 }
 
@@ -129,10 +129,10 @@ trait test_crate::loopy::Foo<Self>
     type FooTy
 }
 
-impl test_crate::loopy::{impl test_crate::loopy::Foo for ()#1} : test_crate::loopy::Foo<()>
+impl test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1 : test_crate::loopy::Foo<()>
 {
     parent_clause0 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
-    parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Foo for ()#1}
+    parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1
     type FooTy = ()
 }
 
@@ -143,9 +143,9 @@ trait test_crate::loopy::Baz<Self, T>
     type BazTy
 }
 
-impl test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()#2} : test_crate::loopy::Baz<(), ()>
+impl test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()}#2 : test_crate::loopy::Baz<(), ()>
 {
-    parent_clause0 = test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()#2}
+    parent_clause0 = test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()}#2
     parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
     type BazTy = usize
 }

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -322,11 +322,11 @@ where
     return
 }
 
-fn core::clone::impls::{impl core::clone::Clone for u32#8}::clone<'_0>(@1: &'_0 (u32)) -> u32
+fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 (u32)) -> u32
 
-impl core::clone::impls::{impl core::clone::Clone for u32#8} : core::clone::Clone<u32>
+impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32#8}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
 }
 
 fn test_crate::test_id_clone(@1: u32) -> u32
@@ -337,7 +337,7 @@ fn test_crate::test_id_clone(@1: u32) -> u32
     let @3: fn(u32) -> u32; // anonymous local
     let @4: u32; // anonymous local
 
-    f@2 := cast<fn(u32) -> u32, fn(u32) -> u32>(const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
+    f@2 := cast<fn(u32) -> u32, fn(u32) -> u32>(const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32}#8]))
     @fake_read(f@2)
     @3 := copy (f@2)
     @4 := copy (x@1)
@@ -377,7 +377,7 @@ fn test_crate::test_map_option_id_clone(@1: core::option::Option<u32>) -> core::
     let @2: core::option::Option<u32>; // anonymous local
 
     @2 := copy (x@1)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32#8}]))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), const (test_crate::id_clone<u32>[core::clone::impls::{impl core::clone::Clone for u32}#8]))
     drop @2
     return
 }
@@ -551,7 +551,7 @@ fn test_crate::test_array_map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
     return
 }
 
-fn core::array::{Array<T, const N : usize>#23}::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
+fn core::array::{Array<T, const N : usize>}#23::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (T)>,
     (parents(@TraitClause0)::[@TraitClause0])::Output = U,
@@ -565,7 +565,7 @@ fn test_crate::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : u
 
     @2 := copy (x@1)
     @3 := {test_crate::test_array_map::closure} {}
-    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::ops::function::FnMut<fn(i32) -> i32, (i32)>](move (@2), move (@3))
+    @0 := core::array::{Array<T, const N : usize>}#23::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::ops::function::FnMut<fn(i32) -> i32, (i32)>](move (@2), move (@3))
     drop @3
     drop @2
     return

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -7,13 +7,13 @@ global test_crate::X0  {
     return
 }
 
-global core::num::{u32#8}::MAX 
+global core::num::{u32}#8::MAX 
 
 global test_crate::X1  {
     let @0: u32; // return
     let @1: u32; // anonymous local
 
-    @1 := core::num::{u32#8}::MAX
+    @1 := core::num::{u32}#8::MAX
     @0 := move (@1)
     return
 }
@@ -283,7 +283,7 @@ struct test_crate::V<T, const N : usize> =
   x: Array<T, const N : usize>
 }
 
-global test_crate::{test_crate::V<T, const N : usize>#1}::LEN<T, const N : usize>  {
+global test_crate::{test_crate::V<T, const N : usize>}#1::LEN<T, const N : usize>  {
     let @0: usize; // return
 
     @0 := const (const N : usize)
@@ -295,7 +295,7 @@ fn test_crate::use_v<T, const N : usize>() -> usize
     let @0: usize; // return
     let @1: usize; // anonymous local
 
-    @1 := test_crate::{test_crate::V<T, const N : usize>#1}::LEN<T, const N : usize>
+    @1 := test_crate::{test_crate::V<T, const N : usize>}#1::LEN<T, const N : usize>
     @0 := move (@1)
     return
 }

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -27,16 +27,16 @@ trait alloc::string::ToString<Self>
     fn to_string : alloc::string::ToString::to_string
 }
 
-fn alloc::string::{impl alloc::string::ToString for T#32}::to_string<'_0, T>(@1: &'_0 (T)) -> alloc::string::String
+fn alloc::string::{impl alloc::string::ToString for T}#32::to_string<'_0, T>(@1: &'_0 (T)) -> alloc::string::String
 where
     // Inherited clauses:
     [@TraitClause0]: core::fmt::Display<T>,
 
-impl<T> alloc::string::{impl alloc::string::ToString for T#32}<T> : alloc::string::ToString<T>
+impl<T> alloc::string::{impl alloc::string::ToString for T}#32<T> : alloc::string::ToString<T>
 where
     [@TraitClause0]: core::fmt::Display<T>,
 {
-    fn to_string = alloc::string::{impl alloc::string::ToString for T#32}::to_string
+    fn to_string = alloc::string::{impl alloc::string::ToString for T}#32::to_string
 }
 
 fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::string::String
@@ -48,7 +48,7 @@ fn test_crate::destruct<'_0>(@1: &'_0 (dyn (exists(TODO)))) -> alloc::string::St
     let @2: &'_ (dyn (exists(TODO))); // anonymous local
 
     @2 := &*(x@1)
-    @0 := alloc::string::{impl alloc::string::ToString for T#32}<dyn (exists(TODO))>[core::fmt::Display<dyn (exists(TODO))>]::to_string(move (@2))
+    @0 := alloc::string::{impl alloc::string::ToString for T}#32<dyn (exists(TODO))>[core::fmt::Display<dyn (exists(TODO))>]::to_string(move (@2))
     drop @2
     return
 }

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -45,40 +45,40 @@ opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::num::nonzero::ZeroablePrimitive<T>,
 
-fn core::clone::impls::{impl core::clone::Clone for u32#8}::clone<'_0>(@1: &'_0 (u32)) -> u32
+fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 (u32)) -> u32
 
-impl core::clone::impls::{impl core::clone::Clone for u32#8} : core::clone::Clone<u32>
+impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32#8}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
 }
 
-impl core::marker::{impl core::marker::Copy for u32#41} : core::marker::Copy<u32>
+impl core::marker::{impl core::marker::Copy for u32}#41 : core::marker::Copy<u32>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32#8}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32}#8
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32#19} : core::num::nonzero::private::Sealed<u32>
+impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32}#19 : core::num::nonzero::private::Sealed<u32>
 
 opaque type core::num::nonzero::private::NonZeroU32Inner
 
-fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroU32Inner)) -> core::num::nonzero::private::NonZeroU32Inner
+fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroU32Inner)) -> core::num::nonzero::private::NonZeroU32Inner
 
-impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11} : core::clone::Clone<core::num::nonzero::private::NonZeroU32Inner>
+impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11 : core::clone::Clone<core::num::nonzero::private::NonZeroU32Inner>
 {
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}::clone
+    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11::clone
 }
 
-impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner#12} : core::marker::Copy<core::num::nonzero::private::NonZeroU32Inner>
+impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner}#12 : core::marker::Copy<core::num::nonzero::private::NonZeroU32Inner>
 {
-    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}
+    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20} : core::num::nonzero::ZeroablePrimitive<u32>
+impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20 : core::num::nonzero::ZeroablePrimitive<u32>
 {
-    parent_clause0 = core::marker::{impl core::marker::Copy for u32#41}
-    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32#19}
-    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner#12}
-    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner#11}
+    parent_clause0 = core::marker::{impl core::marker::Copy for u32}#41
+    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32}#19
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner}#12
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11
     type NonZeroInner = core::num::nonzero::private::NonZeroU32Inner
 }
 
@@ -87,23 +87,23 @@ enum core::option::Option<T> =
 |  Some(T)
 
 
-fn core::num::nonzero::{core::num::nonzero::NonZero<T, @TraitClause0>#14}::new<T>(@1: T) -> core::option::Option<core::num::nonzero::NonZero<T, @TraitClause0>>
+fn core::num::nonzero::{core::num::nonzero::NonZero<T, @TraitClause0>}#14::new<T>(@1: T) -> core::option::Option<core::num::nonzero::NonZero<T, @TraitClause0>>
 where
     [@TraitClause0]: core::num::nonzero::ZeroablePrimitive<T>,
 
 fn core::option::{core::option::Option<T>}::unwrap<T>(@1: core::option::Option<T>) -> T
 
-fn test_crate::test_new_non_zero_u32(@1: u32) -> core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}>
+fn test_crate::test_new_non_zero_u32(@1: u32) -> core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20>
 {
-    let @0: core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}>; // return
+    let @0: core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20>; // return
     let x@1: u32; // arg #1
-    let @2: core::option::Option<core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}>>; // anonymous local
+    let @2: core::option::Option<core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20>>; // anonymous local
     let @3: u32; // anonymous local
 
     @3 := copy (x@1)
-    @2 := core::num::nonzero::{core::num::nonzero::NonZero<T, @TraitClause0>#14}::new<u32>[core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}](move (@3))
+    @2 := core::num::nonzero::{core::num::nonzero::NonZero<T, @TraitClause0>}#14::new<u32>[core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20](move (@3))
     drop @3
-    @0 := core::option::{core::option::Option<T>}::unwrap<core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32#20}>>(move (@2))
+    @0 := core::option::{core::option::Option<T>}::unwrap<core::num::nonzero::NonZero<u32, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20>>(move (@2))
     drop @2
     return
 }
@@ -114,7 +114,7 @@ struct alloc::alloc::Global = {}
 
 fn alloc::vec::{alloc::vec::Vec<T, alloc::alloc::Global>}::new<T>() -> alloc::vec::Vec<T, alloc::alloc::Global>
 
-fn alloc::vec::{alloc::vec::Vec<T, A>#1}::push<'_0, T, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>), @2: T)
+fn alloc::vec::{alloc::vec::Vec<T, A>}#1::push<'_0, T, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>), @2: T)
 
 fn test_crate::test_vec_push()
 {
@@ -127,7 +127,7 @@ fn test_crate::test_vec_push()
     v@1 := alloc::vec::{alloc::vec::Vec<T, alloc::alloc::Global>}::new<u32>()
     @fake_read(v@1)
     @3 := &two-phase-mut v@1
-    @2 := alloc::vec::{alloc::vec::Vec<T, A>#1}::push<u32, alloc::alloc::Global>(move (@3), const (0 : u32))
+    @2 := alloc::vec::{alloc::vec::Vec<T, A>}#1::push<u32, alloc::alloc::Global>(move (@3), const (0 : u32))
     drop @3
     drop @2
     @4 := ()
@@ -140,7 +140,7 @@ fn test_crate::test_vec_push()
 
 opaque type core::cell::Cell<T>
 
-fn core::cell::{core::cell::Cell<T>#10}::get<'_0, T>(@1: &'_0 (core::cell::Cell<T>)) -> T
+fn core::cell::{core::cell::Cell<T>}#10::get<'_0, T>(@1: &'_0 (core::cell::Cell<T>)) -> T
 where
     [@TraitClause0]: core::marker::Copy<T>,
 
@@ -151,12 +151,12 @@ fn test_crate::use_get<'_0>(@1: &'_0 (core::cell::Cell<u32>)) -> u32
     let @2: &'_ (core::cell::Cell<u32>); // anonymous local
 
     @2 := &*(rc@1)
-    @0 := core::cell::{core::cell::Cell<T>#10}::get<u32>[core::marker::{impl core::marker::Copy for u32#41}](move (@2))
+    @0 := core::cell::{core::cell::Cell<T>}#10::get<u32>[core::marker::{impl core::marker::Copy for u32}#41](move (@2))
     drop @2
     return
 }
 
-fn core::cell::{core::cell::Cell<T>#11}::get_mut<'_0, T>(@1: &'_0 mut (core::cell::Cell<T>)) -> &'_0 mut (T)
+fn core::cell::{core::cell::Cell<T>}#11::get_mut<'_0, T>(@1: &'_0 mut (core::cell::Cell<T>)) -> &'_0 mut (T)
 
 fn test_crate::incr<'_0>(@1: &'_0 mut (core::cell::Cell<u32>))
 {
@@ -167,7 +167,7 @@ fn test_crate::incr<'_0>(@1: &'_0 mut (core::cell::Cell<u32>))
     let @4: (); // anonymous local
 
     @3 := &two-phase-mut *(rc@1)
-    @2 := core::cell::{core::cell::Cell<T>#11}::get_mut<u32>(move (@3))
+    @2 := core::cell::{core::cell::Cell<T>}#11::get_mut<u32>(move (@3))
     drop @3
     *(@2) := copy (*(@2)) + const (1 : u32)
     drop @2

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -96,7 +96,7 @@ trait core::convert::From<Self, T>
     fn from : core::convert::From::from
 }
 
-fn core::convert::num::{impl core::convert::From<i32> for i64#83}::from(@1: i32) -> i64
+fn core::convert::num::{impl core::convert::From<i32> for i64}#83::from(@1: i32) -> i64
 {
     let @0: i64; // return
     let small@1: i32; // arg #1
@@ -105,9 +105,9 @@ fn core::convert::num::{impl core::convert::From<i32> for i64#83}::from(@1: i32)
     return
 }
 
-impl core::convert::num::{impl core::convert::From<i32> for i64#83} : core::convert::From<i64, i32>
+impl core::convert::num::{impl core::convert::From<i32> for i64}#83 : core::convert::From<i64, i32>
 {
-    fn from = core::convert::num::{impl core::convert::From<i32> for i64#83}::from
+    fn from = core::convert::num::{impl core::convert::From<i32> for i64}#83::from
 }
 
 fn core::convert::From::from<Self, T>(@1: T) -> Self
@@ -119,7 +119,7 @@ fn test_crate::convert(@1: i32) -> i64
     let @2: i32; // anonymous local
 
     @2 := copy (x@1)
-    @0 := core::convert::num::{impl core::convert::From<i32> for i64#83}::from(move (@2))
+    @0 := core::convert::num::{impl core::convert::From<i32> for i64}#83::from(move (@2))
     drop @2
     return
 }
@@ -170,7 +170,7 @@ fn test_crate::vec(@1: alloc::vec::Vec<u32, alloc::alloc::Global>)
     return
 }
 
-global core::num::{usize#11}::MAX  {
+global core::num::{usize}#11::MAX  {
     let @0: usize; // return
 
     @0 := ~(const (0 : usize))
@@ -182,7 +182,7 @@ fn test_crate::max() -> usize
     let @0: usize; // return
     let @1: usize; // anonymous local
 
-    @1 := core::num::{usize#11}::MAX
+    @1 := core::num::{usize}#11::MAX
     @0 := move (@1)
     return
 }

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -27,7 +27,7 @@ trait core::marker::Copy<Self>
     parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-impl test_crate::{impl core::marker::Copy for test_crate::Foo#1} : core::marker::Copy<test_crate::Foo>
+impl test_crate::{impl core::marker::Copy for test_crate::Foo}#1 : core::marker::Copy<test_crate::Foo>
 {
     parent_clause0 = test_crate::{impl core::clone::Clone for test_crate::Foo}
 }

--- a/charon/tests/ui/issue-166-self-constructors.out
+++ b/charon/tests/ui/issue-166-self-constructors.out
@@ -18,7 +18,7 @@ struct test_crate::Bar<'a> =
   r: &'a (i32)
 }
 
-fn test_crate::{test_crate::Bar<'a>#1}::new<'a>(@1: &'a (i32)) -> test_crate::Bar<'a>
+fn test_crate::{test_crate::Bar<'a>}#1::new<'a>(@1: &'a (i32)) -> test_crate::Bar<'a>
 {
     let @0: test_crate::Bar<'_>; // return
     let r@1: &'_ (i32); // arg #1

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -7,16 +7,16 @@ enum core::result::Result<T, E> =
 
 opaque type core::array::TryFromSliceError
 
-trait core::convert::TryFrom<Self, T>
-{
-    type Error
-    fn try_from : core::convert::TryFrom::try_from
-}
-
 trait core::convert::TryInto<Self, T>
 {
     type Error
     fn try_into : core::convert::TryInto::try_into
+}
+
+trait core::convert::TryFrom<Self, T>
+{
+    type Error
+    fn try_from : core::convert::TryFrom::try_from
 }
 
 fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -19,17 +19,17 @@ trait core::convert::TryInto<Self, T>
     fn try_into : core::convert::TryInto::try_into
 }
 
-fn core::convert::{impl core::convert::TryInto<U> for T#6}::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>
+fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>
 where
     // Inherited clauses:
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 
-impl<T, U> core::convert::{impl core::convert::TryInto<U> for T#6}<T, U> : core::convert::TryInto<T, U>
+impl<T, U> core::convert::{impl core::convert::TryInto<U> for T}#6<T, U> : core::convert::TryInto<T, U>
 where
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 {
     type Error = @TraitClause0::Error
-    fn try_into = core::convert::{impl core::convert::TryInto<U> for T#6}::try_into
+    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into
 }
 
 trait core::clone::Clone<Self>
@@ -43,29 +43,29 @@ trait core::marker::Copy<Self>
     parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from<'_0, '_1, T, const N : usize>(@1: &'_1 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>
+fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, '_1, T, const N : usize>(@1: &'_1 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>
 where
     // Inherited clauses:
     [@TraitClause0]: core::marker::Copy<T>,
 
-impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}<'_0, T, const N : usize> : core::convert::TryFrom<Array<T, const N : usize>, &'_0 (Slice<T>)>
+impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_0, T, const N : usize> : core::convert::TryFrom<Array<T, const N : usize>, &'_0 (Slice<T>)>
 where
     [@TraitClause0]: core::marker::Copy<T>,
 {
     type Error = core::array::TryFromSliceError
-    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from
+    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from
 }
 
-fn core::clone::impls::{impl core::clone::Clone for u8#6}::clone<'_0>(@1: &'_0 (u8)) -> u8
+fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
 
-impl core::clone::impls::{impl core::clone::Clone for u8#6} : core::clone::Clone<u8>
+impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8#6}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
 }
 
-impl core::marker::{impl core::marker::Copy for u8#39} : core::marker::Copy<u8>
+impl core::marker::{impl core::marker::Copy for u8}#39 : core::marker::Copy<u8>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8#6}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8}#6
 }
 
 fn core::convert::TryInto::try_into<Self, T>(@1: Self) -> core::result::Result<T, Self::Error>
@@ -85,11 +85,11 @@ fn core::result::{core::result::Result<T, E>}::unwrap<T, E>(@1: core::result::Re
 where
     [@TraitClause0]: core::fmt::Debug<E>,
 
-fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}::fmt<'_0, '_1, '_2>(@1: &'_0 (core::array::TryFromSliceError), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt<'_0, '_1, '_2>(@1: &'_0 (core::array::TryFromSliceError), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26} : core::fmt::Debug<core::array::TryFromSliceError>
+impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26 : core::fmt::Debug<core::array::TryFromSliceError>
 {
-    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}::fmt
+    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt
 }
 
 fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
@@ -102,9 +102,9 @@ fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
     let @5: (); // anonymous local
 
     @4 := &*(s@1)
-    @3 := core::convert::{impl core::convert::TryInto<U> for T#6}<&'_ (Slice<u8>), Array<u8, 4 : usize>>[core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}<'_, u8, 4 : usize>[core::marker::{impl core::marker::Copy for u8#39}]]::try_into(move (@4))
+    @3 := core::convert::{impl core::convert::TryInto<U> for T}#6<&'_ (Slice<u8>), Array<u8, 4 : usize>>[core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_, u8, 4 : usize>[core::marker::{impl core::marker::Copy for u8}#39]]::try_into(move (@4))
     drop @4
-    _array@2 := core::result::{core::result::Result<T, E>}::unwrap<Array<u8, 4 : usize>, core::array::TryFromSliceError>[core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}](move (@3))
+    _array@2 := core::result::{core::result::Result<T, E>}::unwrap<Array<u8, 4 : usize>, core::array::TryFromSliceError>[core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26](move (@3))
     drop @3
     @fake_read(_array@2)
     @5 := ()

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -7,16 +7,16 @@ enum core::result::Result<T, E> =
 
 opaque type core::array::TryFromSliceError
 
-trait core::convert::TryFrom<Self, T>
-{
-    type Error
-    fn try_from : core::convert::TryFrom::try_from
-}
-
 trait core::convert::TryInto<Self, T>
 {
     type Error
     fn try_into : core::convert::TryInto::try_into
+}
+
+trait core::convert::TryFrom<Self, T>
+{
+    type Error
+    fn try_from : core::convert::TryFrom::try_from
 }
 
 fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -19,17 +19,17 @@ trait core::convert::TryInto<Self, T>
     fn try_into : core::convert::TryInto::try_into
 }
 
-fn core::convert::{impl core::convert::TryInto<U> for T#6}::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>
+fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause0::Error>
 where
     // Inherited clauses:
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 
-impl<T, U> core::convert::{impl core::convert::TryInto<U> for T#6}<T, U> : core::convert::TryInto<T, U>
+impl<T, U> core::convert::{impl core::convert::TryInto<U> for T}#6<T, U> : core::convert::TryInto<T, U>
 where
     [@TraitClause0]: core::convert::TryFrom<U, T>,
 {
     type Error = @TraitClause0::Error
-    fn try_into = core::convert::{impl core::convert::TryInto<U> for T#6}::try_into
+    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into
 }
 
 trait core::clone::Clone<Self>
@@ -43,29 +43,29 @@ trait core::marker::Copy<Self>
     parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from<'_0, '_1, T, const N : usize>(@1: &'_1 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>
+fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, '_1, T, const N : usize>(@1: &'_1 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>
 where
     // Inherited clauses:
     [@TraitClause0]: core::marker::Copy<T>,
 
-impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}<'_0, T, const N : usize> : core::convert::TryFrom<Array<T, const N : usize>, &'_0 (Slice<T>)>
+impl<'_0, T, const N : usize> core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_0, T, const N : usize> : core::convert::TryFrom<Array<T, const N : usize>, &'_0 (Slice<T>)>
 where
     [@TraitClause0]: core::marker::Copy<T>,
 {
     type Error = core::array::TryFromSliceError
-    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}::try_from
+    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from
 }
 
-fn core::clone::impls::{impl core::clone::Clone for u8#6}::clone<'_0>(@1: &'_0 (u8)) -> u8
+fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
 
-impl core::clone::impls::{impl core::clone::Clone for u8#6} : core::clone::Clone<u8>
+impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8#6}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
 }
 
-impl core::marker::{impl core::marker::Copy for u8#39} : core::marker::Copy<u8>
+impl core::marker::{impl core::marker::Copy for u8}#39 : core::marker::Copy<u8>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8#6}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8}#6
 }
 
 fn core::convert::TryInto::try_into<Self, T>(@1: Self) -> core::result::Result<T, Self::Error>
@@ -85,11 +85,11 @@ fn core::result::{core::result::Result<T, E>}::unwrap<T, E>(@1: core::result::Re
 where
     [@TraitClause0]: core::fmt::Debug<E>,
 
-fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}::fmt<'_0, '_1, '_2>(@1: &'_0 (core::array::TryFromSliceError), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt<'_0, '_1, '_2>(@1: &'_0 (core::array::TryFromSliceError), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26} : core::fmt::Debug<core::array::TryFromSliceError>
+impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26 : core::fmt::Debug<core::array::TryFromSliceError>
 {
-    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}::fmt
+    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt
 }
 
 fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
@@ -102,9 +102,9 @@ fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
     let @5: (); // anonymous local
 
     @4 := &*(s@1)
-    @3 := core::convert::{impl core::convert::TryInto<U> for T#6}<&'_ (Slice<u8>), Array<u8, 4 : usize>>[core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>#7}<'_, u8, 4 : usize>[core::marker::{impl core::marker::Copy for u8#39}]]::try_into(move (@4))
+    @3 := core::convert::{impl core::convert::TryInto<U> for T}#6<&'_ (Slice<u8>), Array<u8, 4 : usize>>[core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_, u8, 4 : usize>[core::marker::{impl core::marker::Copy for u8}#39]]::try_into(move (@4))
     drop @4
-    _array@2 := core::result::{core::result::Result<T, E>}::unwrap<Array<u8, 4 : usize>, core::array::TryFromSliceError>[core::array::{impl core::fmt::Debug for core::array::TryFromSliceError#26}](move (@3))
+    _array@2 := core::result::{core::result::Result<T, E>}::unwrap<Array<u8, 4 : usize>, core::array::TryFromSliceError>[core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26](move (@3))
     drop @3
     @fake_read(_array@2)
     @5 := ()

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -22,7 +22,7 @@ trait core::ops::function::FnMut<Self, Args>
     fn call_mut : core::ops::function::FnMut::call_mut
 }
 
-fn core::array::{Array<T, const N : usize>#23}::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
+fn core::array::{Array<T, const N : usize>}#23::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (T)>,
     (parents(@TraitClause0)::[@TraitClause0])::Output = U,
@@ -36,7 +36,7 @@ fn test_crate::map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
 
     @2 := copy (x@1)
     @3 := {test_crate::map::closure} {}
-    @0 := core::array::{Array<T, const N : usize>#23}::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::ops::function::FnMut<fn(i32) -> i32, (i32)>](move (@2), move (@3))
+    @0 := core::array::{Array<T, const N : usize>}#23::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::ops::function::FnMut<fn(i32) -> i32, (i32)>](move (@2), move (@3))
     drop @3
     drop @2
     return
@@ -153,19 +153,19 @@ where
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
-fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter<I>(@1: I) -> I
+fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 
-impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<I> : core::iter::traits::collect::IntoIterator<I>
+impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause0
     type Item = @TraitClause0::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
 }
 
 trait core::clone::Clone<Self>
@@ -209,27 +209,27 @@ trait core::iter::range::Step<Self>
     fn backward_unchecked
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count<A>(@1: core::ops::range::Range<A>) -> usize
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -250,21 +250,21 @@ trait core::cmp::Ord<Self>
     fn clamp
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -294,44 +294,44 @@ opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::num::nonzero::ZeroablePrimitive<T>,
 
-fn core::clone::impls::{impl core::clone::Clone for usize#5}::clone<'_0>(@1: &'_0 (usize)) -> usize
+fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_0 (usize)) -> usize
 
-impl core::clone::impls::{impl core::clone::Clone for usize#5} : core::clone::Clone<usize>
+impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize#5}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
 }
 
-impl core::marker::{impl core::marker::Copy for usize#38} : core::marker::Copy<usize>
+impl core::marker::{impl core::marker::Copy for usize}#38 : core::marker::Copy<usize>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize#5}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize}#5
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25} : core::num::nonzero::private::Sealed<usize>
+impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25 : core::num::nonzero::private::Sealed<usize>
 
 opaque type core::num::nonzero::private::NonZeroUsizeInner
 
-fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
+fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
 
-impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26} : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone
+    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
 }
 
-impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27} : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26} : core::num::nonzero::ZeroablePrimitive<usize>
+impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26 : core::num::nonzero::ZeroablePrimitive<usize>
 {
-    parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
-    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
-    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::marker::{impl core::marker::Copy for usize}#38
+    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -342,92 +342,92 @@ trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     fn size
 }
 
-unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<A>[@TraitClause0]::Item
+unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A>[@TraitClause0]::Item
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<core::ops::range::Range<A>>,
 
-impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<A> : core::iter::traits::iterator::Iterator<core::ops::range::Range<A>>
+impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A> : core::iter::traits::iterator::Iterator<core::ops::range::Range<A>>
 where
     [@TraitClause0]: core::iter::range::Step<A>,
 {
     type Item = A
-    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next
-    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint
-    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::nth
-    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::last
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::min
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::max
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::is_sorted
-    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by
-    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::__iterator_get_unchecked
+    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next
+    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint
+    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count
+    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
+    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last
+    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
+    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
+    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by
+    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked
 }
 
-fn core::clone::impls::{impl core::clone::Clone for u8#6}::clone<'_0>(@1: &'_0 (u8)) -> u8
+fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
 
-impl core::clone::impls::{impl core::clone::Clone for u8#6} : core::clone::Clone<u8>
+impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8#6}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22}::eq<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22}::ne<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::ne<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22} : core::cmp::PartialEq<u8, u8>
+impl core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22 : core::cmp::PartialEq<u8, u8>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22}::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22}::ne
+    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq
+    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::ne
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::partial_cmp<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<core::cmp::Ordering>
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<core::cmp::Ordering>
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::lt<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::le<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::ge<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::gt<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60} : core::cmp::PartialOrd<u8, u8>
+impl core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60 : core::cmp::PartialOrd<u8, u8>
 {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8#22}
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::ge
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}::gt
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22
+    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp
+    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt
+    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge
+    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt
 }
 
-fn core::iter::range::{impl core::iter::range::Step for u8#35}::steps_between<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for u8#35}::forward_checked(@1: u8, @2: usize) -> core::option::Option<u8>
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::forward_checked(@1: u8, @2: usize) -> core::option::Option<u8>
 
-fn core::iter::range::{impl core::iter::range::Step for u8#35}::backward_checked(@1: u8, @2: usize) -> core::option::Option<u8>
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward_checked(@1: u8, @2: usize) -> core::option::Option<u8>
 
-fn core::iter::range::{impl core::iter::range::Step for u8#35}::forward(@1: u8, @2: usize) -> u8
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::forward(@1: u8, @2: usize) -> u8
 
-fn core::iter::range::{impl core::iter::range::Step for u8#35}::backward(@1: u8, @2: usize) -> u8
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward(@1: u8, @2: usize) -> u8
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for u8#35}::forward_unchecked(@1: u8, @2: usize) -> u8
+unsafe fn core::iter::range::{impl core::iter::range::Step for u8}#35::forward_unchecked(@1: u8, @2: usize) -> u8
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for u8#35}::backward_unchecked(@1: u8, @2: usize) -> u8
+unsafe fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward_unchecked(@1: u8, @2: usize) -> u8
 
-impl core::iter::range::{impl core::iter::range::Step for u8#35} : core::iter::range::Step<u8>
+impl core::iter::range::{impl core::iter::range::Step for u8}#35 : core::iter::range::Step<u8>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8#6}
-    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8#60}
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for u8#35}::steps_between
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step for u8#35}::forward_checked
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step for u8#35}::backward_checked
-    fn forward = core::iter::range::{impl core::iter::range::Step for u8#35}::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for u8#35}::backward
-    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u8#35}::forward_unchecked
-    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u8#35}::backward_unchecked
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8}#6
+    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60
+    fn steps_between = core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::forward_checked
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::backward_checked
+    fn forward = core::iter::range::{impl core::iter::range::Step for u8}#35::forward
+    fn backward = core::iter::range::{impl core::iter::range::Step for u8}#35::backward
+    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u8}#35::forward_unchecked
+    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u8}#35::backward_unchecked
 }
 
 fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
@@ -456,14 +456,14 @@ fn test_crate::cbd(@1: Array<u8, 33 : usize>)
     let @17: &'_ mut (u8); // anonymous local
 
     @3 := core::ops::range::Range { start: const (0 : u8), end: const (3 : u8) }
-    @2 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::ops::range::Range<u8>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<u8>[core::iter::range::{impl core::iter::range::Step for u8#35}]]::into_iter(move (@3))
+    @2 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::ops::range::Range<u8>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<u8>[core::iter::range::{impl core::iter::range::Step for u8}#35]]::into_iter(move (@3))
     drop @3
     @fake_read(@2)
     iter@4 := move (@2)
     loop {
         @9 := &mut iter@4
         @8 := &two-phase-mut *(@9)
-        @7 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<u8>[core::iter::range::{impl core::iter::range::Step for u8#35}]::next(move (@8))
+        @7 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<u8>[core::iter::range::{impl core::iter::range::Step for u8}#35]::next(move (@8))
         drop @8
         @fake_read(@7)
         match @7 {

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -11,7 +11,7 @@ trait test_crate::Hash<Self>
     fn hash : test_crate::Hash::hash
 }
 
-fn test_crate::{impl test_crate::Hash for u32#1}::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
+fn test_crate::{impl test_crate::Hash for u32}#1::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
 where
     [@TraitClause0]: test_crate::Hasher<H>,
 {
@@ -26,9 +26,9 @@ where
     return
 }
 
-impl test_crate::{impl test_crate::Hash for u32#1} : test_crate::Hash<u32>
+impl test_crate::{impl test_crate::Hash for u32}#1 : test_crate::Hash<u32>
 {
-    fn hash = test_crate::{impl test_crate::Hash for u32#1}::hash
+    fn hash = test_crate::{impl test_crate::Hash for u32}#1::hash
 }
 
 fn test_crate::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
@@ -52,7 +52,7 @@ fn test_crate::main()
     @3 := &@4
     @6 := &mut hasher@1
     @5 := &two-phase-mut *(@6)
-    @2 := test_crate::{impl test_crate::Hash for u32#1}::hash<test_crate::DefaultHasher>[test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher}](move (@3), move (@5))
+    @2 := test_crate::{impl test_crate::Hash for u32}#1::hash<test_crate::DefaultHasher>[test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher}](move (@3), move (@5))
     drop @5
     drop @3
     drop @6

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -17,7 +17,7 @@ where
     panic(core::panicking::panic)
 }
 
-impl test_crate::{impl test_crate::Ord for u32#1} : test_crate::Ord<u32>
+impl test_crate::{impl test_crate::Ord for u32}#1 : test_crate::Ord<u32>
 
 fn test_crate::test(@1: test_crate::AVLTree<u32>)
 {
@@ -28,7 +28,7 @@ fn test_crate::test(@1: test_crate::AVLTree<u32>)
     let @4: (); // anonymous local
 
     @3 := &two-phase-mut tree@1
-    @2 := test_crate::{test_crate::AVLTree<T>}::insert<u32>[test_crate::{impl test_crate::Ord for u32#1}](move (@3))
+    @2 := test_crate::{test_crate::AVLTree<T>}::insert<u32>[test_crate::{impl test_crate::Ord for u32}#1](move (@3))
     drop @3
     drop @2
     @4 := ()

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -882,19 +882,19 @@ where
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
-fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter<I>(@1: I) -> I
+fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 
-impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<I> : core::iter::traits::collect::IntoIterator<I>
+impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause0
     type Item = @TraitClause0::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
 }
 
 trait core::clone::Clone<Self>
@@ -938,27 +938,27 @@ trait core::iter::range::Step<Self>
     fn backward_unchecked
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count<A>(@1: core::ops::range::Range<A>) -> usize
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -979,21 +979,21 @@ trait core::cmp::Ord<Self>
     fn clamp
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -1023,44 +1023,44 @@ opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::num::nonzero::ZeroablePrimitive<T>,
 
-fn core::clone::impls::{impl core::clone::Clone for usize#5}::clone<'_0>(@1: &'_0 (usize)) -> usize
+fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_0 (usize)) -> usize
 
-impl core::clone::impls::{impl core::clone::Clone for usize#5} : core::clone::Clone<usize>
+impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize#5}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
 }
 
-impl core::marker::{impl core::marker::Copy for usize#38} : core::marker::Copy<usize>
+impl core::marker::{impl core::marker::Copy for usize}#38 : core::marker::Copy<usize>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize#5}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize}#5
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25} : core::num::nonzero::private::Sealed<usize>
+impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25 : core::num::nonzero::private::Sealed<usize>
 
 opaque type core::num::nonzero::private::NonZeroUsizeInner
 
-fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
+fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
 
-impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26} : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone
+    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
 }
 
-impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27} : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26} : core::num::nonzero::ZeroablePrimitive<usize>
+impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26 : core::num::nonzero::ZeroablePrimitive<usize>
 {
-    parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
-    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
-    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::marker::{impl core::marker::Copy for usize}#38
+    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -1071,153 +1071,153 @@ trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     fn size
 }
 
-unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<A>[@TraitClause0]::Item
+unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A>[@TraitClause0]::Item
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
     // Local clauses:
     [@TraitClause1]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<core::ops::range::Range<A>>,
 
-impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<A> : core::iter::traits::iterator::Iterator<core::ops::range::Range<A>>
+impl<A> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A> : core::iter::traits::iterator::Iterator<core::ops::range::Range<A>>
 where
     [@TraitClause0]: core::iter::range::Step<A>,
 {
     type Item = A
-    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::next
-    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::size_hint
-    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::count
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::nth
-    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::last
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::min
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::max
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::is_sorted
-    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::advance_by
-    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}::__iterator_get_unchecked
+    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next
+    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint
+    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count
+    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
+    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last
+    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
+    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
+    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by
+    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked
 }
 
-fn core::clone::impls::{impl core::clone::Clone for i32#14}::clone<'_0>(@1: &'_0 (i32)) -> i32
+fn core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0>(@1: &'_0 (i32)) -> i32
 
-impl core::clone::impls::{impl core::clone::Clone for i32#14} : core::clone::Clone<i32>
+impl core::clone::impls::{impl core::clone::Clone for i32}#14 : core::clone::Clone<i32>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for i32#14}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for i32}#14::clone
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30}::eq<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30}::ne<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30} : core::cmp::PartialEq<i32, i32>
+impl core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30 : core::cmp::PartialEq<i32, i32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30}::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30}::ne
+    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq
+    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::partial_cmp<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<core::cmp::Ordering>
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<core::cmp::Ordering>
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::lt<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::le<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::ge<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::gt<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76} : core::cmp::PartialOrd<i32, i32>
+impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76 : core::cmp::PartialOrd<i32, i32>
 {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32#30}
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::ge
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}::gt
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30
+    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp
+    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt
+    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge
+    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt
 }
 
-fn core::iter::range::{impl core::iter::range::Step for i32#40}::steps_between<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for i32#40}::forward_checked(@1: i32, @2: usize) -> core::option::Option<i32>
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::forward_checked(@1: i32, @2: usize) -> core::option::Option<i32>
 
-fn core::iter::range::{impl core::iter::range::Step for i32#40}::backward_checked(@1: i32, @2: usize) -> core::option::Option<i32>
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward_checked(@1: i32, @2: usize) -> core::option::Option<i32>
 
-fn core::iter::range::{impl core::iter::range::Step for i32#40}::forward(@1: i32, @2: usize) -> i32
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::forward(@1: i32, @2: usize) -> i32
 
-fn core::iter::range::{impl core::iter::range::Step for i32#40}::backward(@1: i32, @2: usize) -> i32
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward(@1: i32, @2: usize) -> i32
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for i32#40}::forward_unchecked(@1: i32, @2: usize) -> i32
+unsafe fn core::iter::range::{impl core::iter::range::Step for i32}#40::forward_unchecked(@1: i32, @2: usize) -> i32
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for i32#40}::backward_unchecked(@1: i32, @2: usize) -> i32
+unsafe fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward_unchecked(@1: i32, @2: usize) -> i32
 
-impl core::iter::range::{impl core::iter::range::Step for i32#40} : core::iter::range::Step<i32>
+impl core::iter::range::{impl core::iter::range::Step for i32}#40 : core::iter::range::Step<i32>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for i32#14}
-    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32#76}
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for i32#40}::steps_between
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step for i32#40}::forward_checked
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step for i32#40}::backward_checked
-    fn forward = core::iter::range::{impl core::iter::range::Step for i32#40}::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for i32#40}::backward
-    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for i32#40}::forward_unchecked
-    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for i32#40}::backward_unchecked
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for i32}#14
+    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76
+    fn steps_between = core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::forward_checked
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::backward_checked
+    fn forward = core::iter::range::{impl core::iter::range::Step for i32}#40::forward
+    fn backward = core::iter::range::{impl core::iter::range::Step for i32}#40::backward
+    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for i32}#40::forward_unchecked
+    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for i32}#40::backward_unchecked
 }
 
 fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21}::eq<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::eq<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21}::ne<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::ne<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21} : core::cmp::PartialEq<usize, usize>
+impl core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21 : core::cmp::PartialEq<usize, usize>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21}::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21}::ne
+    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::eq
+    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::ne
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::partial_cmp<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<core::cmp::Ordering>
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<core::cmp::Ordering>
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::lt<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::le<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::ge<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::gt<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58} : core::cmp::PartialOrd<usize, usize>
+impl core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58 : core::cmp::PartialOrd<usize, usize>
 {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize#21}
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::ge
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}::gt
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21
+    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp
+    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt
+    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge
+    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt
 }
 
-fn core::iter::range::{impl core::iter::range::Step for usize#43}::steps_between<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for usize#43}::forward_checked(@1: usize, @2: usize) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::forward_checked(@1: usize, @2: usize) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for usize#43}::backward_checked(@1: usize, @2: usize) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward_checked(@1: usize, @2: usize) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for usize#43}::forward(@1: usize, @2: usize) -> usize
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::forward(@1: usize, @2: usize) -> usize
 
-fn core::iter::range::{impl core::iter::range::Step for usize#43}::backward(@1: usize, @2: usize) -> usize
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward(@1: usize, @2: usize) -> usize
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for usize#43}::forward_unchecked(@1: usize, @2: usize) -> usize
+unsafe fn core::iter::range::{impl core::iter::range::Step for usize}#43::forward_unchecked(@1: usize, @2: usize) -> usize
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for usize#43}::backward_unchecked(@1: usize, @2: usize) -> usize
+unsafe fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward_unchecked(@1: usize, @2: usize) -> usize
 
-impl core::iter::range::{impl core::iter::range::Step for usize#43} : core::iter::range::Step<usize>
+impl core::iter::range::{impl core::iter::range::Step for usize}#43 : core::iter::range::Step<usize>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize#5}
-    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize#58}
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for usize#43}::steps_between
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize#43}::forward_checked
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize#43}::backward_checked
-    fn forward = core::iter::range::{impl core::iter::range::Step for usize#43}::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for usize#43}::backward
-    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for usize#43}::forward_unchecked
-    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for usize#43}::backward_unchecked
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize}#5
+    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58
+    fn steps_between = core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::forward_checked
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::backward_checked
+    fn forward = core::iter::range::{impl core::iter::range::Step for usize}#43::forward
+    fn backward = core::iter::range::{impl core::iter::range::Step for usize}#43::backward
+    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for usize}#43::forward_unchecked
+    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for usize}#43::backward_unchecked
 }
 
 fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
@@ -1264,14 +1264,14 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
     s@3 := const (0 : usize)
     @fake_read(s@3)
     @6 := core::ops::range::Range { start: const (0 : i32), end: const (128 : i32) }
-    @5 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::ops::range::Range<i32>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<i32>[core::iter::range::{impl core::iter::range::Step for i32#40}]]::into_iter(move (@6))
+    @5 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::ops::range::Range<i32>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<i32>[core::iter::range::{impl core::iter::range::Step for i32}#40]]::into_iter(move (@6))
     drop @6
     @fake_read(@5)
     iter@7 := move (@5)
     loop {
         @12 := &mut iter@7
         @11 := &two-phase-mut *(@12)
-        @10 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<i32>[core::iter::range::{impl core::iter::range::Step for i32#40}]::next(move (@11))
+        @10 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<i32>[core::iter::range::{impl core::iter::range::Step for i32}#40]::next(move (@11))
         drop @11
         @fake_read(@10)
         match @10 {
@@ -1302,14 +1302,14 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
     @16 := copy (step_out@1)
     @15 := core::ops::range::Range { start: const (0 : usize), end: move (@16) }
     drop @16
-    @14 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::ops::range::Range<usize>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<usize>[core::iter::range::{impl core::iter::range::Step for usize#43}]]::into_iter(move (@15))
+    @14 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::ops::range::Range<usize>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<usize>[core::iter::range::{impl core::iter::range::Step for usize}#43]]::into_iter(move (@15))
     drop @15
     @fake_read(@14)
     iter@17 := move (@14)
     loop {
         @21 := &mut iter@17
         @20 := &two-phase-mut *(@21)
-        @19 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<usize>[core::iter::range::{impl core::iter::range::Step for usize#43}]::next(move (@20))
+        @19 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<usize>[core::iter::range::{impl core::iter::range::Step for usize}#43]::next(move (@20))
         drop @20
         @fake_read(@19)
         match @19 {
@@ -1320,14 +1320,14 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
                 @24 := copy (step_in@2)
                 @23 := core::ops::range::Range { start: const (0 : usize), end: move (@24) }
                 drop @24
-                @22 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::ops::range::Range<usize>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<usize>[core::iter::range::{impl core::iter::range::Step for usize#43}]]::into_iter(move (@23))
+                @22 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::ops::range::Range<usize>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<usize>[core::iter::range::{impl core::iter::range::Step for usize}#43]]::into_iter(move (@23))
                 drop @23
                 @fake_read(@22)
                 iter@25 := move (@22)
                 loop {
                     @29 := &mut iter@25
                     @28 := &two-phase-mut *(@29)
-                    @27 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<usize>[core::iter::range::{impl core::iter::range::Step for usize#43}]::next(move (@28))
+                    @27 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<usize>[core::iter::range::{impl core::iter::range::Step for usize}#43]::next(move (@28))
                     drop @28
                     @fake_read(@27)
                     match @27 {
@@ -1376,68 +1376,68 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
     return
 }
 
-fn core::clone::impls::{impl core::clone::Clone for u32#8}::clone<'_0>(@1: &'_0 (u32)) -> u32
+fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 (u32)) -> u32
 
-impl core::clone::impls::{impl core::clone::Clone for u32#8} : core::clone::Clone<u32>
+impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32#8}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::ne<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24} : core::cmp::PartialEq<u32, u32>
+impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24 : core::cmp::PartialEq<u32, u32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::ne
+    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq
+    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::partial_cmp<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<core::cmp::Ordering>
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<core::cmp::Ordering>
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::lt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::le<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::gt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64} : core::cmp::PartialOrd<u32, u32>
+impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp::PartialOrd<u32, u32>
 {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::ge
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}::gt
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24
+    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp
+    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt
+    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
+    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt
 }
 
-fn core::iter::range::{impl core::iter::range::Step for u32#39}::steps_between<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<usize>
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<usize>
 
-fn core::iter::range::{impl core::iter::range::Step for u32#39}::forward_checked(@1: u32, @2: usize) -> core::option::Option<u32>
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::forward_checked(@1: u32, @2: usize) -> core::option::Option<u32>
 
-fn core::iter::range::{impl core::iter::range::Step for u32#39}::backward_checked(@1: u32, @2: usize) -> core::option::Option<u32>
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward_checked(@1: u32, @2: usize) -> core::option::Option<u32>
 
-fn core::iter::range::{impl core::iter::range::Step for u32#39}::forward(@1: u32, @2: usize) -> u32
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::forward(@1: u32, @2: usize) -> u32
 
-fn core::iter::range::{impl core::iter::range::Step for u32#39}::backward(@1: u32, @2: usize) -> u32
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward(@1: u32, @2: usize) -> u32
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for u32#39}::forward_unchecked(@1: u32, @2: usize) -> u32
+unsafe fn core::iter::range::{impl core::iter::range::Step for u32}#39::forward_unchecked(@1: u32, @2: usize) -> u32
 
-unsafe fn core::iter::range::{impl core::iter::range::Step for u32#39}::backward_unchecked(@1: u32, @2: usize) -> u32
+unsafe fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward_unchecked(@1: u32, @2: usize) -> u32
 
-impl core::iter::range::{impl core::iter::range::Step for u32#39} : core::iter::range::Step<u32>
+impl core::iter::range::{impl core::iter::range::Step for u32}#39 : core::iter::range::Step<u32>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32#8}
-    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32#64}
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for u32#39}::steps_between
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step for u32#39}::forward_checked
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step for u32#39}::backward_checked
-    fn forward = core::iter::range::{impl core::iter::range::Step for u32#39}::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for u32#39}::backward
-    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u32#39}::forward_unchecked
-    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u32#39}::backward_unchecked
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32}#8
+    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64
+    fn steps_between = core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::forward_checked
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::backward_checked
+    fn forward = core::iter::range::{impl core::iter::range::Step for u32}#39::forward
+    fn backward = core::iter::range::{impl core::iter::range::Step for u32}#39::backward
+    fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u32}#39::forward_unchecked
+    fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u32}#39::backward_unchecked
 }
 
 fn test_crate::loop_inside_if(@1: bool, @2: u32) -> u32
@@ -1470,14 +1470,14 @@ fn test_crate::loop_inside_if(@1: bool, @2: u32) -> u32
         @8 := copy (n@2)
         @7 := core::ops::range::Range { start: const (0 : u32), end: move (@8) }
         drop @8
-        @6 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::ops::range::Range<u32>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<u32>[core::iter::range::{impl core::iter::range::Step for u32#39}]]::into_iter(move (@7))
+        @6 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::ops::range::Range<u32>>[core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<u32>[core::iter::range::{impl core::iter::range::Step for u32}#39]]::into_iter(move (@7))
         drop @7
         @fake_read(@6)
         iter@9 := move (@6)
         loop {
             @14 := &mut iter@9
             @13 := &two-phase-mut *(@14)
-            @12 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>#6}<u32>[core::iter::range::{impl core::iter::range::Step for u32#39}]::next(move (@13))
+            @12 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<u32>[core::iter::range::{impl core::iter::range::Step for u32}#39]::next(move (@13))
             drop @13
             @fake_read(@12)
             match @12 {
@@ -1635,7 +1635,7 @@ opaque type alloc::vec::Vec<T, A>
 
 struct alloc::alloc::Global = {}
 
-fn alloc::vec::{alloc::vec::Vec<T, A>#1}::len<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>)) -> usize
+fn alloc::vec::{alloc::vec::Vec<T, A>}#1::len<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>)) -> usize
 
 trait core::slice::index::private_slice_index::Sealed<Self>
 
@@ -1663,56 +1663,56 @@ trait core::ops::index::IndexMut<Self, Idx>
     fn index_mut : core::ops::index::IndexMut::index_mut
 }
 
-fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>), @2: I) -> &'_0 (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}<T, I, A>[@TraitClause0]::Output)
+fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>), @2: I) -> &'_0 (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13<T, I, A>[@TraitClause0]::Output)
 where
     // Inherited clauses:
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 
-impl<T, I, A> alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}<T, I, A> : core::ops::index::Index<alloc::vec::Vec<T, A>, I>
+impl<T, I, A> alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13<T, I, A> : core::ops::index::Index<alloc::vec::Vec<T, A>, I>
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     type Output = @TraitClause0::Output
-    fn index = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}::index
+    fn index = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13::index
 }
 
-fn alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>#14}::index_mut<'_0, T, I, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>), @2: I) -> &'_0 mut (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}<T, I, A>[@TraitClause0]::Output)
+fn alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>}#14::index_mut<'_0, T, I, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>), @2: I) -> &'_0 mut (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13<T, I, A>[@TraitClause0]::Output)
 where
     // Inherited clauses:
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 
-impl<T, I, A> alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>#14}<T, I, A> : core::ops::index::IndexMut<alloc::vec::Vec<T, A>, I>
+impl<T, I, A> alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>}#14<T, I, A> : core::ops::index::IndexMut<alloc::vec::Vec<T, A>, I>
 where
     [@TraitClause0]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
-    parent_clause0 = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>#13}<T, I, A>[@TraitClause0]
-    fn index_mut = alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>#14}::index_mut
+    parent_clause0 = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13<T, I, A>[@TraitClause0]
+    fn index_mut = alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>}#14::index_mut
 }
 
 impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize} : core::slice::index::private_slice_index::Sealed<usize>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (T)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (T)>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (T)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (T)>
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_unchecked<T>(@1: usize, @2: *mut Slice<T>) -> *mut T
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked<T>(@1: usize, @2: *mut Slice<T>) -> *mut T
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_unchecked_mut<T>(@1: usize, @2: *const Slice<T>) -> *const T
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked_mut<T>(@1: usize, @2: *const Slice<T>) -> *const T
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::index<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> &'_0 (T)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> &'_0 (T)
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::index_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (T)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (T)
 
-impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}<T> : core::slice::index::SliceIndex<usize, Slice<T>>
+impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2<T> : core::slice::index::SliceIndex<usize, Slice<T>>
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize}
     type Output = T
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}::index_mut
+    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get
+    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_mut
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked_mut
+    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index
+    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index_mut
 }
 
 fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut ((parents(Self)::[@TraitClause0])::Output)
@@ -1739,7 +1739,7 @@ fn test_crate::clear<'_0>(@1: &'_0 mut (alloc::vec::Vec<u32, alloc::alloc::Globa
     loop {
         @5 := copy (i@2)
         @7 := &*(v@1)
-        @6 := alloc::vec::{alloc::vec::Vec<T, A>#1}::len<u32, alloc::alloc::Global>(move (@7))
+        @6 := alloc::vec::{alloc::vec::Vec<T, A>}#1::len<u32, alloc::alloc::Global>(move (@7))
         drop @7
         @4 := move (@5) < move (@6)
         if move (@4) {
@@ -1752,7 +1752,7 @@ fn test_crate::clear<'_0>(@1: &'_0 mut (alloc::vec::Vec<u32, alloc::alloc::Globa
         drop @5
         @9 := &mut *(v@1)
         @10 := copy (i@2)
-        @8 := alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>#14}<u32, usize, alloc::alloc::Global>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize#2}<u32>]::index_mut(move (@9), move (@10))
+        @8 := alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>}#14<u32, usize, alloc::alloc::Global>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2<u32>]::index_mut(move (@9), move (@10))
         drop @10
         drop @9
         *(@8) := const (0 : u32)

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -1637,6 +1637,18 @@ struct alloc::alloc::Global = {}
 
 fn alloc::vec::{alloc::vec::Vec<T, A>}#1::len<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>)) -> usize
 
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index : core::ops::index::Index::index
+}
+
+trait core::ops::index::IndexMut<Self, Idx>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
+    fn index_mut : core::ops::index::IndexMut::index_mut
+}
+
 trait core::slice::index::private_slice_index::Sealed<Self>
 
 trait core::slice::index::SliceIndex<Self, T>
@@ -1649,18 +1661,6 @@ trait core::slice::index::SliceIndex<Self, T>
     fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
     fn index : core::slice::index::SliceIndex::index
     fn index_mut : core::slice::index::SliceIndex::index_mut
-}
-
-trait core::ops::index::Index<Self, Idx>
-{
-    type Output
-    fn index : core::ops::index::Index::index
-}
-
-trait core::ops::index::IndexMut<Self, Idx>
-{
-    parent_clause_0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
-    fn index_mut : core::ops::index::IndexMut::index_mut
 }
 
 fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>), @2: I) -> &'_0 (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>}#13<T, I, A>[@TraitClause0]::Output)

--- a/charon/tests/ui/name-matcher-tests.out
+++ b/charon/tests/ui/name-matcher-tests.out
@@ -60,6 +60,12 @@ struct core::ops::range::RangeFrom<Idx> =
 
 fn core::option::{core::option::Option<T>}::is_some<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> bool
 
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index : core::ops::index::Index::index
+}
+
 trait core::slice::index::private_slice_index::Sealed<Self>
 
 trait core::slice::index::SliceIndex<Self, T>
@@ -72,12 +78,6 @@ trait core::slice::index::SliceIndex<Self, T>
     fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
     fn index : core::slice::index::SliceIndex::index
     fn index_mut : core::slice::index::SliceIndex::index_mut
-}
-
-trait core::ops::index::Index<Self, Idx>
-{
-    type Output
-    fn index : core::ops::index::Index::index
 }
 
 fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause0::Output)

--- a/charon/tests/ui/name-matcher-tests.out
+++ b/charon/tests/ui/name-matcher-tests.out
@@ -37,7 +37,7 @@ impl<T> test_crate::{impl test_crate::Trait<core::option::Option<T>> for alloc::
     fn method = test_crate::{impl test_crate::Trait<core::option::Option<T>> for alloc::boxed::Box<T>}::method
 }
 
-fn test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}::method<T, U, V>()
+fn test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>}#1::method<T, U, V>()
 {
     let @0: (); // return
     let @1: (); // anonymous local
@@ -48,9 +48,9 @@ fn test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::O
     return
 }
 
-impl<T, U> test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}<T, U> : test_crate::Trait<core::option::Option<U>, alloc::boxed::Box<T>>
+impl<T, U> test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>}#1<T, U> : test_crate::Trait<core::option::Option<U>, alloc::boxed::Box<T>>
 {
-    fn method = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>#1}::method
+    fn method = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>> for core::option::Option<U>}#1::method
 }
 
 struct core::ops::range::RangeFrom<Idx> =
@@ -93,30 +93,30 @@ where
     fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
 }
 
-impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>#3} : core::slice::index::private_slice_index::Sealed<core::ops::range::RangeFrom<usize>>
+impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>}#3 : core::slice::index::private_slice_index::Sealed<core::ops::range::RangeFrom<usize>>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked<T>(@1: core::ops::range::RangeFrom<usize>, @2: *mut Slice<T>) -> *mut Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_unchecked<T>(@1: core::ops::range::RangeFrom<usize>, @2: *mut Slice<T>) -> *mut Slice<T>
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked_mut<T>(@1: core::ops::range::RangeFrom<usize>, @2: *const Slice<T>) -> *const Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_unchecked_mut<T>(@1: core::ops::range::RangeFrom<usize>, @2: *const Slice<T>) -> *const Slice<T>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::index<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::index_mut<'_0, T>(@1: core::ops::range::RangeFrom<usize>, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
 
-impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}<T> : core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, Slice<T>>
+impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6<T> : core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, Slice<T>>
 {
-    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>#3}
+    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>}#3
     type Output = Slice<T>
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}::index_mut
+    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get
+    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_mut
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_unchecked
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::get_unchecked_mut
+    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::index
+    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6::index_mut
 }
 
 fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
@@ -153,7 +153,7 @@ fn test_crate::foo()
     drop @6
     @10 := &*(slice@4)
     @11 := core::ops::range::RangeFrom { start: const (1 : usize) }
-    @9 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<bool, core::ops::range::RangeFrom<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>#6}<bool>]::index(move (@10), move (@11))
+    @9 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<bool, core::ops::range::RangeFrom<usize>>[core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>}#6<bool>]::index(move (@10), move (@11))
     drop @11
     drop @10
     @8 := &*(@9)

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -264,20 +264,20 @@ trait core::ops::deref::DerefMut<Self>
     fn deref_mut : core::ops::deref::DerefMut::deref_mut
 }
 
-fn alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}::deref<'_0, T, A>(@1: &'_0 (alloc::boxed::Box<T>)) -> &'_0 (T)
+fn alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>}#38::deref<'_0, T, A>(@1: &'_0 (alloc::boxed::Box<T>)) -> &'_0 (T)
 
-impl<T, A> alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}<T, A> : core::ops::deref::Deref<alloc::boxed::Box<T>>
+impl<T, A> alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>}#38<T, A> : core::ops::deref::Deref<alloc::boxed::Box<T>>
 {
     type Target = T
-    fn deref = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}::deref
+    fn deref = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>}#38::deref
 }
 
-fn alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>#39}::deref_mut<'_0, T, A>(@1: &'_0 mut (alloc::boxed::Box<T>)) -> &'_0 mut (T)
+fn alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>}#39::deref_mut<'_0, T, A>(@1: &'_0 mut (alloc::boxed::Box<T>)) -> &'_0 mut (T)
 
-impl<T, A> alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>#39}<T, A> : core::ops::deref::DerefMut<alloc::boxed::Box<T>>
+impl<T, A> alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>}#39<T, A> : core::ops::deref::DerefMut<alloc::boxed::Box<T>>
 {
-    parent_clause0 = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}<T, A>
-    fn deref_mut = alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>#39}::deref_mut
+    parent_clause0 = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>}#38<T, A>
+    fn deref_mut = alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>}#39::deref_mut
 }
 
 struct alloc::alloc::Global = {}
@@ -303,12 +303,12 @@ fn test_crate::test_box1()
     b@1 := @BoxNew<i32>(const (0 : i32))
     @fake_read(b@1)
     @3 := &two-phase-mut b@1
-    x@2 := alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>#39}<i32, alloc::alloc::Global>::deref_mut(move (@3))
+    x@2 := alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>}#39<i32, alloc::alloc::Global>::deref_mut(move (@3))
     drop @3
     @fake_read(x@2)
     *(x@2) := const (1 : i32)
     @5 := &b@1
-    x@4 := alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>#38}<i32, alloc::alloc::Global>::deref(move (@5))
+    x@4 := alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>}#38<i32, alloc::alloc::Global>::deref(move (@5))
     drop @5
     @fake_read(x@4)
     @8 := copy (*(x@4))

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -11,7 +11,7 @@ opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
-fn core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> core::fmt::Arguments<'a>
+fn core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> core::fmt::Arguments<'a>
 
 fn test_crate::panic2()
 {
@@ -24,16 +24,16 @@ fn test_crate::panic2()
     @4 := [const ("O no!"); 1 : usize]
     @3 := &@4
     @2 := &*(@3)
-    @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_, 1 : usize>(move (@2))
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))
     drop @2
     panic(core::panicking::panic_fmt)
 }
 
 opaque type core::fmt::rt::Argument<'a>
 
-fn core::fmt::rt::{core::fmt::rt::Argument<'a>#1}::none<'a>() -> Array<core::fmt::rt::Argument<'a>, 0 : usize>
+fn core::fmt::rt::{core::fmt::rt::Argument<'a>}#1::none<'a>() -> Array<core::fmt::rt::Argument<'a>, 0 : usize>
 
-fn core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'a, const P : usize, const A : usize>(@1: &'a (Array<&'static (Str), const P : usize>), @2: &'a (Array<core::fmt::rt::Argument<'a>, const A : usize>)) -> core::fmt::Arguments<'a>
+fn core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'a, const P : usize, const A : usize>(@1: &'a (Array<&'static (Str), const P : usize>), @2: &'a (Array<core::fmt::rt::Argument<'a>, const A : usize>)) -> core::fmt::Arguments<'a>
 
 fn test_crate::panic3()
 {
@@ -49,10 +49,10 @@ fn test_crate::panic3()
     @4 := [const ("O no!"); 1 : usize]
     @3 := &@4
     @2 := &*(@3)
-    @7 := core::fmt::rt::{core::fmt::rt::Argument<'a>#1}::none<'_>()
+    @7 := core::fmt::rt::{core::fmt::rt::Argument<'a>}#1::none<'_>()
     @6 := &@7
     @5 := &*(@6)
-    @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
     drop @5
     drop @2
     panic(core::panicking::panic_fmt)
@@ -103,7 +103,7 @@ fn test_crate::panic5()
         @6 := [const ("assert failed"); 1 : usize]
         @5 := &@6
         @4 := &*(@5)
-        @3 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_, 1 : usize>(move (@4))
+        @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))
         drop @4
         panic(core::panicking::panic_fmt)
     }
@@ -138,10 +138,10 @@ fn test_crate::panic7()
     @4 := [const ("internal error: entered unreachable code: can't reach this"); 1 : usize]
     @3 := &@4
     @2 := &*(@3)
-    @7 := core::fmt::rt::{core::fmt::rt::Argument<'a>#1}::none<'_>()
+    @7 := core::fmt::rt::{core::fmt::rt::Argument<'a>}#1::none<'_>()
     @6 := &@7
     @5 := &*(@6)
-    @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
     drop @5
     drop @2
     panic(core::panicking::panic_fmt)

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -4,7 +4,7 @@ opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
-fn core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> core::fmt::Arguments<'a>
+fn core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> core::fmt::Arguments<'a>
 
 fn test_crate::main()
 {
@@ -17,7 +17,7 @@ fn test_crate::main()
     @4 := [const ("O no"); 1 : usize]
     @3 := &@4
     @2 := &*(@3)
-    @1 := core::fmt::{core::fmt::Arguments<'a>#2}::new_const<'_, 1 : usize>(move (@2))
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))
     drop @2
     panic(core::panicking::panic_fmt)
 }

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -60,7 +60,7 @@ trait core::borrow::Borrow<Self, Borrowed>
     fn borrow : core::borrow::Borrow::borrow
 }
 
-fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>#2}::get<'_0, '_1, K, V, S, Q>(@1: &'_0 (std::collections::hash::map::HashMap<K, V, S>), @2: &'_1 (Q)) -> core::option::Option<&'_0 (V)>
+fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>}#2::get<'_0, '_1, K, V, S, Q>(@1: &'_0 (std::collections::hash::map::HashMap<K, V, S>), @2: &'_1 (Q)) -> core::option::Option<&'_0 (V)>
 where
     [@TraitClause0]: core::cmp::Eq<K>,
     [@TraitClause1]: core::hash::Hash<K>,
@@ -76,60 +76,60 @@ impl<T> core::borrow::{impl core::borrow::Borrow<T> for T}<T> : core::borrow::Bo
     fn borrow = core::borrow::{impl core::borrow::Borrow<T> for T}::borrow
 }
 
-fn core::hash::impls::{impl core::hash::Hash for u32#11}::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
+fn core::hash::impls::{impl core::hash::Hash for u32}#11::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
 where
     [@TraitClause0]: core::hash::Hasher<H>,
 
-fn core::hash::impls::{impl core::hash::Hash for u32#11}::hash_slice<'_0, '_1, H>(@1: &'_0 (Slice<u32>), @2: &'_1 mut (H))
+fn core::hash::impls::{impl core::hash::Hash for u32}#11::hash_slice<'_0, '_1, H>(@1: &'_0 (Slice<u32>), @2: &'_1 mut (H))
 where
     [@TraitClause0]: core::hash::Hasher<H>,
 
-impl core::hash::impls::{impl core::hash::Hash for u32#11} : core::hash::Hash<u32>
+impl core::hash::impls::{impl core::hash::Hash for u32}#11 : core::hash::Hash<u32>
 {
-    fn hash = core::hash::impls::{impl core::hash::Hash for u32#11}::hash
-    fn hash_slice = core::hash::impls::{impl core::hash::Hash for u32#11}::hash_slice
+    fn hash = core::hash::impls::{impl core::hash::Hash for u32}#11::hash
+    fn hash_slice = core::hash::impls::{impl core::hash::Hash for u32}#11::hash_slice
 }
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::ne<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24} : core::cmp::PartialEq<u32, u32>
+impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24 : core::cmp::PartialEq<u32, u32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}::ne
+    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq
+    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne
 }
 
-impl core::cmp::impls::{impl core::cmp::Eq for u32#43} : core::cmp::Eq<u32>
+impl core::cmp::impls::{impl core::cmp::Eq for u32}#43 : core::cmp::Eq<u32>
 {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32#24}
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24
 }
 
 opaque type std::hash::random::DefaultHasher
 
-fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::write<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Slice<u8>))
+fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Slice<u8>))
 
-fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::finish<'_0>(@1: &'_0 (std::hash::random::DefaultHasher)) -> u64
+fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish<'_0>(@1: &'_0 (std::hash::random::DefaultHasher)) -> u64
 
-fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::write_str<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Str))
+fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Str))
 
-impl std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4} : core::hash::Hasher<std::hash::random::DefaultHasher>
+impl std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4 : core::hash::Hasher<std::hash::random::DefaultHasher>
 {
-    fn write = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::write
-    fn finish = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::finish
-    fn write_str = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}::write_str
+    fn write = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write
+    fn finish = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish
+    fn write_str = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str
 }
 
-fn std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}::build_hasher<'_0>(@1: &'_0 (std::hash::random::RandomState)) -> std::hash::random::DefaultHasher
+fn std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher<'_0>(@1: &'_0 (std::hash::random::RandomState)) -> std::hash::random::DefaultHasher
 
-impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1} : core::hash::BuildHasher<std::hash::random::RandomState>
+impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1 : core::hash::BuildHasher<std::hash::random::RandomState>
 {
-    parent_clause0 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher#4}
+    parent_clause0 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4
     type Hasher = std::hash::random::DefaultHasher
-    fn build_hasher = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}::build_hasher
+    fn build_hasher = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher
 }
 
-fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>#2}::insert<'_0, K, V, S>(@1: &'_0 mut (std::collections::hash::map::HashMap<K, V, S>), @2: K, @3: V) -> core::option::Option<V>
+fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>}#2::insert<'_0, K, V, S>(@1: &'_0 mut (std::collections::hash::map::HashMap<K, V, S>), @2: K, @3: V) -> core::option::Option<V>
 where
     [@TraitClause0]: core::cmp::Eq<K>,
     [@TraitClause1]: core::hash::Hash<K>,
@@ -141,7 +141,7 @@ trait core::ops::index::Index<Self, Idx>
     fn index : core::ops::index::Index::index
 }
 
-fn std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>#9}::index<'_0, '_1, '_2, K, Q, V, S>(@1: &'_1 (std::collections::hash::map::HashMap<K, V, S>), @2: &'_2 (Q)) -> &'_1 (V)
+fn std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>}#9::index<'_0, '_1, '_2, K, Q, V, S>(@1: &'_1 (std::collections::hash::map::HashMap<K, V, S>), @2: &'_2 (Q)) -> &'_1 (V)
 where
     // Inherited clauses:
     [@TraitClause0]: core::cmp::Eq<K>,
@@ -151,7 +151,7 @@ where
     [@TraitClause4]: core::hash::Hash<Q>,
     [@TraitClause5]: core::hash::BuildHasher<S>,
 
-impl<'_0, K, Q, V, S> std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>#9}<'_0, K, Q, V, S> : core::ops::index::Index<std::collections::hash::map::HashMap<K, V, S>, &'_0 (Q)>
+impl<'_0, K, Q, V, S> std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>}#9<'_0, K, Q, V, S> : core::ops::index::Index<std::collections::hash::map::HashMap<K, V, S>, &'_0 (Q)>
 where
     [@TraitClause0]: core::cmp::Eq<K>,
     [@TraitClause1]: core::hash::Hash<K>,
@@ -161,7 +161,7 @@ where
     [@TraitClause5]: core::hash::BuildHasher<S>,
 {
     type Output = V
-    fn index = std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>#9}::index
+    fn index = std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>}#9::index
 }
 
 fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
@@ -189,21 +189,21 @@ fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map::Has
     @6 := const (22 : u32)
     @5 := &@6
     @4 := &*(@5)
-    @2 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>#2}::get<u32, u32, std::hash::random::RandomState, u32>[core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::hash::impls::{impl core::hash::Hash for u32#11}, core::cmp::impls::{impl core::cmp::Eq for u32#43}, core::cmp::impls::{impl core::cmp::Eq for u32#43}, core::hash::impls::{impl core::hash::Hash for u32#11}, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}](move (@3), move (@4))
+    @2 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>}#2::get<u32, u32, std::hash::random::RandomState, u32>[core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::hash::impls::{impl core::hash::Hash for u32}#11, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@3), move (@4))
     drop @4
     drop @3
     @fake_read(@2)
     match @2 {
         0 => {
             @9 := &two-phase-mut *(map@1)
-            @8 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>#2}::insert<u32, u32, std::hash::random::RandomState>[core::cmp::impls::{impl core::cmp::Eq for u32#43}, core::hash::impls::{impl core::hash::Hash for u32#11}, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}](move (@9), const (22 : u32), const (33 : u32))
+            @8 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>}#2::insert<u32, u32, std::hash::random::RandomState>[core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@9), const (22 : u32), const (33 : u32))
             drop @9
             drop @8
             @12 := &*(map@1)
             @15 := const (22 : u32)
             @14 := &@15
             @13 := &*(@14)
-            @11 := std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>#9}<'_, u32, u32, u32, std::hash::random::RandomState>[core::cmp::impls::{impl core::cmp::Eq for u32#43}, core::hash::impls::{impl core::hash::Hash for u32#11}, core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::cmp::impls::{impl core::cmp::Eq for u32#43}, core::hash::impls::{impl core::hash::Hash for u32#11}, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState#1}]::index(move (@12), move (@13))
+            @11 := std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>}#9<'_, u32, u32, u32, std::hash::random::RandomState>[core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1]::index(move (@12), move (@13))
             drop @13
             drop @12
             @10 := &*(@11)

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -50,9 +50,9 @@ opaque type core::cell::Ref<'b, T>
 
 struct core::cell::BorrowError = {}
 
-fn core::cell::{core::cell::RefCell<T>#21}::new<T>(@1: T) -> core::cell::RefCell<T>
+fn core::cell::{core::cell::RefCell<T>}#21::new<T>(@1: T) -> core::cell::RefCell<T>
 
-fn core::cell::{core::cell::RefCell<T>#22}::try_borrow<'_0, T>(@1: &'_0 (core::cell::RefCell<T>)) -> core::result::Result<core::cell::Ref<'_0, T>, core::cell::BorrowError>
+fn core::cell::{core::cell::RefCell<T>}#22::try_borrow<'_0, T>(@1: &'_0 (core::cell::RefCell<T>)) -> core::result::Result<core::cell::Ref<'_0, T>, core::cell::BorrowError>
 
 fn test_crate::foo()
 {
@@ -62,10 +62,10 @@ fn test_crate::foo()
     let @3: &'_ (core::cell::RefCell<bool>); // anonymous local
     let @4: (); // anonymous local
 
-    ref_b@1 := core::cell::{core::cell::RefCell<T>#21}::new<bool>(const (false))
+    ref_b@1 := core::cell::{core::cell::RefCell<T>}#21::new<bool>(const (false))
     @fake_read(ref_b@1)
     @3 := &ref_b@1
-    @2 := core::cell::{core::cell::RefCell<T>#22}::try_borrow<bool>(move (@3))
+    @2 := core::cell::{core::cell::RefCell<T>}#22::try_borrow<bool>(move (@3))
     drop @3
     @fake_read(@2)
     drop @2

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -71,11 +71,11 @@ trait core::fmt::Display<Self>
     fn fmt : core::fmt::Display::fmt
 }
 
-fn core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::fmt::num::imp::{impl core::fmt::Display for u32}#5::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-impl core::fmt::num::imp::{impl core::fmt::Display for u32#5} : core::fmt::Display<u32>
+impl core::fmt::num::imp::{impl core::fmt::Display for u32}#5 : core::fmt::Display<u32>
 {
-    fn fmt = core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt
+    fn fmt = core::fmt::num::imp::{impl core::fmt::Display for u32}#5::fmt
 }
 
 fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
@@ -85,11 +85,11 @@ trait core::fmt::UpperHex<Self>
     fn fmt : core::fmt::UpperHex::fmt
 }
 
-fn core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-impl core::fmt::num::{impl core::fmt::UpperHex for u32#61} : core::fmt::UpperHex<u32>
+impl core::fmt::num::{impl core::fmt::UpperHex for u32}#61 : core::fmt::UpperHex<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt
+    fn fmt = core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt
 }
 
 fn core::fmt::UpperHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
@@ -99,16 +99,16 @@ trait core::fmt::LowerHex<Self>
     fn fmt : core::fmt::LowerHex::fmt
 }
 
-fn core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-impl core::fmt::num::{impl core::fmt::LowerHex for u32#60} : core::fmt::LowerHex<u32>
+impl core::fmt::num::{impl core::fmt::LowerHex for u32}#60 : core::fmt::LowerHex<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt
+    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt
 }
 
 fn core::fmt::LowerHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 
-fn core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
+fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 {
     let @0: core::result::Result<(), core::fmt::Error>; // return
     let self@1: &'_ (u32); // arg #1
@@ -130,25 +130,25 @@ fn core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt<'_0, '_1, '_2>(@1: &'
             switch move (@5) {
                 0 : u32 => {
                     drop @5
-                    @0 := core::fmt::num::imp::{impl core::fmt::Display for u32#5}::fmt(move (self@1), move (f@2))
+                    @0 := core::fmt::num::imp::{impl core::fmt::Display for u32}#5::fmt(move (self@1), move (f@2))
                 },
                 _ => {
                     drop @5
-                    @0 := core::fmt::num::{impl core::fmt::UpperHex for u32#61}::fmt(move (self@1), move (f@2))
+                    @0 := core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt(move (self@1), move (f@2))
                 }
             }
         },
         _ => {
             drop @3
-            @0 := core::fmt::num::{impl core::fmt::LowerHex for u32#60}::fmt(move (self@1), move (f@2))
+            @0 := core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt(move (self@1), move (f@2))
         }
     }
     return
 }
 
-impl core::fmt::num::{impl core::fmt::Debug for u32#86} : core::fmt::Debug<u32>
+impl core::fmt::num::{impl core::fmt::Debug for u32}#86 : core::fmt::Debug<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::Debug for u32#86}::fmt
+    fn fmt = core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt
 }
 
 fn test_crate::unwrap(@1: core::result::Result<u32, u32>) -> u32
@@ -158,7 +158,7 @@ fn test_crate::unwrap(@1: core::result::Result<u32, u32>) -> u32
     let @2: core::result::Result<u32, u32>; // anonymous local
 
     @2 := copy (res@1)
-    @0 := core::result::{core::result::Result<T, E>}::unwrap<u32, u32>[core::fmt::num::{impl core::fmt::Debug for u32#86}](move (@2))
+    @0 := core::result::{core::result::Result<T, E>}::unwrap<u32, u32>[core::fmt::num::{impl core::fmt::Debug for u32}#86](move (@2))
     drop @2
     return
 }

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -14,7 +14,7 @@ impl<'a> test_crate::{impl test_crate::Trait<'a> for &'a (())}<'a> : test_crate:
 
 opaque type test_crate::Foo<'a>
 
-fn test_crate::{test_crate::Foo<'_0>#1}::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
+fn test_crate::{test_crate::Foo<'_0>}#1::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
 
 fn test_crate::foo<'_0>(@1: &'_0 (fn<'_1_0>(&'_1_0 (u32)) -> u32))
 

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -31,11 +31,11 @@ trait alloc::string::ToString<Self>
     fn to_string : alloc::string::ToString::to_string
 }
 
-fn alloc::string::{impl alloc::string::ToString for Str#38}::to_string<'_0>(@1: &'_0 (Str)) -> alloc::string::String
+fn alloc::string::{impl alloc::string::ToString for Str}#38::to_string<'_0>(@1: &'_0 (Str)) -> alloc::string::String
 
-impl alloc::string::{impl alloc::string::ToString for Str#38} : alloc::string::ToString<Str>
+impl alloc::string::{impl alloc::string::ToString for Str}#38 : alloc::string::ToString<Str>
 {
-    fn to_string = alloc::string::{impl alloc::string::ToString for Str#38}::to_string
+    fn to_string = alloc::string::{impl alloc::string::ToString for Str}#38::to_string
 }
 
 fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::string::String
@@ -50,7 +50,7 @@ fn test_crate::main()
 
     @3 := const ("Hello")
     @2 := &*(@3)
-    _s@1 := alloc::string::{impl alloc::string::ToString for Str#38}::to_string(move (@2))
+    _s@1 := alloc::string::{impl alloc::string::ToString for Str}#38::to_string(move (@2))
     drop @2
     @fake_read(_s@1)
     drop @3

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -124,9 +124,9 @@ where
     fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
 }
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>)) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>::Item>
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>)) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::size_hint<'_0, T, const N : usize>(@1: &'_0 (core::array::iter::IntoIter<T, const N : usize>)) -> (usize, core::option::Option<usize>)
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint<'_0, T, const N : usize>(@1: &'_0 (core::array::iter::IntoIter<T, const N : usize>)) -> (usize, core::option::Option<usize>)
 
 trait core::ops::function::FnOnce<Self, Args>
 {
@@ -140,14 +140,14 @@ trait core::ops::function::FnMut<Self, Args>
     fn call_mut : core::ops::function::FnMut::call_mut
 }
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
 where
     [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
-    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>#2}<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
+    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>}#2<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>::Item>
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
 
 enum core::result::Result<T, E> =
 |  Ok(T)
@@ -180,64 +180,64 @@ opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::num::nonzero::ZeroablePrimitive<T>,
 
-fn core::clone::impls::{impl core::clone::Clone for usize#5}::clone<'_0>(@1: &'_0 (usize)) -> usize
+fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_0 (usize)) -> usize
 
-impl core::clone::impls::{impl core::clone::Clone for usize#5} : core::clone::Clone<usize>
+impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize#5}::clone
+    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
 }
 
-impl core::marker::{impl core::marker::Copy for usize#38} : core::marker::Copy<usize>
+impl core::marker::{impl core::marker::Copy for usize}#38 : core::marker::Copy<usize>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize#5}
+    parent_clause0 = core::clone::impls::{impl core::clone::Clone for usize}#5
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25} : core::num::nonzero::private::Sealed<usize>
+impl core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25 : core::num::nonzero::private::Sealed<usize>
 
 opaque type core::num::nonzero::private::NonZeroUsizeInner
 
-fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
+fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0>(@1: &'_0 (core::num::nonzero::private::NonZeroUsizeInner)) -> core::num::nonzero::private::NonZeroUsizeInner
 
-impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26} : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}::clone
+    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
 }
 
-impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27} : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
+impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
 {
-    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
 }
 
-impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26} : core::num::nonzero::ZeroablePrimitive<usize>
+impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26 : core::num::nonzero::ZeroablePrimitive<usize>
 {
-    parent_clause0 = core::marker::{impl core::marker::Copy for usize#38}
-    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize#25}
-    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner#27}
-    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner#26}
+    parent_clause0 = core::marker::{impl core::marker::Copy for usize}#38
+    parent_clause1 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
+    parent_clause2 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
+    parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::advance_by<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::advance_by<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 
-unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::__iterator_get_unchecked<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>::Item
+unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::__iterator_get_unchecked<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item
 
-impl<T, const N : usize> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize> : core::iter::traits::iterator::Iterator<core::array::iter::IntoIter<T, const N : usize>>
+impl<T, const N : usize> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize> : core::iter::traits::iterator::Iterator<core::array::iter::IntoIter<T, const N : usize>>
 {
     type Item = T
-    fn next = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::next
-    fn size_hint = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::size_hint
-    fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::fold
-    fn count = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::count
-    fn last = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::last
-    fn advance_by = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::advance_by
-    fn __iterator_get_unchecked = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}::__iterator_get_unchecked
+    fn next = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::next
+    fn size_hint = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint
+    fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold
+    fn count = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count
+    fn last = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last
+    fn advance_by = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::advance_by
+    fn __iterator_get_unchecked = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::__iterator_get_unchecked
 }
 
 fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>(@1: Array<T, const N : usize>) -> core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize>::IntoIter
 
 impl<T, const N : usize> core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize> : core::iter::traits::collect::IntoIterator<Array<T, const N : usize>>
 {
-    parent_clause0 = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<T, const N : usize>
+    parent_clause0 = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>
     type Item = T
     type IntoIter = core::array::iter::IntoIter<T, const N : usize>
     fn into_iter = core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter
@@ -245,68 +245,68 @@ impl<T, const N : usize> core::array::iter::{impl core::iter::traits::collect::I
 
 fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
-fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter<I>(@1: I) -> I
+fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 
-impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<I> : core::iter::traits::collect::IntoIterator<I>
+impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause0
     type Item = @TraitClause0::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
 }
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>
 
 fn core::slice::{Slice<T>}::iter<'_0, T>(@1: &'_0 (Slice<T>)) -> core::slice::iter::Iter<'_0, T>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>)) -> core::option::Option<&'a (T)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>)) -> core::option::Option<&'a (T)>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::Iter<'a, T>)) -> (usize, core::option::Option<usize>)
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::Iter<'a, T>)) -> (usize, core::option::Option<usize>)
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::count<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> usize
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::count<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::option::Option<&'a (T)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::option::Option<&'a (T)>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::advance_by<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize#26}>>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::advance_by<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::last<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> core::option::Option<&'a (T)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::last<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> core::option::Option<&'a (T)>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::fold<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>, @2: B, @3: F) -> B
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>, @2: B, @3: F) -> B
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>) (context: core::slice::iter::{impl#182}::fold)))::[@TraitClause0])::Output = B,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>) (context: core::slice::iter::{impl#182}::fold)))::[@TraitClause0])::Output = B,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::for_each<'a, T, F>(@1: core::slice::iter::Iter<'a, T>, @2: F)
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::for_each<'a, T, F>(@1: core::slice::iter::Iter<'a, T>, @2: F)
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::for_each)))::[@TraitClause0])::Output = (),
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::for_each)))::[@TraitClause0])::Output = (),
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::all<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::all<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::all)))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::all)))::[@TraitClause0])::Output = bool,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::any<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::any<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::any)))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::any)))::[@TraitClause0])::Output = bool,
 
 Unknown decl: 39
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::find_map<'a, '_1, T, B, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> core::option::Option<B>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map<'a, '_1, T, B, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> core::option::Option<B>
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::find_map)))::[@TraitClause0])::Output = core::option::Option<B>,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::find_map)))::[@TraitClause0])::Output = core::option::Option<B>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::position<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::position<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause0]: core::ops::function::FnMut<P, (&'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>#182}<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, (&'_ (T))>) (context: core::slice::iter::{impl#182}::position)))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, (&'_ (T))>) (context: core::slice::iter::{impl#182}::position)))::[@TraitClause0])::Output = bool,
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
@@ -326,35 +326,35 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
     fn rfind
 }
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>,
     [@TraitClause1]: core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'_, T>>,
     [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>>,
     (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl9<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl10<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl9<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl10<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Output = bool,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}<'_, T>::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, T>::Item
 
 Unknown decl: 44
 
-impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
+impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
 {
     type Item = &'a (T)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::nth
-    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::advance_by
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::last
-    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::fold
-    fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::for_each
-    fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::all
-    fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::any
+    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::next
+    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::size_hint
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::count
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth
+    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::advance_by
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::last
+    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold
+    fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::for_each
+    fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::all
+    fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::any
     fn find = @Fun39
-    fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::find_map
-    fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::position
-    fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::rposition
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}::__iterator_get_unchecked
+    fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map
+    fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::position
+    fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition
+    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked
     fn is_sorted_by = @Fun44
 }
 
@@ -363,63 +363,63 @@ trait core::ops::arith::AddAssign<Self, Rhs>
     fn add_assign : core::ops::arith::AddAssign::add_assign
 }
 
-fn core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32#365}::add_assign<'_0, '_1, '_2>(@1: &'_1 mut (i32), @2: &'_2 (i32))
+fn core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365::add_assign<'_0, '_1, '_2>(@1: &'_1 mut (i32), @2: &'_2 (i32))
 
-impl<'_0> core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32#365}<'_0> : core::ops::arith::AddAssign<i32, &'_0 (i32)>
+impl<'_0> core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365<'_0> : core::ops::arith::AddAssign<i32, &'_0 (i32)>
 {
-    fn add_assign = core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32#365}::add_assign
+    fn add_assign = core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365::add_assign
 }
 
 fn core::ops::arith::AddAssign::add_assign<'_0, Self, Rhs>(@1: &'_0 mut (Self), @2: Rhs)
 
 fn core::slice::{Slice<T>}::chunks<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> core::slice::iter::Chunks<'_0, T>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>)) -> core::option::Option<&'a (Slice<T>)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>)) -> core::option::Option<&'a (Slice<T>)>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::Chunks<'a, T>)) -> (usize, core::option::Option<usize>)
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::Chunks<'a, T>)) -> (usize, core::option::Option<usize>)
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::count<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> usize
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::count<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'_, T>::Item>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'_, T>::Item>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item>
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'_, T>::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item
 
-impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Chunks<'a, T>>
+impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Chunks<'a, T>>
 {
     type Item = &'a (Slice<T>)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::nth
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::last
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}::__iterator_get_unchecked
+    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::next
+    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::size_hint
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::count
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::last
+    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::__iterator_get_unchecked
 }
 
 fn core::slice::{Slice<T>}::chunks_exact<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> core::slice::iter::ChunksExact<'_0, T>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>)) -> core::option::Option<&'a (Slice<T>)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::next<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>)) -> core::option::Option<&'a (Slice<T>)>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::ChunksExact<'a, T>)) -> (usize, core::option::Option<usize>)
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::ChunksExact<'a, T>)) -> (usize, core::option::Option<usize>)
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::count<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> usize
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::count<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'_, T>::Item>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::last<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'_, T>::Item>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::last<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item>
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'_, T>::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item
 
-impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::ChunksExact<'a, T>>
+impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::ChunksExact<'a, T>>
 {
     type Item = &'a (Slice<T>)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::nth
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::last
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}::__iterator_get_unchecked
+    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::next
+    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::size_hint
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::count
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::last
+    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::__iterator_get_unchecked
 }
 
 fn test_crate::main()
@@ -512,14 +512,14 @@ fn test_crate::main()
     @6 := copy (a@1)
     @5 := core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<i32, 7 : usize>::into_iter(move (@6))
     drop @6
-    @4 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::array::iter::IntoIter<i32, 7 : usize>>[core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<i32, 7 : usize>]::into_iter(move (@5))
+    @4 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::array::iter::IntoIter<i32, 7 : usize>>[core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<i32, 7 : usize>]::into_iter(move (@5))
     drop @5
     @fake_read(@4)
     iter@7 := move (@4)
     loop {
         @12 := &mut iter@7
         @11 := &two-phase-mut *(@12)
-        @10 := core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>#2}<i32, 7 : usize>::next(move (@11))
+        @10 := core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<i32, 7 : usize>::next(move (@11))
         drop @11
         @fake_read(@10)
         match @10 {
@@ -558,14 +558,14 @@ fn test_crate::main()
     drop @19
     @17 := core::slice::{Slice<T>}::iter<i32>(move (@18))
     drop @18
-    @16 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::slice::iter::Iter<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}<'_, i32>]::into_iter(move (@17))
+    @16 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::slice::iter::Iter<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, i32>]::into_iter(move (@17))
     drop @17
     @fake_read(@16)
     iter@20 := move (@16)
     loop {
         @24 := &mut iter@20
         @23 := &two-phase-mut *(@24)
-        @22 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>#182}<'_, i32>::next(move (@23))
+        @22 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, i32>::next(move (@23))
         drop @23
         @fake_read(@22)
         match @22 {
@@ -576,7 +576,7 @@ fn test_crate::main()
                 v@25 := copy ((@22 as variant @1).0)
                 @27 := &two-phase-mut i@2
                 @28 := copy (v@25)
-                @26 := core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32#365}<'_>::add_assign(move (@27), move (@28))
+                @26 := core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365<'_>::add_assign(move (@27), move (@28))
                 drop @28
                 drop @27
                 drop @26
@@ -605,14 +605,14 @@ fn test_crate::main()
     drop @33
     @31 := core::slice::{Slice<T>}::chunks<i32>(move (@32), const (2 : usize))
     drop @32
-    @30 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::slice::iter::Chunks<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'_, i32>]::into_iter(move (@31))
+    @30 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::slice::iter::Chunks<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, i32>]::into_iter(move (@31))
     drop @31
     @fake_read(@30)
     iter@34 := move (@30)
     loop {
         @38 := &mut iter@34
         @37 := &two-phase-mut *(@38)
-        @36 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>#71}<'_, i32>::next(move (@37))
+        @36 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, i32>::next(move (@37))
         drop @37
         @fake_read(@36)
         match @36 {
@@ -645,14 +645,14 @@ fn test_crate::main()
     drop @43
     @41 := core::slice::{Slice<T>}::chunks_exact<i32>(move (@42), const (2 : usize))
     drop @42
-    @40 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I#1}<core::slice::iter::ChunksExact<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'_, i32>]::into_iter(move (@41))
+    @40 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<core::slice::iter::ChunksExact<'_, i32>>[core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, i32>]::into_iter(move (@41))
     drop @41
     @fake_read(@40)
     iter@44 := move (@40)
     loop {
         @48 := &mut iter@44
         @47 := &two-phase-mut *(@48)
-        @46 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>#90}<'_, i32>::next(move (@47))
+        @46 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, i32>::next(move (@47))
         drop @47
         @fake_read(@46)
         match @46 {

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -60,7 +60,7 @@ enum core::option::Option<T> =
 |  Some(T)
 
 
-fn test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}::get_bool<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> bool
+fn test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1::get_bool<'_0, T>(@1: &'_0 (core::option::Option<T>)) -> bool
 {
     let @0: bool; // return
     let self@1: &'_ (core::option::Option<T>); // arg #1
@@ -77,9 +77,9 @@ fn test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}::get_b
     return
 }
 
-impl<T> test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}<T> : test_crate::BoolTrait<core::option::Option<T>>
+impl<T> test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1<T> : test_crate::BoolTrait<core::option::Option<T>>
 {
-    fn get_bool = test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}::get_bool
+    fn get_bool = test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1::get_bool
 }
 
 fn test_crate::test_bool_trait_option<T>(@1: core::option::Option<T>) -> bool
@@ -91,11 +91,11 @@ fn test_crate::test_bool_trait_option<T>(@1: core::option::Option<T>) -> bool
     let @4: &'_ (core::option::Option<T>); // anonymous local
 
     @3 := &x@1
-    @2 := test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}<T>::get_bool(move (@3))
+    @2 := test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1<T>::get_bool(move (@3))
     if move (@2) {
         drop @3
         @4 := &x@1
-        @0 := test_crate::{impl test_crate::BoolTrait for core::option::Option<T>#1}<T>::ret_true(move (@4))
+        @0 := test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1<T>::ret_true(move (@4))
         drop @4
     }
     else {
@@ -127,7 +127,7 @@ trait test_crate::ToU64<Self>
     fn to_u64 : test_crate::ToU64::to_u64
 }
 
-fn test_crate::{impl test_crate::ToU64 for u64#2}::to_u64(@1: u64) -> u64
+fn test_crate::{impl test_crate::ToU64 for u64}#2::to_u64(@1: u64) -> u64
 {
     let @0: u64; // return
     let self@1: u64; // arg #1
@@ -136,14 +136,14 @@ fn test_crate::{impl test_crate::ToU64 for u64#2}::to_u64(@1: u64) -> u64
     return
 }
 
-impl test_crate::{impl test_crate::ToU64 for u64#2} : test_crate::ToU64<u64>
+impl test_crate::{impl test_crate::ToU64 for u64}#2 : test_crate::ToU64<u64>
 {
-    fn to_u64 = test_crate::{impl test_crate::ToU64 for u64#2}::to_u64
+    fn to_u64 = test_crate::{impl test_crate::ToU64 for u64}#2::to_u64
 }
 
 fn test_crate::ToU64::to_u64<Self>(@1: Self) -> u64
 
-fn test_crate::{impl test_crate::ToU64 for (A, A)#3}::to_u64<A>(@1: (A, A)) -> u64
+fn test_crate::{impl test_crate::ToU64 for (A, A)}#3::to_u64<A>(@1: (A, A)) -> u64
 where
     // Inherited clauses:
     [@TraitClause0]: test_crate::ToU64<A>,
@@ -168,11 +168,11 @@ where
     return
 }
 
-impl<A> test_crate::{impl test_crate::ToU64 for (A, A)#3}<A> : test_crate::ToU64<(A, A)>
+impl<A> test_crate::{impl test_crate::ToU64 for (A, A)}#3<A> : test_crate::ToU64<(A, A)>
 where
     [@TraitClause0]: test_crate::ToU64<A>,
 {
-    fn to_u64 = test_crate::{impl test_crate::ToU64 for (A, A)#3}::to_u64
+    fn to_u64 = test_crate::{impl test_crate::ToU64 for (A, A)}#3::to_u64
 }
 
 fn test_crate::f<T>(@1: (T, T)) -> u64
@@ -184,7 +184,7 @@ where
     let @2: (T, T); // anonymous local
 
     @2 := move (x@1)
-    @0 := test_crate::{impl test_crate::ToU64 for (A, A)#3}<T>[@TraitClause0]::to_u64(move (@2))
+    @0 := test_crate::{impl test_crate::ToU64 for (A, A)}#3<T>[@TraitClause0]::to_u64(move (@2))
     drop @2
     drop x@1
     return
@@ -212,7 +212,7 @@ fn test_crate::h0(@1: u64) -> u64
     let @2: u64; // anonymous local
 
     @2 := copy (x@1)
-    @0 := test_crate::{impl test_crate::ToU64 for u64#2}::to_u64(move (@2))
+    @0 := test_crate::{impl test_crate::ToU64 for u64}#2::to_u64(move (@2))
     drop @2
     return
 }
@@ -222,7 +222,7 @@ struct test_crate::Wrapper<T> =
   x: T
 }
 
-fn test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>#4}::to_u64<T>(@1: test_crate::Wrapper<T>) -> u64
+fn test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>}#4::to_u64<T>(@1: test_crate::Wrapper<T>) -> u64
 where
     // Inherited clauses:
     [@TraitClause0]: test_crate::ToU64<T>,
@@ -238,11 +238,11 @@ where
     return
 }
 
-impl<T> test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>#4}<T> : test_crate::ToU64<test_crate::Wrapper<T>>
+impl<T> test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>}#4<T> : test_crate::ToU64<test_crate::Wrapper<T>>
 where
     [@TraitClause0]: test_crate::ToU64<T>,
 {
-    fn to_u64 = test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>#4}::to_u64
+    fn to_u64 = test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>}#4::to_u64
 }
 
 fn test_crate::h1(@1: test_crate::Wrapper<u64>) -> u64
@@ -252,7 +252,7 @@ fn test_crate::h1(@1: test_crate::Wrapper<u64>) -> u64
     let @2: test_crate::Wrapper<u64>; // anonymous local
 
     @2 := move (x@1)
-    @0 := test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>#4}<u64>[test_crate::{impl test_crate::ToU64 for u64#2}]::to_u64(move (@2))
+    @0 := test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>}#4<u64>[test_crate::{impl test_crate::ToU64 for u64}#2]::to_u64(move (@2))
     drop @2
     return
 }
@@ -266,7 +266,7 @@ where
     let @2: test_crate::Wrapper<T>; // anonymous local
 
     @2 := move (x@1)
-    @0 := test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>#4}<T>[@TraitClause0]::to_u64(move (@2))
+    @0 := test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>}#4<T>[@TraitClause0]::to_u64(move (@2))
     drop @2
     drop x@1
     return
@@ -277,7 +277,7 @@ trait test_crate::ToType<Self, T>
     fn to_type : test_crate::ToType::to_type
 }
 
-fn test_crate::{impl test_crate::ToType<bool> for u64#5}::to_type(@1: u64) -> bool
+fn test_crate::{impl test_crate::ToType<bool> for u64}#5::to_type(@1: u64) -> bool
 {
     let @0: bool; // return
     let self@1: u64; // arg #1
@@ -289,9 +289,9 @@ fn test_crate::{impl test_crate::ToType<bool> for u64#5}::to_type(@1: u64) -> bo
     return
 }
 
-impl test_crate::{impl test_crate::ToType<bool> for u64#5} : test_crate::ToType<u64, bool>
+impl test_crate::{impl test_crate::ToType<bool> for u64}#5 : test_crate::ToType<u64, bool>
 {
-    fn to_type = test_crate::{impl test_crate::ToType<bool> for u64#5}::to_type
+    fn to_type = test_crate::{impl test_crate::ToType<bool> for u64}#5::to_type
 }
 
 trait test_crate::OfType<Self>
@@ -348,20 +348,20 @@ struct test_crate::TestType<T> =
   T
 }
 
-struct test_crate::{test_crate::TestType<T>#6}::test::TestType1 =
+struct test_crate::{test_crate::TestType<T>}#6::test::TestType1 =
 {
   u64
 }
 
-trait test_crate::{test_crate::TestType<T>#6}::test::TestTrait<Self>
+trait test_crate::{test_crate::TestType<T>}#6::test::TestTrait<Self>
 {
-    fn test : test_crate::{test_crate::TestType<T>#6}::test::TestTrait::test
+    fn test : test_crate::{test_crate::TestType<T>}#6::test::TestTrait::test
 }
 
-fn test_crate::{test_crate::TestType<T>#6}::test::{impl test_crate::{test_crate::TestType<T>#6}::test::TestTrait for test_crate::{test_crate::TestType<T>#6}::test::TestType1}::test<'_0>(@1: &'_0 (test_crate::{test_crate::TestType<T>#6}::test::TestType1)) -> bool
+fn test_crate::{test_crate::TestType<T>}#6::test::{impl test_crate::{test_crate::TestType<T>}#6::test::TestTrait for test_crate::{test_crate::TestType<T>}#6::test::TestType1}::test<'_0>(@1: &'_0 (test_crate::{test_crate::TestType<T>}#6::test::TestType1)) -> bool
 {
     let @0: bool; // return
-    let self@1: &'_ (test_crate::{test_crate::TestType<T>#6}::test::TestType1); // arg #1
+    let self@1: &'_ (test_crate::{test_crate::TestType<T>}#6::test::TestType1); // arg #1
     let @2: u64; // anonymous local
 
     @2 := copy ((*(self@1)).0)
@@ -370,14 +370,14 @@ fn test_crate::{test_crate::TestType<T>#6}::test::{impl test_crate::{test_crate:
     return
 }
 
-impl test_crate::{test_crate::TestType<T>#6}::test::{impl test_crate::{test_crate::TestType<T>#6}::test::TestTrait for test_crate::{test_crate::TestType<T>#6}::test::TestType1} : test_crate::{test_crate::TestType<T>#6}::test::TestTrait<test_crate::{test_crate::TestType<T>#6}::test::TestType1>
+impl test_crate::{test_crate::TestType<T>}#6::test::{impl test_crate::{test_crate::TestType<T>}#6::test::TestTrait for test_crate::{test_crate::TestType<T>}#6::test::TestType1} : test_crate::{test_crate::TestType<T>}#6::test::TestTrait<test_crate::{test_crate::TestType<T>}#6::test::TestType1>
 {
-    fn test = test_crate::{test_crate::TestType<T>#6}::test::{impl test_crate::{test_crate::TestType<T>#6}::test::TestTrait for test_crate::{test_crate::TestType<T>#6}::test::TestType1}::test
+    fn test = test_crate::{test_crate::TestType<T>}#6::test::{impl test_crate::{test_crate::TestType<T>}#6::test::TestTrait for test_crate::{test_crate::TestType<T>}#6::test::TestType1}::test
 }
 
-fn test_crate::{test_crate::TestType<T>#6}::test::TestTrait::test<'_0, Self>(@1: &'_0 (Self)) -> bool
+fn test_crate::{test_crate::TestType<T>}#6::test::TestTrait::test<'_0, Self>(@1: &'_0 (Self)) -> bool
 
-fn test_crate::{test_crate::TestType<T>#6}::test<'_0, T>(@1: &'_0 (test_crate::TestType<T>), @2: T) -> bool
+fn test_crate::{test_crate::TestType<T>}#6::test<'_0, T>(@1: &'_0 (test_crate::TestType<T>), @2: T) -> bool
 where
     [@TraitClause0]: test_crate::ToU64<T>,
 {
@@ -386,23 +386,23 @@ where
     let x@2: T; // arg #2
     let x@3: u64; // local
     let @4: T; // anonymous local
-    let y@5: test_crate::{test_crate::TestType<T>#6}::test::TestType1; // local
+    let y@5: test_crate::{test_crate::TestType<T>}#6::test::TestType1; // local
     let @6: bool; // anonymous local
     let @7: u64; // anonymous local
-    let @8: &'_ (test_crate::{test_crate::TestType<T>#6}::test::TestType1); // anonymous local
+    let @8: &'_ (test_crate::{test_crate::TestType<T>}#6::test::TestType1); // anonymous local
 
     @4 := move (x@2)
     x@3 := @TraitClause0::to_u64(move (@4))
     drop @4
     @fake_read(x@3)
-    y@5 := test_crate::{test_crate::TestType<T>#6}::test::TestType1 { 0: const (0 : u64) }
+    y@5 := test_crate::{test_crate::TestType<T>}#6::test::TestType1 { 0: const (0 : u64) }
     @fake_read(y@5)
     @7 := copy (x@3)
     @6 := move (@7) > const (0 : u64)
     if move (@6) {
         drop @7
         @8 := &y@5
-        @0 := test_crate::{test_crate::TestType<T>#6}::test::{impl test_crate::{test_crate::TestType<T>#6}::test::TestTrait for test_crate::{test_crate::TestType<T>#6}::test::TestType1}::test(move (@8))
+        @0 := test_crate::{test_crate::TestType<T>}#6::test::{impl test_crate::{test_crate::TestType<T>}#6::test::TestTrait for test_crate::{test_crate::TestType<T>}#6::test::TestType1}::test(move (@8))
         drop @8
     }
     else {
@@ -423,7 +423,7 @@ struct test_crate::BoolWrapper =
 
 fn test_crate::ToType::to_type<Self, T>(@1: Self) -> T
 
-fn test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper#7}::to_type<T>(@1: test_crate::BoolWrapper) -> T
+fn test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper}#7::to_type<T>(@1: test_crate::BoolWrapper) -> T
 where
     // Inherited clauses:
     [@TraitClause0]: test_crate::ToType<bool, T>,
@@ -438,11 +438,11 @@ where
     return
 }
 
-impl<T> test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper#7}<T> : test_crate::ToType<test_crate::BoolWrapper, T>
+impl<T> test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper}#7<T> : test_crate::ToType<test_crate::BoolWrapper, T>
 where
     [@TraitClause0]: test_crate::ToType<bool, T>,
 {
-    fn to_type = test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper#7}::to_type
+    fn to_type = test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper}#7::to_type
 }
 
 global test_crate::WithConstTy::LEN2<Self, const LEN : usize>  {
@@ -462,14 +462,14 @@ trait test_crate::WithConstTy<Self, const LEN : usize>
     fn f : test_crate::WithConstTy::f
 }
 
-global test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::LEN1  {
+global test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1  {
     let @0: usize; // return
 
     @0 := const (12 : usize)
     return
 }
 
-fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::f<'_0, '_1>(@1: &'_0 mut (test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::W), @2: &'_1 (Array<u8, 32 : usize>))
+fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f<'_0, '_1>(@1: &'_0 mut (test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::W), @2: &'_1 (Array<u8, 32 : usize>))
 {
     let @0: (); // return
     let @1: &'_ mut (u64); // arg #1
@@ -482,14 +482,14 @@ fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::f<'_0, '_1
     return
 }
 
-impl test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8} : test_crate::WithConstTy<bool, 32 : usize>
+impl test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8 : test_crate::WithConstTy<bool, 32 : usize>
 {
-    parent_clause0 = test_crate::{impl test_crate::ToU64 for u64#2}
-    const LEN1 = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::LEN1
+    parent_clause0 = test_crate::{impl test_crate::ToU64 for u64}#2
+    const LEN1 = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1
     const LEN2 = test_crate::WithConstTy::LEN2<bool, 32 : usize>
     type V = u8
     type W = u64
-    fn f = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool#8}::f
+    fn f = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f
 }
 
 fn test_crate::use_with_const_ty1<H, const LEN : usize>() -> usize
@@ -630,11 +630,11 @@ trait test_crate::ChildTrait1<Self>
     parent_clause_0 : [@TraitClause0]: test_crate::ParentTrait1<Self>
 }
 
-impl test_crate::{impl test_crate::ParentTrait1 for usize#9} : test_crate::ParentTrait1<usize>
+impl test_crate::{impl test_crate::ParentTrait1 for usize}#9 : test_crate::ParentTrait1<usize>
 
-impl test_crate::{impl test_crate::ChildTrait1 for usize#10} : test_crate::ChildTrait1<usize>
+impl test_crate::{impl test_crate::ChildTrait1 for usize}#10 : test_crate::ChildTrait1<usize>
 {
-    parent_clause0 = test_crate::{impl test_crate::ParentTrait1 for usize#9}
+    parent_clause0 = test_crate::{impl test_crate::ParentTrait1 for usize}#9
 }
 
 trait test_crate::Iterator<Self>
@@ -677,18 +677,18 @@ trait test_crate::ChildTrait2<Self>
     fn convert : test_crate::ChildTrait2::convert
 }
 
-impl test_crate::{impl test_crate::WithTarget for u32#11} : test_crate::WithTarget<u32>
+impl test_crate::{impl test_crate::WithTarget for u32}#11 : test_crate::WithTarget<u32>
 {
     type Target = u32
 }
 
-impl test_crate::{impl test_crate::ParentTrait2 for u32#12} : test_crate::ParentTrait2<u32>
+impl test_crate::{impl test_crate::ParentTrait2 for u32}#12 : test_crate::ParentTrait2<u32>
 {
-    parent_clause0 = test_crate::{impl test_crate::WithTarget for u32#11}
+    parent_clause0 = test_crate::{impl test_crate::WithTarget for u32}#11
     type U = u32
 }
 
-fn test_crate::{impl test_crate::ChildTrait2 for u32#13}::convert(@1: u32) -> u32
+fn test_crate::{impl test_crate::ChildTrait2 for u32}#13::convert(@1: u32) -> u32
 {
     let @0: u32; // return
     let x@1: u32; // arg #1
@@ -697,10 +697,10 @@ fn test_crate::{impl test_crate::ChildTrait2 for u32#13}::convert(@1: u32) -> u3
     return
 }
 
-impl test_crate::{impl test_crate::ChildTrait2 for u32#13} : test_crate::ChildTrait2<u32>
+impl test_crate::{impl test_crate::ChildTrait2 for u32}#13 : test_crate::ChildTrait2<u32>
 {
-    parent_clause0 = test_crate::{impl test_crate::ParentTrait2 for u32#12}
-    fn convert = test_crate::{impl test_crate::ChildTrait2 for u32#13}::convert
+    parent_clause0 = test_crate::{impl test_crate::ParentTrait2 for u32}#12
+    fn convert = test_crate::{impl test_crate::ChildTrait2 for u32}#13::convert
 }
 
 trait test_crate::CFnOnce<Self, Args>
@@ -748,19 +748,19 @@ trait test_crate::Trait<Self>
     const LEN : usize
 }
 
-global test_crate::{impl test_crate::Trait for Array<T, const N : usize>#14}::LEN<T, const N : usize>  {
+global test_crate::{impl test_crate::Trait for Array<T, const N : usize>}#14::LEN<T, const N : usize>  {
     let @0: usize; // return
 
     @0 := const (const N : usize)
     return
 }
 
-impl<T, const N : usize> test_crate::{impl test_crate::Trait for Array<T, const N : usize>#14}<T, const N : usize> : test_crate::Trait<Array<T, const N : usize>>
+impl<T, const N : usize> test_crate::{impl test_crate::Trait for Array<T, const N : usize>}#14<T, const N : usize> : test_crate::Trait<Array<T, const N : usize>>
 {
-    const LEN = test_crate::{impl test_crate::Trait for Array<T, const N : usize>#14}::LEN<T, const N : usize>
+    const LEN = test_crate::{impl test_crate::Trait for Array<T, const N : usize>}#14::LEN<T, const N : usize>
 }
 
-global test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>#15}::LEN<T>
+global test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>}#15::LEN<T>
   where
       [@TraitClause0]: test_crate::Trait<T>,
   {
@@ -770,11 +770,11 @@ global test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>#15}::LEN<T
     return
 }
 
-impl<T> test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>#15}<T> : test_crate::Trait<test_crate::Wrapper<T>>
+impl<T> test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>}#15<T> : test_crate::Trait<test_crate::Wrapper<T>>
 where
     [@TraitClause0]: test_crate::Trait<T>,
 {
-    const LEN = test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>#15}::LEN<T>[@TraitClause0]
+    const LEN = test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>}#15::LEN<T>[@TraitClause0]
 }
 
 fn test_crate::use_wrapper_len<T>() -> usize
@@ -783,7 +783,7 @@ where
 {
     let @0: usize; // return
 
-    @0 := const (test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>#15}<T>[@TraitClause0]::LEN)
+    @0 := const (test_crate::{impl test_crate::Trait for test_crate::Wrapper<T>}#15<T>[@TraitClause0]::LEN)
     return
 }
 
@@ -798,7 +798,7 @@ enum core::result::Result<T, E> =
 |  Err(E)
 
 
-global test_crate::{test_crate::Foo<T, U>#16}::FOO<T, U>
+global test_crate::{test_crate::Foo<T, U>}#16::FOO<T, U>
   where
       [@TraitClause0]: test_crate::Trait<T>,
   {
@@ -815,7 +815,7 @@ where
     let @0: core::result::Result<T, i32>; // return
     let @1: core::result::Result<T, i32>; // anonymous local
 
-    @1 := test_crate::{test_crate::Foo<T, U>#16}::FOO<T, U>[@TraitClause0]
+    @1 := test_crate::{test_crate::Foo<T, U>}#16::FOO<T, U>[@TraitClause0]
     @0 := move (@1)
     return
 }
@@ -827,7 +827,7 @@ where
     let @0: core::result::Result<U, i32>; // return
     let @1: core::result::Result<U, i32>; // anonymous local
 
-    @1 := test_crate::{test_crate::Foo<T, U>#16}::FOO<U, T>[@TraitClause0]
+    @1 := test_crate::{test_crate::Foo<T, U>}#16::FOO<U, T>[@TraitClause0]
     @0 := move (@1)
     return
 }
@@ -838,9 +838,9 @@ trait test_crate::RecursiveImpl<Self>
     type Item
 }
 
-impl test_crate::{impl test_crate::RecursiveImpl for ()#17} : test_crate::RecursiveImpl<()>
+impl test_crate::{impl test_crate::RecursiveImpl for ()}#17 : test_crate::RecursiveImpl<()>
 {
-    parent_clause0 = test_crate::{impl test_crate::RecursiveImpl for ()#17}
+    parent_clause0 = test_crate::{impl test_crate::RecursiveImpl for ()}#17
     type Item = ()
 }
 

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -35,38 +35,38 @@ enum alloc::borrow::Cow<'a, B>
 
 opaque type alloc::vec::Vec<T, A>
 
-fn alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}::borrow<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>)) -> &'_0 (Slice<T>)
+fn alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>}#5::borrow<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>)) -> &'_0 (Slice<T>)
 
-impl<T, A> alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}<T, A> : core::borrow::Borrow<alloc::vec::Vec<T, A>, Slice<T>>
+impl<T, A> alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>}#5<T, A> : core::borrow::Borrow<alloc::vec::Vec<T, A>, Slice<T>>
 {
-    fn borrow = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}::borrow
+    fn borrow = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>}#5::borrow
 }
 
 struct alloc::alloc::Global = {}
 
-fn alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::to_owned<'_0, T>(@1: &'_0 (Slice<T>)) -> alloc::vec::Vec<T, alloc::alloc::Global>
+fn alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned<'_0, T>(@1: &'_0 (Slice<T>)) -> alloc::vec::Vec<T, alloc::alloc::Global>
 where
     // Inherited clauses:
     [@TraitClause0]: core::clone::Clone<T>,
 
-fn alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::clone_into<'_0, '_1, T>(@1: &'_0 (Slice<T>), @2: &'_1 mut (alloc::vec::Vec<T, alloc::alloc::Global>))
+fn alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into<'_0, '_1, T>(@1: &'_0 (Slice<T>), @2: &'_1 mut (alloc::vec::Vec<T, alloc::alloc::Global>))
 where
     // Inherited clauses:
     [@TraitClause0]: core::clone::Clone<T>,
 
-impl<T> alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}<T> : alloc::borrow::ToOwned<Slice<T>>
+impl<T> alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9<T> : alloc::borrow::ToOwned<Slice<T>>
 where
     [@TraitClause0]: core::clone::Clone<T>,
 {
-    parent_clause0 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>#5}<T, alloc::alloc::Global>
+    parent_clause0 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>}#5<T, alloc::alloc::Global>
     type Owned = alloc::vec::Vec<T, alloc::alloc::Global>
-    fn to_owned = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::to_owned
-    fn clone_into = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}::clone_into
+    fn to_owned = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned
+    fn clone_into = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into
 }
 
 type test_crate::Generic2<'a, T>
   where
-      [@TraitClause0]: core::clone::Clone<T>, = alloc::borrow::Cow<'a, Slice<T>, alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>#9}<T>[@TraitClause0]>
+      [@TraitClause0]: core::clone::Clone<T>, = alloc::borrow::Cow<'a, Slice<T>, alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9<T>[@TraitClause0]>
 
 fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
 

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -6,7 +6,7 @@ struct alloc::alloc::Global = {}
 
 opaque type alloc::string::String
 
-fn alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<T>(@1: T) -> alloc::rc::Rc<T, alloc::alloc::Global>
+fn alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>}#8::new<T>(@1: T) -> alloc::rc::Rc<T, alloc::alloc::Global>
 
 fn alloc::string::{alloc::string::String}::new() -> alloc::string::String
 
@@ -16,14 +16,14 @@ trait core::clone::Clone<Self>
     fn clone_from
 }
 
-fn alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone<'_0>(@1: &'_0 (alloc::string::String)) -> alloc::string::String
+fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone<'_0>(@1: &'_0 (alloc::string::String)) -> alloc::string::String
 
-fn alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone_from<'_0, '_1>(@1: &'_0 mut (alloc::string::String), @2: &'_1 (alloc::string::String))
+fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_from<'_0, '_1>(@1: &'_0 mut (alloc::string::String), @2: &'_1 (alloc::string::String))
 
-impl alloc::string::{impl core::clone::Clone for alloc::string::String#6} : core::clone::Clone<alloc::string::String>
+impl alloc::string::{impl core::clone::Clone for alloc::string::String}#6 : core::clone::Clone<alloc::string::String>
 {
-    fn clone = alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone
-    fn clone_from = alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone_from
+    fn clone = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone
+    fn clone_from = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_from
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
@@ -74,7 +74,7 @@ fn test_crate::foo()
     drop @5
     drop @5
     @10 := copy (array@1)
-    @9 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<Array<i32, 2 : usize>>(move (@10))
+    @9 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>}#8::new<Array<i32, 2 : usize>>(move (@10))
     @8 := unsize_cast<alloc::rc::Rc<Array<i32, 2 : usize>, alloc::alloc::Global>, alloc::rc::Rc<Slice<i32>, alloc::alloc::Global>>(move (@9))
     drop @9
     drop @10
@@ -92,7 +92,7 @@ fn test_crate::foo()
     drop @14
     drop @12
     @18 := &string@11
-    @17 := alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone(move (@18))
+    @17 := alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone(move (@18))
     drop @18
     @16 := @BoxNew<alloc::string::String>(move (@17))
     @15 := unsize_cast<alloc::boxed::Box<alloc::string::String>, alloc::boxed::Box<dyn (exists(TODO))>>(move (@16))
@@ -103,9 +103,9 @@ fn test_crate::foo()
     drop @15
     drop @15
     @22 := &string@11
-    @21 := alloc::string::{impl core::clone::Clone for alloc::string::String#6}::clone(move (@22))
+    @21 := alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone(move (@22))
     drop @22
-    @20 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>#8}::new<alloc::string::String>(move (@21))
+    @20 := alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>}#8::new<alloc::string::String>(move (@21))
     @19 := unsize_cast<alloc::rc::Rc<alloc::string::String, alloc::alloc::Global>, alloc::rc::Rc<dyn (exists(TODO)), alloc::alloc::Global>>(move (@20))
     drop @20
     drop @21


### PR DESCRIPTION
This is important for #127, as otherwise we don't have enough information in the names to ensure they call traits with the appropriate number of parameters. This also removes one source of generics complexity.