### PR TITLE
Add `--exclude` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ charon-ml-tests: build-charon-ml charon-tests
 # Generate some of the ml code automatically from the rust definitions.
 .PHONY: generate-ml
 generate-ml:
-	cd charon && cargo run --bin generate-ml
+	cd charon && cargo run --release --bin generate-ml
 	cd charon-ml && make format 2> /dev/null
 
 # Same as `generate-ml` but don't re-run charon on itself. Useful when developping.

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.27"
+let supported_charon_version = "0.1.28"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1404,6 +1404,7 @@ and gtranslated_crate_of_json
           ("real_crate_name", _);
           ("id_to_file", id_to_file);
           ("all_ids", _);
+          ("item_names", _);
           ("type_decls", types);
           ("fun_decls", functions);
           ("global_decls", globals);

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -201,6 +201,7 @@ dependencies = [
  "regex",
  "rustc_version",
  "serde",
+ "serde-map-to-array",
  "serde_json",
  "serde_stacker",
  "snapbox",
@@ -1016,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-map-to-array"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c14b52efc56c711e0dbae3f26e0cc233f5dac336c1bf0b07e1b7dc2dca3b2cc7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 
@@ -61,6 +61,7 @@ pretty = "0.12"
 regex = "1.7.1"
 rustc_version = "0.4"
 serde_json = { version = "1.0.91", features = ["unbounded_depth"] }
+serde-map-to-array = { version = "1.1.1", features = ["std"] }
 serde_stacker = "0.1.11"
 serde = { version = "1.0.152", features = ["derive"] }
 stacker = "0.1"

--- a/charon/Charon.toml
+++ b/charon/Charon.toml
@@ -1,9 +1,9 @@
 [charon]
-opaque_modules = [
-    "cli_options",
-    "common",
-    "deps_errors",
-    "ids",
-    "logger",
-    "pretty",
+exclude = [
+    "crate::cli_options",
+    "crate::common",
+    "crate::deps_errors",
+    "crate::ids",
+    "crate::logger",
+    "crate::pretty",
 ]

--- a/charon/Charon.toml
+++ b/charon/Charon.toml
@@ -1,9 +1,32 @@
 [charon]
 exclude = [
-    "crate::cli_options",
-    "crate::common",
-    "crate::deps_errors",
-    "crate::ids",
-    "crate::logger",
-    "crate::pretty",
+    "_",
+    "derive_visitor::Drive::_",
+    "derive_visitor::DriveMut::_",
+    "crate",
+    "crate::ast::_::{impl derive_visitor::Drive for _}",
+    "crate::ast::_::{impl derive_visitor::DriveMut for _}",
+]
+include = [
+    "alloc::alloc::Global",
+    "alloc::string::String",
+    "alloc::vec::Vec",
+    "core::option::Option",
+    "std::path::PathBuf",
+    # Include these two so we can pattern-match on them.
+    # TODO: keep names of excluded items.
+    "derive_visitor::Drive",
+    "derive_visitor::DriveMut",
+    "crate::ast::krate::AnyTransId",
+    "crate::ast::expressions",
+    "crate::ast::gast",
+    "crate::ast::llbc_ast",
+    "crate::ast::meta",
+    "crate::ast::names",
+    "crate::ast::types",
+    "crate::ast::ullbc_ast",
+    "crate::ast::values",
+    "crate::ids::vector::Vector",
+    "crate::transform::reorder_decls::GDeclarationGroup",
+    "crate::transform::reorder_decls::DeclarationGroup",
 ]

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -7,6 +7,7 @@ use hashlink::LinkedHashSet;
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use rustc_span::def_id::DefId;
 use serde::{Deserialize, Serialize};
+use serde_map_to_array::HashMapToArray;
 use std::cmp::{Ord, PartialOrd};
 use std::collections::HashMap;
 use std::fmt;
@@ -98,6 +99,10 @@ pub struct TranslatedCrate {
     /// All the ids, in the order in which we encountered them
     #[drive(skip)]
     pub all_ids: LinkedHashSet<AnyTransId>,
+    /// The names of all registered items. Available so we can know the names even of items that
+    /// failed to translate.
+    #[serde(with = "HashMapToArray::<AnyTransId, Name>")]
+    pub item_names: HashMap<AnyTransId, Name>,
     /// The map from rustc id to translated id.
     #[drive(skip)]
     #[serde(skip)]

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -176,9 +176,13 @@ pub struct AttrInfo {
     EnumIsA,
 )]
 pub enum ItemOpacity {
-    /// Translate nothing of this item. The corresponding map will not have an entry for the
-    /// `AnyTransId`. Useful when even the signature of the item causes errors.
-    Invisible,
+    /// Translate the item fully.
+    Transparent,
+    /// Translate the item depending on the normal rust visibility of its contents: for types, we
+    /// translate fully if it is a struct with public fields or an enum; for functions and globals
+    /// this is equivalent to `Opaque`; for trait decls and impls this is equivalent to
+    /// `Transparent`.
+    Foreign,
     /// Translate the item name and signature, but not its contents. For function and globals, this
     /// means we don't translate the body (the code); for ADTs, this means we don't translate the
     /// fields/variants. For traits and trait impls, this doesn't change anything. For modules,
@@ -188,13 +192,9 @@ pub enum ItemOpacity {
     /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
     /// declared opaque via a command-line argument.
     Opaque,
-    /// Translate the item depending on the normal rust visibility of its contents: for types, we
-    /// translate fully if it is a struct with public fields or an enum; for functions and globals
-    /// this is equivalent to `Opaque`; for trait decls and impls this is equivalent to
-    /// `Transparent`.
-    Foreign,
-    /// Translate the item fully.
-    Transparent,
+    /// Translate nothing of this item. The corresponding map will not have an entry for the
+    /// `AnyTransId`. Useful when even the signature of the item causes errors.
+    Invisible,
 }
 
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -176,6 +176,9 @@ pub struct AttrInfo {
     EnumIsA,
 )]
 pub enum ItemOpacity {
+    /// Translate nothing of this item. The corresponding map will not have an entry for the
+    /// `AnyTransId`. Useful when even the signature of the item causes errors.
+    Invisible,
     /// Translate the item name and signature, but not its contents. For function and globals, this
     /// means we don't translate the body (the code); for ADTs, this means we don't translate the
     /// fields/variants. For traits and trait impls, this doesn't change anything. For modules,

--- a/charon/src/ast/meta_utils.rs
+++ b/charon/src/ast/meta_utils.rs
@@ -190,6 +190,7 @@ impl ItemOpacity {
     pub fn with_content_visibility(self, contents_are_public: bool) -> Self {
         use ItemOpacity::*;
         match self {
+            Invisible => Invisible,
             Transparent => Transparent,
             Foreign if contents_are_public => Transparent,
             Foreign => Opaque,

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -309,6 +309,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         // Translate the meta information
         let def: Arc<hax::FullDef> = self.hax_def(rust_id);
         let item_meta = self.translate_item_meta(&def)?;
+        if item_meta.opacity.is_invisible() {
+            // Don't even start translating the item.
+            return Ok(());
+        }
         match trans_id {
             AnyTransId::Type(id) => {
                 let ty = self.translate_type(id, rust_id, item_meta, &def)?;

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -310,6 +310,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         trans_id: AnyTransId,
     ) -> Result<(), Error> {
         let name = self.def_id_to_name(rust_id)?;
+        self.translated.item_names.insert(trans_id, name.clone());
         let opacity = self.opacity_for_name(&name);
         if opacity.is_invisible() {
             // Don't even start translating the item. In particular don't call `hax_def` on it.

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -201,7 +201,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 // exist
                 trace!("{:?}", def_id);
                 let def = self.hax_def(def_id);
-                let item_meta = self.translate_item_meta(&def)?;
+                let name = self.def_id_to_name(def_id)?;
+                let opacity = self.opacity_for_name(&name);
+                // Go through `item_meta` to get take into account the `charon::opaque` attribute.
+                let item_meta = self.translate_item_meta(&def, name, opacity)?;
                 if item_meta.opacity.is_opaque() {
                     // Ignore
                     trace!("Ignoring module [{:?}] because marked as opaque", def_id);
@@ -306,13 +309,15 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         rust_id: DefId,
         trans_id: AnyTransId,
     ) -> Result<(), Error> {
-        // Translate the meta information
-        let def: Arc<hax::FullDef> = self.hax_def(rust_id);
-        let item_meta = self.translate_item_meta(&def)?;
-        if item_meta.opacity.is_invisible() {
-            // Don't even start translating the item.
+        let name = self.def_id_to_name(rust_id)?;
+        let opacity = self.opacity_for_name(&name);
+        if opacity.is_invisible() {
+            // Don't even start translating the item. In particular don't call `hax_def` on it.
             return Ok(());
         }
+        // Translate the meta information
+        let def: Arc<hax::FullDef> = self.hax_def(rust_id);
+        let item_meta = self.translate_item_meta(&def, name, opacity)?;
         match trans_id {
             AnyTransId::Type(id) => {
                 let ty = self.translate_type(id, rust_id, item_meta, &def)?;

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -839,7 +839,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     pub(crate) fn opacity_for_name(&self, name: &Name) -> ItemOpacity {
         // Find the most precise pattern that matches this name. There is always one since
         // the list contains the `_` pattern. If there are conflicting settings for this item, we
-        // err on the side of being more transparent.
+        // err on the side of being more opaque.
         let (_, opacity) = self
             .options
             .item_opacities

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -88,14 +88,10 @@ impl TranslateOptions {
             // We always include the items from the crate.
             opacities.push(("crate".to_owned(), Transparent));
 
-            for module in options.opaque_modules.iter() {
-                opacities.push((format!("crate::{module}"), Opaque));
-            }
-
             for pat in options.include.iter() {
                 opacities.push((pat.to_string(), Transparent));
             }
-            for pat in options.exclude.iter() {
+            for pat in options.opaque.iter() {
                 opacities.push((pat.to_string(), Opaque));
             }
 

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -547,10 +547,14 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     /// Compute the meta information for a Rust item.
-    pub(crate) fn translate_item_meta(&mut self, def: &hax::FullDef) -> Result<ItemMeta, Error> {
+    pub(crate) fn translate_item_meta(
+        &mut self,
+        def: &hax::FullDef,
+        name: Name,
+        opacity: ItemOpacity,
+    ) -> Result<ItemMeta, Error> {
         let def_id = (&def.def_id).into();
         let span = self.translate_span_from_rspan(def.span.clone());
-        let name = self.def_id_to_name(def_id)?;
         let attr_info = self.translate_attr_info_from_rid(def_id, span);
         let is_local = def_id.is_local();
 
@@ -558,9 +562,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             || attr_info.attributes.iter().any(|attr| attr.is_opaque())
         {
             // Force opaque in these cases.
-            ItemOpacity::Opaque
+            ItemOpacity::Opaque.max(opacity)
         } else {
-            self.opacity_for_name(&name)
+            opacity
         };
 
         Ok(ItemMeta {

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -94,6 +94,9 @@ impl TranslateOptions {
             for pat in options.opaque.iter() {
                 opacities.push((pat.to_string(), Opaque));
             }
+            for pat in options.exclude.iter() {
+                opacities.push((pat.to_string(), Invisible));
+            }
 
             opacities
                 .into_iter()

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -833,11 +833,11 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trait_info: &Option<hax::ImplExpr>,
     ) -> Result<SubstFunIdOrPanic, Error> {
         let rust_id = DefId::from(def_id);
-        let name = self.t_ctx.hax_def_id_to_name(def_id)?;
         let is_local = rust_id.is_local();
 
         let builtin_fun = self.recognize_builtin_fun(def_id)?;
         if matches!(builtin_fun, Some(BuiltinFun::Panic)) {
+            let name = self.t_ctx.hax_def_id_to_name(def_id)?;
             return Ok(SubstFunIdOrPanic::Panic(name));
         }
 

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -98,7 +98,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let span = item_meta.span.rust_span();
         let erase_regions = false;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
-        let name = bt_ctx.t_ctx.def_id_to_name(rust_id)?;
 
         let hax::FullDefKind::Trait { items, .. } = &def.kind else {
             panic!("Unexpected definition: {def:?}")
@@ -251,7 +250,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 item_meta.span,
                 format!(
                     "Trait declarations cannot be \"opaque\"; the trait `{}` will be translated as normal.",
-                    name.fmt_with_ctx(&ctx)
+                    item_meta.name.fmt_with_ctx(&ctx)
                 ),
             )
         }

--- a/charon/src/bin/charon/toml_config.rs
+++ b/charon/src/bin/charon/toml_config.rs
@@ -30,13 +30,11 @@ pub struct CharonTomlConfig {
     #[serde(default)]
     pub no_code_duplication: bool,
     #[serde(default)]
-    pub opaque_modules: Vec<String>,
-    #[serde(default)]
     pub extract_opaque_bodies: bool,
     #[serde(default)]
     pub include: Vec<String>,
     #[serde(default)]
-    pub exclude: Vec<String>,
+    pub opaque: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -55,10 +53,9 @@ impl TomlConfig {
         config.mir_optimized |= self.charon.mir_optimized;
         config.use_polonius |= self.charon.polonius;
         config.no_code_duplication |= self.charon.no_code_duplication;
-        config.opaque_modules.extend(self.charon.opaque_modules);
         config.extract_opaque_bodies |= self.charon.extract_opaque_bodies;
         config.include.extend(self.charon.include);
-        config.exclude.extend(self.charon.exclude);
+        config.opaque.extend(self.charon.opaque);
         config.rustc_args.extend(self.rustc.flags);
         config
     }

--- a/charon/src/bin/charon/toml_config.rs
+++ b/charon/src/bin/charon/toml_config.rs
@@ -35,6 +35,8 @@ pub struct CharonTomlConfig {
     pub include: Vec<String>,
     #[serde(default)]
     pub opaque: Vec<String>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -56,6 +58,7 @@ impl TomlConfig {
         config.extract_opaque_bodies |= self.charon.extract_opaque_bodies;
         config.include.extend(self.charon.include);
         config.opaque.extend(self.charon.opaque);
+        config.exclude.extend(self.charon.exclude);
         config.rustc_args.extend(self.rustc.flags);
         config
     }

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -261,6 +261,7 @@ and gtranslated_crate_of_json
           ("real_crate_name", _);
           ("id_to_file", id_to_file);
           ("all_ids", _);
+          ("item_names", _);
           ("type_decls", types);
           ("fun_decls", functions);
           ("global_decls", globals);

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -146,6 +146,13 @@ pub struct CliOpts {
     )]
     #[serde(default)]
     pub opaque: Vec<String>,
+    /// Blacklist of items to not translate at all. These use the name-matcher syntax.
+    #[clap(
+        long = "exclude",
+        help = "Blacklist of items to not translate at all. Works just like `--include`, see the doc there."
+    )]
+    #[serde(default)]
+    pub exclude: Vec<String>,
     /// Do not run cargo; instead, run the driver directly.
     // FIXME: use a subcommand instead, when we update clap to support flattening.
     #[clap(long = "no-cargo")]

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -110,12 +110,6 @@ pub struct CliOpts {
     "))]
     #[serde(default)]
     pub no_code_duplication: bool,
-    /// A list of modules of the extracted crate that we consider as opaque: we
-    /// extract only the signature information, without the definition content
-    /// (of the functions, types, etc.).
-    #[clap(long = "opaque")]
-    #[serde(default)]
-    pub opaque_modules: Vec<String>,
     /// Usually we skip the bodies of foreign methods and structs with private fields. When this
     /// flag is on, we don't.
     #[clap(long = "extract-opaque-bodies")]
@@ -138,8 +132,8 @@ pub struct CliOpts {
               - `core::convert::{impl core::convert::Into<_> for _}`: retrieve the body of this
                   very useful impl;
 
-            When multiple patterns in the `--include` and `--exclude` options match the same item,
-            the most precise pattern wins. E.g.: `charon --exclude crate::module --include
+            When multiple patterns in the `--include` and `--opaque` options match the same item,
+            the most precise pattern wins. E.g.: `charon --opaque crate::module --include
             crate::module::_` makes the `module` opaque (we won't explore its contents), but the
             items in it transparent (we will translate them if we encounter them.)
     "))]
@@ -147,11 +141,11 @@ pub struct CliOpts {
     pub include: Vec<String>,
     /// Blacklist of items to keep opaque. These use the name-matcher syntax.
     #[clap(
-        long = "exclude",
+        long = "opaque",
         help = "Blacklist of items to keep opaque. Works just like `--include`, see the doc there."
     )]
     #[serde(default)]
-    pub exclude: Vec<String>,
+    pub opaque: Vec<String>,
     /// Do not run cargo; instead, run the driver directly.
     // FIXME: use a subcommand instead, when we update clap to support flattening.
     #[clap(long = "no-cargo")]

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -54,6 +54,18 @@ impl<C: AstFormatter> FmtWithCtx<C> for AbortKind {
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for AnyTransItem<'_> {
+    fn fmt_with_ctx(&self, ctx: &C) -> String {
+        match self {
+            AnyTransItem::Type(d) => d.fmt_with_ctx(ctx),
+            AnyTransItem::Fun(d) => d.fmt_with_ctx(ctx),
+            AnyTransItem::Global(d) => d.fmt_with_ctx(ctx),
+            AnyTransItem::TraitDecl(d) => d.fmt_with_ctx(ctx),
+            AnyTransItem::TraitImpl(d) => d.fmt_with_ctx(ctx),
+        }
+    }
+}
+
 impl<C: AstFormatter> FmtWithCtx<C> for BlockData {
     fn fmt_with_ctx_and_indent(&self, tab: &str, ctx: &C) -> String {
         let mut out: Vec<String> = Vec::new();

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -221,6 +221,28 @@ impl<'a> FmtCtx<'a> {
             AnyTransId::TraitImpl(id) => self.format_decl(id),
         }
     }
+
+    pub fn get_item(&self, id: AnyTransId) -> Result<AnyTransItem<'_>, Option<&Name>> {
+        let Some(translated) = &self.translated else {
+            return Err(None);
+        };
+        translated
+            .get_item(id)
+            .ok_or_else(|| translated.item_names.get(&id))
+    }
+
+    fn format_any_decl(&self, id: AnyTransId) -> String {
+        match self.get_item(id) {
+            Ok(d) => d.fmt_with_ctx(self),
+            Err(opt_name) => {
+                let opt_name = opt_name
+                    .map(|n| n.fmt_with_ctx(self))
+                    .map(|n| format!(" ({n})"))
+                    .unwrap_or_default();
+                format!("Missing decl: {id:?}{opt_name}")
+            }
+        }
+    }
 }
 
 impl<'a> Formatter<TypeDeclId> for FmtCtx<'a> {
@@ -585,70 +607,30 @@ impl<'a> Formatter<&gast::TraitImpl> for FmtCtx<'a> {
 
 impl<'a> DeclFormatter<TypeDeclId> for FmtCtx<'a> {
     fn format_decl(&self, id: TypeDeclId) -> String {
-        match &self.translated {
-            None => format!("Unknown decl: {:?}", id),
-            Some(translated) => match translated.type_decls.get(id) {
-                None => {
-                    format!("Unknown decl: {:?}", id)
-                }
-                Some(d) => d.fmt_with_ctx(self),
-            },
-        }
+        self.format_any_decl(id.into())
     }
 }
 
 impl<'a> DeclFormatter<GlobalDeclId> for FmtCtx<'a> {
     fn format_decl(&self, id: GlobalDeclId) -> String {
-        match &self.translated {
-            None => format!("Unknown decl: {:?}", id),
-            Some(translated) => match translated.global_decls.get(id) {
-                None => {
-                    format!("Unknown decl: {:?}", id)
-                }
-                Some(d) => d.fmt_with_ctx(self),
-            },
-        }
+        self.format_any_decl(id.into())
     }
 }
 
 impl<'a> DeclFormatter<FunDeclId> for FmtCtx<'a> {
     fn format_decl(&self, id: FunDeclId) -> String {
-        match &self.translated {
-            None => format!("Unknown decl: {:?}", id),
-            Some(translated) => match translated.fun_decls.get(id) {
-                None => {
-                    format!("Unknown decl: {:?}", id)
-                }
-                Some(d) => d.fmt_with_ctx(self),
-            },
-        }
+        self.format_any_decl(id.into())
     }
 }
 
 impl<'a> DeclFormatter<TraitDeclId> for FmtCtx<'a> {
     fn format_decl(&self, id: TraitDeclId) -> String {
-        match &self.translated {
-            None => format!("Unknown decl: {:?}", id),
-            Some(translated) => match translated.trait_decls.get(id) {
-                None => {
-                    format!("Unknown decl: {:?}", id)
-                }
-                Some(d) => d.fmt_with_ctx(self),
-            },
-        }
+        self.format_any_decl(id.into())
     }
 }
 
 impl<'a> DeclFormatter<TraitImplId> for FmtCtx<'a> {
     fn format_decl(&self, id: TraitImplId) -> String {
-        match &self.translated {
-            None => format!("Unknown impl: {:?}", id),
-            Some(translated) => match translated.trait_impls.get(id) {
-                None => {
-                    format!("Unknown impl: {:?}", id)
-                }
-                Some(d) => d.fmt_with_ctx(self),
-            },
-        }
+        self.format_any_decl(id.into())
     }
 }

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -54,8 +54,17 @@ impl UllbcPass for Transform {
                         else {
                             unreachable!()
                         };
-                        let new_id = trait_item_clause_ids[trait_decl][&item_name][item_clause_id];
-                        ParentClause(trait_ref, trait_decl, new_id)
+                        let new_id = (|| {
+                            let new_id = *trait_item_clause_ids
+                                .get(trait_decl)?
+                                .get(&item_name)?
+                                .get(item_clause_id)?;
+                            Some(new_id)
+                        })();
+                        match new_id {
+                            Some(new_id) => ParentClause(trait_ref, trait_decl, new_id),
+                            None => ItemClause(trait_ref, trait_decl, item_name, item_clause_id),
+                        }
                     })
                 }
             }));

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -56,7 +56,6 @@ impl Transform {
                 let Some(variants) = variants else {
                     // An error occurred. We can't keep the `Rvalue::Discriminant` around so we
                     // `Nop` the discriminant read.
-                    assert!(ctx.has_errors());
                     seq[i].content = RawStatement::Nop;
                     return;
                 };

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -68,6 +68,8 @@ impl core::convert::num::{impl core::convert::From<u32> for u64}#72 : core::conv
 
 fn core::convert::Into::into<Self, T>(@1: Self) -> T
 
+Unknown decl: 4
+
 fn test_crate::foo()
 {
     let @0: (); // return
@@ -75,7 +77,11 @@ fn test_crate::foo()
     let @2: &'_ (core::option::Option<i32>); // anonymous local
     let @3: core::option::Option<i32>; // anonymous local
     let @4: u64; // anonymous local
-    let @5: (); // anonymous local
+    let @5: &'_ (Slice<i32>); // anonymous local
+    let @6: &'_ (i32); // anonymous local
+    let @7: &'_ (i32); // anonymous local
+    let @8: i32; // anonymous local
+    let @9: (); // anonymous local
 
     @3 := core::option::Option::Some { 0: const (0 : i32) }
     @2 := &@3
@@ -87,8 +93,17 @@ fn test_crate::foo()
     @4 := core::convert::{impl core::convert::Into<U> for T}#3<u32, u64>[core::convert::num::{impl core::convert::From<u32> for u64}#72]::into(const (42 : u32))
     @fake_read(@4)
     drop @4
-    @5 := ()
-    @0 := move (@5)
+    @8 := const (0 : i32)
+    @7 := &@8
+    @6 := &*(@7)
+    @5 := @Fun4<i32>(move (@6))
+    drop @6
+    @fake_read(@5)
+    drop @8
+    drop @7
+    drop @5
+    @9 := ()
+    @0 := move (@9)
     @0 := ()
     return
 }

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -68,7 +68,7 @@ impl core::convert::num::{impl core::convert::From<u32> for u64}#72 : core::conv
 
 fn core::convert::Into::into<Self, T>(@1: Self) -> T
 
-Unknown decl: 4
+Missing decl: Fun(4) (core::slice::raw::from_ref)
 
 fn test_crate::foo()
 {

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -5,12 +5,14 @@
 //@ charon-args=--include core::convert::{core::convert::Into<_,_>}::into
 //@ charon-args=--include core::convert::num::{core::convert::From<_,_>}
 //@ charon-args=--opaque _::exclude_me
+//@ charon-args=--exclude core::slice::raw::from_ref
 // Note: we don't use the `impl Trait for T` syntax above because we can't have spaces in these
 // options.
 
 fn foo() {
     let _ = Some(0).is_some();
     let _: u64 = 42u32.into();
+    let _ = std::slice::from_ref(&0);
 }
 
 mod module {

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -1,4 +1,5 @@
 //@ charon-args=--include core::option
+//@ charon-args=--include test_crate::module::dont_translate_body
 //@ charon-args=--opaque test_crate::module::dont_translate_body
 //@ charon-args=--opaque crate::module::other_mod
 //@ charon-args=--include crate::module::other_mod::_

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -1,10 +1,10 @@
 //@ charon-args=--include core::option
-//@ charon-args=--exclude test_crate::module::dont_translate_body
-//@ charon-args=--exclude crate::module::other_mod
+//@ charon-args=--opaque test_crate::module::dont_translate_body
+//@ charon-args=--opaque crate::module::other_mod
 //@ charon-args=--include crate::module::other_mod::_
 //@ charon-args=--include core::convert::{core::convert::Into<_,_>}::into
 //@ charon-args=--include core::convert::num::{core::convert::From<_,_>}
-//@ charon-args=--exclude _::exclude_me
+//@ charon-args=--opaque _::exclude_me
 // Note: we don't use the `impl Trait for T` syntax above because we can't have spaces in these
 // options.
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -296,7 +296,7 @@ where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
     (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::any)))::[@TraitClause0])::Output = bool,
 
-Unknown decl: 39
+Missing decl: Fun(39) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find)
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map<'a, '_1, T, B, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> core::option::Option<B>
 where
@@ -335,7 +335,7 @@ where
 
 unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, T>::Item
 
-Unknown decl: 44
+Missing decl: Fun(44) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::is_sorted_by)
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
 {


### PR DESCRIPTION
This complements `--include` and `--exclude`: `--exclude` means "translate the signature of the item but not its contents". When even the signature is something we can't handle, we can now use `--hide` to skip its translation entirely.