### PR TITLE
Improve logging

### DIFF
--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -126,7 +126,7 @@ let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
     | _ -> Error "")
 
 (** Strict type for the number of function declarations (see {!global_to_fun_id} below) *)
-type global_id_converter = { fun_count : int } [@@deriving show]
+type global_id_converter = { max_fun_id : int } [@@deriving show]
 
 (** Converts a global id to its corresponding function id.
     To do so, it adds the global id to the number of function declarations :
@@ -134,7 +134,7 @@ type global_id_converter = { fun_count : int } [@@deriving show]
 *)
 let global_to_fun_id (conv : global_id_converter) (gid : GlobalDeclId.id) :
     FunDeclId.id =
-  FunDeclId.of_int (GlobalDeclId.to_int gid + conv.fun_count)
+  FunDeclId.of_int (GlobalDeclId.to_int gid + conv.max_fun_id)
 
 (** Deserialize a global declaration, and decompose it into a global declaration
     and a function declaration.
@@ -178,11 +178,11 @@ let crate_of_json (js : json) : (crate, string) result =
     (* When deserializing the globals, we split the global declarations
      * between the globals themselves and their bodies, which are simply
      * functions with no arguments. We add the global bodies to the list
-     * of function declarations: the (fresh) ids we use for those bodies
-     * are simply given by: [num_functions + global_id] *)
+     * of function declarations; we give fresh ids to these new bodies
+     * by incrementing from the last function id recorded *)
     let gid_conv =
       {
-        fun_count =
+        max_fun_id =
           List.fold_left
             (fun acc (id, _) -> max acc (1 + FunDeclId.to_int id))
             0

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -313,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,12 +785,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -818,6 +842,12 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -1227,6 +1257,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,11 +1386,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56c62d2c80033cb36fae448730a2f2ef99410fe3ecbffc916681a32f6807dbe"
+version = "0.4.0"
+source = "git+https://github.com/Nadrieril/tracing-tree#841286bfffd3c2200810244506cd127013dbeff9"
 dependencies = [
  "nu-ansi-term 0.50.0",
+ "time",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -69,7 +69,8 @@ stacker = "0.1"
 take_mut = "0.2.2"
 toml = { version = "0.8", features = ["parse"] }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "fmt" ] }
-tracing-tree = "0.3"
+tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [ "time" ] } # Fork with improved formating and timing info.
+# tracing-tree = { path = "../../tracing-tree", features = [ "time" ] }
 tracing = { version = "0.1", features = [ "max_level_trace", "release_max_level_warn" ] }
 which = "6.0.1"
 

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -360,6 +360,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 }
 
+#[tracing::instrument(skip(tcx))]
 pub fn translate<'tcx, 'ctx>(options: &CliOpts, tcx: TyCtxt<'tcx>) -> TransformCtx<'tcx> {
     let hax_state = hax::state::State::new(
         tcx,

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -1099,7 +1099,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             .iter()
             .enumerate()
             .all(|(i, c)| c.clause_id.index() == i));
-        GenericParams {
+        let generic_params = GenericParams {
             regions: self.region_vars[0].clone(),
             types: self.type_vars.clone(),
             const_generics: self.const_generic_vars.clone(),
@@ -1107,7 +1107,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             regions_outlive: self.regions_outlive.clone(),
             types_outlive: self.types_outlive.clone(),
             trait_type_constraints: self.trait_type_constraints.clone(),
-        }
+        };
+        trace!("Translated generics: {generic_params:?}");
+        generic_params
     }
 
     pub(crate) fn make_dep_source(&self, span: rustc_span::Span) -> Option<DepSource> {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1479,6 +1479,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Translate one function.
+    #[tracing::instrument(skip(self, rust_id, item_meta))]
     pub fn translate_function(
         &mut self,
         def_id: FunDeclId,
@@ -1532,6 +1533,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     /// Translate one global.
+    #[tracing::instrument(skip(self, rust_id, item_meta))]
     pub fn translate_global(
         &mut self,
         def_id: GlobalDeclId,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -393,6 +393,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     /// Returns an [Option] because we may ignore some builtin or auto traits
     /// like [core::marker::Sized] or [core::marker::Sync].
+    #[tracing::instrument(skip(self, span, erase_regions))]
     pub(crate) fn translate_trait_impl_expr(
         &mut self,
         span: rustc_span::Span,
@@ -607,6 +608,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     /// Find the trait instance fullfilling a trait obligation.
     /// TODO: having to do this is very annoying. Isn't there a better way?
+    #[tracing::instrument(skip(self))]
     fn find_trait_clause_for_param(
         &self,
         trait_id: TraitDeclId,
@@ -651,7 +653,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             );
         } else {
             // Return the UNKNOWN clause
-            log::warn!(
+            tracing::warn!(
                 "Could not find a clause for parameter:\n- target param: {}\n- available clauses:\n{}\n- context: {:?}",
                 trait_ref, clauses.join("\n"), self.def_id
             );

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -83,6 +83,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         Ok(TraitItemName(name.to_string()))
     }
 
+    #[tracing::instrument(skip(self, rust_id, item_meta))]
     pub fn translate_trait_decl(
         &mut self,
         def_id: TraitDeclId,
@@ -268,6 +269,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         })
     }
 
+    #[tracing::instrument(skip(self, rust_id, item_meta))]
     pub fn translate_trait_impl(
         &mut self,
         def_id: TraitImplId,

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -117,6 +117,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
     /// Note that we take as parameter a function to translate regions, because
     /// regions can be translated in several manners (non-erased region or erased
     /// regions), in which case the return type is different.
+    #[tracing::instrument(skip(self, span, erase_regions))]
     pub(crate) fn translate_ty(
         &mut self,
         span: rustc_span::Span,
@@ -763,6 +764,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Note that we translate the types one by one: we don't need to take into
     /// account the fact that some types are mutually recursive at this point
     /// (we will need to take that into account when generating the code in a file).
+    #[tracing::instrument(skip(self, rust_id, item_meta))]
     pub fn translate_type(
         &mut self,
         trans_id: TypeDeclId,

--- a/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
@@ -84,7 +84,7 @@ let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
     | _ -> Error "")
 
 (** Strict type for the number of function declarations (see {!global_to_fun_id} below) *)
-type global_id_converter = { fun_count : int } [@@deriving show]
+type global_id_converter = { max_fun_id : int } [@@deriving show]
 
 (** Converts a global id to its corresponding function id.
     To do so, it adds the global id to the number of function declarations :
@@ -92,7 +92,7 @@ type global_id_converter = { fun_count : int } [@@deriving show]
 *)
 let global_to_fun_id (conv : global_id_converter) (gid : GlobalDeclId.id) :
     FunDeclId.id =
-  FunDeclId.of_int (GlobalDeclId.to_int gid + conv.fun_count)
+  FunDeclId.of_int (GlobalDeclId.to_int gid + conv.max_fun_id)
 
 (** Deserialize a global declaration, and decompose it into a global declaration
     and a function declaration.
@@ -136,11 +136,11 @@ let crate_of_json (js : json) : (crate, string) result =
     (* When deserializing the globals, we split the global declarations
      * between the globals themselves and their bodies, which are simply
      * functions with no arguments. We add the global bodies to the list
-     * of function declarations: the (fresh) ids we use for those bodies
-     * are simply given by: [num_functions + global_id] *)
+     * of function declarations; we give fresh ids to these new bodies
+     * by incrementing from the last function id recorded *)
     let gid_conv =
       {
-        fun_count =
+        max_fun_id =
           List.fold_left
             (fun acc (id, _) -> max acc (1 + FunDeclId.to_int id))
             0

--- a/charon/src/logger.rs
+++ b/charon/src/logger.rs
@@ -1,7 +1,6 @@
 extern crate env_logger;
 
-/// Initialize the logger. We use a custom initialization to add some
-/// useful debugging information, including the line number in the file.
+/// Initialize the logger.
 pub fn initialize_logger() {
     {
         // Initialize the logger only once (useful when running the driver in tests).
@@ -11,82 +10,43 @@ pub fn initialize_logger() {
             return;
         }
     }
-    use env_logger::fmt::style;
-    use env_logger::{Builder, Env};
-    use std::io::Write;
 
-    // Create a default environment, by using the environment variables.
-    // We do this to let the user choose the log level (i.e.: trace,
-    // debug, warning, etc.)
-    let env = Env::default();
-    // If the log level is not set, set it to "info"
-    let env = env.default_filter_or("info");
-
-    // Initialize the log builder from the environment we just created
-    let mut builder = Builder::from_env(env);
-
-    // Modify the output format - we add the line number
-    builder.format(|buf, record| {
-        // Retreive the path (CRATE::MODULE) and the line number
-        let path = record.module_path().unwrap_or_default();
-        let line = record.line().unwrap_or_default();
-
-        // Style for the brackets (change the color)
-        let brackets_style = style::RgbColor(120, 120, 120).on_default();
-        let level_style = buf.default_level_style(record.level()); // Print the level with colors
-
-        write!(buf, "{brackets_style}[{brackets_style:#}")?;
-        write!(
-            buf,
-            "{level_style}{}{level_style:#} {path}:{line}",
-            record.level(),
-        )?;
-        write!(buf, "{brackets_style}]{brackets_style:#} ")?;
-        writeln!(buf, "{}", record.args())?;
-        Ok(())
-    });
-
-    builder.init();
-
-    // Also set up `tracing` so we get tracing data from `hax`.
     use tracing_subscriber::prelude::*;
-    let subscriber = tracing_subscriber::Registry::default()
+    tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::from_default_env())
         .with(
-            tracing_tree::HierarchicalLayer::new(2)
+            tracing_tree::HierarchicalLayer::new(1)
                 .with_ansi(true)
-                .with_indent_amount(1)
-                .with_indent_lines(true),
-        );
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+                .with_indent_lines(true)
+                .with_bracketed_fields(true)
+                .with_timer(tracing_tree::time::Uptime::default()),
+        )
+        .init();
 }
 
-/// This macro computes the name of the function in which it is called.
+/// This macro computes the name of the function in which it is called and the line number.
 /// We adapted it from:
 /// <https://stackoverflow.com/questions/38088067/equivalent-of-func-or-function-in-rust>
-/// Note that we can't define it in macros due to technical reasons
 #[macro_export]
-macro_rules! function_name {
-    () => {{
+macro_rules! code_location {
+    ($color:ident) => {{
         fn f() {}
         fn type_name_of<T>(_: T) -> &'static str {
             std::any::type_name::<T>()
         }
         let name = type_name_of(f);
 
-        // Remove the "::f" suffix
-        let name = &name[..name.len() - 3];
+        let path: Vec<_> = name.split("::").collect();
+        // The path looks like `crate::module::function::f`.
+        let name = path.iter().rev().skip(1).next().unwrap();
 
-        // Remove the CRATE::MODULE:: prefix
-        let name = match &name.find("::") {
-            Some(pos) => &name[pos + 2..name.len()],
-            None => name,
-        };
+        let line = line!();
+        let file = file!();
 
-        match &name.find("::") {
-            Some(pos) => &name[pos + 2..name.len()],
-            None => name,
-        }
+        use colored::Colorize;
+        let name = name.$color();
+        let location = format!("{file}:{line}").dimmed();
+        format!("in {name} at {location}")
     }};
 }
 
@@ -94,13 +54,11 @@ macro_rules! function_name {
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)+) => {{
-        use colored::Colorize;
         let msg = format!($($arg)+);
-        log::trace!("[{}]:\n{}", $crate::function_name!().yellow(), msg)
+        tracing::trace!("{}:\n{}", $crate::code_location!(yellow), msg)
     }};
     () => {{
-        use colored::Colorize;
-        log::trace!("[{}]", $crate::function_name!().yellow())
+        tracing::trace!("{}", $crate::code_location!(yellow))
     }};
 }
 
@@ -108,9 +66,8 @@ macro_rules! trace {
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)+) => {{
-        use colored::Colorize;
         let msg = format!($($arg)+);
-        log::error!("[{}]:\n{}", $crate::function_name!().red(), msg)
+        tracing::error!("{}:\n{}", $crate::code_location!(red), msg)
     }};
 }
 
@@ -118,9 +75,8 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)+) => {{
-        use colored::Colorize;
         let msg = format!($($arg)+);
-        log::warn!("[{}]:\n{}", $crate::function_name!().yellow(), msg)
+        tracing::warn!("{}:\n{}", $crate::code_location!(yellow), msg)
     }};
 }
 
@@ -128,13 +84,12 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)+) => {{
-        use colored::Colorize;
         let msg = format!($($arg)+);
         // As for info we generally output simple messages, we don't insert
         // a breakline
-        log::info!("[{}]: {}", $crate::function_name!().yellow(), msg)
+        tracing::info!("{}: {}", $crate::code_location!(yellow), msg)
     }};
     () => {{
-        log::info!("[{}]", $crate::function_name!().yellow())
+        tracing::info!("{}", $crate::code_location!(yellow))
     }};
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -336,7 +336,7 @@ impl<'a> Formatter<(DeBruijnId, RegionId)> for FmtCtx<'a> {
             Some(gr) => match gr.get(id) {
                 None => {
                     let region = Region::BVar(grid, id);
-                    log::warn!(
+                    tracing::warn!(
                         "Found incorrect region `{region}` while pretty-printing. Look for \
                         \"wrong_region\" in the pretty output"
                     );

--- a/charon/tests/ui/bitwise.out
+++ b/charon/tests/ui/bitwise.out
@@ -1,5 +1,59 @@
 # Final LLBC before serialization:
 
+fn test_crate::shift_u32(@1: u32) -> u32
+{
+    let @0: u32; // return
+    let a@1: u32; // arg #1
+    let i@2: usize; // local
+    let t@3: u32; // local
+    let @4: u32; // anonymous local
+    let @5: usize; // anonymous local
+    let @6: usize; // anonymous local
+
+    i@2 := const (16 : usize)
+    @fake_read(i@2)
+    @4 := copy (a@1)
+    @5 := copy (i@2)
+    t@3 := move (@4) >> move (@5)
+    drop @5
+    drop @4
+    @fake_read(t@3)
+    @6 := copy (i@2)
+    t@3 := copy (t@3) << move (@6)
+    drop @6
+    @0 := copy (t@3)
+    drop t@3
+    drop i@2
+    return
+}
+
+fn test_crate::shift_i32(@1: i32) -> i32
+{
+    let @0: i32; // return
+    let a@1: i32; // arg #1
+    let i@2: isize; // local
+    let t@3: i32; // local
+    let @4: i32; // anonymous local
+    let @5: isize; // anonymous local
+    let @6: isize; // anonymous local
+
+    i@2 := const (16 : isize)
+    @fake_read(i@2)
+    @4 := copy (a@1)
+    @5 := copy (i@2)
+    t@3 := move (@4) >> move (@5)
+    drop @5
+    drop @4
+    @fake_read(t@3)
+    @6 := copy (i@2)
+    t@3 := copy (t@3) << move (@6)
+    drop @6
+    @0 := copy (t@3)
+    drop t@3
+    drop i@2
+    return
+}
+
 fn test_crate::xor_u32(@1: u32, @2: u32) -> u32
 {
     let @0: u32; // return

--- a/charon/tests/ui/bitwise.rs
+++ b/charon/tests/ui/bitwise.rs
@@ -1,19 +1,19 @@
 //! Exercise the bitwise operations
 
 // FIXME: This errors today.
-// pub fn shift_u32(a: u32) -> u32 {
-//     let i: usize = 16;
-//     let mut t = a >> i;
-//     t <<= i;
-//     t
-// }
+pub fn shift_u32(a: u32) -> u32 {
+    let i: usize = 16;
+    let mut t = a >> i;
+    t <<= i;
+    t
+}
 
-// pub fn shift_i32(a: i32) -> i32 {
-//     let i: isize = 16;
-//     let mut t = a >> i;
-//     t <<= i;
-//     t
-// }
+pub fn shift_i32(a: i32) -> i32 {
+    let i: isize = 16;
+    let mut t = a >> i;
+    t <<= i;
+    t
+}
 
 pub fn xor_u32(a: u32, b: u32) -> u32 {
     a ^ b

--- a/charon/tests/ui/find-sized-clause.out
+++ b/charon/tests/ui/find-sized-clause.out
@@ -1,0 +1,18 @@
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_predicates.rs:650:13:
+internal error: entered unreachable code: Could not find a clause for parameter:
+- target param: @TraitDecl1<T>
+- available clauses:
+
+- context: test_crate::{impl#0}
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Thread panicked when extracting item `test_crate::{impl#0}`.
+ --> tests/ui/find-sized-clause.rs:5:1
+  |
+5 | impl<T> Trait for Option<T> {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_crate_to_ullbc.rs:284:25:
+Thread panicked when extracting item `test_crate::{impl#0}`.
+error: aborting due to 1 previous error
+
+Error: Charon driver exited with code 101

--- a/charon/tests/ui/find-sized-clause.rs
+++ b/charon/tests/ui/find-sized-clause.rs
@@ -1,0 +1,5 @@
+//@ known-failure
+//@ charon-args=--abort-on-error
+
+trait Trait {}
+impl<T> Trait for Option<T> {}


### PR DESCRIPTION
This improves the logging setup to in particular include timing information for functions annotated with `#[tracing::instrument]`. To get these logs, call charon with `RUSTC_LOG=charon`.