### PR TITLE
Ask rustc to recognize built-ins

### DIFF
--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -294,7 +294,7 @@ class virtual ['self] map_ty_base =
     TODO: move to assumed.rs?
  *)
 type assumed_ty =
-  | TBox  (** Boxes have a special treatment: we translate them as identity. *)
+  | TBox  (** Boxes are de facto a primitive type. *)
   | TArray  (** Primitive type *)
   | TSlice  (** Primitive type *)
   | TStr  (** Primitive type *)

--- a/charon/src/ast/assumed.rs
+++ b/charon/src/ast/assumed.rs
@@ -59,8 +59,6 @@ impl BuiltinFun {
 pub fn get_name_from_type_id(id: AssumedTy) -> Vec<String> {
     let name: &[_] = match id {
         AssumedTy::Box => &["alloc", "boxed", "Box"],
-        AssumedTy::PtrUnique => &["core", "ptr", "Unique"],
-        AssumedTy::PtrNonNull => &["core", "ptr", "NonNull"],
         AssumedTy::Str => &["Str"],
         AssumedTy::Array => &["Array"],
         AssumedTy::Slice => &["Slice"],
@@ -76,9 +74,6 @@ pub fn type_to_used_params(id: AssumedTy) -> Vec<bool> {
     match id {
         AssumedTy::Box => {
             vec![true, false]
-        }
-        AssumedTy::PtrUnique | AssumedTy::PtrNonNull => {
-            vec![true]
         }
         AssumedTy::Str => {
             vec![]

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -710,15 +710,8 @@ pub enum Ty {
 )]
 #[charon::variants_prefix("T")]
 pub enum AssumedTy {
-    /// Boxes have a special treatment: we translate them as identity.
+    /// Boxes are de facto a primitive type.
     Box,
-    /// Comes from the standard library. See the comments for [Ty::RawPtr]
-    /// as to why we have this here.
-    #[charon::opaque]
-    PtrUnique,
-    /// Same comments as for [AssumedTy::PtrUnique]
-    #[charon::opaque]
-    PtrNonNull,
     /// Primitive type
     Array,
     /// Primitive type

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -496,10 +496,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         let rust_id = DefId::from(def_id);
         let ty = if tcx.is_lang_item(rust_id, LangItem::OwnedBox) {
             Some(AssumedTy::Box)
-        } else if tcx.is_lang_item(rust_id, LangItem::PtrUnique) {
-            Some(AssumedTy::PtrUnique)
-        } else if tcx.is_diagnostic_item(rustc_span::sym::NonNull, rust_id) {
-            Some(AssumedTy::PtrNonNull)
         } else {
             None
         };

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -124,19 +124,6 @@ fn test_crate::convert(@1: i32) -> i64
     return
 }
 
-struct core::ptr::non_null::NonNull<T> =
-{
-  pointer: *mut T
-}
-
-struct core::marker::PhantomData<T> = {}
-
-struct core::ptr::unique::Unique<T> =
-{
-  pointer: core::ptr::non_null::NonNull<T>,
-  _marker: core::marker::PhantomData<T>
-}
-
 struct alloc::raw_vec::Cap =
 {
   usize
@@ -144,7 +131,7 @@ struct alloc::raw_vec::Cap =
 
 struct alloc::raw_vec::RawVec<T, A> =
 {
-  ptr: core::ptr::unique::Unique<T>,
+  ptr: core::ptr::Unique<T>,
   cap: alloc::raw_vec::Cap,
   alloc: A
 }

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -124,6 +124,19 @@ fn test_crate::convert(@1: i32) -> i64
     return
 }
 
+struct core::ptr::non_null::NonNull<T> =
+{
+  pointer: *mut T
+}
+
+struct core::marker::PhantomData<T> = {}
+
+struct core::ptr::unique::Unique<T> =
+{
+  pointer: core::ptr::non_null::NonNull<T>,
+  _marker: core::marker::PhantomData<T>
+}
+
 struct alloc::raw_vec::Cap =
 {
   usize
@@ -131,7 +144,7 @@ struct alloc::raw_vec::Cap =
 
 struct alloc::raw_vec::RawVec<T, A> =
 {
-  ptr: core::ptr::Unique<T>,
+  ptr: core::ptr::unique::Unique<T>,
   cap: alloc::raw_vec::Cap,
   alloc: A
 }

--- a/charon/tests/ui/send_bound.out
+++ b/charon/tests/ui/send_bound.out
@@ -1,10 +1,6 @@
 # Final LLBC before serialization:
 
-trait core::marker::Send<Self>
-
 fn test_crate::foo<M>(@1: M)
-where
-    [@TraitClause0]: core::marker::Send<M>,
 {
     let @0: (); // return
     let _msg@1: M; // arg #1
@@ -25,7 +21,7 @@ fn test_crate::main()
     let @3: (); // anonymous local
 
     @2 := ()
-    @1 := test_crate::foo<()>[core::marker::Send<()>](move (@2))
+    @1 := test_crate::foo<()>(move (@2))
     drop @2
     drop @1
     @3 := ()


### PR DESCRIPTION
Rustc has a mechanism to recognize specific items: lang items and diagnostic items. For most of our built-ins we can use these mechanisms instead of matching on names.