### PR TITLE
Cleanup predicate handling again

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -159,9 +159,6 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// The map from rust const generic variables to translate const generic
     /// variable indices.
     pub const_generic_vars_map: MapGenerator<u32, ConstGenericVarId>,
-    /// A context for clause translation. It remembers what kind of clauses we're currently
-    /// translating.
-    pub clause_translation_context: PredicateLocation,
     /// Accumulated clauses to be put into the item's `GenericParams`.
     pub param_trait_clauses: Vector<TraitClauseId, TraitClause>,
     /// (For traits only) accumulated implied trait clauses.
@@ -357,6 +354,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                                 None,
                                 cur_id,
                                 PredicateOrigin::WhereClauseOnImpl,
+                                &PredicateLocation::Base,
                             )?;
                             let erase_regions = false;
                             // Inherent impl ("regular" impl)
@@ -936,7 +934,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             vars_map: MapGenerator::new(),
             const_generic_vars: Vector::new(),
             const_generic_vars_map: MapGenerator::new(),
-            clause_translation_context: PredicateLocation::Base,
             param_trait_clauses: Default::default(),
             parent_trait_clauses: Default::default(),
             item_trait_clauses: Default::default(),
@@ -1132,33 +1129,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             types_outlive: self.types_outlive.clone(),
             trait_type_constraints: self.trait_type_constraints.clone(),
         }
-    }
-
-    /// We use this when exploring the clauses of a predicate, to introduce
-    /// its parent clauses, etc. in the context. We temporarily replace the
-    /// trait instance id generator so that the continuation registers the
-    ///
-    pub(crate) fn with_clause_translation_context<F, T>(
-        &mut self,
-        new_ctx: PredicateLocation,
-        f: F,
-    ) -> T
-    where
-        F: FnOnce(&mut Self) -> T,
-    {
-        use std::mem::replace;
-
-        // Save the trait instance id generator
-        let old_ctx = replace(&mut self.clause_translation_context, new_ctx);
-
-        // Apply the continuation
-        let out = f(self);
-
-        // Restore
-        let _ = replace(&mut self.clause_translation_context, old_ctx);
-
-        // Return
-        out
     }
 
     pub(crate) fn make_dep_source(&self, span: rustc_span::Span) -> Option<DepSource> {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -7,6 +7,8 @@ use std::mem;
 use std::panic;
 use std::rc::Rc;
 
+use crate::translate::translate_traits::PredicateLocation;
+
 use super::get_mir::{boxes_are_desugared, get_mir_for_def_id_and_level};
 use super::translate_ctx::*;
 use super::translate_types;
@@ -1635,7 +1637,12 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         // Translate the predicates (in particular, the trait clauses)
         match &fun_kind {
             ItemKind::Regular | ItemKind::TraitItemImpl { .. } => {
-                self.translate_predicates_of(None, def_id, PredicateOrigin::WhereClauseOnFn)?;
+                self.translate_predicates_of(
+                    None,
+                    def_id,
+                    PredicateOrigin::WhereClauseOnFn,
+                    &PredicateLocation::Base,
+                )?;
             }
             ItemKind::TraitItemProvided(trait_decl_id, ..)
             | ItemKind::TraitItemDecl(trait_decl_id, ..) => {
@@ -1643,6 +1650,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     Some(*trait_decl_id),
                     def_id,
                     PredicateOrigin::WhereClauseOnFn,
+                    &PredicateLocation::Base,
                 )?;
             }
         }
@@ -1797,7 +1805,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // }
         // ```
         bt_ctx.translate_generic_params(rust_id)?;
-        bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnFn)?;
+        bt_ctx.translate_predicates_of(
+            None,
+            rust_id,
+            PredicateOrigin::WhereClauseOnFn,
+            &PredicateLocation::Base,
+        )?;
 
         let hax_state = &bt_ctx.hax_state;
 

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -15,56 +15,13 @@ use std::collections::HashMap;
 
 /// The context in which we are translating a clause, used to generate the appropriate ids and
 /// trait references.
-pub(crate) enum ClauseTransCtx {
+pub(crate) enum PredicateLocation {
     /// We're translating the parent clauses of a trait.
-    Parent(Vector<TraitClauseId, TraitClause>, TraitDeclId),
+    Parent(TraitDeclId),
     /// We're translating the item clauses of a trait.
-    Item(
-        Vector<TraitClauseId, TraitClause>,
-        TraitDeclId,
-        TraitItemName,
-    ),
+    Item(TraitDeclId, TraitItemName),
     /// We're translating anything else.
-    Base(Vector<TraitClauseId, TraitClause>),
-}
-
-impl ClauseTransCtx {
-    pub(crate) fn as_mut_clauses(&mut self) -> &mut Vector<TraitClauseId, TraitClause> {
-        match self {
-            ClauseTransCtx::Base(clauses, ..)
-            | ClauseTransCtx::Parent(clauses, ..)
-            | ClauseTransCtx::Item(clauses, ..) => clauses,
-        }
-    }
-    pub(crate) fn into_clauses(self) -> Vector<TraitClauseId, TraitClause> {
-        match self {
-            ClauseTransCtx::Base(clauses, ..)
-            | ClauseTransCtx::Parent(clauses, ..)
-            | ClauseTransCtx::Item(clauses, ..) => clauses,
-        }
-    }
-    pub(crate) fn generate_instance_id(&mut self) -> (TraitClauseId, TraitRefKind) {
-        let fresh_id = self.as_mut_clauses().next_id();
-        let instance_id = match self {
-            ClauseTransCtx::Base { .. } => TraitRefKind::Clause(fresh_id),
-            ClauseTransCtx::Parent(_, trait_decl_id) => {
-                TraitRefKind::ParentClause(Box::new(TraitRefKind::SelfId), *trait_decl_id, fresh_id)
-            }
-            ClauseTransCtx::Item(_, trait_decl_id, item_name) => TraitRefKind::ItemClause(
-                Box::new(TraitRefKind::SelfId),
-                *trait_decl_id,
-                item_name.clone(),
-                fresh_id,
-            ),
-        };
-        (fresh_id, instance_id)
-    }
-}
-
-impl Default for ClauseTransCtx {
-    fn default() -> Self {
-        ClauseTransCtx::Base(Default::default())
-    }
+    Base,
 }
 
 impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
@@ -222,13 +179,10 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         &mut self,
         trait_decl_id: TraitDeclId,
         f: impl FnOnce(&mut Self) -> Result<(), Error>,
-    ) -> Result<Vector<TraitClauseId, TraitClause>, Error> {
-        let (out, ctx) = self.with_clause_translation_context(
-            ClauseTransCtx::Parent(Default::default(), trait_decl_id),
-            f,
-        );
+    ) -> Result<(), Error> {
+        let out = self.with_clause_translation_context(PredicateLocation::Parent(trait_decl_id), f);
         out?;
-        Ok(ctx.into_clauses())
+        Ok(())
     }
 
     pub(crate) fn with_item_trait_clauses(
@@ -236,13 +190,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trait_decl_id: TraitDeclId,
         item_name: TraitItemName,
         f: impl FnOnce(&mut Self) -> Result<(), Error>,
-    ) -> Result<Vector<TraitClauseId, TraitClause>, Error> {
-        let (out, ctx) = self.with_clause_translation_context(
-            ClauseTransCtx::Item(Default::default(), trait_decl_id, item_name),
-            f,
-        );
+    ) -> Result<(), Error> {
+        let out = self
+            .with_clause_translation_context(PredicateLocation::Item(trait_decl_id, item_name), f);
         out?;
-        Ok(ctx.into_clauses())
+        Ok(())
     }
 }
 
@@ -281,7 +233,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_trait_decl_self_trait_clause(rust_id)?;
 
         // Translate the predicates.
-        let parent_clauses = bt_ctx.with_parent_trait_clauses(def_id, |s| {
+        bt_ctx.with_parent_trait_clauses(def_id, |s| {
             s.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnTrait)
         })?;
 
@@ -291,24 +243,35 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             match &item.kind {
                 AssocKind::Type => {
                     let item_name = TraitItemName(item.name.to_string());
-                    let item_trait_clauses = {
-                        // TODO: this is an ugly manip
-                        let bounds = tcx.item_bounds(item.def_id).instantiate_identity();
-                        use crate::rustc_middle::query::Key;
-                        let span = bounds.default_span(tcx);
-                        let bounds: Vec<_> = bounds
-                            .into_iter()
-                            .map(|x| (x.as_predicate(), span))
-                            .collect();
-                        let bounds = bounds.sinto(&bt_ctx.hax_state);
-                        let origin = PredicateOrigin::TraitItem(item_name.clone());
+                    // TODO: this is an ugly manip
+                    let bounds = tcx.item_bounds(item.def_id).instantiate_identity();
+                    use crate::rustc_middle::query::Key;
+                    let span = bounds.default_span(tcx);
+                    let bounds: Vec<_> = bounds
+                        .into_iter()
+                        .map(|x| (x.as_predicate(), span))
+                        .collect();
+                    let bounds = bounds.sinto(&bt_ctx.hax_state);
+                    let origin = PredicateOrigin::TraitItem(item_name.clone());
 
-                        // Register the trait clauses as item trait clauses
-                        bt_ctx.with_item_trait_clauses(def_id, item_name.clone(), |s| {
-                            s.translate_predicates_vec(&bounds, origin)
-                        })?
-                    };
-                    type_clauses.push((item_name, item_trait_clauses));
+                    // Register the trait clauses as item trait clauses
+                    bt_ctx.with_item_trait_clauses(def_id, item_name.clone(), |s| {
+                        s.translate_predicates_vec(&bounds, origin)
+                    })?
+                }
+                AssocKind::Fn => {}
+                AssocKind::Const => {}
+            }
+        }
+
+        // Push the collected clauses in definition order.
+        for item in tcx.associated_items(rust_id).in_definition_order() {
+            match &item.kind {
+                AssocKind::Type => {
+                    let item_name = TraitItemName(item.name.to_string());
+                    if let Some(clauses) = bt_ctx.item_trait_clauses.get(&item_name) {
+                        type_clauses.push((item_name, clauses.clone()));
+                    }
                 }
                 AssocKind::Fn => {}
                 AssocKind::Const => {}
@@ -423,7 +386,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             def_id,
             item_meta,
             generics,
-            parent_clauses,
+            parent_clauses: bt_ctx.parent_trait_clauses,
             type_clauses,
             consts,
             const_defaults,

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -1,3 +1,5 @@
+use crate::translate::translate_traits::PredicateLocation;
+
 use super::translate_ctx::*;
 use charon_lib::assumed;
 use charon_lib::ast::*;
@@ -787,7 +789,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         bt_ctx.translate_generic_params(rust_id)?;
 
         // Translate the predicates
-        bt_ctx.translate_predicates_of(None, rust_id, PredicateOrigin::WhereClauseOnType)?;
+        bt_ctx.translate_predicates_of(
+            None,
+            rust_id,
+            PredicateOrigin::WhereClauseOnType,
+            &PredicateLocation::Base,
+        )?;
 
         let kind = match bt_ctx.translate_type_body(trans_id, rust_id, &item_meta) {
             Ok(kind) => kind,


### PR DESCRIPTION
Simplify predicate handling again. `ClauseTransCtx` was quite confusing, so I replaced it with a simpler enum passed in function arguments and straightforward vectors of clauses in `BodyTransCtx`. I also discovered that we no longer need to use `predicates_of` to get some of the predicates we care about: `predicates_defined_on` now returns all the predicates we need.