### PR TITLE
Translate additional unsafe MIR operations

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.36"
+let supported_charon_version = "0.1.37"

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -467,8 +467,13 @@ and rvalue =
           together with its state.
        *)
   | Global of global_decl_ref
-      (** Not present in MIR: we introduce it when replacing constant variables
-          in operands in [extract_global_assignments.rs].
+      (** Copy the value of the referenced global.
+          Not present in MIR; introduced in [simplify_constants.rs].
+       *)
+  | GlobalRef of global_decl_ref * ref_kind
+      (** Reference the value of the global. This has type `&T` or `*mut T` depending on desired
+          mutability.
+          Not present in MIR; introduced in [simplify_constants.rs].
        *)
   | Len of place * ty * const_generic option
       (** Length of a memory location. The run-time length of e.g. a vector or a slice is

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -412,7 +412,12 @@ type operand =
     the field 0, etc.).
  *)
 and aggregate_kind =
-  | AggregatedAdt of type_id * variant_id option * generic_args
+  | AggregatedAdt of
+      type_id * variant_id option * field_id option * generic_args
+      (** A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum
+          and the aggregate uses that variant. The `FieldId`, if present, indicates this is a union
+          and the aggregate writes into that field. Otherwise this is a struct.
+       *)
   | AggregatedArray of ty * const_generic
       (** We don't put this with the ADT cas because this is the only built-in type
           with aggregates, and it is a primitive type. In particular, it makes

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -110,7 +110,7 @@ type field_proj_kind =
     language, we thus merge downcasts and field projections.
  *)
 and projection_elem =
-  | Deref  (** Dereference a shared/mutable reference. *)
+  | Deref  (** Dereference a shared/mutable reference or a raw pointer. *)
   | DerefBox
       (** Dereference a boxed value.
           Note that this doesn't exist in MIR where `Deref` is used both for the

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1042,11 +1042,12 @@ and operand_of_json (js : json) : (operand, string) result =
 and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Adt", `List [ x_0; x_1; x_2 ]) ] ->
+    | `Assoc [ ("Adt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
         let* x_0 = type_id_of_json x_0 in
         let* x_1 = option_of_json variant_id_of_json x_1 in
-        let* x_2 = generic_args_of_json x_2 in
-        Ok (AggregatedAdt (x_0, x_1, x_2))
+        let* x_2 = option_of_json field_id_of_json x_2 in
+        let* x_3 = generic_args_of_json x_3 in
+        Ok (AggregatedAdt (x_0, x_1, x_2, x_3))
     | `Assoc [ ("Array", `List [ x_0; x_1 ]) ] ->
         let* x_0 = ty_of_json x_0 in
         let* x_1 = const_generic_of_json x_1 in

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1095,6 +1095,10 @@ and rvalue_of_json (js : json) : (rvalue, string) result =
     | `Assoc [ ("Global", global) ] ->
         let* global = global_decl_ref_of_json global in
         Ok (Global global)
+    | `Assoc [ ("GlobalRef", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = global_decl_ref_of_json x_0 in
+        let* x_1 = ref_kind_of_json x_1 in
+        Ok (GlobalRef (x_0, x_1))
     | `Assoc [ ("Len", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = place_of_json x_0 in
         let* x_1 = ty_of_json x_1 in

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -178,6 +178,14 @@ let rvalue_to_string (env : ('a, 'b) fmt_env) (rv : rvalue) : string =
   | Global global_ref ->
       let generics = generic_args_to_string env global_ref.global_generics in
       "global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
+  | GlobalRef (global_ref, RShared) ->
+      let generics = generic_args_to_string env global_ref.global_generics in
+      "&global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
+  | GlobalRef (global_ref, RMut) ->
+      let generics = generic_args_to_string env global_ref.global_generics in
+      "&raw mut global "
+      ^ global_decl_id_to_string env global_ref.global_id
+      ^ generics
   | Aggregate (akind, ops) -> (
       let ops = List.map (operand_to_string env) ops in
       match akind with

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -189,7 +189,7 @@ let rvalue_to_string (env : ('a, 'b) fmt_env) (rv : rvalue) : string =
   | Aggregate (akind, ops) -> (
       let ops = List.map (operand_to_string env) ops in
       match akind with
-      | AggregatedAdt (type_id, opt_variant_id, _generics) -> (
+      | AggregatedAdt (type_id, opt_variant_id, opt_field_id, _generics) -> (
           match type_id with
           | TTuple -> "(" ^ String.concat ", " ops ^ ")"
           | TAdtId def_id ->
@@ -205,6 +205,13 @@ let rvalue_to_string (env : ('a, 'b) fmt_env) (rv : rvalue) : string =
                 match adt_field_names env def_id opt_variant_id with
                 | None -> "(" ^ String.concat ", " ops ^ ")"
                 | Some field_names ->
+                    let field_names =
+                      match opt_field_id with
+                      | None -> field_names
+                      (* Only keep the selected field *)
+                      | Some field_id ->
+                          [ List.nth field_names (FieldId.to_int field_id) ]
+                    in
                     let fields = List.combine field_names ops in
                     let fields =
                       List.map

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -31,6 +31,7 @@ module Ast = struct
     | StorageDead var_id ->
         indent ^ "storage_dead " ^ var_id_to_string env var_id
     | Deinit p -> indent ^ "deinit " ^ place_to_string env p
+    | StAssert a -> assertion_to_string env indent a
 
   let switch_to_string (indent : string) (tgt : switch) : string =
     match tgt with

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -36,6 +36,7 @@ and raw_statement =
       (** We translate this to [crate::llbc_ast::RawStatement::Drop] in LLBC *)
   | Deinit of place
       (** We translate this to [crate::llbc_ast::RawStatement::Drop] in LLBC *)
+  | StAssert of assertion
 [@@deriving
   show,
     visitors

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -43,6 +43,9 @@ and raw_statement_of_json (js : json) : (raw_statement, string) result =
     | `Assoc [ ("Deinit", deinit) ] ->
         let* deinit = place_of_json deinit in
         Ok (Deinit deinit)
+    | `Assoc [ ("Assert", assert_) ] ->
+        let* assert_ = assertion_of_json assert_ in
+        Ok (StAssert assert_)
     | _ -> Error "")
 
 and switch_of_json (js : json) : (switch, string) result =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#6d493af879767475a269327513208d4a491c6179"
+source = "git+https://github.com/Nadrieril/hax?branch=charon#5199a6307b0e52a6855f8ed25f58540ace97caf8"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#6d493af879767475a269327513208d4a491c6179"
+source = "git+https://github.com/Nadrieril/hax?branch=charon#5199a6307b0e52a6855f8ed25f58540ace97caf8"
 dependencies = [
  "bincode",
  "extension-traits",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?branch=main#6d493af879767475a269327513208d4a491c6179"
+source = "git+https://github.com/Nadrieril/hax?branch=charon#5199a6307b0e52a6855f8ed25f58540ace97caf8"
 dependencies = [
  "bincode",
  "hax-adt-into",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.36"
+version = "0.1.37"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -74,8 +74,8 @@ tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [
 tracing = { version = "0.1", features = [ "max_level_trace", "release_max_level_warn" ] }
 which = "6.0.1"
 
-hax-frontend-exporter = { git = "https://github.com/hacspec/hax", branch = "main", optional = true }
-# hax-frontend-exporter = { git = "https://github.com/Nadrieril/hax", branch = "update-rustc", optional = true }
+# hax-frontend-exporter = { git = "https://github.com/hacspec/hax", branch = "main", optional = true }
+hax-frontend-exporter = { git = "https://github.com/Nadrieril/hax", branch = "charon", optional = true }
 # hax-frontend-exporter = { path = "../../hax/frontend/exporter", optional = true }
 macros = { path = "./macros" }
 

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -413,8 +413,7 @@ pub enum RawConstantExpr {
     /// We eliminate this case in a micro-pass.
     #[charon::opaque]
     Adt(Option<VariantId>, Vec<ConstantExpr>),
-    ///
-    /// The value is a top-level value.
+    /// The value is a top-level constant/static.
     ///
     /// We eliminate this case in a micro-pass.
     ///
@@ -447,12 +446,16 @@ pub enum RawConstantExpr {
     /// Remark: trait constants can not be used in types, they are necessarily
     /// values.
     TraitConst(TraitRef, TraitItemName),
-    ///
-    /// A shared reference to a constant value
+    /// A shared reference to a constant value.
     ///
     /// We eliminate this case in a micro-pass.
     #[charon::opaque]
     Ref(Box<ConstantExpr>),
+    /// A mutable pointer to a mutable static.
+    ///
+    /// We eliminate this case in a micro-pass.
+    #[charon::opaque]
+    MutPtr(Box<ConstantExpr>),
     /// A const generic var
     Var(ConstGenericVarId),
     /// Function pointer
@@ -512,9 +515,13 @@ pub enum Rvalue {
     /// Remark: in case of closures, the aggregated value groups the closure id
     /// together with its state.
     Aggregate(AggregateKind, Vec<Operand>),
-    /// Not present in MIR: we introduce it when replacing constant variables
-    /// in operands in [extract_global_assignments.rs].
+    /// Copy the value of the referenced global.
+    /// Not present in MIR; introduced in [simplify_constants.rs].
     Global(GlobalDeclRef),
+    /// Reference the value of the global. This has type `&T` or `*mut T` depending on desired
+    /// mutability.
+    /// Not present in MIR; introduced in [simplify_constants.rs].
+    GlobalRef(GlobalDeclRef, RefKind),
     /// Length of a memory location. The run-time length of e.g. a vector or a slice is
     /// represented differently (but pretty-prints the same, FIXME).
     /// Should be seen as a function of signature:

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -580,7 +580,10 @@ pub enum Rvalue {
 #[derive(Debug, Clone, VariantIndexArity, Serialize, Deserialize, Drive, DriveMut)]
 #[charon::variants_prefix("Aggregated")]
 pub enum AggregateKind {
-    Adt(TypeId, Option<VariantId>, GenericArgs),
+    /// A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum
+    /// and the aggregate uses that variant. The `FieldId`, if present, indicates this is a union
+    /// and the aggregate writes into that field. Otherwise this is a struct.
+    Adt(TypeId, Option<VariantId>, Option<FieldId>, GenericArgs),
     /// We don't put this with the ADT cas because this is the only built-in type
     /// with aggregates, and it is a primitive type. In particular, it makes
     /// sense to treat it differently because it has a variable number of fields.

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -40,7 +40,7 @@ pub type Projection = Vec<ProjectionElem>;
     DriveMut,
 )]
 pub enum ProjectionElem {
-    /// Dereference a shared/mutable reference.
+    /// Dereference a shared/mutable reference or a raw pointer.
     Deref,
     /// Dereference a boxed value.
     /// Note that this doesn't exist in MIR where `Deref` is used both for the
@@ -49,12 +49,6 @@ pub enum ProjectionElem {
     /// during the translation.
     /// In rust, this comes from the `*` operator applied on boxes.
     DerefBox,
-    /// Dereference a raw pointer. See the comments for [crate::types::Ty::RawPtr].
-    /// TODO: remove those (we would also need: `DerefPtrUnique`, `DerefPtrNonNull`, etc.)
-    /// and only keep a single `Deref` variant?
-    /// Or if we keep them, change to: `Deref(DerefKind)`?
-    #[charon::opaque]
-    DerefRawPtr,
     /// Projection from ADTs (variants, structures).
     /// We allow projections to be used as left-values and right-values.
     /// We should never have projections to fields of symbolic variants (they

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -29,6 +29,8 @@ pub enum RawStatement {
     StorageDead(VarId),
     /// We translate this to [crate::llbc_ast::RawStatement::Drop] in LLBC
     Deinit(Place),
+    #[charon::rename("StAssert")]
+    Assert(Assert),
     #[charon::opaque]
     Error(String),
 }

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -126,8 +126,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let be = self.translate_constant_expr_to_constant_expr(span, be)?;
                 RawConstantExpr::Ref(Box::new(be))
             }
-            ConstantExprKind::MutPtr(_) => {
-                todo!()
+            ConstantExprKind::MutPtr(be) => {
+                let be = self.translate_constant_expr_to_constant_expr(span, be)?;
+                RawConstantExpr::MutPtr(Box::new(be))
             }
             ConstantExprKind::ConstRef { id } => {
                 let var_id = self.const_generic_vars_map.get(&id.index);
@@ -199,6 +200,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             RawConstantExpr::Adt(..)
             | RawConstantExpr::TraitConst { .. }
             | RawConstantExpr::Ref(_)
+            | RawConstantExpr::MutPtr(_)
             | RawConstantExpr::FnPtr { .. } => {
                 error_or_panic!(
                     self,

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -126,6 +126,9 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let be = self.translate_constant_expr_to_constant_expr(span, be)?;
                 RawConstantExpr::Ref(Box::new(be))
             }
+            ConstantExprKind::MutPtr(_) => {
+                todo!()
+            }
             ConstantExprKind::ConstRef { id } => {
                 let var_id = self.const_generic_vars_map.get(&id.index);
                 if let Some(var_id) = var_id {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -310,7 +310,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     hax::ProjectionElem::Deref => {
                         // We use the type to disambiguate
                         match current_ty {
-                            Ty::Ref(_, _, _) => {
+                            Ty::Ref(_, _, _) | Ty::RawPtr(_, _) => {
                                 projection.push(ProjectionElem::Deref);
                             }
                             Ty::Adt(TypeId::Builtin(BuiltinTy::Box), generics) => {
@@ -320,9 +320,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                                 assert!(generics.types.len() == 1);
                                 assert!(generics.const_generics.is_empty());
                                 projection.push(ProjectionElem::DerefBox);
-                            }
-                            Ty::RawPtr(_, _) => {
-                                projection.push(ProjectionElem::DerefRawPtr);
                             }
                             _ => {
                                 unreachable!(

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -99,8 +99,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let erase_regions = false;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
+        if let hax::FullDefKind::TraitAlias { .. } = def.kind() {
+            error_or_panic!(self, span, &format!("Trait aliases are not supported"));
+        }
+
         let hax::FullDefKind::Trait { items, .. } = &def.kind else {
-            panic!("Unexpected definition: {def:?}")
+            error_or_panic!(self, span, &format!("Unexpected definition: {def:?}"));
         };
         let items: Vec<(TraitItemName, &hax::AssocItem, Option<Arc<hax::FullDef>>)> = items
             .iter()

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -819,6 +819,9 @@ impl<C: AstFormatter> FmtWithCtx<C> for RawConstantExpr {
             RawConstantExpr::Ref(cv) => {
                 format!("&{}", cv.fmt_with_ctx(ctx))
             }
+            RawConstantExpr::MutPtr(cv) => {
+                format!("&raw mut {}", cv.fmt_with_ctx(ctx))
+            }
             RawConstantExpr::Var(id) => format!("{}", ctx.format_object(*id)),
             RawConstantExpr::FnPtr(f) => {
                 format!("{}", f.fmt_with_ctx(ctx),)
@@ -915,6 +918,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                 }
             }
             Rvalue::Global(global_ref) => global_ref.fmt_with_ctx(ctx),
+            Rvalue::GlobalRef(global_ref, RefKind::Shared) => {
+                format!("&{}", global_ref.fmt_with_ctx(ctx))
+            }
+            Rvalue::GlobalRef(global_ref, RefKind::Mut) => {
+                format!("&raw mut {}", global_ref.fmt_with_ctx(ctx))
+            }
             Rvalue::Len(place, ..) => format!("len({})", place.fmt_with_ctx(ctx)),
             Rvalue::Repeat(op, _ty, cg) => {
                 format!("[{}; {}]", op.fmt_with_ctx(ctx), cg.fmt_with_ctx(ctx))

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -740,9 +740,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for Place {
                 ProjectionElem::DerefBox => {
                     out = format!("deref_box ({out})");
                 }
-                ProjectionElem::DerefRawPtr => {
-                    out = format!("deref_raw_ptr ({out})");
-                }
                 ProjectionElem::Field(proj_kind, field_id) => match proj_kind {
                     FieldProjKind::Adt(adt_id, opt_variant_id) => {
                         let field_name = ctx.format_object((*adt_id, *opt_variant_id, *field_id));

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -878,7 +878,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
             Rvalue::Aggregate(kind, ops) => {
                 let ops_s: Vec<String> = ops.iter().map(|op| op.fmt_with_ctx(ctx)).collect();
                 match kind {
-                    AggregateKind::Adt(def_id, variant_id, _) => {
+                    AggregateKind::Adt(def_id, variant_id, field_id, _) => {
                         match def_id {
                             TypeId::Tuple => format!("({})", ops_s.join(", ")),
                             TypeId::Builtin(_) => unreachable!(),
@@ -886,7 +886,13 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                                 // Format every field
                                 let mut fields = vec![];
                                 for (i, op) in ops.iter().enumerate() {
-                                    let field_id = FieldId::new(i);
+                                    let field_id = match *field_id {
+                                        None => FieldId::new(i),
+                                        Some(field_id) => {
+                                            assert_eq!(i, 0); // there should be only one operand
+                                            field_id
+                                        }
+                                    };
                                     let field_name =
                                         ctx.format_object((*def_id, *variant_id, field_id));
                                     fields.push(format!(

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -968,6 +968,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for ullbc::Statement {
             RawStatement::Deinit(place) => {
                 format!("@deinit({})", place.fmt_with_ctx(ctx))
             }
+            RawStatement::Assert(assert) => format!("{}", assert.fmt_with_ctx(ctx)),
             RawStatement::Error(s) => {
                 format!("@Error({})", s)
             }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -512,7 +512,7 @@ impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
                                 None => field_id.to_string(),
                             }
                         }
-                        (TypeDeclKind::Struct(fields), None) => {
+                        (TypeDeclKind::Struct(fields) | TypeDeclKind::Union(fields), None) => {
                             let field = fields.get(field_id).unwrap();
                             match &field.name {
                                 Some(name) => name.clone(),

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -74,7 +74,7 @@ impl CheckGenericsVisitor<'_, '_> {
 impl CheckGenericsVisitor<'_, '_> {
     fn enter_aggregate_kind(&mut self, agg: &AggregateKind) {
         match agg {
-            AggregateKind::Adt(kind, _, args) => {
+            AggregateKind::Adt(kind, _, _, args) => {
                 self.check_typeid_generics(args, kind);
             }
             AggregateKind::Closure(id, args) => {

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -224,7 +224,7 @@ impl<'a> Visitor<'a> {
         use Rvalue::*;
         match rv {
             Use(_) | NullaryOp(..) | UnaryOp(..) | BinaryOp(..) | Aggregate(..) | Global(..)
-            | Repeat(..) | ShallowInitBox(..) => {}
+            | GlobalRef(..) | Repeat(..) | ShallowInitBox(..) => {}
             RawPtr(_, ptrkind) => match *ptrkind {
                 RefKind::Mut => {
                     self.place_mutability_stack.push(true);

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -16,7 +16,7 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
             projection: Projection::new(),
         };
         let unit_value = Rvalue::Aggregate(
-            AggregateKind::Adt(TypeId::Tuple, None, GenericArgs::empty()),
+            AggregateKind::Adt(TypeId::Tuple, None, None, GenericArgs::empty()),
             Vec::new(),
         );
         let assign_st = Statement::new(st.span, RawStatement::Assign(ret_place, unit_value));

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1463,6 +1463,7 @@ fn translate_statement(st: &src::Statement) -> Option<tgt::Statement> {
         src::RawStatement::StorageDead(var_id) => tgt::RawStatement::Drop(Place::new(var_id)),
         // We translate a deinit as a drop
         src::RawStatement::Deinit(place) => tgt::RawStatement::Drop(place),
+        src::RawStatement::Assert(assert) => tgt::RawStatement::Assert(assert),
         src::RawStatement::Error(s) => tgt::RawStatement::Error(s),
     };
     Some(tgt::Statement::new(src_span, st))

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1453,24 +1453,17 @@ fn opt_statement_to_nop_if_none(span: Span, opt_st: Option<tgt::Statement>) -> t
 
 fn translate_statement(st: &src::Statement) -> Option<tgt::Statement> {
     let src_span = st.span;
-    let st = match &st.content {
-        src::RawStatement::Assign(place, rvalue) => {
-            tgt::RawStatement::Assign(place.clone(), rvalue.clone())
-        }
-        src::RawStatement::FakeRead(place) => tgt::RawStatement::FakeRead(place.clone()),
+    let st = match st.content.clone() {
+        src::RawStatement::Assign(place, rvalue) => tgt::RawStatement::Assign(place, rvalue),
+        src::RawStatement::FakeRead(place) => tgt::RawStatement::FakeRead(place),
         src::RawStatement::SetDiscriminant(place, variant_id) => {
-            tgt::RawStatement::SetDiscriminant(place.clone(), *variant_id)
+            tgt::RawStatement::SetDiscriminant(place, variant_id)
         }
-        src::RawStatement::StorageDead(var_id) => {
-            // We translate a StorageDead as a drop
-            let place = Place::new(*var_id);
-            tgt::RawStatement::Drop(place)
-        }
-        src::RawStatement::Deinit(place) => {
-            // We translate a deinit as a drop
-            tgt::RawStatement::Drop(place.clone())
-        }
-        src::RawStatement::Error(s) => tgt::RawStatement::Error(s.clone()),
+        // We translate a StorageDead as a drop
+        src::RawStatement::StorageDead(var_id) => tgt::RawStatement::Drop(Place::new(var_id)),
+        // We translate a deinit as a drop
+        src::RawStatement::Deinit(place) => tgt::RawStatement::Drop(place),
+        src::RawStatement::Error(s) => tgt::RawStatement::Error(s),
     };
     Some(tgt::Statement::new(src_span, st))
 }

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -247,14 +247,10 @@ global test_crate::S2  {
     let @0: u32; // return
     let @1: u32; // anonymous local
     let @2: &'_ (u32); // anonymous local
-    let @3: u32; // anonymous local
-    let @4: u32; // anonymous local
-    let @5: &'_ (u32); // anonymous local
+    let @3: &'_ (u32); // anonymous local
 
-    @3 := test_crate::S1
-    @4 := move (@3)
-    @5 := &@4
-    @2 := move (@5)
+    @3 := &test_crate::S1
+    @2 := move (@3)
     @1 := copy (*(@2))
     @0 := test_crate::incr(move (@1))
     drop @2

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -1,9 +1,138 @@
-error: Unsupported statement kind: intrinsic
-  --> tests/ui/issue-91-enum-to-discriminant-cast.rs:16:13
-   |
-16 |     let _ = x as isize;
-   |             ^^^^^^^^^^
+# Final LLBC before serialization:
 
-error: aborting due to 1 previous error
+enum test_crate::Foo =
+|  A()
+|  B()
 
-Error: Charon driver exited with code 101
+
+trait core::clone::Clone<Self>
+{
+    fn clone : core::clone::Clone::clone
+    fn clone_from : core::clone::Clone::clone_from
+}
+
+trait core::marker::Copy<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::clone::Clone<Self>
+}
+
+fn test_crate::{impl core::clone::Clone for test_crate::Foo}#1::clone<'_0>(@1: &'_0 (test_crate::Foo)) -> test_crate::Foo
+{
+    let @0: test_crate::Foo; // return
+    let self@1: &'_ (test_crate::Foo); // arg #1
+
+    @0 := copy (*(self@1))
+    return
+}
+
+impl test_crate::{impl core::clone::Clone for test_crate::Foo}#1 : core::clone::Clone<test_crate::Foo>
+{
+    fn clone = test_crate::{impl core::clone::Clone for test_crate::Foo}#1::clone
+}
+
+impl test_crate::{impl core::marker::Copy for test_crate::Foo} : core::marker::Copy<test_crate::Foo>
+{
+    parent_clause0 = test_crate::{impl core::clone::Clone for test_crate::Foo}#1
+}
+
+enum test_crate::Ordering =
+|  Less()
+|  Equal()
+|  Greater()
+
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let x@1: test_crate::Foo; // local
+    let @2: isize; // anonymous local
+    let @3: test_crate::Foo; // anonymous local
+    let @4: isize; // anonymous local
+    let @5: u8; // anonymous local
+    let @6: bool; // anonymous local
+    let @7: u8; // anonymous local
+    let @8: test_crate::Foo; // anonymous local
+    let @9: isize; // anonymous local
+    let @10: u8; // anonymous local
+    let @11: bool; // anonymous local
+    let x@12: test_crate::Ordering; // local
+    let @13: isize; // anonymous local
+    let @14: test_crate::Ordering; // anonymous local
+    let @15: isize; // anonymous local
+    let @16: u8; // anonymous local
+    let @17: bool; // anonymous local
+    let @18: bool; // anonymous local
+    let @19: bool; // anonymous local
+    let @20: (); // anonymous local
+
+    x@1 := test_crate::Foo::A {  }
+    @fake_read(x@1)
+    @3 := copy (x@1)
+    match @3 {
+        0 => {
+            @4 := const (0 : isize)
+        },
+        1 => {
+            @4 := const (1 : isize)
+        }
+    }
+    @5 := cast<isize, u8>(copy (@4))
+    @6 := copy (@5) <= const (1 : u8)
+    assert(move (@6) == true)
+    @2 := cast<isize, isize>(move (@4))
+    drop @3
+    @fake_read(@2)
+    drop @2
+    @8 := copy (x@1)
+    match @8 {
+        0 => {
+            @9 := const (0 : isize)
+        },
+        1 => {
+            @9 := const (1 : isize)
+        }
+    }
+    @10 := cast<isize, u8>(copy (@9))
+    @11 := copy (@10) <= const (1 : u8)
+    assert(move (@11) == true)
+    @7 := cast<isize, u8>(move (@9))
+    drop @8
+    @fake_read(@7)
+    drop @7
+    x@12 := test_crate::Ordering::Greater {  }
+    @fake_read(x@12)
+    @14 := move (x@12)
+    match @14 {
+        0 => {
+            @15 := const (-1 : isize)
+        },
+        1 => {
+            @15 := const (0 : isize)
+        },
+        2 => {
+            @15 := const (1 : isize)
+        }
+    }
+    @16 := cast<isize, u8>(copy (@15))
+    @17 := copy (@16) >= const (255 : u8)
+    @18 := copy (@16) <= const (1 : u8)
+    @19 := move (@17) | move (@18)
+    assert(move (@19) == true)
+    @13 := cast<isize, isize>(move (@15))
+    drop @14
+    @fake_read(@13)
+    drop @13
+    @20 := ()
+    @0 := move (@20)
+    drop x@12
+    drop x@1
+    @0 := ()
+    return
+}
+
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+
+

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.rs
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 #[derive(Copy, Clone)]
 enum Foo {
     A,

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -56,29 +56,93 @@ fn test_crate::shared_static()
     let @2: &'_ (usize); // anonymous local
     let _ref@3: &'_ (usize); // local
     let @4: &'_ (usize); // anonymous local
-    let @5: usize; // anonymous local
-    let @6: usize; // anonymous local
+    let _ptr@5: *const usize; // local
+    let @6: &'_ (usize); // anonymous local
     let @7: &'_ (usize); // anonymous local
-    let @8: usize; // anonymous local
-    let @9: usize; // anonymous local
-    let @10: &'_ (usize); // anonymous local
-    let @11: (); // anonymous local
+    let @8: &'_ (usize); // anonymous local
+    let @9: &'_ (usize); // anonymous local
+    let @10: (); // anonymous local
 
-    @5 := test_crate::shared_static::SHARED_STATIC
-    @6 := move (@5)
-    @7 := &@6
+    @7 := &test_crate::shared_static::SHARED_STATIC
     @2 := move (@7)
     _val@1 := copy (*(@2))
     @fake_read(_val@1)
     drop @2
-    @8 := test_crate::shared_static::SHARED_STATIC
-    @9 := move (@8)
-    @10 := &@9
-    @4 := move (@10)
+    @8 := &test_crate::shared_static::SHARED_STATIC
+    @4 := move (@8)
     _ref@3 := &*(@4)
     @fake_read(_ref@3)
-    @11 := ()
-    @0 := move (@11)
+    @9 := &test_crate::shared_static::SHARED_STATIC
+    @6 := move (@9)
+    _ptr@5 := &raw const *(@6)
+    @fake_read(_ptr@5)
+    @10 := ()
+    @0 := move (@10)
+    drop @6
+    drop _ptr@5
+    drop @4
+    drop _ref@3
+    drop _val@1
+    @0 := ()
+    return
+}
+
+global test_crate::mut_static::MUT_STATIC  {
+    let @0: usize; // return
+
+    @0 := const (0 : usize)
+    return
+}
+
+fn test_crate::mut_static()
+{
+    let @0: (); // return
+    let _val@1: usize; // local
+    let @2: *mut usize; // anonymous local
+    let _ref@3: &'_ (usize); // local
+    let @4: *mut usize; // anonymous local
+    let _ref_mut@5: &'_ mut (usize); // local
+    let @6: *mut usize; // anonymous local
+    let _ptr@7: *const usize; // local
+    let @8: *mut usize; // anonymous local
+    let _ptr_mut@9: *mut usize; // local
+    let @10: *mut usize; // anonymous local
+    let @11: *mut usize; // anonymous local
+    let @12: *mut usize; // anonymous local
+    let @13: *mut usize; // anonymous local
+    let @14: *mut usize; // anonymous local
+    let @15: *mut usize; // anonymous local
+    let @16: (); // anonymous local
+
+    @11 := &raw mut test_crate::mut_static::MUT_STATIC
+    @2 := move (@11)
+    _val@1 := copy (*(@2))
+    @fake_read(_val@1)
+    drop @2
+    @12 := &raw mut test_crate::mut_static::MUT_STATIC
+    @4 := move (@12)
+    _ref@3 := &*(@4)
+    @fake_read(_ref@3)
+    @13 := &raw mut test_crate::mut_static::MUT_STATIC
+    @6 := move (@13)
+    _ref_mut@5 := &mut *(@6)
+    @fake_read(_ref_mut@5)
+    @14 := &raw mut test_crate::mut_static::MUT_STATIC
+    @8 := move (@14)
+    _ptr@7 := &raw const *(@8)
+    @fake_read(_ptr@7)
+    @15 := &raw mut test_crate::mut_static::MUT_STATIC
+    @10 := move (@15)
+    _ptr_mut@9 := &raw mut *(@10)
+    @fake_read(_ptr_mut@9)
+    @16 := ()
+    @0 := move (@16)
+    drop @10
+    drop _ptr_mut@9
+    drop @8
+    drop _ptr@7
+    drop @6
+    drop _ref_mut@5
     drop @4
     drop _ref@3
     drop _val@1
@@ -112,14 +176,10 @@ fn test_crate::non_copy_static()
     let @0: (); // return
     let @1: &'_ (test_crate::non_copy_static::Foo); // anonymous local
     let @2: &'_ (test_crate::non_copy_static::Foo); // anonymous local
-    let @3: test_crate::non_copy_static::Foo; // anonymous local
-    let @4: test_crate::non_copy_static::Foo; // anonymous local
-    let @5: &'_ (test_crate::non_copy_static::Foo); // anonymous local
+    let @3: &'_ (test_crate::non_copy_static::Foo); // anonymous local
 
-    @3 := test_crate::non_copy_static::FOO
-    @4 := move (@3)
-    @5 := &@4
-    @2 := move (@5)
+    @3 := &test_crate::non_copy_static::FOO
+    @2 := move (@3)
     @1 := &*(@2)
     @0 := test_crate::non_copy_static::{test_crate::non_copy_static::Foo}::method(move (@1))
     drop @1

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -1,0 +1,132 @@
+# Final LLBC before serialization:
+
+global test_crate::constant::CONST  {
+    let @0: usize; // return
+
+    @0 := const (0 : usize)
+    return
+}
+
+fn test_crate::constant()
+{
+    let @0: (); // return
+    let _val@1: usize; // local
+    let _ref@2: &'_ (usize); // local
+    let @3: usize; // anonymous local
+    let _ref_mut@4: &'_ mut (usize); // local
+    let @5: usize; // anonymous local
+    let @6: usize; // anonymous local
+    let @7: usize; // anonymous local
+    let @8: usize; // anonymous local
+    let @9: (); // anonymous local
+
+    @6 := test_crate::constant::CONST
+    _val@1 := move (@6)
+    @fake_read(_val@1)
+    @7 := test_crate::constant::CONST
+    @3 := move (@7)
+    _ref@2 := &@3
+    @fake_read(_ref@2)
+    @8 := test_crate::constant::CONST
+    @5 := move (@8)
+    _ref_mut@4 := &mut @5
+    @fake_read(_ref_mut@4)
+    @9 := ()
+    @0 := move (@9)
+    drop @5
+    drop _ref_mut@4
+    drop @3
+    drop _ref@2
+    drop _val@1
+    @0 := ()
+    return
+}
+
+global test_crate::shared_static::SHARED_STATIC  {
+    let @0: usize; // return
+
+    @0 := const (0 : usize)
+    return
+}
+
+fn test_crate::shared_static()
+{
+    let @0: (); // return
+    let _val@1: usize; // local
+    let @2: &'_ (usize); // anonymous local
+    let _ref@3: &'_ (usize); // local
+    let @4: &'_ (usize); // anonymous local
+    let @5: usize; // anonymous local
+    let @6: usize; // anonymous local
+    let @7: &'_ (usize); // anonymous local
+    let @8: usize; // anonymous local
+    let @9: usize; // anonymous local
+    let @10: &'_ (usize); // anonymous local
+    let @11: (); // anonymous local
+
+    @5 := test_crate::shared_static::SHARED_STATIC
+    @6 := move (@5)
+    @7 := &@6
+    @2 := move (@7)
+    _val@1 := copy (*(@2))
+    @fake_read(_val@1)
+    drop @2
+    @8 := test_crate::shared_static::SHARED_STATIC
+    @9 := move (@8)
+    @10 := &@9
+    @4 := move (@10)
+    _ref@3 := &*(@4)
+    @fake_read(_ref@3)
+    @11 := ()
+    @0 := move (@11)
+    drop @4
+    drop _ref@3
+    drop _val@1
+    @0 := ()
+    return
+}
+
+struct test_crate::non_copy_static::Foo = {}
+
+global test_crate::non_copy_static::FOO  {
+    let @0: test_crate::non_copy_static::Foo; // return
+
+    @0 := test_crate::non_copy_static::Foo {  }
+    return
+}
+
+fn test_crate::non_copy_static::{test_crate::non_copy_static::Foo}::method<'_0>(@1: &'_0 (test_crate::non_copy_static::Foo))
+{
+    let @0: (); // return
+    let self@1: &'_ (test_crate::non_copy_static::Foo); // arg #1
+    let @2: (); // anonymous local
+
+    @2 := ()
+    @0 := move (@2)
+    @0 := ()
+    return
+}
+
+fn test_crate::non_copy_static()
+{
+    let @0: (); // return
+    let @1: &'_ (test_crate::non_copy_static::Foo); // anonymous local
+    let @2: &'_ (test_crate::non_copy_static::Foo); // anonymous local
+    let @3: test_crate::non_copy_static::Foo; // anonymous local
+    let @4: test_crate::non_copy_static::Foo; // anonymous local
+    let @5: &'_ (test_crate::non_copy_static::Foo); // anonymous local
+
+    @3 := test_crate::non_copy_static::FOO
+    @4 := move (@3)
+    @5 := &@4
+    @2 := move (@5)
+    @1 := &*(@2)
+    @0 := test_crate::non_copy_static::{test_crate::non_copy_static::Foo}::method(move (@1))
+    drop @1
+    drop @2
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/statics.rs
+++ b/charon/tests/ui/statics.rs
@@ -1,0 +1,39 @@
+#![feature(raw_ref_op)]
+
+fn constant() {
+    const CONST: usize = 0;
+
+    let _val = CONST;
+    let _ref = &CONST;
+    let _ref_mut = &mut CONST;
+}
+
+fn shared_static() {
+    static SHARED_STATIC: usize = 0;
+
+    let _val = SHARED_STATIC;
+    let _ref = &SHARED_STATIC;
+    // let _ptr = &raw const SHARED_STATIC;
+}
+
+// fn mut_static() {
+//     static mut MUT_STATIC: usize = 0;
+
+//     unsafe {
+//         let _val = MUT_STATIC;
+//         let _ref = &MUT_STATIC;
+//         let _ref_mut = &mut MUT_STATIC;
+//         let _ptr = &raw const MUT_STATIC;
+//         let _ptr_mut = &raw mut MUT_STATIC;
+//     }
+// }
+
+fn non_copy_static() {
+    struct Foo;
+    impl Foo {
+        fn method(&self) {}
+    }
+
+    static FOO: Foo = Foo;
+    FOO.method()
+}

--- a/charon/tests/ui/statics.rs
+++ b/charon/tests/ui/statics.rs
@@ -13,20 +13,20 @@ fn shared_static() {
 
     let _val = SHARED_STATIC;
     let _ref = &SHARED_STATIC;
-    // let _ptr = &raw const SHARED_STATIC;
+    let _ptr = &raw const SHARED_STATIC;
 }
 
-// fn mut_static() {
-//     static mut MUT_STATIC: usize = 0;
+fn mut_static() {
+    static mut MUT_STATIC: usize = 0;
 
-//     unsafe {
-//         let _val = MUT_STATIC;
-//         let _ref = &MUT_STATIC;
-//         let _ref_mut = &mut MUT_STATIC;
-//         let _ptr = &raw const MUT_STATIC;
-//         let _ptr_mut = &raw mut MUT_STATIC;
-//     }
-// }
+    unsafe {
+        let _val = MUT_STATIC;
+        let _ref = &MUT_STATIC;
+        let _ref_mut = &mut MUT_STATIC;
+        let _ptr = &raw const MUT_STATIC;
+        let _ptr_mut = &raw mut MUT_STATIC;
+    }
+}
 
 fn non_copy_static() {
     struct Foo;

--- a/charon/tests/ui/unions.out
+++ b/charon/tests/ui/unions.out
@@ -1,0 +1,35 @@
+# Final LLBC before serialization:
+
+union test_crate::Foo =
+{
+  one: u64,
+  two: Array<u32, 2 : usize>,
+}
+
+fn test_crate::use_union()
+{
+    let @0: (); // return
+    let one@1: test_crate::Foo; // local
+    let @2: (); // anonymous local
+    let _two@3: Array<u32, 2 : usize>; // local
+    let @4: (); // anonymous local
+    let @5: (); // anonymous local
+
+    one@1 := test_crate::Foo { one: const (42 : u64) }
+    @fake_read(one@1)
+    (one@1).one := const (43 : u64)
+    @4 := ()
+    @2 := move (@4)
+    drop @2
+    _two@3 := copy ((one@1).two)
+    @fake_read(_two@3)
+    @5 := ()
+    @0 := move (@5)
+    drop _two@3
+    drop one@1
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/unions.rs
+++ b/charon/tests/ui/unions.rs
@@ -1,6 +1,3 @@
-//@ known-failure
-//@ no-check-output
-
 union Foo {
     one: u64,
     two: [u32; 2],

--- a/charon/tests/ui/unions.rs
+++ b/charon/tests/ui/unions.rs
@@ -7,6 +7,9 @@ union Foo {
 }
 
 fn use_union() {
-    let one = Foo { one: 42 };
+    let mut one = Foo { one: 42 };
+    unsafe {
+        one.one = 43;
+    }
     let _two = unsafe { one.two };
 }

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -100,5 +100,16 @@ fn test_crate::access_union_field()
     return
 }
 
+unsafe fn core::intrinsics::assume(@1: bool)
+
+fn test_crate::assume()
+{
+    let @0: (); // return
+
+    @0 := core::intrinsics::assume(const (true))
+    @0 := ()
+    return
+}
+
 
 

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -75,5 +75,30 @@ fn test_crate::access_mutable_static()
     return
 }
 
+union test_crate::Foo =
+{
+  one: u64,
+  two: Array<u32, 2 : usize>,
+}
+
+fn test_crate::access_union_field()
+{
+    let @0: (); // return
+    let one@1: test_crate::Foo; // local
+    let _two@2: Array<u32, 2 : usize>; // local
+    let @3: (); // anonymous local
+
+    one@1 := test_crate::Foo { one: const (42 : u64) }
+    @fake_read(one@1)
+    _two@2 := copy ((one@1).two)
+    @fake_read(_two@2)
+    @3 := ()
+    @0 := move (@3)
+    drop _two@2
+    drop one@1
+    @0 := ()
+    return
+}
+
 
 

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -1,0 +1,55 @@
+# Final LLBC before serialization:
+
+fn core::ptr::null<T>() -> *const T
+where
+    [@TraitClause0]: @TraitDecl1<T>,
+
+unsafe fn core::ptr::const_ptr::{*const T}::read<T>(@1: *const T) -> T
+
+fn test_crate::call_unsafe_fn()
+{
+    let @0: (); // return
+    let x@1: *const u32; // local
+    let @2: u32; // anonymous local
+    let @3: *const u32; // anonymous local
+    let @4: (); // anonymous local
+
+    x@1 := core::ptr::null<u32>[@TraitDecl1<u32>]()
+    @fake_read(x@1)
+    @3 := copy (x@1)
+    @2 := core::ptr::const_ptr::{*const T}::read<u32>(move (@3))
+    drop @3
+    @fake_read(@2)
+    drop @2
+    @4 := ()
+    @0 := move (@4)
+    drop x@1
+    @0 := ()
+    return
+}
+
+fn test_crate::deref_raw_ptr()
+{
+    let @0: (); // return
+    let x@1: *const u32; // local
+    let @2: u32; // anonymous local
+    let @3: (); // anonymous local
+
+    x@1 := core::ptr::null<u32>[@TraitDecl1<u32>]()
+    @fake_read(x@1)
+    @2 := copy (*(x@1))
+    @fake_read(@2)
+    drop @2
+    @3 := ()
+    @0 := move (@3)
+    drop x@1
+    @0 := ()
+    return
+}
+
+trait test_crate::Trait<Self>
+
+impl test_crate::{impl test_crate::Trait for ()} : test_crate::Trait<()>
+
+
+

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -51,5 +51,29 @@ trait test_crate::Trait<Self>
 
 impl test_crate::{impl test_crate::Trait for ()} : test_crate::Trait<()>
 
+global test_crate::COUNTER  {
+    let @0: usize; // return
+
+    @0 := const (0 : usize)
+    return
+}
+
+fn test_crate::access_mutable_static()
+{
+    let @0: (); // return
+    let @1: *mut usize; // anonymous local
+    let @2: *mut usize; // anonymous local
+    let @3: (); // anonymous local
+
+    @2 := &raw mut test_crate::COUNTER
+    @1 := move (@2)
+    *(@1) := copy (*(@1)) + const (1 : usize)
+    drop @1
+    @3 := ()
+    @0 := move (@3)
+    @0 := ()
+    return
+}
+
 
 

--- a/charon/tests/ui/unsafe.rs
+++ b/charon/tests/ui/unsafe.rs
@@ -34,3 +34,7 @@ fn access_union_field() {
     let one = Foo { one: 42 };
     let _two = unsafe { one.two };
 }
+
+fn assume() {
+    std::intrinsics::assume(true)
+}

--- a/charon/tests/ui/unsafe.rs
+++ b/charon/tests/ui/unsafe.rs
@@ -17,13 +17,13 @@ unsafe trait Trait {}
 
 unsafe impl Trait for () {}
 
-// static mut COUNTER: usize = 0;
+static mut COUNTER: usize = 0;
 
-// fn access_mutable_static() {
-//     unsafe {
-//         COUNTER += 1;
-//     }
-// }
+fn access_mutable_static() {
+    unsafe {
+        COUNTER += 1;
+    }
+}
 
 // union Foo {
 //     one: u64,

--- a/charon/tests/ui/unsafe.rs
+++ b/charon/tests/ui/unsafe.rs
@@ -1,7 +1,15 @@
 //@ known-failure
 //@ no-check-output
 
-fn foo() {
+//! The 5 "unsafe superpowers" (https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#unsafe-superpowers).
+#![feature(raw_ref_op)]
+
+fn call_unsafe_fn() {
+    let x: *const _ = std::ptr::null::<u32>();
+    let _ = unsafe { x.read() };
+}
+
+fn deref_raw_ptr() {
     let x: *const _ = std::ptr::null::<u32>();
     let _ = unsafe { *x };
 }
@@ -12,8 +20,18 @@ unsafe impl Trait for () {}
 
 static mut COUNTER: usize = 0;
 
-fn increment() {
+fn access_mutable_static() {
     unsafe {
         COUNTER += 1;
     }
+}
+
+union Foo {
+    one: u64,
+    two: [u32; 2],
+}
+
+fn access_union_field() {
+    let one = Foo { one: 42 };
+    let _two = unsafe { one.two };
 }

--- a/charon/tests/ui/unsafe.rs
+++ b/charon/tests/ui/unsafe.rs
@@ -25,12 +25,12 @@ fn access_mutable_static() {
     }
 }
 
-// union Foo {
-//     one: u64,
-//     two: [u32; 2],
-// }
+union Foo {
+    one: u64,
+    two: [u32; 2],
+}
 
-// fn access_union_field() {
-//     let one = Foo { one: 42 };
-//     let _two = unsafe { one.two };
-// }
+fn access_union_field() {
+    let one = Foo { one: 42 };
+    let _two = unsafe { one.two };
+}

--- a/charon/tests/ui/unsafe.rs
+++ b/charon/tests/ui/unsafe.rs
@@ -1,5 +1,4 @@
-//@ known-failure
-//@ no-check-output
+//@ charon-args=--exclude=core::ptr::metadata::Thin
 
 //! The 5 "unsafe superpowers" (https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#unsafe-superpowers).
 #![feature(raw_ref_op)]
@@ -18,20 +17,20 @@ unsafe trait Trait {}
 
 unsafe impl Trait for () {}
 
-static mut COUNTER: usize = 0;
+// static mut COUNTER: usize = 0;
 
-fn access_mutable_static() {
-    unsafe {
-        COUNTER += 1;
-    }
-}
+// fn access_mutable_static() {
+//     unsafe {
+//         COUNTER += 1;
+//     }
+// }
 
-union Foo {
-    one: u64,
-    two: [u32; 2],
-}
+// union Foo {
+//     one: u64,
+//     two: [u32; 2],
+// }
 
-fn access_union_field() {
-    let one = Foo { one: 42 };
-    let _two = unsafe { one.two };
-}
+// fn access_union_field() {
+//     let one = Foo { one: 42 };
+//     let _two = unsafe { one.two };
+// }


### PR DESCRIPTION
Fixes #280, fixes #91, fixes #335.

This required updates to `hax`. Since @W95Psp is on vacation, I will use my own `hax` fork in Charon until these changes can be merged upstream.