### PR TITLE
Cache `Name` computation

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -391,6 +391,7 @@ pub fn translate<'tcx, 'ctx>(
         translate_stack: Default::default(),
         cached_defs: Default::default(),
         cached_path_elems: Default::default(),
+        cached_names: Default::default(),
     };
 
     // First push all the items in the stack of items to translate.


### PR DESCRIPTION
We compute names _a lot_ (e.g. every time we translate a type, to check if it refers to a built-in). This makes a significant difference iun debug mode (~30% speedup when running `make generate-ml`), not so much when charon is compiled in release mode.