### PR TITLE
Always name provided methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ charon-ml-tests: build-charon-ml charon-tests
 # Generate some of the ml code automatically from the rust definitions.
 .PHONY: generate-ml
 generate-ml:
-	cd charon && cargo run --release --bin generate-ml
+	cd charon && cargo build --release && cargo run --release --bin generate-ml
 	cd charon-ml && make format 2> /dev/null
 
 # Same as `generate-ml` but don't re-run charon on itself. Useful when developping.

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.29"
+let supported_charon_version = "0.1.30"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -338,22 +338,14 @@ type trait_decl = {
   required_methods : (trait_item_name * fun_decl_id) list;
       (** The *required* methods.
 
-        The required methods are the methods declared by the trait but with
-        no default implementation.
+        The required methods are the methods declared by the trait but with no default
+        implementation. The corresponding `FunDecl`s don't have a body.
      *)
-  provided_methods : (trait_item_name * fun_decl_id option) list;
+  provided_methods : (trait_item_name * fun_decl_id) list;
       (** The *provided* methods.
 
-        The provided methods are the methods with a default implementation.
-
-        We include the [FunDeclId] identifiers *only* for the local
-        trait declarations. Otherwise, it would mean we extract *all* the
-        provided methods, which is not something we want to do *yet* for
-        the external traits.
-
-        TODO: allow to optionnaly extract information. For instance: attempt
-        to extract, and fail nicely if we don't succeed (definition not in
-        the supported subset, etc.).
+        The provided methods are the methods with a default implementation. The corresponding
+        `FunDecl`s may have a body, according to the usual rules for extracting function bodies.
      *)
 }
 

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1255,8 +1255,7 @@ and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json
-               (option_of_json fun_decl_id_of_json))
+            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
             provided_methods
         in
         Ok

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -183,12 +183,7 @@ let trait_decl_to_string (env : ('a, 'b) fmt_env) (indent : string)
     let provided_methods =
       List.map
         (fun (name, f) ->
-          match f with
-          | None -> indent1 ^ "fn " ^ name ^ "\n"
-          | Some f ->
-              indent1 ^ "fn " ^ name ^ " : "
-              ^ fun_decl_id_to_string env f
-              ^ "\n")
+          indent1 ^ "fn " ^ name ^ " : " ^ fun_decl_id_to_string env f ^ "\n")
         def.provided_methods
     in
     let items =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.29"
+version = "0.1.30"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 

--- a/charon/Charon.toml
+++ b/charon/Charon.toml
@@ -3,7 +3,9 @@ exclude = [
     "_",
     "derive_visitor::Drive::_",
     "derive_visitor::DriveMut::_",
-    "crate",
+    "crate::_",
+    "crate::ast::_",
+    "crate::ast::krate::_",
     "crate::ast::_::{impl derive_visitor::Drive for _}",
     "crate::ast::_::{impl derive_visitor::DriveMut for _}",
 ]
@@ -17,7 +19,10 @@ include = [
     # TODO: keep names of excluded items.
     "derive_visitor::Drive",
     "derive_visitor::DriveMut",
+    "crate::ast",
+    "crate::ast::krate",
     "crate::ast::krate::AnyTransId",
+    "crate::ast::krate::TranslatedCrate",
     "crate::ast::expressions",
     "crate::ast::gast",
     "crate::ast::llbc_ast",

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -268,22 +268,14 @@ pub struct TraitDecl {
     pub type_clauses: Vec<(TraitItemName, Vector<TraitClauseId, TraitClause>)>,
     /// The *required* methods.
     ///
-    /// The required methods are the methods declared by the trait but with
-    /// no default implementation.
+    /// The required methods are the methods declared by the trait but with no default
+    /// implementation. The corresponding `FunDecl`s don't have a body.
     pub required_methods: Vec<(TraitItemName, FunDeclId)>,
     /// The *provided* methods.
     ///
-    /// The provided methods are the methods with a default implementation.
-    ///
-    /// We include the [FunDeclId] identifiers *only* for the local
-    /// trait declarations. Otherwise, it would mean we extract *all* the
-    /// provided methods, which is not something we want to do *yet* for
-    /// the external traits.
-    ///
-    /// TODO: allow to optionnaly extract information. For instance: attempt
-    /// to extract, and fail nicely if we don't succeed (definition not in
-    /// the supported subset, etc.).
-    pub provided_methods: Vec<(TraitItemName, Option<FunDeclId>)>,
+    /// The provided methods are the methods with a default implementation. The corresponding
+    /// `FunDecl`s may have a body, according to the usual rules for extracting function bodies.
+    pub provided_methods: Vec<(TraitItemName, FunDeclId)>,
 }
 
 /// A trait **implementation**.

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -205,7 +205,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 let opacity = self.opacity_for_name(&name);
                 // Go through `item_meta` to get take into account the `charon::opaque` attribute.
                 let item_meta = self.translate_item_meta(&def, name, opacity)?;
-                if item_meta.opacity.is_opaque() {
+                if item_meta.opacity.is_opaque() || opacity.is_invisible() {
                     // Ignore
                     trace!("Ignoring module [{:?}] because marked as opaque", def_id);
                 } else {

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -166,19 +166,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             let item_span = bt_ctx.t_ctx.tcx.def_span(rust_item_id);
             match &hax_item.kind {
                 AssocKind::Fn => {
-                    // Skip the provided methods for the *external* trait declarations,
-                    // but still remember their name (unless `extract_opaque_bodies` is set).
-                    // TODO: translate function signatures unconditionally.
                     if hax_item.has_value {
                         // This is a *provided* method,
-                        // TODO: this branch is a hack: we should always give an id to methods and
-                        // skip translating their body. However today we run into `for<'a>` crashes.
-                        if rust_id.is_local() || bt_ctx.t_ctx.options.extract_opaque_bodies {
-                            let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
-                            provided_methods.push((item_name.clone(), Some(fun_id)));
-                        } else {
-                            provided_methods.push((item_name.clone(), None));
-                        }
+                        let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
+                        provided_methods.push((item_name.clone(), Some(fun_id)));
                     } else {
                         // This is a required method (no default implementation)
                         let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -8,7 +8,6 @@ use charon_lib::pretty::FmtWithCtx;
 use charon_lib::types::*;
 use charon_lib::ullbc_ast as ast;
 use hax_frontend_exporter as hax;
-use hax_frontend_exporter::AssocItemContainer;
 use hax_frontend_exporter::SInto;
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
@@ -362,8 +361,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let tcx = bt_ctx.t_ctx.tcx;
         let mut consts = HashMap::new();
         let mut types: HashMap<TraitItemName, Ty> = HashMap::new();
-        let mut required_methods = Vec::new();
-        let mut provided_methods = Vec::new();
+        let mut methods = HashMap::new();
 
         for item in impl_items {
             let name = TraitItemName(item.name.clone());
@@ -372,17 +370,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             match &item.kind {
                 hax::AssocKind::Fn => {
                     let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
-                    let AssocItemContainer::TraitImplContainer {
-                        overrides_default, ..
-                    } = item.container
-                    else {
-                        unreachable!()
-                    };
-                    if overrides_default {
-                        provided_methods.push((name, fun_id));
-                    } else {
-                        required_methods.push((name, fun_id));
-                    }
+                    methods.insert(name, fun_id);
                 }
                 hax::AssocKind::Const => {
                     // The parameters of the constant are the same as those of the item that
@@ -418,13 +406,27 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let mut consts = Vec::new();
         let mut type_clauses = Vec::new();
         let mut types: Vec<(TraitItemName, Ty)> = Vec::new();
-        for item in decl_items {
-            let item_def_id = (&item.def_id).into();
+        let mut required_methods = Vec::new();
+        let mut provided_methods = Vec::new();
+
+        for decl_item in decl_items {
+            let item_def_id = (&decl_item.def_id).into();
             let item_span = tcx.def_span(item_def_id);
-            match &item.kind {
-                hax::AssocKind::Fn => (),
+            let name = TraitItemName(decl_item.name.to_string());
+            match &decl_item.kind {
+                hax::AssocKind::Fn => {
+                    if let Some(&fun_id) = methods.get(&name) {
+                        // Check if we implement a required method or reimplement a provided
+                        // method.
+                        if decl_item.has_value {
+                            provided_methods.push((name, fun_id));
+                        } else {
+                            required_methods.push((name, fun_id));
+                        }
+                    }
+                }
+
                 hax::AssocKind::Const => {
-                    let name = TraitItemName(item.name.to_string());
                     // Does the trait impl provide an implementation for this const?
                     let c = match partial_consts.get(&name) {
                         Some(c) => c.clone(),
@@ -442,7 +444,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     consts.push((name, c));
                 }
                 hax::AssocKind::Type => {
-                    let name = TraitItemName(item.name.to_string());
                     // Does the trait impl provide an implementation for this type?
                     let ty = match partial_types.get(&name) {
                         Some(ty) => ty.clone(),

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -166,13 +166,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             let item_span = bt_ctx.t_ctx.tcx.def_span(rust_item_id);
             match &hax_item.kind {
                 AssocKind::Fn => {
+                    let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
                     if hax_item.has_value {
                         // This is a *provided* method,
-                        let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
-                        provided_methods.push((item_name.clone(), Some(fun_id)));
+                        provided_methods.push((item_name.clone(), fun_id));
                     } else {
                         // This is a required method (no default implementation)
-                        let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
                         required_methods.push((item_name.clone(), fun_id));
                     }
                 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1097,9 +1097,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
                     .chain(self.required_methods.iter().map(|(name, f)| {
                         format!("{TAB_INCR}fn {name} : {}\n", ctx.format_object(*f))
                     }))
-                    .chain(self.provided_methods.iter().map(|(name, f)| match f {
-                        None => format!("{TAB_INCR}fn {name}\n"),
-                        Some(f) => format!("{TAB_INCR}fn {name} : {}\n", ctx.format_object(*f)),
+                    .chain(self.provided_methods.iter().map(|(name, f)| {
+                        format!("{TAB_INCR}fn {name} : {}\n", ctx.format_object(*f))
                     }))
                     .collect::<Vec<String>>();
             if items.is_empty() {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -369,8 +369,8 @@ fn compute_declarations_graph<'tcx, 'ctx>(ctx: &'tcx TransformCtx<'ctx>) -> Deps
 
                 let method_ids = required_methods
                     .iter()
+                    .chain(provided_methods.iter())
                     .map(|(_, id)| id)
-                    .chain(provided_methods.iter().filter_map(|(_, id)| id.as_ref()))
                     .copied();
                 for id in method_ids {
                     // Important: we must ignore the function id, because

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -3,7 +3,7 @@
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::marker::Copy<Self>
@@ -160,7 +160,7 @@ trait alloc::borrow::ToOwned<Self>
     parent_clause_0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
     type Owned
     fn to_owned : alloc::borrow::ToOwned::to_owned
-    fn clone_into
+    fn clone_into : alloc::borrow::ToOwned::clone_into
 }
 
 enum test_crate::cow::Cow<'a, B>
@@ -194,7 +194,11 @@ fn test_crate::Foo::use_item<'a, '_1, Self>(@1: &'_1 (Self::Item)) -> &'_1 (Self
     return
 }
 
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
 fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
+
+fn alloc::borrow::ToOwned::clone_into<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 mut (Self::Owned))
 
 fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
 

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -343,7 +343,7 @@ fn test_crate::test_map_option_id2(@1: core::option::Option<u32>) -> core::optio
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
@@ -730,6 +730,8 @@ global test_crate::BLAH  {
     drop clo@1
     return
 }
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> (parents(Self)::[@TraitClause0])::Output
 

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -22,7 +22,7 @@ fn test_crate::swap<'a, T>(@1: &'a mut (T), @2: &'a mut (T))
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::marker::Copy<Self>
@@ -180,6 +180,8 @@ fn test_crate::incr<'_0>(@1: &'_0 mut (core::cell::Cell<u32>))
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -5,7 +5,7 @@ struct test_crate::Foo = {}
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 fn test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0>(@1: &'_0 (test_crate::Foo)) -> test_crate::Foo
@@ -104,6 +104,8 @@ where
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -35,7 +35,7 @@ where
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::marker::Copy<Self>
@@ -117,6 +117,8 @@ fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
 fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -35,7 +35,7 @@ where
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::marker::Copy<Self>
@@ -117,6 +117,8 @@ fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
 fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>
 

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -61,218 +61,18 @@ enum core::option::Option<T> =
 |  Some(T)
 
 
-trait core::iter::traits::iterator::Iterator<Self>
-{
-    type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk
-    fn size_hint
-    fn count
-    fn last
-    fn advance_by
-    fn nth
-    fn step_by
-    fn chain
-    fn zip
-    fn intersperse
-    fn intersperse_with
-    fn map
-    fn for_each
-    fn filter
-    fn filter_map
-    fn enumerate
-    fn peekable
-    fn skip_while
-    fn take_while
-    fn map_while
-    fn skip
-    fn take
-    fn scan
-    fn flat_map
-    fn flatten
-    fn map_windows
-    fn fuse
-    fn inspect
-    fn by_ref
-    fn collect
-    fn try_collect
-    fn collect_into
-    fn partition
-    fn partition_in_place
-    fn is_partitioned
-    fn try_fold
-    fn try_for_each
-    fn fold
-    fn reduce
-    fn try_reduce
-    fn all
-    fn any
-    fn find
-    fn find_map
-    fn try_find
-    fn position
-    fn rposition
-    fn max
-    fn min
-    fn max_by_key
-    fn max_by
-    fn min_by_key
-    fn min_by
-    fn rev
-    fn unzip
-    fn copied
-    fn cloned
-    fn cycle
-    fn array_chunks
-    fn sum
-    fn product
-    fn cmp
-    fn cmp_by
-    fn partial_cmp
-    fn partial_cmp_by
-    fn eq
-    fn eq_by
-    fn ne
-    fn lt
-    fn le
-    fn gt
-    fn ge
-    fn is_sorted
-    fn is_sorted_by
-    fn is_sorted_by_key
-    fn __iterator_get_unchecked
-}
-
-trait core::iter::traits::collect::IntoIterator<Self>
-where
-    (parents(Self)::[@TraitClause0])::Item = Self::Item,
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    type Item
-    type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
-}
-
-fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
-
-impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
-{
-    parent_clause0 = @TraitClause0
-    type Item = @TraitClause0::Item
-    type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
-}
-
-trait core::clone::Clone<Self>
-{
-    fn clone : core::clone::Clone::clone
-    fn clone_from
-}
-
-trait core::cmp::PartialEq<Self, Rhs>
-{
-    fn eq : core::cmp::PartialEq::eq
-    fn ne
-}
-
-enum core::cmp::Ordering =
-|  Less()
-|  Equal()
-|  Greater()
-
-
-trait core::cmp::PartialOrd<Self, Rhs>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt
-    fn le
-    fn gt
-    fn ge
-}
-
-trait core::iter::range::Step<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
-    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn steps_between : core::iter::range::Step::steps_between
-    fn forward_checked : core::iter::range::Step::forward_checked
-    fn backward_checked : core::iter::range::Step::backward_checked
-    fn forward
-    fn forward_unchecked
-    fn backward
-    fn backward_unchecked
-}
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-trait core::cmp::Eq<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq
-}
-
-trait core::cmp::Ord<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::Eq<Self>
-    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max
-    fn min
-    fn clamp
-}
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
 enum core::result::Result<T, E> =
 |  Ok(T)
 |  Err(E)
 
+
+opaque type core::array::iter::IntoIter<T, const N : usize>
+
+trait core::clone::Clone<Self>
+{
+    fn clone : core::clone::Clone::clone
+    fn clone_from : core::clone::Clone::clone_from
+}
 
 trait core::marker::Copy<Self>
 {
@@ -331,16 +131,340 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+opaque type core::iter::adapters::step_by::StepBy<I>
+
+opaque type core::iter::adapters::chain::Chain<A, B>
+
+opaque type core::iter::adapters::zip::Zip<A, B>
+
+opaque type core::iter::adapters::map::Map<I, F>
+
+opaque type core::iter::adapters::filter_map::FilterMap<I, F>
+
+opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::map_while::MapWhile<I, P>
+
+opaque type core::iter::adapters::skip::Skip<I>
+
+opaque type core::iter::adapters::take::Take<I>
+
+opaque type core::iter::adapters::fuse::Fuse<I>
+
+trait core::ops::try_trait::FromResidual<Self, R>
+{
+    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+}
+
+enum core::ops::control_flow::ControlFlow<B, C> =
+|  Continue(C)
+|  Break(B)
+
+
+trait core::ops::try_trait::Try<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
+    type Output
+    type Residual
+    fn from_output : core::ops::try_trait::Try::from_output
+    fn branch : core::ops::try_trait::Try::branch
+}
+
+trait core::ops::try_trait::Residual<Self, O>
 where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
+    (parents(Self)::[@TraitClause0])::Residual = Self,
+    (parents(Self)::[@TraitClause0])::Output = O,
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::Try<Self::TryType>
+    parent_clause_1 : [@TraitClause1]: core::ops::try_trait::FromResidual<Self::TryType, Self>
+    type TryType
+}
+
+trait core::cmp::PartialEq<Self, Rhs>
+{
+    fn eq : core::cmp::PartialEq::eq
+    fn ne : core::cmp::PartialEq::ne
+}
+
+trait core::cmp::Eq<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
+    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+}
+
+enum core::cmp::Ordering =
+|  Less()
+|  Equal()
+|  Greater()
+
+
+trait core::cmp::PartialOrd<Self, Rhs>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
+    fn lt : core::cmp::PartialOrd::lt
+    fn le : core::cmp::PartialOrd::le
+    fn gt : core::cmp::PartialOrd::gt
+    fn ge : core::cmp::PartialOrd::ge
+}
+
+trait core::cmp::Ord<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::Eq<Self>
+    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn cmp : core::cmp::Ord::cmp
+    fn max : core::cmp::Ord::max
+    fn min : core::cmp::Ord::min
+    fn clamp : core::cmp::Ord::clamp
+}
+
+opaque type core::iter::adapters::rev::Rev<T>
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
+}
+
+opaque type core::iter::adapters::copied::Copied<I>
+
+opaque type core::iter::adapters::cloned::Cloned<I>
+
+opaque type core::iter::adapters::cycle::Cycle<I>
+
+trait core::iter::traits::iterator::Iterator<Self>
+{
+    type Item
+    fn next : core::iter::traits::iterator::Iterator::next
+    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
+    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
+    fn count : core::iter::traits::iterator::Iterator::count
+    fn last : core::iter::traits::iterator::Iterator::last
+    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
+    fn nth : core::iter::traits::iterator::Iterator::nth
+    fn step_by : core::iter::traits::iterator::Iterator::step_by
+    fn chain : core::iter::traits::iterator::Iterator::chain
+    fn zip : core::iter::traits::iterator::Iterator::zip
+    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
+    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
+    fn map : core::iter::traits::iterator::Iterator::map
+    fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : @Fun39
+    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
+    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
+    fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : @Fun43
+    fn take_while : @Fun44
+    fn map_while : core::iter::traits::iterator::Iterator::map_while
+    fn skip : core::iter::traits::iterator::Iterator::skip
+    fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : @Fun48
+    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
+    fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : @Fun51
+    fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : @Fun53
+    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
+    fn collect : core::iter::traits::iterator::Iterator::collect
+    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
+    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : @Fun58
+    fn partition_in_place : @Fun59
+    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
+    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
+    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
+    fn fold : core::iter::traits::iterator::Iterator::fold
+    fn reduce : core::iter::traits::iterator::Iterator::reduce
+    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
+    fn all : core::iter::traits::iterator::Iterator::all
+    fn any : core::iter::traits::iterator::Iterator::any
+    fn find : @Fun68
+    fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : @Fun70
+    fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : @Fun72
+    fn max : core::iter::traits::iterator::Iterator::max
+    fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : @Fun75
+    fn max_by : @Fun76
+    fn min_by_key : @Fun77
+    fn min_by : @Fun78
+    fn rev : core::iter::traits::iterator::Iterator::rev
+    fn unzip : core::iter::traits::iterator::Iterator::unzip
+    fn copied : core::iter::traits::iterator::Iterator::copied
+    fn cloned : core::iter::traits::iterator::Iterator::cloned
+    fn cycle : core::iter::traits::iterator::Iterator::cycle
+    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
+    fn sum : core::iter::traits::iterator::Iterator::sum
+    fn product : core::iter::traits::iterator::Iterator::product
+    fn cmp : core::iter::traits::iterator::Iterator::cmp
+    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
+    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
+    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
+    fn eq : core::iter::traits::iterator::Iterator::eq
+    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
+    fn ne : core::iter::traits::iterator::Iterator::ne
+    fn lt : core::iter::traits::iterator::Iterator::lt
+    fn le : core::iter::traits::iterator::Iterator::le
+    fn gt : core::iter::traits::iterator::Iterator::gt
+    fn ge : core::iter::traits::iterator::Iterator::ge
+    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : @Fun99
+    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
+    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+}
+
+trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
+    type Item
+    type IntoIter
+    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+}
+
+opaque type core::iter::adapters::intersperse::Intersperse<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::clone::Clone<@TraitClause0::Item>,
+
+opaque type core::iter::adapters::intersperse::IntersperseWith<I, G>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::peekable::Peekable<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::flatten::FlatMap<I, U, F>
+  where
+      [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+opaque type core::iter::adapters::flatten::Flatten<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::iter::traits::collect::IntoIterator<@TraitClause0::Item>,
+
+trait core::iter::traits::collect::FromIterator<Self, A>
+{
+    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+}
+
+trait core::iter::traits::collect::Extend<Self, A>
+{
+    fn extend : core::iter::traits::collect::Extend::extend
+    fn extend_one : core::iter::traits::collect::Extend::extend_one
+    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
+    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+}
+
+trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
+    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
+    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
+    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
+    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : @Fun150
+}
+
+opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+trait core::iter::traits::accum::Sum<Self, A>
+{
+    fn sum : core::iter::traits::accum::Sum::sum
+}
+
+trait core::iter::traits::accum::Product<Self, A>
+{
+    fn product : core::iter::traits::accum::Product::product
+}
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size
+    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
 }
+
+fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+{
+    parent_clause0 = @TraitClause0
+    type Item = @TraitClause0::Item
+    type IntoIter = I
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
+}
+
+trait core::iter::range::Step<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
+    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn steps_between : core::iter::range::Step::steps_between
+    fn forward_checked : core::iter::range::Step::forward_checked
+    fn backward_checked : core::iter::range::Step::backward_checked
+    fn forward : core::iter::range::Step::forward
+    fn forward_unchecked : core::iter::range::Step::forward_unchecked
+    fn backward : core::iter::range::Step::backward
+    fn backward_unchecked : core::iter::range::Step::backward_unchecked
+}
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
 
 unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A>[@TraitClause0]::Item
 where
@@ -614,15 +738,368 @@ fn core::iter::range::Step::steps_between<'_0, '_1, Self>(@1: &'_0 (Self), @2: &
 
 fn core::iter::range::Step::forward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>
 
+fn core::iter::range::Step::forward<Self>(@1: Self, @2: usize) -> Self
+
+unsafe fn core::iter::range::Step::forward_unchecked<Self>(@1: Self, @2: usize) -> Self
+
 fn core::iter::range::Step::backward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>
+
+fn core::iter::range::Step::backward<Self>(@1: Self, @2: usize) -> Self
+
+unsafe fn core::iter::range::Step::backward_unchecked<Self>(@1: Self, @2: usize) -> Self
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
 fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> core::result::Result<Array<Self::Item, const N : usize>, core::array::iter::IntoIter<Self::Item, const N : usize>>
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>)
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>
+
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+fn core::iter::traits::iterator::Iterator::intersperse<Self>(@1: Self, @2: Self::Item) -> core::iter::adapters::intersperse::Intersperse<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::clone::Clone<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::intersperse_with<Self, G>(@1: Self, @2: G) -> core::iter::adapters::intersperse::IntersperseWith<Self, G, Self>
+where
+    [@TraitClause0]: core::ops::function::FnMut<G, ()>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::map::Map<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::for_each<Self, F>(@1: Self, @2: F)
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = (),
+
+fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::iter::adapters::enumerate::Enumerate<Self>
+
+fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
+
+fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
+
+fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = U,
+
+fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter::adapters::flatten::Flatten<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
+
+fn core::iter::traits::iterator::Iterator::collect<Self, B>(@1: Self) -> B
+where
+    [@TraitClause0]: core::iter::traits::collect::FromIterator<B, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::try_collect<'_0, Self, B>(@1: &'_0 mut (Self)) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<Self::Item>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, B>,
+    [@TraitClause2]: core::iter::traits::collect::FromIterator<B, @TraitClause0::Output>,
+
+fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
+where
+    [@TraitClause0]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::try_fold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::iterator::Iterator::try_for_each<'_0, Self, F, R>(@1: &'_0 mut (Self), @2: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = (),
+
+fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::reduce<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::try_reduce<'_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(Self::Item, Self::Item) -> R) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<R>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause2]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>,
+    @TraitClause0::Output = Self::Item,
+    (parents(@TraitClause2)::[@TraitClause0])::Output = R,
+
+fn core::iter::traits::iterator::Iterator::all<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::any<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
+where
+    [@TraitClause0]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+
+fn core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>(@1: Self) -> (FromA, FromB)
+where
+    [@TraitClause0]: core::default::Default<FromA>,
+    [@TraitClause1]: core::iter::traits::collect::Extend<FromA, A>,
+    [@TraitClause2]: core::default::Default<FromB>,
+    [@TraitClause3]: core::iter::traits::collect::Extend<FromB, B>,
+    [@TraitClause4]: core::iter::traits::iterator::Iterator<Self>,
+    Self::Item = (A, B),
+
+fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(@1: Self) -> core::iter::adapters::copied::Copied<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::marker::Copy<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(@1: Self) -> core::iter::adapters::cloned::Cloned<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::clone::Clone<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cycle<Self>(@1: Self) -> core::iter::adapters::cycle::Cycle<Self>
+where
+    [@TraitClause0]: core::clone::Clone<Self>,
+
+fn core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>(@1: Self) -> core::iter::adapters::array_chunks::ArrayChunks<Self, const N : usize, Self>
+
+fn core::iter::traits::iterator::Iterator::sum<Self, S>(@1: Self) -> S
+where
+    [@TraitClause0]: core::iter::traits::accum::Sum<S, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::product<Self, P>(@1: Self) -> P
+where
+    [@TraitClause0]: core::iter::traits::accum::Product<P, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::cmp<Self, I>(@1: Self, @2: I) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp<Self, I>(@1: Self, @2: I) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::option::Option<core::cmp::Ordering>,
+
+fn core::iter::traits::iterator::Iterator::eq<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::eq_by<Self, I, F>(@1: Self, @2: I, @3: F) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::ne<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::lt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::le<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::gt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::ge<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self::Item, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::cmp::PartialOrd<K, K>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = K,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
+
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self, Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
+
+fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>
+
+fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::collect::Extend::extend_one<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mut (Self), @2: usize)
+
+unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::default::Default::default<Self>() -> Self
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
 
 
 

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -432,22 +432,20 @@ where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
@@ -456,12 +454,14 @@ where
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -481,12 +481,12 @@ where
     fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next
     fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint
     fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
     fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
     fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by
+    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
+    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
+    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
     fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked
 }
 
@@ -513,9 +513,9 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt<'_0, '_1>(@1
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
-
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60 : core::cmp::PartialOrd<u8, u8>
 {
@@ -523,8 +523,8 @@ impl core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60 : core::cmp::P
     fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp
     fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt
     fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge
     fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge
 }
 
 fn core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<usize>
@@ -535,9 +535,9 @@ fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward_checked
 
 fn core::iter::range::{impl core::iter::range::Step for u8}#35::forward(@1: u8, @2: usize) -> u8
 
-fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward(@1: u8, @2: usize) -> u8
-
 unsafe fn core::iter::range::{impl core::iter::range::Step for u8}#35::forward_unchecked(@1: u8, @2: usize) -> u8
+
+fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward(@1: u8, @2: usize) -> u8
 
 unsafe fn core::iter::range::{impl core::iter::range::Step for u8}#35::backward_unchecked(@1: u8, @2: usize) -> u8
 
@@ -549,8 +549,8 @@ impl core::iter::range::{impl core::iter::range::Step for u8}#35 : core::iter::r
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for u8}#35::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for u8}#35::backward
     fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u8}#35::forward_unchecked
+    fn backward = core::iter::range::{impl core::iter::range::Step for u8}#35::backward
     fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u8}#35::backward_unchecked
 }
 

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -3,13 +3,13 @@
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq : core::cmp::PartialEq::eq
-    fn ne
+    fn ne : core::cmp::PartialEq::ne
 }
 
 trait test_crate::GenericTrait<Self, T>
@@ -175,6 +175,10 @@ where
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 
 

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -8,7 +8,7 @@ enum core::option::Option<T> =
 trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq : core::cmp::PartialEq::eq
-    fn ne
+    fn ne : core::cmp::PartialEq::ne
 }
 
 fn core::option::{impl core::cmp::PartialEq<core::option::Option<T>> for core::option::Option<T>}#14::eq<'_0, '_1, T>(@1: &'_0 (core::option::Option<T>), @2: &'_1 (core::option::Option<T>)) -> bool
@@ -102,10 +102,10 @@ trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
     fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt
-    fn le
-    fn gt
-    fn ge
+    fn lt : core::cmp::PartialOrd::lt
+    fn le : core::cmp::PartialOrd::le
+    fn gt : core::cmp::PartialOrd::gt
+    fn ge : core::cmp::PartialOrd::ge
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
@@ -167,6 +167,16 @@ impl test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Fo
     parent_clause0 = test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1
     fn partial_cmp = test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}#2::partial_cmp
 }
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 
 

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -124,9 +124,9 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0, '_1>(
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
-
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp::PartialOrd<u32, u32>
 {
@@ -134,8 +134,8 @@ impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp:
     fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp
     fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt
     fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
     fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
 }
 
 fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -790,218 +790,18 @@ enum core::option::Option<T> =
 |  Some(T)
 
 
-trait core::iter::traits::iterator::Iterator<Self>
-{
-    type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk
-    fn size_hint
-    fn count
-    fn last
-    fn advance_by
-    fn nth
-    fn step_by
-    fn chain
-    fn zip
-    fn intersperse
-    fn intersperse_with
-    fn map
-    fn for_each
-    fn filter
-    fn filter_map
-    fn enumerate
-    fn peekable
-    fn skip_while
-    fn take_while
-    fn map_while
-    fn skip
-    fn take
-    fn scan
-    fn flat_map
-    fn flatten
-    fn map_windows
-    fn fuse
-    fn inspect
-    fn by_ref
-    fn collect
-    fn try_collect
-    fn collect_into
-    fn partition
-    fn partition_in_place
-    fn is_partitioned
-    fn try_fold
-    fn try_for_each
-    fn fold
-    fn reduce
-    fn try_reduce
-    fn all
-    fn any
-    fn find
-    fn find_map
-    fn try_find
-    fn position
-    fn rposition
-    fn max
-    fn min
-    fn max_by_key
-    fn max_by
-    fn min_by_key
-    fn min_by
-    fn rev
-    fn unzip
-    fn copied
-    fn cloned
-    fn cycle
-    fn array_chunks
-    fn sum
-    fn product
-    fn cmp
-    fn cmp_by
-    fn partial_cmp
-    fn partial_cmp_by
-    fn eq
-    fn eq_by
-    fn ne
-    fn lt
-    fn le
-    fn gt
-    fn ge
-    fn is_sorted
-    fn is_sorted_by
-    fn is_sorted_by_key
-    fn __iterator_get_unchecked
-}
-
-trait core::iter::traits::collect::IntoIterator<Self>
-where
-    (parents(Self)::[@TraitClause0])::Item = Self::Item,
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    type Item
-    type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
-}
-
-fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
-
-impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
-{
-    parent_clause0 = @TraitClause0
-    type Item = @TraitClause0::Item
-    type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
-}
-
-trait core::clone::Clone<Self>
-{
-    fn clone : core::clone::Clone::clone
-    fn clone_from
-}
-
-trait core::cmp::PartialEq<Self, Rhs>
-{
-    fn eq : core::cmp::PartialEq::eq
-    fn ne
-}
-
-enum core::cmp::Ordering =
-|  Less()
-|  Equal()
-|  Greater()
-
-
-trait core::cmp::PartialOrd<Self, Rhs>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt
-    fn le
-    fn gt
-    fn ge
-}
-
-trait core::iter::range::Step<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
-    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn steps_between : core::iter::range::Step::steps_between
-    fn forward_checked : core::iter::range::Step::forward_checked
-    fn backward_checked : core::iter::range::Step::backward_checked
-    fn forward
-    fn forward_unchecked
-    fn backward
-    fn backward_unchecked
-}
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
-trait core::cmp::Eq<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq
-}
-
-trait core::cmp::Ord<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::cmp::Eq<Self>
-    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max
-    fn min
-    fn clamp
-}
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
-
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
 enum core::result::Result<T, E> =
 |  Ok(T)
 |  Err(E)
 
+
+opaque type core::array::iter::IntoIter<T, const N : usize>
+
+trait core::clone::Clone<Self>
+{
+    fn clone : core::clone::Clone::clone
+    fn clone_from : core::clone::Clone::clone_from
+}
 
 trait core::marker::Copy<Self>
 {
@@ -1060,16 +860,352 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+opaque type core::iter::adapters::step_by::StepBy<I>
+
+opaque type core::iter::adapters::chain::Chain<A, B>
+
+opaque type core::iter::adapters::zip::Zip<A, B>
+
+trait core::ops::function::FnOnce<Self, Args>
+{
+    type Output
+    fn call_once : core::ops::function::FnOnce::call_once
+}
+
+trait core::ops::function::FnMut<Self, Args>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
+    fn call_mut : core::ops::function::FnMut::call_mut
+}
+
+opaque type core::iter::adapters::map::Map<I, F>
+
+opaque type core::iter::adapters::filter_map::FilterMap<I, F>
+
+opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::map_while::MapWhile<I, P>
+
+opaque type core::iter::adapters::skip::Skip<I>
+
+opaque type core::iter::adapters::take::Take<I>
+
+opaque type core::iter::adapters::fuse::Fuse<I>
+
+trait core::ops::try_trait::FromResidual<Self, R>
+{
+    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+}
+
+enum core::ops::control_flow::ControlFlow<B, C> =
+|  Continue(C)
+|  Break(B)
+
+
+trait core::ops::try_trait::Try<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
+    type Output
+    type Residual
+    fn from_output : core::ops::try_trait::Try::from_output
+    fn branch : core::ops::try_trait::Try::branch
+}
+
+trait core::ops::try_trait::Residual<Self, O>
 where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
+    (parents(Self)::[@TraitClause0])::Residual = Self,
+    (parents(Self)::[@TraitClause0])::Output = O,
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::Try<Self::TryType>
+    parent_clause_1 : [@TraitClause1]: core::ops::try_trait::FromResidual<Self::TryType, Self>
+    type TryType
+}
+
+trait core::cmp::PartialEq<Self, Rhs>
+{
+    fn eq : core::cmp::PartialEq::eq
+    fn ne : core::cmp::PartialEq::ne
+}
+
+trait core::cmp::Eq<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
+    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+}
+
+enum core::cmp::Ordering =
+|  Less()
+|  Equal()
+|  Greater()
+
+
+trait core::cmp::PartialOrd<Self, Rhs>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
+    fn lt : core::cmp::PartialOrd::lt
+    fn le : core::cmp::PartialOrd::le
+    fn gt : core::cmp::PartialOrd::gt
+    fn ge : core::cmp::PartialOrd::ge
+}
+
+trait core::cmp::Ord<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::Eq<Self>
+    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn cmp : core::cmp::Ord::cmp
+    fn max : core::cmp::Ord::max
+    fn min : core::cmp::Ord::min
+    fn clamp : core::cmp::Ord::clamp
+}
+
+opaque type core::iter::adapters::rev::Rev<T>
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
+}
+
+opaque type core::iter::adapters::copied::Copied<I>
+
+opaque type core::iter::adapters::cloned::Cloned<I>
+
+opaque type core::iter::adapters::cycle::Cycle<I>
+
+trait core::iter::traits::iterator::Iterator<Self>
+{
+    type Item
+    fn next : core::iter::traits::iterator::Iterator::next
+    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
+    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
+    fn count : core::iter::traits::iterator::Iterator::count
+    fn last : core::iter::traits::iterator::Iterator::last
+    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
+    fn nth : core::iter::traits::iterator::Iterator::nth
+    fn step_by : core::iter::traits::iterator::Iterator::step_by
+    fn chain : core::iter::traits::iterator::Iterator::chain
+    fn zip : core::iter::traits::iterator::Iterator::zip
+    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
+    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
+    fn map : core::iter::traits::iterator::Iterator::map
+    fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : @Fun46
+    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
+    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
+    fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : @Fun50
+    fn take_while : @Fun51
+    fn map_while : core::iter::traits::iterator::Iterator::map_while
+    fn skip : core::iter::traits::iterator::Iterator::skip
+    fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : @Fun55
+    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
+    fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : @Fun58
+    fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : @Fun60
+    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
+    fn collect : core::iter::traits::iterator::Iterator::collect
+    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
+    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : @Fun65
+    fn partition_in_place : @Fun66
+    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
+    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
+    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
+    fn fold : core::iter::traits::iterator::Iterator::fold
+    fn reduce : core::iter::traits::iterator::Iterator::reduce
+    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
+    fn all : core::iter::traits::iterator::Iterator::all
+    fn any : core::iter::traits::iterator::Iterator::any
+    fn find : @Fun75
+    fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : @Fun77
+    fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : @Fun79
+    fn max : core::iter::traits::iterator::Iterator::max
+    fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : @Fun82
+    fn max_by : @Fun83
+    fn min_by_key : @Fun84
+    fn min_by : @Fun85
+    fn rev : core::iter::traits::iterator::Iterator::rev
+    fn unzip : core::iter::traits::iterator::Iterator::unzip
+    fn copied : core::iter::traits::iterator::Iterator::copied
+    fn cloned : core::iter::traits::iterator::Iterator::cloned
+    fn cycle : core::iter::traits::iterator::Iterator::cycle
+    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
+    fn sum : core::iter::traits::iterator::Iterator::sum
+    fn product : core::iter::traits::iterator::Iterator::product
+    fn cmp : core::iter::traits::iterator::Iterator::cmp
+    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
+    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
+    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
+    fn eq : core::iter::traits::iterator::Iterator::eq
+    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
+    fn ne : core::iter::traits::iterator::Iterator::ne
+    fn lt : core::iter::traits::iterator::Iterator::lt
+    fn le : core::iter::traits::iterator::Iterator::le
+    fn gt : core::iter::traits::iterator::Iterator::gt
+    fn ge : core::iter::traits::iterator::Iterator::ge
+    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : @Fun106
+    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
+    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+}
+
+trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
+    type Item
+    type IntoIter
+    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+}
+
+opaque type core::iter::adapters::intersperse::Intersperse<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::clone::Clone<@TraitClause0::Item>,
+
+opaque type core::iter::adapters::intersperse::IntersperseWith<I, G>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::peekable::Peekable<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::flatten::FlatMap<I, U, F>
+  where
+      [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+opaque type core::iter::adapters::flatten::Flatten<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::iter::traits::collect::IntoIterator<@TraitClause0::Item>,
+
+trait core::iter::traits::collect::FromIterator<Self, A>
+{
+    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+}
+
+trait core::iter::traits::collect::Extend<Self, A>
+{
+    fn extend : core::iter::traits::collect::Extend::extend
+    fn extend_one : core::iter::traits::collect::Extend::extend_one
+    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
+    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+}
+
+trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
+    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
+    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
+    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
+    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : @Fun206
+}
+
+opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+trait core::iter::traits::accum::Sum<Self, A>
+{
+    fn sum : core::iter::traits::accum::Sum::sum
+}
+
+trait core::iter::traits::accum::Product<Self, A>
+{
+    fn product : core::iter::traits::accum::Product::product
+}
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size
+    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
 }
+
+fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+{
+    parent_clause0 = @TraitClause0
+    type Item = @TraitClause0::Item
+    type IntoIter = I
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
+}
+
+trait core::iter::range::Step<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
+    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn steps_between : core::iter::range::Step::steps_between
+    fn forward_checked : core::iter::range::Step::forward_checked
+    fn backward_checked : core::iter::range::Step::backward_checked
+    fn forward : core::iter::range::Step::forward
+    fn forward_unchecked : core::iter::range::Step::forward_unchecked
+    fn backward : core::iter::range::Step::backward
+    fn backward_unchecked : core::iter::range::Step::backward_unchecked
+}
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>)) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint<'_0, A>(@1: &'_0 (core::ops::range::Range<A>)) -> (usize, core::option::Option<usize>)
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count<A>(@1: core::ops::range::Range<A>) -> usize
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
 
 unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6<A>[@TraitClause0]::Item
 where
@@ -1900,13 +2036,300 @@ fn core::iter::range::Step::steps_between<'_0, '_1, Self>(@1: &'_0 (Self), @2: &
 
 fn core::iter::range::Step::forward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>
 
+fn core::iter::range::Step::forward<Self>(@1: Self, @2: usize) -> Self
+
+unsafe fn core::iter::range::Step::forward_unchecked<Self>(@1: Self, @2: usize) -> Self
+
 fn core::iter::range::Step::backward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>
+
+fn core::iter::range::Step::backward<Self>(@1: Self, @2: usize) -> Self
+
+unsafe fn core::iter::range::Step::backward_unchecked<Self>(@1: Self, @2: usize) -> Self
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
 fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>
 
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
 fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> core::result::Result<Array<Self::Item, const N : usize>, core::array::iter::IntoIter<Self::Item, const N : usize>>
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>)
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>
+
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+fn core::iter::traits::iterator::Iterator::intersperse<Self>(@1: Self, @2: Self::Item) -> core::iter::adapters::intersperse::Intersperse<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::clone::Clone<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::intersperse_with<Self, G>(@1: Self, @2: G) -> core::iter::adapters::intersperse::IntersperseWith<Self, G, Self>
+where
+    [@TraitClause0]: core::ops::function::FnMut<G, ()>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::map::Map<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::for_each<Self, F>(@1: Self, @2: F)
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = (),
+
+fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::iter::adapters::enumerate::Enumerate<Self>
+
+fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
+
+fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
+
+fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = U,
+
+fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter::adapters::flatten::Flatten<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
+
+fn core::iter::traits::iterator::Iterator::collect<Self, B>(@1: Self) -> B
+where
+    [@TraitClause0]: core::iter::traits::collect::FromIterator<B, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::try_collect<'_0, Self, B>(@1: &'_0 mut (Self)) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<Self::Item>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, B>,
+    [@TraitClause2]: core::iter::traits::collect::FromIterator<B, @TraitClause0::Output>,
+
+fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
+where
+    [@TraitClause0]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::try_fold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::iterator::Iterator::try_for_each<'_0, Self, F, R>(@1: &'_0 mut (Self), @2: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = (),
+
+fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::reduce<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::try_reduce<'_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(Self::Item, Self::Item) -> R) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<R>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause2]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>,
+    @TraitClause0::Output = Self::Item,
+    (parents(@TraitClause2)::[@TraitClause0])::Output = R,
+
+fn core::iter::traits::iterator::Iterator::all<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::any<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
+where
+    [@TraitClause0]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+
+fn core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>(@1: Self) -> (FromA, FromB)
+where
+    [@TraitClause0]: core::default::Default<FromA>,
+    [@TraitClause1]: core::iter::traits::collect::Extend<FromA, A>,
+    [@TraitClause2]: core::default::Default<FromB>,
+    [@TraitClause3]: core::iter::traits::collect::Extend<FromB, B>,
+    [@TraitClause4]: core::iter::traits::iterator::Iterator<Self>,
+    Self::Item = (A, B),
+
+fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(@1: Self) -> core::iter::adapters::copied::Copied<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::marker::Copy<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(@1: Self) -> core::iter::adapters::cloned::Cloned<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::clone::Clone<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cycle<Self>(@1: Self) -> core::iter::adapters::cycle::Cycle<Self>
+where
+    [@TraitClause0]: core::clone::Clone<Self>,
+
+fn core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>(@1: Self) -> core::iter::adapters::array_chunks::ArrayChunks<Self, const N : usize, Self>
+
+fn core::iter::traits::iterator::Iterator::sum<Self, S>(@1: Self) -> S
+where
+    [@TraitClause0]: core::iter::traits::accum::Sum<S, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::product<Self, P>(@1: Self) -> P
+where
+    [@TraitClause0]: core::iter::traits::accum::Product<P, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::cmp<Self, I>(@1: Self, @2: I) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp<Self, I>(@1: Self, @2: I) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::option::Option<core::cmp::Ordering>,
+
+fn core::iter::traits::iterator::Iterator::eq<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::eq_by<Self, I, F>(@1: Self, @2: I, @3: F) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::ne<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::lt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::le<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::gt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::ge<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self::Item, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::cmp::PartialOrd<K, K>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = K,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
 fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>
 
@@ -1923,6 +2346,76 @@ fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mu
 fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
 
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self, Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> (parents(Self)::[@TraitClause0])::Output
+
+fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
+
+fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>
+
+fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::collect::Extend::extend_one<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mut (Self), @2: usize)
+
+unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::default::Default::default<Self>() -> Self
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
 
 
 

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -1173,22 +1173,20 @@ where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
-where
-    // Inherited clauses:
-    [@TraitClause0]: core::iter::range::Step<A>,
-
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
-    // Local clauses:
-    [@TraitClause1]: core::cmp::Ord<A>,
+
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::option::Option<A>
+where
+    // Inherited clauses:
+    [@TraitClause0]: core::iter::range::Step<A>,
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
@@ -1197,12 +1195,14 @@ where
     // Local clauses:
     [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min<A>(@1: core::ops::range::Range<A>) -> core::option::Option<A>
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
+    // Local clauses:
+    [@TraitClause1]: core::cmp::Ord<A>,
 
-fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted<A>(@1: core::ops::range::Range<A>) -> bool
 where
     // Inherited clauses:
     [@TraitClause0]: core::iter::range::Step<A>,
@@ -1222,12 +1222,12 @@ where
     fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::next
     fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::size_hint
     fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::count
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
     fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::last
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
     fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::advance_by
+    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::nth
+    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::max
+    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::min
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::is_sorted
     fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>}#6::__iterator_get_unchecked
 }
 
@@ -1254,9 +1254,9 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt<'_0, '_1>(
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
-
 fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+
+fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76 : core::cmp::PartialOrd<i32, i32>
 {
@@ -1264,8 +1264,8 @@ impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76 : core::cmp:
     fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp
     fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt
     fn le = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge
     fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge
 }
 
 fn core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<usize>
@@ -1276,9 +1276,9 @@ fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward_checke
 
 fn core::iter::range::{impl core::iter::range::Step for i32}#40::forward(@1: i32, @2: usize) -> i32
 
-fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward(@1: i32, @2: usize) -> i32
-
 unsafe fn core::iter::range::{impl core::iter::range::Step for i32}#40::forward_unchecked(@1: i32, @2: usize) -> i32
+
+fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward(@1: i32, @2: usize) -> i32
 
 unsafe fn core::iter::range::{impl core::iter::range::Step for i32}#40::backward_unchecked(@1: i32, @2: usize) -> i32
 
@@ -1290,8 +1290,8 @@ impl core::iter::range::{impl core::iter::range::Step for i32}#40 : core::iter::
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for i32}#40::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for i32}#40::backward
     fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for i32}#40::forward_unchecked
+    fn backward = core::iter::range::{impl core::iter::range::Step for i32}#40::backward
     fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for i32}#40::backward_unchecked
 }
 
@@ -1315,9 +1315,9 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt<'_0, '
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
-
 fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
+
+fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58 : core::cmp::PartialOrd<usize, usize>
 {
@@ -1325,8 +1325,8 @@ impl core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58 : core::
     fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp
     fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt
     fn le = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge
     fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge
 }
 
 fn core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<usize>
@@ -1337,9 +1337,9 @@ fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward_chec
 
 fn core::iter::range::{impl core::iter::range::Step for usize}#43::forward(@1: usize, @2: usize) -> usize
 
-fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward(@1: usize, @2: usize) -> usize
-
 unsafe fn core::iter::range::{impl core::iter::range::Step for usize}#43::forward_unchecked(@1: usize, @2: usize) -> usize
+
+fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward(@1: usize, @2: usize) -> usize
 
 unsafe fn core::iter::range::{impl core::iter::range::Step for usize}#43::backward_unchecked(@1: usize, @2: usize) -> usize
 
@@ -1351,8 +1351,8 @@ impl core::iter::range::{impl core::iter::range::Step for usize}#43 : core::iter
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for usize}#43::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for usize}#43::backward
     fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for usize}#43::forward_unchecked
+    fn backward = core::iter::range::{impl core::iter::range::Step for usize}#43::backward
     fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for usize}#43::backward_unchecked
 }
 
@@ -1535,9 +1535,9 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0, '_1>(
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
-fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
-
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
+
+fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp::PartialOrd<u32, u32>
 {
@@ -1545,8 +1545,8 @@ impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp:
     fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp
     fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt
     fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
     fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt
+    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
 }
 
 fn core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<usize>
@@ -1557,9 +1557,9 @@ fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward_checke
 
 fn core::iter::range::{impl core::iter::range::Step for u32}#39::forward(@1: u32, @2: usize) -> u32
 
-fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward(@1: u32, @2: usize) -> u32
-
 unsafe fn core::iter::range::{impl core::iter::range::Step for u32}#39::forward_unchecked(@1: u32, @2: usize) -> u32
+
+fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward(@1: u32, @2: usize) -> u32
 
 unsafe fn core::iter::range::{impl core::iter::range::Step for u32}#39::backward_unchecked(@1: u32, @2: usize) -> u32
 
@@ -1571,8 +1571,8 @@ impl core::iter::range::{impl core::iter::range::Step for u32}#39 : core::iter::
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for u32}#39::forward
-    fn backward = core::iter::range::{impl core::iter::range::Step for u32}#39::backward
     fn forward_unchecked = core::iter::range::{impl core::iter::range::Step for u32}#39::forward_unchecked
+    fn backward = core::iter::range::{impl core::iter::range::Step for u32}#39::backward
     fn backward_unchecked = core::iter::range::{impl core::iter::range::Step for u32}#39::backward_unchecked
 }
 

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -1,4 +1,5 @@
 //@ charon-args=--include core::option
+//@ charon-args=--exclude core::slice::raw::from_ref
 //@ charon-args=--include test_crate::module::dont_translate_body
 //@ charon-args=--opaque test_crate::module::dont_translate_body
 //@ charon-args=--opaque crate::module::other_mod
@@ -6,7 +7,7 @@
 //@ charon-args=--include core::convert::{core::convert::Into<_,_>}::into
 //@ charon-args=--include core::convert::num::{core::convert::From<_,_>}
 //@ charon-args=--opaque _::exclude_me
-//@ charon-args=--exclude core::slice::raw::from_ref
+//@ charon-args=--exclude crate::invisible_mod
 // Note: we don't use the `impl Trait for T` syntax above because we can't have spaces in these
 // options.
 
@@ -26,3 +27,7 @@ mod module {
 }
 
 fn exclude_me() {}
+
+mod invisible_mod {
+    fn invisible() {}
+}

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -12,39 +12,39 @@ enum core::option::Option<T> =
 trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq : core::cmp::PartialEq::eq
-    fn ne
+    fn ne : core::cmp::PartialEq::ne
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
 }
 
 trait core::hash::Hasher<Self>
 {
     fn finish : core::hash::Hasher::finish
     fn write : core::hash::Hasher::write
-    fn write_u8
-    fn write_u16
-    fn write_u32
-    fn write_u64
-    fn write_u128
-    fn write_usize
-    fn write_i8
-    fn write_i16
-    fn write_i32
-    fn write_i64
-    fn write_i128
-    fn write_isize
-    fn write_length_prefix
-    fn write_str
+    fn write_u8 : core::hash::Hasher::write_u8
+    fn write_u16 : core::hash::Hasher::write_u16
+    fn write_u32 : core::hash::Hasher::write_u32
+    fn write_u64 : core::hash::Hasher::write_u64
+    fn write_u128 : core::hash::Hasher::write_u128
+    fn write_usize : core::hash::Hasher::write_usize
+    fn write_i8 : core::hash::Hasher::write_i8
+    fn write_i16 : core::hash::Hasher::write_i16
+    fn write_i32 : core::hash::Hasher::write_i32
+    fn write_i64 : core::hash::Hasher::write_i64
+    fn write_i128 : core::hash::Hasher::write_i128
+    fn write_isize : core::hash::Hasher::write_isize
+    fn write_length_prefix : core::hash::Hasher::write_length_prefix
+    fn write_str : core::hash::Hasher::write_str
 }
 
 trait core::hash::Hash<Self>
 {
     fn hash : core::hash::Hash::hash
-    fn hash_slice
+    fn hash_slice : core::hash::Hash::hash_slice
 }
 
 trait core::hash::BuildHasher<Self>
@@ -52,7 +52,7 @@ trait core::hash::BuildHasher<Self>
     parent_clause_0 : [@TraitClause0]: core::hash::Hasher<Self::Hasher>
     type Hasher
     fn build_hasher : core::hash::BuildHasher::build_hasher
-    fn hash_one
+    fn hash_one : core::hash::BuildHasher::hash_one
 }
 
 trait core::borrow::Borrow<Self, Borrowed>
@@ -230,17 +230,58 @@ fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map::Has
 
 fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
 
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
 fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 fn core::hash::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
 where
     [@TraitClause0]: core::hash::Hasher<H>,
 
+fn core::hash::Hash::hash_slice<'_0, '_1, Self, H>(@1: &'_0 (Slice<Self>), @2: &'_1 mut (H))
+where
+    [@TraitClause0]: core::hash::Hasher<H>,
+
 fn core::hash::BuildHasher::build_hasher<'_0, Self>(@1: &'_0 (Self)) -> Self::Hasher
+
+fn core::hash::BuildHasher::hash_one<'_0, Self, T>(@1: &'_0 (Self), @2: T) -> u64
+where
+    [@TraitClause0]: core::hash::Hash<T>,
+    [@TraitClause1]: core::hash::Hasher<Self::Hasher>,
 
 fn core::hash::Hasher::finish<'_0, Self>(@1: &'_0 (Self)) -> u64
 
 fn core::hash::Hasher::write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+
+fn core::hash::Hasher::write_u8<'_0, Self>(@1: &'_0 mut (Self), @2: u8)
+
+fn core::hash::Hasher::write_u16<'_0, Self>(@1: &'_0 mut (Self), @2: u16)
+
+fn core::hash::Hasher::write_u32<'_0, Self>(@1: &'_0 mut (Self), @2: u32)
+
+fn core::hash::Hasher::write_u64<'_0, Self>(@1: &'_0 mut (Self), @2: u64)
+
+fn core::hash::Hasher::write_u128<'_0, Self>(@1: &'_0 mut (Self), @2: u128)
+
+fn core::hash::Hasher::write_usize<'_0, Self>(@1: &'_0 mut (Self), @2: usize)
+
+fn core::hash::Hasher::write_i8<'_0, Self>(@1: &'_0 mut (Self), @2: i8)
+
+fn core::hash::Hasher::write_i16<'_0, Self>(@1: &'_0 mut (Self), @2: i16)
+
+fn core::hash::Hasher::write_i32<'_0, Self>(@1: &'_0 mut (Self), @2: i32)
+
+fn core::hash::Hasher::write_i64<'_0, Self>(@1: &'_0 mut (Self), @2: i64)
+
+fn core::hash::Hasher::write_i128<'_0, Self>(@1: &'_0 mut (Self), @2: i128)
+
+fn core::hash::Hasher::write_isize<'_0, Self>(@1: &'_0 mut (Self), @2: isize)
+
+fn core::hash::Hasher::write_length_prefix<'_0, Self>(@1: &'_0 mut (Self), @2: usize)
+
+fn core::hash::Hasher::write_str<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Str))
 
 
 

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -109,16 +109,16 @@ impl core::cmp::impls::{impl core::cmp::Eq for u32}#43 : core::cmp::Eq<u32>
 
 opaque type std::hash::random::DefaultHasher
 
-fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Slice<u8>))
-
 fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish<'_0>(@1: &'_0 (std::hash::random::DefaultHasher)) -> u64
+
+fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Slice<u8>))
 
 fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str<'_0, '_1>(@1: &'_0 mut (std::hash::random::DefaultHasher), @2: &'_1 (Str))
 
 impl std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4 : core::hash::Hasher<std::hash::random::DefaultHasher>
 {
-    fn write = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write
     fn finish = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish
+    fn write = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write
     fn write_str = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str
 }
 

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -20,7 +20,7 @@ fn test_crate::wrap<'a>(@1: &'a (u32)) -> core::option::Option<&'a (u32)>
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 fn test_crate::wrap2<'a>(@1: &'a (u32)) -> core::option::Option<&'a (u32)>
@@ -94,6 +94,8 @@ where
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -32,123 +32,6 @@ opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
-trait core::iter::traits::iterator::Iterator<Self>
-{
-    type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk
-    fn size_hint
-    fn count
-    fn last
-    fn advance_by
-    fn nth
-    fn step_by
-    fn chain
-    fn zip
-    fn intersperse
-    fn intersperse_with
-    fn map
-    fn for_each
-    fn filter
-    fn filter_map
-    fn enumerate
-    fn peekable
-    fn skip_while
-    fn take_while
-    fn map_while
-    fn skip
-    fn take
-    fn scan
-    fn flat_map
-    fn flatten
-    fn map_windows
-    fn fuse
-    fn inspect
-    fn by_ref
-    fn collect
-    fn try_collect
-    fn collect_into
-    fn partition
-    fn partition_in_place
-    fn is_partitioned
-    fn try_fold
-    fn try_for_each
-    fn fold
-    fn reduce
-    fn try_reduce
-    fn all
-    fn any
-    fn find
-    fn find_map
-    fn try_find
-    fn position
-    fn rposition
-    fn max
-    fn min
-    fn max_by_key
-    fn max_by
-    fn min_by_key
-    fn min_by
-    fn rev
-    fn unzip
-    fn copied
-    fn cloned
-    fn cycle
-    fn array_chunks
-    fn sum
-    fn product
-    fn cmp
-    fn cmp_by
-    fn partial_cmp
-    fn partial_cmp_by
-    fn eq
-    fn eq_by
-    fn ne
-    fn lt
-    fn le
-    fn gt
-    fn ge
-    fn is_sorted
-    fn is_sorted_by
-    fn is_sorted_by_key
-    fn __iterator_get_unchecked
-}
-
-trait core::iter::traits::collect::IntoIterator<Self>
-where
-    (parents(Self)::[@TraitClause0])::Item = Self::Item,
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    type Item
-    type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
-}
-
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>)) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
-
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint<'_0, T, const N : usize>(@1: &'_0 (core::array::iter::IntoIter<T, const N : usize>)) -> (usize, core::option::Option<usize>)
-
-trait core::ops::function::FnOnce<Self, Args>
-{
-    type Output
-    fn call_once : core::ops::function::FnOnce::call_once
-}
-
-trait core::ops::function::FnMut<Self, Args>
-{
-    parent_clause_0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
-}
-
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
-where
-    [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
-    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>}#2<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
-
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
-
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
-
 enum core::result::Result<T, E> =
 |  Ok(T)
 |  Err(E)
@@ -157,7 +40,7 @@ enum core::result::Result<T, E> =
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::marker::Copy<Self>
@@ -216,6 +99,289 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause3 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
+
+opaque type core::iter::adapters::step_by::StepBy<I>
+
+opaque type core::iter::adapters::chain::Chain<A, B>
+
+opaque type core::iter::adapters::zip::Zip<A, B>
+
+trait core::ops::function::FnOnce<Self, Args>
+{
+    type Output
+    fn call_once : core::ops::function::FnOnce::call_once
+}
+
+trait core::ops::function::FnMut<Self, Args>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
+    fn call_mut : core::ops::function::FnMut::call_mut
+}
+
+opaque type core::iter::adapters::map::Map<I, F>
+
+opaque type core::iter::adapters::filter_map::FilterMap<I, F>
+
+opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::map_while::MapWhile<I, P>
+
+opaque type core::iter::adapters::skip::Skip<I>
+
+opaque type core::iter::adapters::take::Take<I>
+
+opaque type core::iter::adapters::fuse::Fuse<I>
+
+trait core::ops::try_trait::FromResidual<Self, R>
+{
+    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+}
+
+enum core::ops::control_flow::ControlFlow<B, C> =
+|  Continue(C)
+|  Break(B)
+
+
+trait core::ops::try_trait::Try<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
+    type Output
+    type Residual
+    fn from_output : core::ops::try_trait::Try::from_output
+    fn branch : core::ops::try_trait::Try::branch
+}
+
+trait core::ops::try_trait::Residual<Self, O>
+where
+    (parents(Self)::[@TraitClause0])::Residual = Self,
+    (parents(Self)::[@TraitClause0])::Output = O,
+{
+    parent_clause_0 : [@TraitClause0]: core::ops::try_trait::Try<Self::TryType>
+    parent_clause_1 : [@TraitClause1]: core::ops::try_trait::FromResidual<Self::TryType, Self>
+    type TryType
+}
+
+trait core::cmp::PartialEq<Self, Rhs>
+{
+    fn eq : core::cmp::PartialEq::eq
+    fn ne : core::cmp::PartialEq::ne
+}
+
+trait core::cmp::Eq<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
+    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+}
+
+enum core::cmp::Ordering =
+|  Less()
+|  Equal()
+|  Greater()
+
+
+trait core::cmp::PartialOrd<Self, Rhs>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
+    fn lt : core::cmp::PartialOrd::lt
+    fn le : core::cmp::PartialOrd::le
+    fn gt : core::cmp::PartialOrd::gt
+    fn ge : core::cmp::PartialOrd::ge
+}
+
+trait core::cmp::Ord<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::cmp::Eq<Self>
+    parent_clause_1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn cmp : core::cmp::Ord::cmp
+    fn max : core::cmp::Ord::max
+    fn min : core::cmp::Ord::min
+    fn clamp : core::cmp::Ord::clamp
+}
+
+opaque type core::iter::adapters::rev::Rev<T>
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
+}
+
+opaque type core::iter::adapters::copied::Copied<I>
+
+opaque type core::iter::adapters::cloned::Cloned<I>
+
+opaque type core::iter::adapters::cycle::Cycle<I>
+
+trait core::iter::traits::collect::IntoIterator<Self>
+where
+    (parents(Self)::[@TraitClause0])::Item = Self::Item,
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self::IntoIter>
+    type Item
+    type IntoIter
+    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+}
+
+trait core::iter::traits::iterator::Iterator<Self>
+{
+    type Item
+    fn next : core::iter::traits::iterator::Iterator::next
+    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
+    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
+    fn count : core::iter::traits::iterator::Iterator::count
+    fn last : core::iter::traits::iterator::Iterator::last
+    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
+    fn nth : core::iter::traits::iterator::Iterator::nth
+    fn step_by : core::iter::traits::iterator::Iterator::step_by
+    fn chain : core::iter::traits::iterator::Iterator::chain
+    fn zip : core::iter::traits::iterator::Iterator::zip
+    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
+    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
+    fn map : core::iter::traits::iterator::Iterator::map
+    fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : @Fun20
+    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
+    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
+    fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : @Fun24
+    fn take_while : @Fun25
+    fn map_while : core::iter::traits::iterator::Iterator::map_while
+    fn skip : core::iter::traits::iterator::Iterator::skip
+    fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : @Fun29
+    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
+    fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : @Fun32
+    fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : @Fun34
+    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
+    fn collect : core::iter::traits::iterator::Iterator::collect
+    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
+    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : @Fun39
+    fn partition_in_place : @Fun40
+    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
+    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
+    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
+    fn fold : core::iter::traits::iterator::Iterator::fold
+    fn reduce : core::iter::traits::iterator::Iterator::reduce
+    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
+    fn all : core::iter::traits::iterator::Iterator::all
+    fn any : core::iter::traits::iterator::Iterator::any
+    fn find : @Fun49
+    fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : @Fun51
+    fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : @Fun53
+    fn max : core::iter::traits::iterator::Iterator::max
+    fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : @Fun56
+    fn max_by : @Fun57
+    fn min_by_key : @Fun58
+    fn min_by : @Fun59
+    fn rev : core::iter::traits::iterator::Iterator::rev
+    fn unzip : core::iter::traits::iterator::Iterator::unzip
+    fn copied : core::iter::traits::iterator::Iterator::copied
+    fn cloned : core::iter::traits::iterator::Iterator::cloned
+    fn cycle : core::iter::traits::iterator::Iterator::cycle
+    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
+    fn sum : core::iter::traits::iterator::Iterator::sum
+    fn product : core::iter::traits::iterator::Iterator::product
+    fn cmp : core::iter::traits::iterator::Iterator::cmp
+    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
+    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
+    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
+    fn eq : core::iter::traits::iterator::Iterator::eq
+    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
+    fn ne : core::iter::traits::iterator::Iterator::ne
+    fn lt : core::iter::traits::iterator::Iterator::lt
+    fn le : core::iter::traits::iterator::Iterator::le
+    fn gt : core::iter::traits::iterator::Iterator::gt
+    fn ge : core::iter::traits::iterator::Iterator::ge
+    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : @Fun80
+    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
+    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+}
+
+opaque type core::iter::adapters::intersperse::Intersperse<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::clone::Clone<@TraitClause0::Item>,
+
+opaque type core::iter::adapters::intersperse::IntersperseWith<I, G>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::peekable::Peekable<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+opaque type core::iter::adapters::flatten::FlatMap<I, U, F>
+  where
+      [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+opaque type core::iter::adapters::flatten::Flatten<I>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+      [@TraitClause1]: core::iter::traits::collect::IntoIterator<@TraitClause0::Item>,
+
+trait core::iter::traits::collect::FromIterator<Self, A>
+{
+    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+}
+
+trait core::iter::traits::collect::Extend<Self, A>
+{
+    fn extend : core::iter::traits::collect::Extend::extend
+    fn extend_one : core::iter::traits::collect::Extend::extend_one
+    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
+    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+}
+
+trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
+    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
+    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
+    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
+    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : @Fun152
+}
+
+opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
+  where
+      [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+
+trait core::iter::traits::accum::Sum<Self, A>
+{
+    fn sum : core::iter::traits::accum::Sum::sum
+}
+
+trait core::iter::traits::accum::Product<Self, A>
+{
+    fn product : core::iter::traits::accum::Product::product
+}
+
+trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
+{
+    const MAY_HAVE_SIDE_EFFECT : bool
+    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+}
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>)) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint<'_0, T, const N : usize>(@1: &'_0 (core::array::iter::IntoIter<T, const N : usize>)) -> (usize, core::option::Option<usize>)
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
+where
+    [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
+    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>}#2<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::advance_by<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 
@@ -296,7 +462,7 @@ where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
     (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::any)))::[@TraitClause0])::Output = bool,
 
-Missing decl: Fun(39) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find)
+Missing decl: Fun(115) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find)
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map<'a, '_1, T, B, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> core::option::Option<B>
 where
@@ -311,31 +477,20 @@ where
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len
-    fn is_empty
-}
-
-trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by
-    fn nth_back
-    fn try_rfold
-    fn rfold
-    fn rfind
+    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
+    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
 }
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
-    [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>,
+    [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>,
     [@TraitClause1]: core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'_, T>>,
     [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl9<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl10<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl9<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause1]: @TraitDecl9<@Adt2<'_, T>>; [@TraitClause2]: @TraitDecl10<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Output = bool,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<@Adt2<'_, T>>; [@TraitClause1]: @TraitDecl23<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<@Adt2<'_, T>>; [@TraitClause1]: @TraitDecl23<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Output = bool,
 
 unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, T>::Item
 
-Missing decl: Fun(44) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::is_sorted_by)
+Missing decl: Fun(120) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::is_sorted_by)
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
 {
@@ -350,12 +505,12 @@ impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for 
     fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::for_each
     fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::all
     fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::any
-    fn find = @Fun39
+    fn find = @Fun115
     fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map
     fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::position
     fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition
     fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked
-    fn is_sorted_by = @Fun44
+    fn is_sorted_by = @Fun120
 }
 
 trait core::ops::arith::AddAssign<Self, Rhs>
@@ -727,13 +882,366 @@ fn test_crate::main()
     return
 }
 
+fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> core::result::Result<Array<Self::Item, const N : usize>, core::array::iter::IntoIter<Self::Item, const N : usize>>
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>)
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>
+
+fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>
+
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause0::IntoIter>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+
+fn core::iter::traits::iterator::Iterator::intersperse<Self>(@1: Self, @2: Self::Item) -> core::iter::adapters::intersperse::Intersperse<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::clone::Clone<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::intersperse_with<Self, G>(@1: Self, @2: G) -> core::iter::adapters::intersperse::IntersperseWith<Self, G, Self>
+where
+    [@TraitClause0]: core::ops::function::FnMut<G, ()>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::map::Map<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::for_each<Self, F>(@1: Self, @2: F)
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = (),
+
+fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::iter::adapters::enumerate::Enumerate<Self>
+
+fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
+
+fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
+
+fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<U>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = U,
+
+fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter::adapters::flatten::Flatten<Self, Self, @TraitClause0>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
+
+fn core::iter::traits::iterator::Iterator::collect<Self, B>(@1: Self) -> B
+where
+    [@TraitClause0]: core::iter::traits::collect::FromIterator<B, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::try_collect<'_0, Self, B>(@1: &'_0 mut (Self)) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<Self::Item>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, B>,
+    [@TraitClause2]: core::iter::traits::collect::FromIterator<B, @TraitClause0::Output>,
+
+fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
+where
+    [@TraitClause0]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::try_fold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::iterator::Iterator::try_for_each<'_0, Self, F, R>(@1: &'_0 mut (Self), @2: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = (),
+
+fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::reduce<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::try_reduce<'_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(Self::Item, Self::Item) -> R) -> @TraitClause1::TryType
+where
+    [@TraitClause0]: core::ops::try_trait::Try<R>,
+    [@TraitClause1]: core::ops::try_trait::Residual<@TraitClause0::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause2]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>,
+    @TraitClause0::Output = Self::Item,
+    (parents(@TraitClause2)::[@TraitClause0])::Output = R,
+
+fn core::iter::traits::iterator::Iterator::all<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::any<'_0, Self, F>(@1: &'_0 mut (Self), @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = core::option::Option<B>,
+
+fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause0]: core::ops::function::FnMut<P, (Self::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
+where
+    [@TraitClause0]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
+where
+    [@TraitClause0]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+
+fn core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>(@1: Self) -> (FromA, FromB)
+where
+    [@TraitClause0]: core::default::Default<FromA>,
+    [@TraitClause1]: core::iter::traits::collect::Extend<FromA, A>,
+    [@TraitClause2]: core::default::Default<FromB>,
+    [@TraitClause3]: core::iter::traits::collect::Extend<FromB, B>,
+    [@TraitClause4]: core::iter::traits::iterator::Iterator<Self>,
+    Self::Item = (A, B),
+
+fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(@1: Self) -> core::iter::adapters::copied::Copied<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::marker::Copy<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(@1: Self) -> core::iter::adapters::cloned::Cloned<Self>
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    [@TraitClause1]: core::clone::Clone<T>,
+    T : 'a,
+    Self::Item = &'a (T),
+
+fn core::iter::traits::iterator::Iterator::cycle<Self>(@1: Self) -> core::iter::adapters::cycle::Cycle<Self>
+where
+    [@TraitClause0]: core::clone::Clone<Self>,
+
+fn core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>(@1: Self) -> core::iter::adapters::array_chunks::ArrayChunks<Self, const N : usize, Self>
+
+fn core::iter::traits::iterator::Iterator::sum<Self, S>(@1: Self) -> S
+where
+    [@TraitClause0]: core::iter::traits::accum::Sum<S, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::product<Self, P>(@1: Self) -> P
+where
+    [@TraitClause0]: core::iter::traits::accum::Product<P, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::cmp<Self, I>(@1: Self, @2: I) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+    @TraitClause0::Item = Self::Item,
+
+fn core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::cmp::Ordering
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp<Self, I>(@1: Self, @2: I) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>(@1: Self, @2: I, @3: F) -> core::option::Option<core::cmp::Ordering>
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = core::option::Option<core::cmp::Ordering>,
+
+fn core::iter::traits::iterator::Iterator::eq<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::eq_by<Self, I, F>(@1: Self, @2: I, @3: F) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::ops::function::FnMut<F, (Self::Item, @TraitClause0::Item)>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::ne<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialEq<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::lt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::le<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::gt<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::ge<Self, I>(@1: Self, @2: I) -> bool
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<I>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, @TraitClause0::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self::Item, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (Self::Item)>,
+    [@TraitClause1]: core::cmp::PartialOrd<K, K>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = K,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
+
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> (parents(Self)::[@TraitClause0])::Output
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
+
+fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>
+
+fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
+where
+    [@TraitClause0]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::collect::Extend::extend_one<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mut (Self), @2: usize)
+
+unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
+
+fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::cmp::PartialOrd<Self, Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    [@TraitClause1]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = R,
+    @TraitClause1::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    (parents(@TraitClause0)::[@TraitClause0])::Output = B,
+
+fn core::default::Default::default<Self>() -> Self
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause0::Item = A,
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
+
+fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -374,16 +374,16 @@ fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::arr
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint<'_0, T, const N : usize>(@1: &'_0 (core::array::iter::IntoIter<T, const N : usize>)) -> (usize, core::option::Option<usize>)
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
-where
-    [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
-    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>}#2<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
-
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> usize
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item>
 
 fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::advance_by<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold<T, Acc, Fold, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>, @2: Acc, @3: Fold) -> Acc
+where
+    [@TraitClause0]: core::ops::function::FnMut<Fold, (Acc, T)>,
+    (parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl3<Fold, (Acc, core::array::iter::{impl core::iter::traits::iterator::Iterator for @Adt0<T, const N : usize>}#2<T, const N : usize>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt0<T, const N : usize>>; [@TraitClause0]: @TraitDecl3<Fold, (Acc, T)>) (context: core::array::iter::{impl#2}::fold)))::[@TraitClause0])::Output = Acc,
 
 unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::__iterator_get_unchecked<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>), @2: usize) -> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2<T, const N : usize>::Item
 
@@ -392,10 +392,10 @@ impl<T, const N : usize> core::array::iter::{impl core::iter::traits::iterator::
     type Item = T
     fn next = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::next
     fn size_hint = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::size_hint
-    fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold
     fn count = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::count
     fn last = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::last
     fn advance_by = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::advance_by
+    fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::fold
     fn __iterator_get_unchecked = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>}#2::__iterator_get_unchecked
 }
 
@@ -436,21 +436,21 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::count<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::option::Option<&'a (T)>
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::last<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> core::option::Option<&'a (T)>
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::advance_by<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::last<'a, T>(@1: core::slice::iter::Iter<'a, T>) -> core::option::Option<&'a (T)>
-
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>, @2: B, @3: F) -> B
-where
-    [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>,
-    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>) (context: core::slice::iter::{impl#182}::fold)))::[@TraitClause0])::Output = B,
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::option::Option<&'a (T)>
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::for_each<'a, T, F>(@1: core::slice::iter::Iter<'a, T>, @2: F)
 where
     [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>,
     (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (&'_ (T))>) (context: core::slice::iter::{impl#182}::for_each)))::[@TraitClause0])::Output = (),
+
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>,
+    (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<F, (B, core::slice::iter::{impl core::iter::traits::iterator::Iterator for @Adt2<'a, T>}#182<'_, T>::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<F, (B, &'_ (T))>) (context: core::slice::iter::{impl#182}::fold)))::[@TraitClause0])::Output = B,
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::all<'a, '_1, T, F>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: F) -> bool
 where
@@ -488,9 +488,9 @@ where
     [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>>,
     (parents(UNKNOWN(Could not find a clause for parameter: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<@Adt2<'_, T>>; [@TraitClause1]: @TraitDecl23<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>; [@TraitClause0]: core::ops::function::FnMut<P, ((parents(UNKNOWN(Could not find a clause for parameter: @TraitDecl23<@Adt2<'a, T>> (available clauses: [Self]: core::iter::traits::iterator::Iterator<@Adt2<'a, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Item)>; [@TraitClause2]: core::iter::traits::double_ended::DoubleEndedIterator<@Adt2<'_, T>>; [@TraitClause1]: @TraitDecl23<@Adt2<'_, T>>) (context: core::slice::iter::{impl#182}::rposition)))::[@TraitClause0])::Output = bool,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, T>::Item
-
 Missing decl: Fun(120) (core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::is_sorted_by)
+
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'_, T>::Item
 
 impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182<'a, T> : core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>>
 {
@@ -498,19 +498,19 @@ impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for 
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth
-    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::advance_by
     fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::last
-    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold
+    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::advance_by
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::nth
     fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::for_each
+    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::fold
     fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::all
     fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::any
     fn find = @Fun115
     fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::find_map
     fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::position
     fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked
     fn is_sorted_by = @Fun120
+    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::__iterator_get_unchecked
 }
 
 trait core::ops::arith::AddAssign<Self, Rhs>
@@ -535,9 +535,9 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::count<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item>
-
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item>
+
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item>
 
 unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71<'_, T>::Item
 
@@ -547,8 +547,8 @@ impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for 
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth
     fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::last
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::nth
     fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>}#71::__iterator_get_unchecked
 }
 
@@ -560,9 +560,9 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::count<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> usize
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item>
-
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::last<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item>
+
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item>
 
 unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90<'_, T>::Item
 
@@ -572,8 +572,8 @@ impl<'a, T> core::slice::iter::{impl core::iter::traits::iterator::Iterator for 
     fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::next
     fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::size_hint
     fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::count
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth
     fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::last
+    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::nth
     fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>}#90::__iterator_get_unchecked
 }
 

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -7,7 +7,7 @@ type test_crate::Generic<'a, T> = &'a (T)
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 trait core::borrow::Borrow<Self, Borrowed>
@@ -20,7 +20,7 @@ trait alloc::borrow::ToOwned<Self>
     parent_clause_0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
     type Owned
     fn to_owned : alloc::borrow::ToOwned::to_owned
-    fn clone_into
+    fn clone_into : alloc::borrow::ToOwned::clone_into
 }
 
 enum alloc::borrow::Cow<'a, B>
@@ -70,9 +70,13 @@ type test_crate::Generic2<'a, T>
 
 fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
 
+fn alloc::borrow::ToOwned::clone_into<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 mut (Self::Owned))
+
 fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -13,7 +13,7 @@ fn alloc::string::{alloc::string::String}::new() -> alloc::string::String
 trait core::clone::Clone<Self>
 {
     fn clone : core::clone::Clone::clone
-    fn clone_from
+    fn clone_from : core::clone::Clone::clone_from
 }
 
 fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone<'_0>(@1: &'_0 (alloc::string::String)) -> alloc::string::String
@@ -121,6 +121,8 @@ fn test_crate::foo()
     @0 := ()
     return
 }
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,9 @@
             pkgs.ocamlPackages.ocamlformat
             pkgs.ocamlPackages.menhir
             pkgs.ocamlPackages.odoc
+            # ocamllsp's version must match the ocaml version used, hence we
+            # can't an use externally-provided ocamllsp.
+            pkgs.ocamlPackages.ocaml-lsp
           ];
 
           nativeBuildInputs = [


### PR DESCRIPTION
Using the newly-added `ItemOpacity::Invisible`, we can exclude items from translation entirely. I used this to exclude known methods of the `Iterator` trait on which `hax` crashes. This means we can finally register `FunDeclId` for all trait methods, including for foreign traits. While I was at it, I also reordered trait impl methods to follow the order of the trait *declaration*.

This is progress towards #180.