### PR TITLE
Gracefully fallback on stolen bodies

### DIFF
--- a/charon/tests/ui/stealing.out
+++ b/charon/tests/ui/stealing.out
@@ -1,0 +1,22 @@
+# Final LLBC before serialization:
+
+global test_crate::SLICE  {
+    let @0: Array<(), 4 : usize>; // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := @ArrayRepeat<'_, (), 4 : usize>(move (@1))
+    drop @1
+    return
+}
+
+fn test_crate::four() -> usize
+{
+    let @0: usize; // return
+
+    @0 := const (4 : usize)
+    return
+}
+
+
+

--- a/charon/tests/ui/stealing.rs
+++ b/charon/tests/ui/stealing.rs
@@ -1,0 +1,7 @@
+// Translating this needs the evaluatable MIR of `fn four()`, which steals its `mir_built` body.
+// There's no simple ordering of the translation of items that can avoid all stealing.
+static SLICE: [(); four()] = [(); 4];
+
+const fn four() -> usize {
+    2 + 2
+}


### PR DESCRIPTION
There's no simple order to translate items that would avoid stolen MIR bodies. Using the new `Steal::is_stolen()` API (https://github.com/rust-lang/rust/pull/128815) we fallback to `optimized_mir` if the body was stolen, instead of panicking.