### PR TITLE
Add license

### DIFF
--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -3,6 +3,7 @@ name = "charon"
 version = "0.1.30"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 name = "charon_lib"

--- a/charon/attributes/Cargo.toml
+++ b/charon/attributes/Cargo.toml
@@ -3,6 +3,7 @@ name = "attributes"
 version = "0.1.0"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true

--- a/charon/macros/Cargo.toml
+++ b/charon/macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "macros"
 version = "0.1.0"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
These are suggested edits to the `Cargo.toml` files to add a license.

Background: when including `charon` as a dependency in Kani, [cargo deny](https://github.com/EmbarkStudios/cargo-deny/) rejects the dependency because of the missing licenses.

To test, I added the following `deny.toml` file to `charon/`:
```toml
[licenses]
allow = [
    "MIT",
    "Apache-2.0",
    "MPL-2.0",
    #"Apache-2.0 WITH LLVM-exception",
]
confidence-threshold = 0.8
exceptions = [
    # Each entry is the crate and version constraint, and its specific allow
    # list
    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
]
```
This is the output of `cargo deny` without this PR:
```bash
$ cargo deny check license
error[unlicensed]: charon = 0.1.30 is unlicensed
  ┌─ path+file:///home/ubuntu/git/ttt/charon#0.1.30:2:9
  │
2 │ name = "charon"
  │         ━━━━━━ a valid license expression could not be retrieved for the crate
3 │ version = "0.1.30"
4 │ license = ""
  │            ─ license expression was not specified
  │
  ├ charon v0.1.30

error[unlicensed]: macros = 0.1.0 is unlicensed
  ┌─ path+file:///home/ubuntu/git/ttt/charon/macros#0.1.0:2:9
  │
2 │ name = "macros"
  │         ━━━━━━ a valid license expression could not be retrieved for the crate
3 │ version = "0.1.0"
4 │ license = ""
  │            ─ license expression was not specified
  │
  ├ macros v0.1.0
    └── charon v0.1.30

licenses FAILED
```
and this is the output with this PR:
```bash
$ cargo deny check license
licenses ok
```
