### PR TITLE
Simplify code generation and visitors

### DIFF
--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -72,24 +72,18 @@ and abort_kind =
        *)
 [@@deriving show, ord]
 
-(** Ancestor the field_proj_kind iter visitor *)
+(* Ancestors for the place visitors *)
 class ['self] iter_place_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.iter
-    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
+  object (self : 'self)
+    inherit [_] iter_ty
     method visit_var_id : 'env -> var_id -> unit = fun _ _ -> ()
     method visit_variant_id : 'env -> variant_id -> unit = fun _ _ -> ()
     method visit_field_id : 'env -> field_id -> unit = fun _ _ -> ()
   end
 
-(** Ancestor the field_proj_kind map visitor *)
 class ['self] map_place_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.map
-
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
-      fun _ x -> x
-
+  object (self : 'self)
+    inherit [_] map_ty
     method visit_var_id : 'env -> var_id -> var_id = fun _ x -> x
     method visit_variant_id : 'env -> variant_id -> variant_id = fun _ x -> x
     method visit_field_id : 'env -> field_id -> field_id = fun _ x -> x
@@ -129,16 +123,14 @@ and field_proj_kind =
         name = "iter_place";
         variety = "iter";
         ancestors = [ "iter_place_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_place";
         variety = "map";
         ancestors = [ "map_place_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 type borrow_kind =
@@ -218,19 +210,16 @@ let all_binops =
     Shr;
   ]
 
-(** Ancestor for the constant_expr iter visitor *)
+(* Ancestors for the constant_expr visitors *)
 class ['self] iter_constant_expr_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] iter_place
-    inherit! [_] iter_ty
     method visit_assumed_fun_id : 'env -> assumed_fun_id -> unit = fun _ _ -> ()
   end
 
-(** Ancestor the constant_expr map visitor *)
 class ['self] map_constant_expr_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] map_place
-    inherit! [_] map_ty
 
     method visit_assumed_fun_id : 'env -> assumed_fun_id -> assumed_fun_id =
       fun _ x -> x
@@ -349,29 +338,26 @@ and constant_expr = { value : raw_constant_expr; ty : ty }
         name = "iter_constant_expr";
         variety = "iter";
         ancestors = [ "iter_constant_expr_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_constant_expr";
         variety = "map";
         ancestors = [ "map_constant_expr_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
-(** Ancestor the operand iter visitor *)
+(* Ancestors for the rvalue visitors *)
 class ['self] iter_rvalue_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] iter_constant_expr
     method visit_binop : 'env -> binop -> unit = fun _ _ -> ()
     method visit_borrow_kind : 'env -> borrow_kind -> unit = fun _ _ -> ()
   end
 
-(** Ancestor the operand map visitor *)
 class ['self] map_rvalue_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] map_constant_expr
     method visit_binop : 'env -> binop -> binop = fun _ x -> x
     method visit_borrow_kind : 'env -> borrow_kind -> borrow_kind = fun _ x -> x
@@ -504,14 +490,12 @@ and aggregate_kind =
         name = "iter_rvalue";
         variety = "iter";
         ancestors = [ "iter_rvalue_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_rvalue";
         variety = "map";
         ancestors = [ "map_rvalue_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -15,11 +15,6 @@ module VarId = IdGen ()
 module GlobalDeclId = Types.GlobalDeclId
 module FunDeclId = Types.FunDeclId
 
-(** We define this type to control the name of the visitor functions
-    (see e.g., {!Charon.UllbcAst.iter_statement_base}).
-  *)
-type var_id = VarId.id [@@deriving show, ord]
-
 (** An built-in function identifier, identifying a function coming from a
     standard library.
  *)
@@ -70,7 +65,8 @@ and abort_kind =
       (** A MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
           machine.
        *)
-[@@deriving show, ord]
+
+and var_id = VarId.id [@@deriving show, ord]
 
 (* Ancestors for the place visitors *)
 class ['self] iter_place_base =

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -15,10 +15,173 @@ module VarId = IdGen ()
 module GlobalDeclId = Types.GlobalDeclId
 module FunDeclId = Types.FunDeclId
 
+type abort_kind =
+  | Panic of name  (** A built-in panicking function. *)
+  | UndefinedBehavior
+      (** A MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
+          machine.
+       *)
+
+and var_id = VarId.id [@@deriving show, ord]
+
+(* Ancestors for the rvalue visitors *)
+class ['self] iter_rvalue_base =
+  object (self : 'self)
+    inherit [_] iter_generic_params
+    method visit_var_id : 'env -> var_id -> unit = fun _ _ -> ()
+    method visit_variant_id : 'env -> variant_id -> unit = fun _ _ -> ()
+    method visit_field_id : 'env -> field_id -> unit = fun _ _ -> ()
+  end
+
+class ['self] map_rvalue_base =
+  object (self : 'self)
+    inherit [_] map_generic_params
+    method visit_var_id : 'env -> var_id -> var_id = fun _ x -> x
+    method visit_variant_id : 'env -> variant_id -> variant_id = fun _ x -> x
+    method visit_field_id : 'env -> field_id -> field_id = fun _ x -> x
+  end
+
+type place = { var_id : var_id; projection : projection_elem list }
+and projection = projection_elem list
+
+(** Note that we don't have the equivalent of "downcasts".
+    Downcasts are actually necessary, for instance when initializing enumeration
+    values: the value is initially `Bottom`, and we need a way of knowing the
+    variant.
+    For example:
+    `((_0 as Right).0: T2) = move _1;`
+    In MIR, downcasts always happen before field projections: in our internal
+    language, we thus merge downcasts and field projections.
+ *)
+and projection_elem =
+  | Deref
+      (** Dereference a shared/mutable reference, a box, or a raw pointer. *)
+  | Field of field_proj_kind * field_id
+      (** Projection from ADTs (variants, structures).
+          We allow projections to be used as left-values and right-values.
+          We should never have projections to fields of symbolic variants (they
+          should have been expanded before through a match).
+       *)
+
+and field_proj_kind =
+  | ProjAdt of type_decl_id * variant_id option
+  | ProjTuple of int
+      (** If we project from a tuple, the projection kind gives the arity of the tuple. *)
+
+and borrow_kind =
+  | BShared
+  | BMut
+  | BTwoPhaseMut
+      (** See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.TwoPhaseBorrow>
+          and <https://rustc-dev-guide.rust-lang.org/borrow_check/two_phase_borrows.html>
+       *)
+  | BShallow
+      (** Those are typically introduced when using guards in matches, to make sure guards don't
+          change the variant of an enum value while me match over it.
+
+          See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.FakeBorrowKind.html#variant.Shallow>.
+       *)
+  | BUniqueImmutable
+      (** Data must be immutable but not aliasable. In other words you can't mutate the data but you
+          can mutate *through it*, e.g. if it points to a `&mut T`. This is only used in closure
+          captures, e.g.
+          ```rust,ignore
+          let mut z = 3;
+          let x: &mut isize = &mut z;
+          let y = || *x += 5;
+          ```
+          Here the captured variable can't be `&mut &mut x` since the `x` binding is not mutable, yet
+          we must be able to mutate what it points to.
+
+          See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.ClosureCapture>.
+       *)
+
+(** Unary operation *)
+and unop =
+  | Not
+  | Neg
+      (** This can overflow. In practice, rust introduces an assert before
+          (in debug mode) to check that it is not equal to the minimum integer
+          value (for the proper type).
+       *)
+  | Cast of cast_kind
+      (** Casts are rvalues in MIR, but we treat them as unops. *)
+
+(** Nullary operation *)
+and nullop = SizeOf | AlignOf | OffsetOf of (int * field_id) list | UbChecks
+
+(** For all the variants: the first type gives the source type, the second one gives
+    the destination type.
+ *)
+and cast_kind =
+  | CastScalar of literal_type * literal_type
+      (** Conversion between types in {Integer, Bool}
+          Remark: for now we don't support conversions with Char.
+       *)
+  | CastRawPtr of ty * ty
+  | CastFnPtr of ty * ty
+  | CastUnsize of ty * ty
+      (** [Unsize coercion](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html). This is
+          either `[T; N]` -> `[T]` or `T: Trait` -> `dyn Trait` coercions, behind a pointer
+          (reference, `Box`, or other type that implements `CoerceUnsized`).
+
+          The special case of `&[T; N]` -> `&[T]` coercion is caught by `UnOp::ArrayToSlice`.
+       *)
+  | CastTransmute of ty * ty
+      (** Reinterprets the bits of a value of one type as another type, i.e. exactly what
+          [`std::mem::transmute`] does.
+       *)
+
+(** Binary operations. *)
+and binop =
+  | BitXor
+  | BitAnd
+  | BitOr
+  | Eq
+  | Lt
+  | Le
+  | Ne
+  | Ge
+  | Gt
+  | Div
+      (** Fails if the divisor is 0, or if the operation is `int::MIN / -1`. *)
+  | Rem
+      (** Fails if the divisor is 0, or if the operation is `int::MIN % -1`. *)
+  | Add  (** Fails on overflow. *)
+  | Sub  (** Fails on overflow. *)
+  | Mul  (** Fails on overflow. *)
+  | CheckedAdd
+      (** Returns `(result, did_overflow)`, where `result` is the result of the operation with
+          wrapping semantics, and `did_overflow` is a boolean that indicates whether the operation
+          overflowed. This operation does not fail.
+       *)
+  | CheckedSub  (** Like `CheckedAdd`. *)
+  | CheckedMul  (** Like `CheckedAdd`. *)
+  | Shl  (** Fails if the shift is bigger than the bit-size of the type. *)
+  | Shr  (** Fails if the shift is bigger than the bit-size of the type. *)
+
+and operand =
+  | Copy of place
+  | Move of place
+  | Constant of constant_expr
+      (** Constant value (including constant and static variables) *)
+
+(** A function identifier. See [crate::ullbc_ast::Terminator] *)
+and fun_id =
+  | FRegular of fun_decl_id
+      (** A "regular" function (function local to the crate, external function
+          not treated as a primitive one).
+       *)
+  | FAssumed of assumed_fun_id
+      (** A primitive function, coming from a standard library (for instance:
+          `alloc::boxed::Box::new`).
+          TODO: rename to "Primitive"
+       *)
+
 (** An built-in function identifier, identifying a function coming from a
     standard library.
  *)
-type assumed_fun_id =
+and assumed_fun_id =
   | BoxNew  (** `alloc::boxed::Box::new` *)
   | ArrayToSliceShared
       (** Cast an array as a slice.
@@ -58,216 +221,6 @@ and builtin_index_op = {
         output is a reference to a single element.
      *)
 }
-
-and abort_kind =
-  | Panic of name  (** A built-in panicking function. *)
-  | UndefinedBehavior
-      (** A MIR `Unreachable` terminator corresponds to undefined behavior in the rust abstract
-          machine.
-       *)
-
-and var_id = VarId.id [@@deriving show, ord]
-
-(* Ancestors for the place visitors *)
-class ['self] iter_place_base =
-  object (self : 'self)
-    inherit [_] iter_ty
-    method visit_var_id : 'env -> var_id -> unit = fun _ _ -> ()
-    method visit_variant_id : 'env -> variant_id -> unit = fun _ _ -> ()
-    method visit_field_id : 'env -> field_id -> unit = fun _ _ -> ()
-  end
-
-class ['self] map_place_base =
-  object (self : 'self)
-    inherit [_] map_ty
-    method visit_var_id : 'env -> var_id -> var_id = fun _ x -> x
-    method visit_variant_id : 'env -> variant_id -> variant_id = fun _ x -> x
-    method visit_field_id : 'env -> field_id -> field_id = fun _ x -> x
-  end
-
-type place = { var_id : var_id; projection : projection_elem list }
-and projection = projection_elem list
-
-(** Note that we don't have the equivalent of "downcasts".
-    Downcasts are actually necessary, for instance when initializing enumeration
-    values: the value is initially `Bottom`, and we need a way of knowing the
-    variant.
-    For example:
-    `((_0 as Right).0: T2) = move _1;`
-    In MIR, downcasts always happen before field projections: in our internal
-    language, we thus merge downcasts and field projections.
- *)
-and projection_elem =
-  | Deref
-      (** Dereference a shared/mutable reference, a box, or a raw pointer. *)
-  | Field of field_proj_kind * field_id
-      (** Projection from ADTs (variants, structures).
-          We allow projections to be used as left-values and right-values.
-          We should never have projections to fields of symbolic variants (they
-          should have been expanded before through a match).
-       *)
-
-and field_proj_kind =
-  | ProjAdt of type_decl_id * variant_id option
-  | ProjTuple of int
-      (** If we project from a tuple, the projection kind gives the arity of the tuple. *)
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_place";
-        variety = "iter";
-        ancestors = [ "iter_place_base" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      },
-    visitors
-      {
-        name = "map_place";
-        variety = "map";
-        ancestors = [ "map_place_base" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      }]
-
-type borrow_kind =
-  | BShared
-  | BMut
-  | BTwoPhaseMut
-      (** See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.TwoPhaseBorrow>
-          and <https://rustc-dev-guide.rust-lang.org/borrow_check/two_phase_borrows.html>
-       *)
-  | BShallow
-      (** Those are typically introduced when using guards in matches, to make sure guards don't
-          change the variant of an enum value while me match over it.
-
-          See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.FakeBorrowKind.html#variant.Shallow>.
-       *)
-  | BUniqueImmutable
-      (** Data must be immutable but not aliasable. In other words you can't mutate the data but you
-          can mutate *through it*, e.g. if it points to a `&mut T`. This is only used in closure
-          captures, e.g.
-          ```rust,ignore
-          let mut z = 3;
-          let x: &mut isize = &mut z;
-          let y = || *x += 5;
-          ```
-          Here the captured variable can't be `&mut &mut x` since the `x` binding is not mutable, yet
-          we must be able to mutate what it points to.
-
-          See <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.ClosureCapture>.
-       *)
-
-(** Binary operations. *)
-and binop =
-  | BitXor
-  | BitAnd
-  | BitOr
-  | Eq
-  | Lt
-  | Le
-  | Ne
-  | Ge
-  | Gt
-  | Div
-      (** Fails if the divisor is 0, or if the operation is `int::MIN / -1`. *)
-  | Rem
-      (** Fails if the divisor is 0, or if the operation is `int::MIN % -1`. *)
-  | Add  (** Fails on overflow. *)
-  | Sub  (** Fails on overflow. *)
-  | Mul  (** Fails on overflow. *)
-  | CheckedAdd
-      (** Returns `(result, did_overflow)`, where `result` is the result of the operation with
-          wrapping semantics, and `did_overflow` is a boolean that indicates whether the operation
-          overflowed. This operation does not fail.
-       *)
-  | CheckedSub  (** Like `CheckedAdd`. *)
-  | CheckedMul  (** Like `CheckedAdd`. *)
-  | Shl  (** Fails if the shift is bigger than the bit-size of the type. *)
-  | Shr  (** Fails if the shift is bigger than the bit-size of the type. *)
-[@@deriving show, ord]
-
-let all_binops =
-  [
-    BitXor;
-    BitAnd;
-    BitOr;
-    Eq;
-    Lt;
-    Le;
-    Ne;
-    Ge;
-    Gt;
-    Div;
-    Rem;
-    Add;
-    Sub;
-    Mul;
-    Shl;
-    Shr;
-  ]
-
-(* Ancestors for the constant_expr visitors *)
-class ['self] iter_constant_expr_base =
-  object (self : 'self)
-    inherit [_] iter_place
-    method visit_assumed_fun_id : 'env -> assumed_fun_id -> unit = fun _ _ -> ()
-  end
-
-class ['self] map_constant_expr_base =
-  object (self : 'self)
-    inherit [_] map_place
-
-    method visit_assumed_fun_id : 'env -> assumed_fun_id -> assumed_fun_id =
-      fun _ x -> x
-  end
-
-(** Unary operation *)
-type unop =
-  | Not
-  | Neg
-      (** This can overflow. In practice, rust introduces an assert before
-          (in debug mode) to check that it is not equal to the minimum integer
-          value (for the proper type).
-       *)
-  | Cast of cast_kind
-      (** Casts are rvalues in MIR, but we treat them as unops. *)
-
-(** Nullary operation *)
-and nullop = SizeOf | AlignOf | OffsetOf of (int * field_id) list | UbChecks
-
-(** For all the variants: the first type gives the source type, the second one gives
-    the destination type.
- *)
-and cast_kind =
-  | CastScalar of literal_type * literal_type
-      (** Conversion between types in {Integer, Bool}
-          Remark: for now we don't support conversions with Char.
-       *)
-  | CastRawPtr of ty * ty
-  | CastFnPtr of ty * ty
-  | CastUnsize of ty * ty
-      (** [Unsize coercion](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html). This is
-          either `[T; N]` -> `[T]` or `T: Trait` -> `dyn Trait` coercions, behind a pointer
-          (reference, `Box`, or other type that implements `CoerceUnsized`).
-
-          The special case of `&[T; N]` -> `&[T]` coercion is caught by `UnOp::ArrayToSlice`.
-       *)
-  | CastTransmute of ty * ty
-      (** Reinterprets the bits of a value of one type as another type, i.e. exactly what
-          [`std::mem::transmute`] does.
-       *)
-
-(** A function identifier. See [crate::ullbc_ast::Terminator] *)
-and fun_id =
-  | FRegular of fun_decl_id
-      (** A "regular" function (function local to the crate, external function
-          not treated as a primitive one).
-       *)
-  | FAssumed of assumed_fun_id
-      (** A primitive function, coming from a standard library (for instance:
-          `alloc::boxed::Box::new`).
-          TODO: rename to "Primitive"
-       *)
 
 and fun_id_or_trait_method_ref =
   | FunId of fun_id
@@ -326,44 +279,6 @@ and raw_constant_expr =
   | CFnPtr of fn_ptr  (** Function pointer *)
 
 and constant_expr = { value : raw_constant_expr; ty : ty }
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_constant_expr";
-        variety = "iter";
-        ancestors = [ "iter_constant_expr_base" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      },
-    visitors
-      {
-        name = "map_constant_expr";
-        variety = "map";
-        ancestors = [ "map_constant_expr_base" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      }]
-
-(* Ancestors for the rvalue visitors *)
-class ['self] iter_rvalue_base =
-  object (self : 'self)
-    inherit [_] iter_constant_expr
-    method visit_binop : 'env -> binop -> unit = fun _ _ -> ()
-    method visit_borrow_kind : 'env -> borrow_kind -> unit = fun _ _ -> ()
-  end
-
-class ['self] map_rvalue_base =
-  object (self : 'self)
-    inherit [_] map_constant_expr
-    method visit_binop : 'env -> binop -> binop = fun _ x -> x
-    method visit_borrow_kind : 'env -> borrow_kind -> borrow_kind = fun _ x -> x
-  end
-
-type operand =
-  | Copy of place
-  | Move of place
-  | Constant of constant_expr
-      (** Constant value (including constant and static variables) *)
 
 (** TODO: we could factor out [Rvalue] and function calls (for LLBC, not ULLBC).
     We can also factor out the unops, binops with the function calls.
@@ -481,6 +396,7 @@ and aggregate_kind =
        *)
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_rvalue";
@@ -495,3 +411,23 @@ and aggregate_kind =
         ancestors = [ "map_rvalue_base" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       }]
+
+let all_binops =
+  [
+    BitXor;
+    BitAnd;
+    BitOr;
+    Eq;
+    Lt;
+    Le;
+    Ne;
+    Ge;
+    Gt;
+    Div;
+    Rem;
+    Add;
+    Sub;
+    Mul;
+    Shl;
+    Shr;
+  ]

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -95,10 +95,8 @@ class ['self] map_place_base =
     method visit_field_id : 'env -> field_id -> field_id = fun _ x -> x
   end
 
-type field_proj_kind =
-  | ProjAdt of type_decl_id * variant_id option
-  | ProjTuple of int
-      (** If we project from a tuple, the projection kind gives the arity of the tuple. *)
+type place = { var_id : var_id; projection : projection_elem list }
+and projection = projection_elem list
 
 (** Note that we don't have the equivalent of "downcasts".
     Downcasts are actually necessary, for instance when initializing enumeration
@@ -119,9 +117,10 @@ and projection_elem =
           should have been expanded before through a match).
        *)
 
-and projection = projection_elem list
-
-and place = { var_id : var_id; projection : projection_elem list }
+and field_proj_kind =
+  | ProjAdt of type_decl_id * variant_id option
+  | ProjTuple of int
+      (** If we project from a tuple, the projection kind gives the arity of the tuple. *)
 [@@deriving
   show,
     ord,
@@ -237,10 +236,24 @@ class ['self] map_constant_expr_base =
       fun _ x -> x
   end
 
+(** Unary operation *)
+type unop =
+  | Not
+  | Neg
+      (** This can overflow. In practice, rust introduces an assert before
+          (in debug mode) to check that it is not equal to the minimum integer
+          value (for the proper type).
+       *)
+  | Cast of cast_kind
+      (** Casts are rvalues in MIR, but we treat them as unops. *)
+
+(** Nullary operation *)
+and nullop = SizeOf | AlignOf | OffsetOf of (int * field_id) list | UbChecks
+
 (** For all the variants: the first type gives the source type, the second one gives
     the destination type.
  *)
-type cast_kind =
+and cast_kind =
   | CastScalar of literal_type * literal_type
       (** Conversion between types in {Integer, Bool}
           Remark: for now we don't support conversions with Char.
@@ -259,19 +272,27 @@ type cast_kind =
           [`std::mem::transmute`] does.
        *)
 
-(** Unary operation *)
-and unop =
-  | Not
-  | Neg
-      (** This can overflow. In practice, rust introduces an assert before
-          (in debug mode) to check that it is not equal to the minimum integer
-          value (for the proper type).
+(** A function identifier. See [crate::ullbc_ast::Terminator] *)
+and fun_id =
+  | FRegular of fun_decl_id
+      (** A "regular" function (function local to the crate, external function
+          not treated as a primitive one).
        *)
-  | Cast of cast_kind
-      (** Casts are rvalues in MIR, but we treat them as unops. *)
+  | FAssumed of assumed_fun_id
+      (** A primitive function, coming from a standard library (for instance:
+          `alloc::boxed::Box::new`).
+          TODO: rename to "Primitive"
+       *)
 
-(** Nullary operation *)
-and nullop = SizeOf | AlignOf | OffsetOf of (int * field_id) list | UbChecks
+and fun_id_or_trait_method_ref =
+  | FunId of fun_id
+  | TraitMethod of trait_ref * trait_item_name * fun_decl_id
+      (** If a trait: the reference to the trait and the id of the trait method.
+          The fun decl id is not really necessary - we put it here for convenience
+          purposes.
+       *)
+
+and fn_ptr = { func : fun_id_or_trait_method_ref; generics : generic_args }
 
 (** A constant expression.
 
@@ -320,27 +341,6 @@ and raw_constant_expr =
   | CFnPtr of fn_ptr  (** Function pointer *)
 
 and constant_expr = { value : raw_constant_expr; ty : ty }
-and fn_ptr = { func : fun_id_or_trait_method_ref; generics : generic_args }
-
-and fun_id_or_trait_method_ref =
-  | FunId of fun_id
-  | TraitMethod of trait_ref * trait_item_name * fun_decl_id
-      (** If a trait: the reference to the trait and the id of the trait method.
-          The fun decl id is not really necessary - we put it here for convenience
-          purposes.
-       *)
-
-(** A function identifier. See [crate::ullbc_ast::Terminator] *)
-and fun_id =
-  | FRegular of fun_decl_id
-      (** A "regular" function (function local to the crate, external function
-          not treated as a primitive one).
-       *)
-  | FAssumed of assumed_fun_id
-      (** A primitive function, coming from a standard library (for instance:
-          `alloc::boxed::Box::new`).
-          TODO: rename to "Primitive"
-       *)
 [@@deriving
   show,
     ord,
@@ -382,44 +382,6 @@ type operand =
   | Move of place
   | Constant of constant_expr
       (** Constant value (including constant and static variables) *)
-
-(** An aggregated ADT.
-
-    Note that ADTs are desaggregated at some point in MIR. For instance, if
-    we have in Rust:
-    ```ignore
-      let ls = Cons(hd, tl);
-    ```
-
-    In MIR we have (yes, the discriminant update happens *at the end* for some
-    reason):
-    ```text
-      (ls as Cons).0 = move hd;
-      (ls as Cons).1 = move tl;
-      discriminant(ls) = 0; // assuming `Cons` is the variant of index 0
-    ```
-
-    Rem.: in the Aeneas semantics, both cases are handled (in case of desaggregated
-    initialization, `ls` is initialized to `⊥`, then this `⊥` is expanded to
-    `Cons (⊥, ⊥)` upon the first assignment, at which point we can initialize
-    the field 0, etc.).
- *)
-and aggregate_kind =
-  | AggregatedAdt of
-      type_id * variant_id option * field_id option * generic_args
-      (** A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum
-          and the aggregate uses that variant. The `FieldId`, if present, indicates this is a union
-          and the aggregate writes into that field. Otherwise this is a struct.
-       *)
-  | AggregatedArray of ty * const_generic
-      (** We don't put this with the ADT cas because this is the only built-in type
-          with aggregates, and it is a primitive type. In particular, it makes
-          sense to treat it differently because it has a variable number of fields.
-       *)
-  | AggregatedClosure of fun_decl_id * generic_args
-      (** Aggregated values for closures group the function id together with its
-          state.
-       *)
 
 (** TODO: we could factor out [Rvalue] and function calls (for LLBC, not ULLBC).
     We can also factor out the unops, binops with the function calls.
@@ -496,6 +458,44 @@ and rvalue =
           ```
           rustc introduces a check that the length of the slice is exactly equal
           to 1 and that we preserve.
+       *)
+
+(** An aggregated ADT.
+
+    Note that ADTs are desaggregated at some point in MIR. For instance, if
+    we have in Rust:
+    ```ignore
+      let ls = Cons(hd, tl);
+    ```
+
+    In MIR we have (yes, the discriminant update happens *at the end* for some
+    reason):
+    ```text
+      (ls as Cons).0 = move hd;
+      (ls as Cons).1 = move tl;
+      discriminant(ls) = 0; // assuming `Cons` is the variant of index 0
+    ```
+
+    Rem.: in the Aeneas semantics, both cases are handled (in case of desaggregated
+    initialization, `ls` is initialized to `⊥`, then this `⊥` is expanded to
+    `Cons (⊥, ⊥)` upon the first assignment, at which point we can initialize
+    the field 0, etc.).
+ *)
+and aggregate_kind =
+  | AggregatedAdt of
+      type_id * variant_id option * field_id option * generic_args
+      (** A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum
+          and the aggregate uses that variant. The `FieldId`, if present, indicates this is a union
+          and the aggregate writes into that field. Otherwise this is a struct.
+       *)
+  | AggregatedArray of ty * const_generic
+      (** We don't put this with the ADT cas because this is the only built-in type
+          with aggregates, and it is a primitive type. In particular, it makes
+          sense to treat it differently because it has a variable number of fields.
+       *)
+  | AggregatedClosure of fun_decl_id * generic_args
+      (** Aggregated values for closures group the function id together with its
+          state.
        *)
 [@@deriving
   show,

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -62,9 +62,6 @@ class ['self] map_ast_base =
     inherit! [_] map_generic_params
   end
 
-(* Below: the types need not be mutually recursive, but it makes it easier
-   to derive the visitors *)
-
 (** A function operand is used in function calls.
     It either designates a top-level function, or a place in case
     we are using function pointers stored in local variables.
@@ -90,16 +87,14 @@ and assertion = { cond : operand; expected : bool }
         name = "iter_call";
         variety = "iter";
         ancestors = [ "iter_ast_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_call";
         variety = "map";
         ancestors = [ "map_ast_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 (** Ancestor the {!LlbcAst.statement} and {!Charon.UllbcAst.statement} iter visitors *)

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -19,22 +19,22 @@ module TraitDeclId = Types.TraitDeclId
 module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
 
-(* Note: this is duplicated in `Types.ml` but re-exported here to not break dependent projects. *)
-type fun_decl_id = FunDeclId.id [@@deriving show, ord]
+(* Imports *)
+type assumed_fun_id = Expressions.assumed_fun_id [@@deriving show, ord]
+type fun_id = Expressions.fun_id [@@deriving show, ord]
+
+type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref
+[@@deriving show, ord]
+
+type fun_decl_id = FunDeclId.id
 
 (** The id of a translated item. *)
-type any_decl_id =
+and any_decl_id =
   | IdType of type_decl_id
   | IdFun of fun_decl_id
   | IdGlobal of global_decl_id
   | IdTraitDecl of trait_decl_id
   | IdTraitImpl of trait_impl_id
-[@@deriving show, ord]
-
-type assumed_fun_id = Expressions.assumed_fun_id [@@deriving show, ord]
-type fun_id = Expressions.fun_id [@@deriving show, ord]
-
-type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref
 [@@deriving show, ord]
 
 (** A variable *)

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -80,6 +80,7 @@ and call = { func : fn_operand; args : operand list; dest : place }
 and assertion = { cond : operand; expected : bool }
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_statement_base";

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -39,134 +39,7 @@ let de_bruijn_id_of_json = int_of_json
 let path_buf_of_json = string_of_json
 let region_id_of_json = RegionVarId.id_of_json
 
-(* A vector can contain empty slots. We filter them out. *)
-let vector_of_json _ item_of_json js =
-  let* list = list_of_json (option_of_json item_of_json) js in
-  Ok (List.filter_map (fun x -> x) list)
-
-(** Deserialize a map from file id to file name.
-
-    In the serialized LLBC, the files in the loc spans are refered to by their
-    ids, in order to save space. In a functional language like OCaml this is
-    not necessary: we thus replace the file ids by the file name themselves in
-    the AST.
-    The "id to file" map is thus only used in the deserialization process.
-  *)
-let rec id_to_file_of_json (js : json) : (id_to_file_map, string) result =
-  combine_error_msgs js __FUNCTION__
-    ((* The map is stored as a list of pairs (key, value): we deserialize
-      * this list then convert it to a map *)
-     let* file_names = list_of_json (option_of_json file_name_of_json) js in
-     let names_with_ids =
-       List.filter_map
-         (fun (i, name) ->
-           match name with None -> None | Some name -> Some (i, name))
-         (List.mapi (fun i name -> (FileId.of_int i, name)) file_names)
-     in
-     Ok (FileId.Map.of_list names_with_ids))
-
-(* This is written by hand because it accessed `id_to_file`. *)
-and raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
-    (raw_span, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("file_id", file_id); ("beg", beg_loc); ("end", end_loc) ] ->
-        let* file_id = file_id_of_json file_id in
-        let file = FileId.Map.find file_id id_to_file in
-        let* beg_loc = loc_of_json beg_loc in
-        let* end_loc = loc_of_json end_loc in
-        Ok { file; beg_loc; end_loc }
-    | _ -> Error "")
-
-and big_int_of_json (js : json) : (big_int, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Int i -> Ok (Z.of_int i)
-    | `String is -> Ok (Z.of_string is)
-    | _ -> Error "")
-
-(** Deserialize a {!Values.scalar_value} from JSON and **check the ranges**.
-
-    Note that in practice we also check that the values are in range
-    in the interpreter functions. Still, it doesn't cost much to be
-    a bit conservative.
-
-    This is written by hand because it does not match the structure of the
-    corresponding rust type. *)
-and scalar_value_of_json (js : json) : (scalar_value, string) result =
-  let res =
-    combine_error_msgs js __FUNCTION__
-      (match js with
-      | `Assoc [ ("Isize", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = Isize }
-      | `Assoc [ ("I8", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = I8 }
-      | `Assoc [ ("I16", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = I16 }
-      | `Assoc [ ("I32", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = I32 }
-      | `Assoc [ ("I64", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = I64 }
-      | `Assoc [ ("I128", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = I128 }
-      | `Assoc [ ("Usize", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = Usize }
-      | `Assoc [ ("U8", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = U8 }
-      | `Assoc [ ("U16", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = U16 }
-      | `Assoc [ ("U32", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = U32 }
-      | `Assoc [ ("U64", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = U64 }
-      | `Assoc [ ("U128", bi) ] ->
-          let* bi = big_int_of_json bi in
-          Ok { value = bi; int_ty = U128 }
-      | _ -> Error "")
-  in
-  match res with
-  | Error _ -> res
-  | Ok sv ->
-      if not (check_scalar_value_in_range sv) then (
-        log#serror ("Scalar value not in range: " ^ show_scalar_value sv);
-        raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv)));
-      res
-
-(* This is written by hand because the corresponding rust type does not exist. *)
-and region_var_group_of_json (js : json) : (region_var_group, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("id", id); ("regions", regions); ("parents", parents) ] ->
-        let* id = RegionGroupId.id_of_json id in
-        let* regions = list_of_json RegionVarId.id_of_json regions in
-        let* parents = list_of_json RegionGroupId.id_of_json parents in
-        Ok { id; regions; parents }
-    | _ -> Error "")
-
-and region_var_groups_of_json (js : json) : (region_var_groups, string) result =
-  combine_error_msgs js __FUNCTION__ (list_of_json region_var_group_of_json js)
-
-and maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
-    (js : json) : ('body gexpr_body option, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Ok", body) ] ->
-        let* body_id = BodyId.id_of_json body in
-        let body = List.nth bodies (BodyId.to_int body_id) in
-        Ok body
-    | `Assoc [ ("Err", `Null) ] -> Ok None
-    | _ -> Error "")
+let rec ___ = ()
 
 and place_of_json (js : json) : (place, string) result =
   combine_error_msgs js __FUNCTION__
@@ -720,6 +593,18 @@ and loc_of_json (js : json) : (loc, string) result =
         let* line = int_of_json line in
         let* col = int_of_json col in
         Ok ({ line; col } : loc)
+    | _ -> Error "")
+
+and raw_span_of_json (id_to_file : id_to_file_map) (js : json) :
+    (raw_span, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("file_id", file_id); ("beg", beg_loc); ("end", end_loc) ] ->
+        let* file_id = file_id_of_json file_id in
+        let file = FileId.Map.find file_id id_to_file in
+        let* beg_loc = loc_of_json beg_loc in
+        let* end_loc = loc_of_json end_loc in
+        Ok { file; beg_loc; end_loc }
     | _ -> Error "")
 
 and span_of_json (id_to_file : id_to_file_map) (js : json) :
@@ -1423,6 +1308,25 @@ and literal_of_json (js : json) : (literal, string) result =
         Ok (VStr str)
     | _ -> Error "")
 
+and scalar_value_of_json (js : json) : (scalar_value, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ (ty, bi) ] ->
+        let big_int_of_json (js : json) : (big_int, string) result =
+          combine_error_msgs js __FUNCTION__
+            (match js with
+            | `Int i -> Ok (Z.of_int i)
+            | `String is -> Ok (Z.of_string is)
+            | _ -> Error "")
+        in
+        let* value = big_int_of_json bi in
+        let* int_ty = integer_type_of_json (`String ty) in
+        let sv = { value; int_ty } in
+        if not (check_scalar_value_in_range sv) then
+          raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv));
+        Ok sv
+    | _ -> Error "")
+
 and float_value_of_json (js : json) : (float_value, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1430,6 +1334,20 @@ and float_value_of_json (js : json) : (float_value, string) result =
         let* float_value = string_of_json value in
         let* float_ty = float_type_of_json ty in
         Ok ({ float_value; float_ty } : float_value)
+    | _ -> Error "")
+
+and vector_of_json :
+      'a0 'a1.
+      (json -> ('a0, string) result) ->
+      (json -> ('a1, string) result) ->
+      json ->
+      (('a0, 'a1) vector, string) result =
+ fun arg0_of_json arg1_of_json js ->
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | js ->
+        let* list = list_of_json (option_of_json arg1_of_json) js in
+        Ok (List.filter_map (fun x -> x) list)
     | _ -> Error "")
 
 and declaration_group_of_json (js : json) : (declaration_group, string) result =
@@ -1477,6 +1395,17 @@ and g_declaration_group_of_json :
         Ok (RecGroup rec_)
     | _ -> Error "")
 
+and maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
+    (js : json) : ('body gexpr_body option, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Ok", body) ] ->
+        let* body_id = BodyId.id_of_json body in
+        let body = List.nth bodies (BodyId.to_int body_id) in
+        Ok body
+    | `Assoc [ ("Err", `Null) ] -> Ok None
+    | _ -> Error "")
+
 (* This is written by hand because the corresponding rust type is not type-generic. *)
 and gfun_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) : ('body gfun_decl, string) result
@@ -1507,6 +1436,7 @@ and gfun_decl_of_json (bodies : 'body gexpr_body option list)
           }
     | _ -> Error "")
 
+(* This is written by hand because the corresponding rust type is not type-generic. *)
 and gglobal_decl_of_json (bodies : 'body gexpr_body option list)
     (id_to_file : id_to_file_map) (js : json) :
     ('body gexpr_body option gglobal_decl, string) result =
@@ -1532,6 +1462,27 @@ and gglobal_decl_of_json (bodies : 'body gexpr_body option list)
         in
         Ok global
     | _ -> Error "")
+
+(** Deserialize a map from file id to file name.
+
+    In the serialized LLBC, the files in the loc spans are refered to by their
+    ids, in order to save space. In a functional language like OCaml this is
+    not necessary: we thus replace the file ids by the file name themselves in
+    the AST.
+    The "id to file" map is thus only used in the deserialization process.
+  *)
+and id_to_file_of_json (js : json) : (id_to_file_map, string) result =
+  combine_error_msgs js __FUNCTION__
+    ((* The map is stored as a list of pairs (key, value): we deserialize
+      * this list then convert it to a map *)
+     let* file_names = list_of_json (option_of_json file_name_of_json) js in
+     let names_with_ids =
+       List.filter_map
+         (fun (i, name) ->
+           match name with None -> None | Some name -> Some (i, name))
+         (List.mapi (fun i name -> (FileId.of_int i, name)) file_names)
+     in
+     Ok (FileId.Map.of_list names_with_ids))
 
 (* This is written by hand because the corresponding rust type is not type-generic. *)
 and gtranslated_crate_of_json

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -37,21 +37,7 @@ type id_to_file_map = file_name FileId.Map.t
 
 let de_bruijn_id_of_json = int_of_json
 let path_buf_of_json = string_of_json
-let trait_item_name_of_json = string_of_json
-let const_generic_var_id_of_json = ConstGenericVarId.id_of_json
-let disambiguator_of_json = Disambiguator.id_of_json
-let field_id_of_json = FieldId.id_of_json
-let fun_decl_id_of_json = FunDeclId.id_of_json
-let global_decl_id_of_json = GlobalDeclId.id_of_json
-let file_id_of_json = FileId.id_of_json
 let region_id_of_json = RegionVarId.id_of_json
-let trait_clause_id_of_json = TraitClauseId.id_of_json
-let trait_decl_id_of_json = TraitDeclId.id_of_json
-let trait_impl_id_of_json = TraitImplId.id_of_json
-let type_decl_id_of_json = TypeDeclId.id_of_json
-let type_var_id_of_json = TypeVarId.id_of_json
-let variant_id_of_json = VariantId.id_of_json
-let var_id_of_json = VarId.id_of_json
 
 (* A vector can contain empty slots. We filter them out. *)
 let vector_of_json _ item_of_json js =
@@ -465,6 +451,10 @@ and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
         Ok (AggregatedClosure (x_0, x_1))
     | _ -> Error "")
 
+and fun_decl_id_of_json (js : json) : (fun_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> FunDeclId.id_of_json x | _ -> Error "")
+
 and var_of_json (js : json) : (var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -542,6 +532,10 @@ and global_decl_ref_of_json (js : json) : (global_decl_ref, string) result =
         let* global_generics = generic_args_of_json generics in
         Ok ({ global_id; global_generics } : global_decl_ref)
     | _ -> Error "")
+
+and trait_item_name_of_json (js : json) : (trait_item_name, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> string_of_json x | _ -> Error "")
 
 and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_decl, string) result =
@@ -715,6 +709,10 @@ and any_decl_id_of_json (js : json) : (any_decl_id, string) result =
         Ok (IdTraitImpl trait_impl)
     | _ -> Error "")
 
+and file_id_of_json (js : json) : (file_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> FileId.id_of_json x | _ -> Error "")
+
 and loc_of_json (js : json) : (loc, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -823,6 +821,10 @@ and file_name_of_json (js : json) : (file_name, string) result =
         Ok (Local local)
     | _ -> Error "")
 
+and disambiguator_of_json (js : json) : (disambiguator, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> Disambiguator.id_of_json x | _ -> Error "")
+
 and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
     (path_elem, string) result =
   combine_error_msgs js __FUNCTION__
@@ -856,6 +858,31 @@ and name_of_json (id_to_file : id_to_file_map) (js : json) :
     (match js with
     | x -> list_of_json (path_elem_of_json id_to_file) x
     | _ -> Error "")
+
+and type_var_id_of_json (js : json) : (type_var_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> TypeVarId.id_of_json x | _ -> Error "")
+
+and type_decl_id_of_json (js : json) : (type_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> TypeDeclId.id_of_json x | _ -> Error "")
+
+and variant_id_of_json (js : json) : (variant_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> VariantId.id_of_json x | _ -> Error "")
+
+and field_id_of_json (js : json) : (field_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> FieldId.id_of_json x | _ -> Error "")
+
+and const_generic_var_id_of_json (js : json) :
+    (const_generic_var_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> ConstGenericVarId.id_of_json x | _ -> Error "")
+
+and global_decl_id_of_json (js : json) : (global_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> GlobalDeclId.id_of_json x | _ -> Error "")
 
 and type_var_of_json (js : json) : (type_var, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1051,6 +1078,18 @@ and existential_predicate_of_json (js : json) :
     (existential_predicate, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with `Null -> Ok () | _ -> Error "")
+
+and trait_clause_id_of_json (js : json) : (trait_clause_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> TraitClauseId.id_of_json x | _ -> Error "")
+
+and trait_decl_id_of_json (js : json) : (trait_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> TraitDeclId.id_of_json x | _ -> Error "")
+
+and trait_impl_id_of_json (js : json) : (trait_impl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> TraitImplId.id_of_json x | _ -> Error "")
 
 and trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
     (trait_clause, string) result =
@@ -1356,6 +1395,10 @@ and fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
            }
             : fun_sig)
     | _ -> Error "")
+
+and var_id_of_json (js : json) : (var_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> VarId.id_of_json x | _ -> Error "")
 
 and literal_of_json (js : json) : (literal, string) result =
   combine_error_msgs js __FUNCTION__

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -182,589 +182,29 @@ and maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
     | `Assoc [ ("Err", `Null) ] -> Ok None
     | _ -> Error "")
 
-and file_name_of_json (js : json) : (file_name, string) result =
+and place_of_json (js : json) : (place, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Virtual", virtual_) ] ->
-        let* virtual_ = path_buf_of_json virtual_ in
-        Ok (Virtual virtual_)
-    | `Assoc [ ("Local", local) ] ->
-        let* local = path_buf_of_json local in
-        Ok (Local local)
+    | `Assoc [ ("var_id", var_id); ("projection", projection) ] ->
+        let* var_id = var_id_of_json var_id in
+        let* projection = list_of_json projection_elem_of_json projection in
+        Ok ({ var_id; projection } : place)
     | _ -> Error "")
 
-and loc_of_json (js : json) : (loc, string) result =
+and projection_of_json (js : json) : (projection, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("line", line); ("col", col) ] ->
-        let* line = int_of_json line in
-        let* col = int_of_json col in
-        Ok ({ line; col } : loc)
+    | x -> list_of_json projection_elem_of_json x
     | _ -> Error "")
 
-and span_of_json (id_to_file : id_to_file_map) (js : json) :
-    (span, string) result =
+and projection_elem_of_json (js : json) : (projection_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("span", span); ("generated_from_span", generated_from_span) ] ->
-        let* span = raw_span_of_json id_to_file span in
-        let* generated_from_span =
-          option_of_json (raw_span_of_json id_to_file) generated_from_span
-        in
-        Ok ({ span; generated_from_span } : span)
-    | _ -> Error "")
-
-and inline_attr_of_json (js : json) : (inline_attr, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Hint" -> Ok Hint
-    | `String "Never" -> Ok Never
-    | `String "Always" -> Ok Always
-    | _ -> Error "")
-
-and attribute_of_json (js : json) : (attribute, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Opaque" -> Ok AttrOpaque
-    | `Assoc [ ("Rename", rename) ] ->
-        let* rename = string_of_json rename in
-        Ok (AttrRename rename)
-    | `Assoc [ ("VariantsPrefix", variants_prefix) ] ->
-        let* variants_prefix = string_of_json variants_prefix in
-        Ok (AttrVariantsPrefix variants_prefix)
-    | `Assoc [ ("VariantsSuffix", variants_suffix) ] ->
-        let* variants_suffix = string_of_json variants_suffix in
-        Ok (AttrVariantsSuffix variants_suffix)
-    | `Assoc [ ("DocComment", doc_comment) ] ->
-        let* doc_comment = string_of_json doc_comment in
-        Ok (AttrDocComment doc_comment)
-    | `Assoc [ ("Unknown", unknown) ] ->
-        let* unknown = raw_attribute_of_json unknown in
-        Ok (AttrUnknown unknown)
-    | _ -> Error "")
-
-and raw_attribute_of_json (js : json) : (raw_attribute, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("path", path); ("args", args) ] ->
-        let* path = string_of_json path in
-        let* args = option_of_json string_of_json args in
-        Ok ({ path; args } : raw_attribute)
-    | _ -> Error "")
-
-and attr_info_of_json (js : json) : (attr_info, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("attributes", attributes);
-          ("inline", inline);
-          ("rename", rename);
-          ("public", public);
-        ] ->
-        let* attributes = list_of_json attribute_of_json attributes in
-        let* inline = option_of_json inline_attr_of_json inline in
-        let* rename = option_of_json string_of_json rename in
-        let* public = bool_of_json public in
-        Ok ({ attributes; inline; rename; public } : attr_info)
-    | _ -> Error "")
-
-and type_var_of_json (js : json) : (type_var, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = type_var_id_of_json index in
-        let* name = string_of_json name in
-        Ok ({ index; name } : type_var)
-    | _ -> Error "")
-
-and region_var_of_json (js : json) : (region_var, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = region_id_of_json index in
-        let* name = option_of_json string_of_json name in
-        Ok ({ index; name } : region_var)
-    | _ -> Error "")
-
-and region_of_json (js : json) : (region, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Static" -> Ok RStatic
-    | `Assoc [ ("BVar", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = de_bruijn_id_of_json x_0 in
-        let* x_1 = region_id_of_json x_1 in
-        Ok (RBVar (x_0, x_1))
-    | `String "Erased" -> Ok RErased
-    | _ -> Error "")
-
-and integer_type_of_json (js : json) : (integer_type, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Isize" -> Ok Isize
-    | `String "I8" -> Ok I8
-    | `String "I16" -> Ok I16
-    | `String "I32" -> Ok I32
-    | `String "I64" -> Ok I64
-    | `String "I128" -> Ok I128
-    | `String "Usize" -> Ok Usize
-    | `String "U8" -> Ok U8
-    | `String "U16" -> Ok U16
-    | `String "U32" -> Ok U32
-    | `String "U64" -> Ok U64
-    | `String "U128" -> Ok U128
-    | _ -> Error "")
-
-and float_type_of_json (js : json) : (float_type, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "F16" -> Ok F16
-    | `String "F32" -> Ok F32
-    | `String "F64" -> Ok F64
-    | `String "F128" -> Ok F128
-    | _ -> Error "")
-
-and literal_type_of_json (js : json) : (literal_type, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Integer", integer) ] ->
-        let* integer = integer_type_of_json integer in
-        Ok (TInteger integer)
-    | `Assoc [ ("Float", float_) ] ->
-        let* float_ = float_type_of_json float_ in
-        Ok (TFloat float_)
-    | `String "Bool" -> Ok TBool
-    | `String "Char" -> Ok TChar
-    | _ -> Error "")
-
-and const_generic_var_of_json (js : json) : (const_generic_var, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = const_generic_var_id_of_json index in
-        let* name = string_of_json name in
-        let* ty = literal_type_of_json ty in
-        Ok ({ index; name; ty } : const_generic_var)
-    | _ -> Error "")
-
-and ref_kind_of_json (js : json) : (ref_kind, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Mut" -> Ok RMut
-    | `String "Shared" -> Ok RShared
-    | _ -> Error "")
-
-and assumed_ty_of_json (js : json) : (assumed_ty, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Box" -> Ok TBox
-    | `String "Array" -> Ok TArray
-    | `String "Slice" -> Ok TSlice
-    | `String "Str" -> Ok TStr
-    | _ -> Error "")
-
-and type_id_of_json (js : json) : (type_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Adt", adt) ] ->
-        let* adt = type_decl_id_of_json adt in
-        Ok (TAdtId adt)
-    | `String "Tuple" -> Ok TTuple
-    | `Assoc [ ("Builtin", builtin) ] ->
-        let* builtin = assumed_ty_of_json builtin in
-        Ok (TAssumed builtin)
-    | _ -> Error "")
-
-and const_generic_of_json (js : json) : (const_generic, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_id_of_json global in
-        Ok (CgGlobal global)
-    | `Assoc [ ("Var", var) ] ->
-        let* var = const_generic_var_id_of_json var in
-        Ok (CgVar var)
-    | `Assoc [ ("Value", value) ] ->
-        let* value = literal_of_json value in
-        Ok (CgValue value)
-    | _ -> Error "")
-
-and ty_of_json (js : json) : (ty, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Adt", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = type_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
-        Ok (TAdt (x_0, x_1))
-    | `Assoc [ ("TypeVar", type_var) ] ->
-        let* type_var = type_var_id_of_json type_var in
-        Ok (TVar type_var)
-    | `Assoc [ ("Literal", literal) ] ->
-        let* literal = literal_type_of_json literal in
-        Ok (TLiteral literal)
-    | `String "Never" -> Ok TNever
-    | `Assoc [ ("Ref", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = region_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
-        let* x_2 = ref_kind_of_json x_2 in
-        Ok (TRef (x_0, x_1, x_2))
-    | `Assoc [ ("RawPtr", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ref_kind_of_json x_1 in
-        Ok (TRawPtr (x_0, x_1))
-    | `Assoc [ ("TraitType", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_ref_of_json x_0 in
-        let* x_1 = trait_item_name_of_json x_1 in
-        Ok (TTraitType (x_0, x_1))
-    | `Assoc [ ("DynTrait", dyn_trait) ] ->
-        let* dyn_trait = existential_predicate_of_json dyn_trait in
-        Ok (TDynTrait dyn_trait)
-    | `Assoc [ ("Arrow", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = vector_of_json region_id_of_json region_var_of_json x_0 in
-        let* x_1 = list_of_json ty_of_json x_1 in
-        let* x_2 = ty_of_json x_2 in
-        Ok (TArrow (x_0, x_1, x_2))
-    | _ -> Error "")
-
-and existential_predicate_of_json (js : json) :
-    (existential_predicate, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with `Null -> Ok () | _ -> Error "")
-
-and trait_ref_of_json (js : json) : (trait_ref, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("kind", kind); ("trait_decl_ref", trait_decl_ref) ] ->
-        let* trait_id = trait_instance_id_of_json kind in
-        let* trait_decl_ref = trait_decl_ref_of_json trait_decl_ref in
-        Ok ({ trait_id; trait_decl_ref } : trait_ref)
-    | _ -> Error "")
-
-and trait_decl_ref_of_json (js : json) : (trait_decl_ref, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("trait_id", trait_id); ("generics", generics) ] ->
-        let* trait_decl_id = trait_decl_id_of_json trait_id in
-        let* decl_generics = generic_args_of_json generics in
-        Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
-    | _ -> Error "")
-
-and global_decl_ref_of_json (js : json) : (global_decl_ref, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* global_id = global_decl_id_of_json id in
-        let* global_generics = generic_args_of_json generics in
-        Ok ({ global_id; global_generics } : global_decl_ref)
-    | _ -> Error "")
-
-and generic_args_of_json (js : json) : (generic_args, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("regions", regions);
-          ("types", types);
-          ("const_generics", const_generics);
-          ("trait_refs", trait_refs);
-        ] ->
-        let* regions =
-          vector_of_json region_id_of_json region_of_json regions
-        in
-        let* types = vector_of_json type_var_id_of_json ty_of_json types in
-        let* const_generics =
-          vector_of_json const_generic_var_id_of_json const_generic_of_json
-            const_generics
-        in
-        let* trait_refs =
-          vector_of_json trait_clause_id_of_json trait_ref_of_json trait_refs
-        in
-        Ok ({ regions; types; const_generics; trait_refs } : generic_args)
-    | _ -> Error "")
-
-and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("TraitImpl", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_impl_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
-        Ok (TraitImpl (x_0, x_1))
-    | `Assoc [ ("Clause", clause) ] ->
-        let* clause = trait_clause_id_of_json clause in
-        Ok (Clause clause)
-    | `Assoc [ ("ParentClause", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = trait_instance_id_of_json x_0 in
-        let* x_1 = trait_decl_id_of_json x_1 in
-        let* x_2 = trait_clause_id_of_json x_2 in
-        Ok (ParentClause (x_0, x_1, x_2))
-    | `String "SelfId" -> Ok Self
-    | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
-        let* builtin_or_auto = trait_decl_ref_of_json builtin_or_auto in
-        Ok (BuiltinOrAuto builtin_or_auto)
-    | `Assoc [ ("Dyn", dyn) ] ->
-        let* dyn = trait_decl_ref_of_json dyn in
-        Ok (Dyn dyn)
-    | `Assoc [ ("Unknown", unknown) ] ->
-        let* unknown = string_of_json unknown in
-        Ok (UnknownTrait unknown)
-    | _ -> Error "")
-
-and field_of_json (id_to_file : id_to_file_map) (js : json) :
-    (field, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [ ("span", span); ("attr_info", attr_info); ("name", name); ("ty", ty) ]
-      ->
-        let* span = span_of_json id_to_file span in
-        let* attr_info = attr_info_of_json attr_info in
-        let* field_name = option_of_json string_of_json name in
-        let* field_ty = ty_of_json ty in
-        Ok ({ span; attr_info; field_name; field_ty } : field)
-    | _ -> Error "")
-
-and variant_of_json (id_to_file : id_to_file_map) (js : json) :
-    (variant, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("span", span);
-          ("attr_info", attr_info);
-          ("name", name);
-          ("fields", fields);
-          ("discriminant", discriminant);
-        ] ->
-        let* span = span_of_json id_to_file span in
-        let* attr_info = attr_info_of_json attr_info in
-        let* variant_name = string_of_json name in
-        let* fields =
-          vector_of_json field_id_of_json (field_of_json id_to_file) fields
-        in
-        let* discriminant = scalar_value_of_json discriminant in
-        Ok ({ span; attr_info; variant_name; fields; discriminant } : variant)
-    | _ -> Error "")
-
-and type_decl_kind_of_json (id_to_file : id_to_file_map) (js : json) :
-    (type_decl_kind, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Struct", struct_) ] ->
-        let* struct_ =
-          vector_of_json field_id_of_json (field_of_json id_to_file) struct_
-        in
-        Ok (Struct struct_)
-    | `Assoc [ ("Enum", enum) ] ->
-        let* enum =
-          vector_of_json variant_id_of_json (variant_of_json id_to_file) enum
-        in
-        Ok (Enum enum)
-    | `Assoc [ ("Union", union) ] ->
-        let* union =
-          vector_of_json field_id_of_json (field_of_json id_to_file) union
-        in
-        Ok (Union union)
-    | `String "Opaque" -> Ok Opaque
-    | `Assoc [ ("Alias", alias) ] ->
-        let* alias = ty_of_json alias in
-        Ok (Alias alias)
-    | `Assoc [ ("Error", error) ] ->
-        let* error = string_of_json error in
-        Ok (Error error)
-    | _ -> Error "")
-
-and trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
-    (trait_clause, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("clause_id", clause_id);
-          ("span", span);
-          ("origin", _);
-          ("trait_", trait);
-        ] ->
-        let* clause_id = trait_clause_id_of_json clause_id in
-        let* span = option_of_json (span_of_json id_to_file) span in
-        let* trait = trait_decl_ref_of_json trait in
-        Ok ({ clause_id; span; trait } : trait_clause)
-    | _ -> Error "")
-
-and outlives_pred_of_json :
-      'a0 'a1.
-      (json -> ('a0, string) result) ->
-      (json -> ('a1, string) result) ->
-      json ->
-      (('a0, 'a1) outlives_pred, string) result =
- fun arg0_of_json arg1_of_json js ->
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `List [ x_0; x_1 ] ->
-        let* x_0 = arg0_of_json x_0 in
-        let* x_1 = arg1_of_json x_1 in
-        Ok (x_0, x_1)
-    | _ -> Error "")
-
-and region_outlives_of_json (js : json) : (region_outlives, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> outlives_pred_of_json region_of_json region_of_json x
-    | _ -> Error "")
-
-and type_outlives_of_json (js : json) : (type_outlives, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> outlives_pred_of_json ty_of_json region_of_json x
-    | _ -> Error "")
-
-and trait_type_constraint_of_json (js : json) :
-    (trait_type_constraint, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("trait_ref", trait_ref); ("type_name", type_name); ("ty", ty) ]
-      ->
-        let* trait_ref = trait_ref_of_json trait_ref in
-        let* type_name = trait_item_name_of_json type_name in
-        let* ty = ty_of_json ty in
-        Ok ({ trait_ref; type_name; ty } : trait_type_constraint)
-    | _ -> Error "")
-
-and generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
-    (generic_params, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("regions", regions);
-          ("types", types);
-          ("const_generics", const_generics);
-          ("trait_clauses", trait_clauses);
-          ("regions_outlive", regions_outlive);
-          ("types_outlive", types_outlive);
-          ("trait_type_constraints", trait_type_constraints);
-        ] ->
-        let* regions =
-          vector_of_json region_id_of_json region_var_of_json regions
-        in
-        let* types =
-          vector_of_json type_var_id_of_json type_var_of_json types
-        in
-        let* const_generics =
-          vector_of_json const_generic_var_id_of_json const_generic_var_of_json
-            const_generics
-        in
-        let* trait_clauses =
-          vector_of_json trait_clause_id_of_json
-            (trait_clause_of_json id_to_file)
-            trait_clauses
-        in
-        let* regions_outlive =
-          list_of_json
-            (outlives_pred_of_json region_of_json region_of_json)
-            regions_outlive
-        in
-        let* types_outlive =
-          list_of_json
-            (outlives_pred_of_json ty_of_json region_of_json)
-            types_outlive
-        in
-        let* trait_type_constraints =
-          list_of_json trait_type_constraint_of_json trait_type_constraints
-        in
-        Ok
-          ({
-             regions;
-             types;
-             const_generics;
-             trait_clauses;
-             regions_outlive;
-             types_outlive;
-             trait_type_constraints;
-           }
-            : generic_params)
-    | _ -> Error "")
-
-and impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
-    (impl_elem, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Ty", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = generic_params_of_json id_to_file x_0 in
-        let* x_1 = ty_of_json x_1 in
-        Ok (ImplElemTy (x_0, x_1))
-    | `Assoc [ ("Trait", trait) ] ->
-        let* trait = trait_impl_id_of_json trait in
-        Ok (ImplElemTrait trait)
-    | _ -> Error "")
-
-and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
-    (path_elem, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Ident", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = string_of_json x_0 in
-        let* x_1 = disambiguator_of_json x_1 in
-        Ok (PeIdent (x_0, x_1))
-    | `Assoc [ ("Impl", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = impl_elem_of_json id_to_file x_0 in
-        let* x_1 = disambiguator_of_json x_1 in
-        Ok (PeImpl (x_0, x_1))
-    | _ -> Error "")
-
-and name_of_json (id_to_file : id_to_file_map) (js : json) :
-    (name, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> list_of_json (path_elem_of_json id_to_file) x
-    | _ -> Error "")
-
-and item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
-    (item_meta, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("name", name);
-          ("span", span);
-          ("source_text", source_text);
-          ("attr_info", attr_info);
-          ("is_local", is_local);
-          ("opacity", _);
-        ] ->
-        let* name = name_of_json id_to_file name in
-        let* span = span_of_json id_to_file span in
-        let* source_text = option_of_json string_of_json source_text in
-        let* attr_info = attr_info_of_json attr_info in
-        let* is_local = bool_of_json is_local in
-        Ok ({ name; span; source_text; attr_info; is_local } : item_meta)
-    | _ -> Error "")
-
-and type_decl_of_json (id_to_file : id_to_file_map) (js : json) :
-    (type_decl, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("def_id", def_id);
-          ("item_meta", item_meta);
-          ("generics", generics);
-          ("kind", kind);
-        ] ->
-        let* def_id = type_decl_id_of_json def_id in
-        let* item_meta = item_meta_of_json id_to_file item_meta in
-        let* generics = generic_params_of_json id_to_file generics in
-        let* kind = type_decl_kind_of_json id_to_file kind in
-        Ok ({ def_id; item_meta; generics; kind } : type_decl)
-    | _ -> Error "")
-
-and var_of_json (js : json) : (var, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = var_id_of_json index in
-        let* name = option_of_json string_of_json name in
-        let* var_ty = ty_of_json ty in
-        Ok ({ index; name; var_ty } : var)
+    | `String "Deref" -> Ok Deref
+    | `Assoc [ ("Field", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = field_proj_kind_of_json x_0 in
+        let* x_1 = field_id_of_json x_1 in
+        Ok (Field (x_0, x_1))
     | _ -> Error "")
 
 and field_proj_kind_of_json (js : json) : (field_proj_kind, string) result =
@@ -779,31 +219,6 @@ and field_proj_kind_of_json (js : json) : (field_proj_kind, string) result =
         Ok (ProjTuple tuple)
     | _ -> Error "")
 
-and projection_elem_of_json (js : json) : (projection_elem, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Deref" -> Ok Deref
-    | `Assoc [ ("Field", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = field_proj_kind_of_json x_0 in
-        let* x_1 = field_id_of_json x_1 in
-        Ok (Field (x_0, x_1))
-    | _ -> Error "")
-
-and projection_of_json (js : json) : (projection, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> list_of_json projection_elem_of_json x
-    | _ -> Error "")
-
-and place_of_json (js : json) : (place, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("var_id", var_id); ("projection", projection) ] ->
-        let* var_id = var_id_of_json var_id in
-        let* projection = list_of_json projection_elem_of_json projection in
-        Ok ({ var_id; projection } : place)
-    | _ -> Error "")
-
 and borrow_kind_of_json (js : json) : (borrow_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -812,6 +227,29 @@ and borrow_kind_of_json (js : json) : (borrow_kind, string) result =
     | `String "TwoPhaseMut" -> Ok BTwoPhaseMut
     | `String "Shallow" -> Ok BShallow
     | `String "UniqueImmutable" -> Ok BUniqueImmutable
+    | _ -> Error "")
+
+and unop_of_json (js : json) : (unop, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Not" -> Ok Not
+    | `String "Neg" -> Ok Neg
+    | `Assoc [ ("Cast", cast) ] ->
+        let* cast = cast_kind_of_json cast in
+        Ok (Cast cast)
+    | _ -> Error "")
+
+and nullop_of_json (js : json) : (nullop, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "SizeOf" -> Ok SizeOf
+    | `String "AlignOf" -> Ok AlignOf
+    | `Assoc [ ("OffsetOf", offset_of) ] ->
+        let* offset_of =
+          list_of_json (pair_of_json int_of_json field_id_of_json) offset_of
+        in
+        Ok (OffsetOf offset_of)
+    | `String "UbChecks" -> Ok UbChecks
     | _ -> Error "")
 
 and cast_kind_of_json (js : json) : (cast_kind, string) result =
@@ -839,48 +277,6 @@ and cast_kind_of_json (js : json) : (cast_kind, string) result =
         Ok (CastTransmute (x_0, x_1))
     | _ -> Error "")
 
-and abort_kind_of_json (id_to_file : id_to_file_map) (js : json) :
-    (abort_kind, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Panic", panic) ] ->
-        let* panic = name_of_json id_to_file panic in
-        Ok (Panic panic)
-    | `String "UndefinedBehavior" -> Ok UndefinedBehavior
-    | _ -> Error "")
-
-and assertion_of_json (js : json) : (assertion, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("cond", cond); ("expected", expected) ] ->
-        let* cond = operand_of_json cond in
-        let* expected = bool_of_json expected in
-        Ok ({ cond; expected } : assertion)
-    | _ -> Error "")
-
-and nullop_of_json (js : json) : (nullop, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "SizeOf" -> Ok SizeOf
-    | `String "AlignOf" -> Ok AlignOf
-    | `Assoc [ ("OffsetOf", offset_of) ] ->
-        let* offset_of =
-          list_of_json (pair_of_json int_of_json field_id_of_json) offset_of
-        in
-        Ok (OffsetOf offset_of)
-    | `String "UbChecks" -> Ok UbChecks
-    | _ -> Error "")
-
-and unop_of_json (js : json) : (unop, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `String "Not" -> Ok Not
-    | `String "Neg" -> Ok Neg
-    | `Assoc [ ("Cast", cast) ] ->
-        let* cast = cast_kind_of_json cast in
-        Ok (Cast cast)
-    | _ -> Error "")
-
 and binop_of_json (js : json) : (binop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -905,36 +301,29 @@ and binop_of_json (js : json) : (binop, string) result =
     | `String "Shr" -> Ok Shr
     | _ -> Error "")
 
-and literal_of_json (js : json) : (literal, string) result =
+and operand_of_json (js : json) : (operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Scalar", scalar) ] ->
-        let* scalar = scalar_value_of_json scalar in
-        Ok (VScalar scalar)
-    | `Assoc [ ("Float", float_) ] ->
-        let* float_ = float_value_of_json float_ in
-        Ok (VFloat float_)
-    | `Assoc [ ("Bool", bool_) ] ->
-        let* bool_ = bool_of_json bool_ in
-        Ok (VBool bool_)
-    | `Assoc [ ("Char", char_) ] ->
-        let* char_ = char_of_json char_ in
-        Ok (VChar char_)
-    | `Assoc [ ("ByteStr", byte_str) ] ->
-        let* byte_str = list_of_json int_of_json byte_str in
-        Ok (VByteStr byte_str)
-    | `Assoc [ ("Str", str) ] ->
-        let* str = string_of_json str in
-        Ok (VStr str)
+    | `Assoc [ ("Copy", copy) ] ->
+        let* copy = place_of_json copy in
+        Ok (Copy copy)
+    | `Assoc [ ("Move", move) ] ->
+        let* move = place_of_json move in
+        Ok (Move move)
+    | `Assoc [ ("Const", const) ] ->
+        let* const = constant_expr_of_json const in
+        Ok (Constant const)
     | _ -> Error "")
 
-and float_value_of_json (js : json) : (float_value, string) result =
+and fun_id_of_json (js : json) : (fun_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("value", value); ("ty", ty) ] ->
-        let* float_value = string_of_json value in
-        let* float_ty = float_type_of_json ty in
-        Ok ({ float_value; float_ty } : float_value)
+    | `Assoc [ ("Regular", regular) ] ->
+        let* regular = fun_decl_id_of_json regular in
+        Ok (FRegular regular)
+    | `Assoc [ ("Builtin", builtin) ] ->
+        let* builtin = assumed_fun_id_of_json builtin in
+        Ok (FAssumed builtin)
     | _ -> Error "")
 
 and assumed_fun_id_of_json (js : json) : (assumed_fun_id, string) result =
@@ -964,17 +353,6 @@ and builtin_index_op_of_json (js : json) : (builtin_index_op, string) result =
         Ok ({ is_array; mutability; is_range } : builtin_index_op)
     | _ -> Error "")
 
-and fun_id_of_json (js : json) : (fun_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Regular", regular) ] ->
-        let* regular = fun_decl_id_of_json regular in
-        Ok (FRegular regular)
-    | `Assoc [ ("Builtin", builtin) ] ->
-        let* builtin = assumed_fun_id_of_json builtin in
-        Ok (FAssumed builtin)
-    | _ -> Error "")
-
 and fun_id_or_trait_method_ref_of_json (js : json) :
     (fun_id_or_trait_method_ref, string) result =
   combine_error_msgs js __FUNCTION__
@@ -998,26 +376,6 @@ and fn_ptr_of_json (js : json) : (fn_ptr, string) result =
         Ok ({ func; generics } : fn_ptr)
     | _ -> Error "")
 
-and fn_operand_of_json (js : json) : (fn_operand, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Regular", regular) ] ->
-        let* regular = fn_ptr_of_json regular in
-        Ok (FnOpRegular regular)
-    | `Assoc [ ("Move", move) ] ->
-        let* move = place_of_json move in
-        Ok (FnOpMove move)
-    | _ -> Error "")
-
-and constant_expr_of_json (js : json) : (constant_expr, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("value", value); ("ty", ty) ] ->
-        let* value = raw_constant_expr_of_json value in
-        let* ty = ty_of_json ty in
-        Ok ({ value; ty } : constant_expr)
-    | _ -> Error "")
-
 and raw_constant_expr_of_json (js : json) : (raw_constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1036,37 +394,13 @@ and raw_constant_expr_of_json (js : json) : (raw_constant_expr, string) result =
         Ok (CFnPtr fn_ptr)
     | _ -> Error "")
 
-and operand_of_json (js : json) : (operand, string) result =
+and constant_expr_of_json (js : json) : (constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Copy", copy) ] ->
-        let* copy = place_of_json copy in
-        Ok (Copy copy)
-    | `Assoc [ ("Move", move) ] ->
-        let* move = place_of_json move in
-        Ok (Move move)
-    | `Assoc [ ("Const", const) ] ->
-        let* const = constant_expr_of_json const in
-        Ok (Constant const)
-    | _ -> Error "")
-
-and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Adt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
-        let* x_0 = type_id_of_json x_0 in
-        let* x_1 = option_of_json variant_id_of_json x_1 in
-        let* x_2 = option_of_json field_id_of_json x_2 in
-        let* x_3 = generic_args_of_json x_3 in
-        Ok (AggregatedAdt (x_0, x_1, x_2, x_3))
-    | `Assoc [ ("Array", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = const_generic_of_json x_1 in
-        Ok (AggregatedArray (x_0, x_1))
-    | `Assoc [ ("Closure", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = fun_decl_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
-        Ok (AggregatedClosure (x_0, x_1))
+    | `Assoc [ ("value", value); ("ty", ty) ] ->
+        let* value = raw_constant_expr_of_json value in
+        let* ty = ty_of_json ty in
+        Ok ({ value; ty } : constant_expr)
     | _ -> Error "")
 
 and rvalue_of_json (js : json) : (rvalue, string) result =
@@ -1118,102 +452,33 @@ and rvalue_of_json (js : json) : (rvalue, string) result =
         Ok (Len (x_0, x_1, x_2))
     | _ -> Error "")
 
-and params_info_of_json (js : json) : (params_info, string) result =
+and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc
-        [
-          ("num_region_params", num_region_params);
-          ("num_type_params", num_type_params);
-          ("num_const_generic_params", num_const_generic_params);
-          ("num_trait_clauses", num_trait_clauses);
-          ("num_regions_outlive", num_regions_outlive);
-          ("num_types_outlive", num_types_outlive);
-          ("num_trait_type_constraints", num_trait_type_constraints);
-        ] ->
-        let* num_region_params = int_of_json num_region_params in
-        let* num_type_params = int_of_json num_type_params in
-        let* num_const_generic_params = int_of_json num_const_generic_params in
-        let* num_trait_clauses = int_of_json num_trait_clauses in
-        let* num_regions_outlive = int_of_json num_regions_outlive in
-        let* num_types_outlive = int_of_json num_types_outlive in
-        let* num_trait_type_constraints =
-          int_of_json num_trait_type_constraints
-        in
-        Ok
-          ({
-             num_region_params;
-             num_type_params;
-             num_const_generic_params;
-             num_trait_clauses;
-             num_regions_outlive;
-             num_types_outlive;
-             num_trait_type_constraints;
-           }
-            : params_info)
+    | `Assoc [ ("Adt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
+        let* x_0 = type_id_of_json x_0 in
+        let* x_1 = option_of_json variant_id_of_json x_1 in
+        let* x_2 = option_of_json field_id_of_json x_2 in
+        let* x_3 = generic_args_of_json x_3 in
+        Ok (AggregatedAdt (x_0, x_1, x_2, x_3))
+    | `Assoc [ ("Array", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = ty_of_json x_0 in
+        let* x_1 = const_generic_of_json x_1 in
+        Ok (AggregatedArray (x_0, x_1))
+    | `Assoc [ ("Closure", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = fun_decl_id_of_json x_0 in
+        let* x_1 = generic_args_of_json x_1 in
+        Ok (AggregatedClosure (x_0, x_1))
     | _ -> Error "")
 
-and closure_kind_of_json (js : json) : (closure_kind, string) result =
+and var_of_json (js : json) : (var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `String "Fn" -> Ok Fn
-    | `String "FnMut" -> Ok FnMut
-    | `String "FnOnce" -> Ok FnOnce
-    | _ -> Error "")
-
-and closure_info_of_json (js : json) : (closure_info, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("kind", kind); ("state", state) ] ->
-        let* kind = closure_kind_of_json kind in
-        let* state = vector_of_json type_var_id_of_json ty_of_json state in
-        Ok ({ kind; state } : closure_info)
-    | _ -> Error "")
-
-and fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
-    (fun_sig, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc
-        [
-          ("is_unsafe", is_unsafe);
-          ("is_closure", is_closure);
-          ("closure_info", closure_info);
-          ("generics", generics);
-          ("parent_params_info", parent_params_info);
-          ("inputs", inputs);
-          ("output", output);
-        ] ->
-        let* is_unsafe = bool_of_json is_unsafe in
-        let* is_closure = bool_of_json is_closure in
-        let* closure_info = option_of_json closure_info_of_json closure_info in
-        let* generics = generic_params_of_json id_to_file generics in
-        let* parent_params_info =
-          option_of_json params_info_of_json parent_params_info
-        in
-        let* inputs = list_of_json ty_of_json inputs in
-        let* output = ty_of_json output in
-        Ok
-          ({
-             is_unsafe;
-             is_closure;
-             closure_info;
-             generics;
-             parent_params_info;
-             inputs;
-             output;
-           }
-            : fun_sig)
-    | _ -> Error "")
-
-and call_of_json (js : json) : (call, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("func", func); ("args", args); ("dest", dest) ] ->
-        let* func = fn_operand_of_json func in
-        let* args = list_of_json operand_of_json args in
-        let* dest = place_of_json dest in
-        Ok ({ func; args; dest } : call)
+    | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
+        let* index = var_id_of_json index in
+        let* name = option_of_json string_of_json name in
+        let* var_ty = ty_of_json ty in
+        Ok ({ index; name; var_ty } : var)
     | _ -> Error "")
 
 and gexpr_body_of_json :
@@ -1273,6 +538,15 @@ and item_kind_of_json (js : json) : (item_kind, string) result =
         let* item_name = trait_item_name_of_json item_name in
         let* reuses_default = bool_of_json reuses_default in
         Ok (TraitImplItem (impl_id, trait_id, item_name, reuses_default))
+    | _ -> Error "")
+
+and global_decl_ref_of_json (js : json) : (global_decl_ref, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("id", id); ("generics", generics) ] ->
+        let* global_id = global_decl_id_of_json id in
+        let* global_generics = generic_args_of_json generics in
+        Ok ({ global_id; global_generics } : global_decl_ref)
     | _ -> Error "")
 
 and trait_decl_of_json (id_to_file : id_to_file_map) (js : json) :
@@ -1387,20 +661,750 @@ and trait_impl_of_json (id_to_file : id_to_file_map) (js : json) :
             : trait_impl)
     | _ -> Error "")
 
-and g_declaration_group_of_json :
-      'a0.
-      (json -> ('a0, string) result) ->
-      json ->
-      ('a0 g_declaration_group, string) result =
- fun arg0_of_json js ->
+and fn_operand_of_json (js : json) : (fn_operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("NonRec", non_rec) ] ->
-        let* non_rec = arg0_of_json non_rec in
-        Ok (NonRecGroup non_rec)
-    | `Assoc [ ("Rec", rec_) ] ->
-        let* rec_ = list_of_json arg0_of_json rec_ in
-        Ok (RecGroup rec_)
+    | `Assoc [ ("Regular", regular) ] ->
+        let* regular = fn_ptr_of_json regular in
+        Ok (FnOpRegular regular)
+    | `Assoc [ ("Move", move) ] ->
+        let* move = place_of_json move in
+        Ok (FnOpMove move)
+    | _ -> Error "")
+
+and call_of_json (js : json) : (call, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("func", func); ("args", args); ("dest", dest) ] ->
+        let* func = fn_operand_of_json func in
+        let* args = list_of_json operand_of_json args in
+        let* dest = place_of_json dest in
+        Ok ({ func; args; dest } : call)
+    | _ -> Error "")
+
+and abort_kind_of_json (id_to_file : id_to_file_map) (js : json) :
+    (abort_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Panic", panic) ] ->
+        let* panic = name_of_json id_to_file panic in
+        Ok (Panic panic)
+    | `String "UndefinedBehavior" -> Ok UndefinedBehavior
+    | _ -> Error "")
+
+and assertion_of_json (js : json) : (assertion, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("cond", cond); ("expected", expected) ] ->
+        let* cond = operand_of_json cond in
+        let* expected = bool_of_json expected in
+        Ok ({ cond; expected } : assertion)
+    | _ -> Error "")
+
+and any_decl_id_of_json (js : json) : (any_decl_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Type", type_) ] ->
+        let* type_ = type_decl_id_of_json type_ in
+        Ok (IdType type_)
+    | `Assoc [ ("Fun", fun_) ] ->
+        let* fun_ = fun_decl_id_of_json fun_ in
+        Ok (IdFun fun_)
+    | `Assoc [ ("Global", global) ] ->
+        let* global = global_decl_id_of_json global in
+        Ok (IdGlobal global)
+    | `Assoc [ ("TraitDecl", trait_decl) ] ->
+        let* trait_decl = trait_decl_id_of_json trait_decl in
+        Ok (IdTraitDecl trait_decl)
+    | `Assoc [ ("TraitImpl", trait_impl) ] ->
+        let* trait_impl = trait_impl_id_of_json trait_impl in
+        Ok (IdTraitImpl trait_impl)
+    | _ -> Error "")
+
+and loc_of_json (js : json) : (loc, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("line", line); ("col", col) ] ->
+        let* line = int_of_json line in
+        let* col = int_of_json col in
+        Ok ({ line; col } : loc)
+    | _ -> Error "")
+
+and span_of_json (id_to_file : id_to_file_map) (js : json) :
+    (span, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("span", span); ("generated_from_span", generated_from_span) ] ->
+        let* span = raw_span_of_json id_to_file span in
+        let* generated_from_span =
+          option_of_json (raw_span_of_json id_to_file) generated_from_span
+        in
+        Ok ({ span; generated_from_span } : span)
+    | _ -> Error "")
+
+and inline_attr_of_json (js : json) : (inline_attr, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Hint" -> Ok Hint
+    | `String "Never" -> Ok Never
+    | `String "Always" -> Ok Always
+    | _ -> Error "")
+
+and attribute_of_json (js : json) : (attribute, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Opaque" -> Ok AttrOpaque
+    | `Assoc [ ("Rename", rename) ] ->
+        let* rename = string_of_json rename in
+        Ok (AttrRename rename)
+    | `Assoc [ ("VariantsPrefix", variants_prefix) ] ->
+        let* variants_prefix = string_of_json variants_prefix in
+        Ok (AttrVariantsPrefix variants_prefix)
+    | `Assoc [ ("VariantsSuffix", variants_suffix) ] ->
+        let* variants_suffix = string_of_json variants_suffix in
+        Ok (AttrVariantsSuffix variants_suffix)
+    | `Assoc [ ("DocComment", doc_comment) ] ->
+        let* doc_comment = string_of_json doc_comment in
+        Ok (AttrDocComment doc_comment)
+    | `Assoc [ ("Unknown", unknown) ] ->
+        let* unknown = raw_attribute_of_json unknown in
+        Ok (AttrUnknown unknown)
+    | _ -> Error "")
+
+and raw_attribute_of_json (js : json) : (raw_attribute, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("path", path); ("args", args) ] ->
+        let* path = string_of_json path in
+        let* args = option_of_json string_of_json args in
+        Ok ({ path; args } : raw_attribute)
+    | _ -> Error "")
+
+and attr_info_of_json (js : json) : (attr_info, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("attributes", attributes);
+          ("inline", inline);
+          ("rename", rename);
+          ("public", public);
+        ] ->
+        let* attributes = list_of_json attribute_of_json attributes in
+        let* inline = option_of_json inline_attr_of_json inline in
+        let* rename = option_of_json string_of_json rename in
+        let* public = bool_of_json public in
+        Ok ({ attributes; inline; rename; public } : attr_info)
+    | _ -> Error "")
+
+and item_meta_of_json (id_to_file : id_to_file_map) (js : json) :
+    (item_meta, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("name", name);
+          ("span", span);
+          ("source_text", source_text);
+          ("attr_info", attr_info);
+          ("is_local", is_local);
+          ("opacity", _);
+        ] ->
+        let* name = name_of_json id_to_file name in
+        let* span = span_of_json id_to_file span in
+        let* source_text = option_of_json string_of_json source_text in
+        let* attr_info = attr_info_of_json attr_info in
+        let* is_local = bool_of_json is_local in
+        Ok ({ name; span; source_text; attr_info; is_local } : item_meta)
+    | _ -> Error "")
+
+and file_name_of_json (js : json) : (file_name, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Virtual", virtual_) ] ->
+        let* virtual_ = path_buf_of_json virtual_ in
+        Ok (Virtual virtual_)
+    | `Assoc [ ("Local", local) ] ->
+        let* local = path_buf_of_json local in
+        Ok (Local local)
+    | _ -> Error "")
+
+and path_elem_of_json (id_to_file : id_to_file_map) (js : json) :
+    (path_elem, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Ident", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = string_of_json x_0 in
+        let* x_1 = disambiguator_of_json x_1 in
+        Ok (PeIdent (x_0, x_1))
+    | `Assoc [ ("Impl", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = impl_elem_of_json id_to_file x_0 in
+        let* x_1 = disambiguator_of_json x_1 in
+        Ok (PeImpl (x_0, x_1))
+    | _ -> Error "")
+
+and impl_elem_of_json (id_to_file : id_to_file_map) (js : json) :
+    (impl_elem, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Ty", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = generic_params_of_json id_to_file x_0 in
+        let* x_1 = ty_of_json x_1 in
+        Ok (ImplElemTy (x_0, x_1))
+    | `Assoc [ ("Trait", trait) ] ->
+        let* trait = trait_impl_id_of_json trait in
+        Ok (ImplElemTrait trait)
+    | _ -> Error "")
+
+and name_of_json (id_to_file : id_to_file_map) (js : json) :
+    (name, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> list_of_json (path_elem_of_json id_to_file) x
+    | _ -> Error "")
+
+and type_var_of_json (js : json) : (type_var, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("index", index); ("name", name) ] ->
+        let* index = type_var_id_of_json index in
+        let* name = string_of_json name in
+        Ok ({ index; name } : type_var)
+    | _ -> Error "")
+
+and region_var_of_json (js : json) : (region_var, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("index", index); ("name", name) ] ->
+        let* index = region_id_of_json index in
+        let* name = option_of_json string_of_json name in
+        Ok ({ index; name } : region_var)
+    | _ -> Error "")
+
+and const_generic_var_of_json (js : json) : (const_generic_var, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
+        let* index = const_generic_var_id_of_json index in
+        let* name = string_of_json name in
+        let* ty = literal_type_of_json ty in
+        Ok ({ index; name; ty } : const_generic_var)
+    | _ -> Error "")
+
+and region_of_json (js : json) : (region, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Static" -> Ok RStatic
+    | `Assoc [ ("BVar", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = de_bruijn_id_of_json x_0 in
+        let* x_1 = region_id_of_json x_1 in
+        Ok (RBVar (x_0, x_1))
+    | `String "Erased" -> Ok RErased
+    | _ -> Error "")
+
+and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("TraitImpl", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = trait_impl_id_of_json x_0 in
+        let* x_1 = generic_args_of_json x_1 in
+        Ok (TraitImpl (x_0, x_1))
+    | `Assoc [ ("Clause", clause) ] ->
+        let* clause = trait_clause_id_of_json clause in
+        Ok (Clause clause)
+    | `Assoc [ ("ParentClause", `List [ x_0; x_1; x_2 ]) ] ->
+        let* x_0 = trait_instance_id_of_json x_0 in
+        let* x_1 = trait_decl_id_of_json x_1 in
+        let* x_2 = trait_clause_id_of_json x_2 in
+        Ok (ParentClause (x_0, x_1, x_2))
+    | `String "SelfId" -> Ok Self
+    | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
+        let* builtin_or_auto = trait_decl_ref_of_json builtin_or_auto in
+        Ok (BuiltinOrAuto builtin_or_auto)
+    | `Assoc [ ("Dyn", dyn) ] ->
+        let* dyn = trait_decl_ref_of_json dyn in
+        Ok (Dyn dyn)
+    | `Assoc [ ("Unknown", unknown) ] ->
+        let* unknown = string_of_json unknown in
+        Ok (UnknownTrait unknown)
+    | _ -> Error "")
+
+and trait_ref_of_json (js : json) : (trait_ref, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("kind", kind); ("trait_decl_ref", trait_decl_ref) ] ->
+        let* trait_id = trait_instance_id_of_json kind in
+        let* trait_decl_ref = trait_decl_ref_of_json trait_decl_ref in
+        Ok ({ trait_id; trait_decl_ref } : trait_ref)
+    | _ -> Error "")
+
+and trait_decl_ref_of_json (js : json) : (trait_decl_ref, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("trait_id", trait_id); ("generics", generics) ] ->
+        let* trait_decl_id = trait_decl_id_of_json trait_id in
+        let* decl_generics = generic_args_of_json generics in
+        Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
+    | _ -> Error "")
+
+and outlives_pred_of_json :
+      'a0 'a1.
+      (json -> ('a0, string) result) ->
+      (json -> ('a1, string) result) ->
+      json ->
+      (('a0, 'a1) outlives_pred, string) result =
+ fun arg0_of_json arg1_of_json js ->
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `List [ x_0; x_1 ] ->
+        let* x_0 = arg0_of_json x_0 in
+        let* x_1 = arg1_of_json x_1 in
+        Ok (x_0, x_1)
+    | _ -> Error "")
+
+and region_outlives_of_json (js : json) : (region_outlives, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> outlives_pred_of_json region_of_json region_of_json x
+    | _ -> Error "")
+
+and type_outlives_of_json (js : json) : (type_outlives, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> outlives_pred_of_json ty_of_json region_of_json x
+    | _ -> Error "")
+
+and trait_type_constraint_of_json (js : json) :
+    (trait_type_constraint, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("trait_ref", trait_ref); ("type_name", type_name); ("ty", ty) ]
+      ->
+        let* trait_ref = trait_ref_of_json trait_ref in
+        let* type_name = trait_item_name_of_json type_name in
+        let* ty = ty_of_json ty in
+        Ok ({ trait_ref; type_name; ty } : trait_type_constraint)
+    | _ -> Error "")
+
+and generic_args_of_json (js : json) : (generic_args, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("regions", regions);
+          ("types", types);
+          ("const_generics", const_generics);
+          ("trait_refs", trait_refs);
+        ] ->
+        let* regions =
+          vector_of_json region_id_of_json region_of_json regions
+        in
+        let* types = vector_of_json type_var_id_of_json ty_of_json types in
+        let* const_generics =
+          vector_of_json const_generic_var_id_of_json const_generic_of_json
+            const_generics
+        in
+        let* trait_refs =
+          vector_of_json trait_clause_id_of_json trait_ref_of_json trait_refs
+        in
+        Ok ({ regions; types; const_generics; trait_refs } : generic_args)
+    | _ -> Error "")
+
+and generic_params_of_json (id_to_file : id_to_file_map) (js : json) :
+    (generic_params, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("regions", regions);
+          ("types", types);
+          ("const_generics", const_generics);
+          ("trait_clauses", trait_clauses);
+          ("regions_outlive", regions_outlive);
+          ("types_outlive", types_outlive);
+          ("trait_type_constraints", trait_type_constraints);
+        ] ->
+        let* regions =
+          vector_of_json region_id_of_json region_var_of_json regions
+        in
+        let* types =
+          vector_of_json type_var_id_of_json type_var_of_json types
+        in
+        let* const_generics =
+          vector_of_json const_generic_var_id_of_json const_generic_var_of_json
+            const_generics
+        in
+        let* trait_clauses =
+          vector_of_json trait_clause_id_of_json
+            (trait_clause_of_json id_to_file)
+            trait_clauses
+        in
+        let* regions_outlive =
+          list_of_json
+            (outlives_pred_of_json region_of_json region_of_json)
+            regions_outlive
+        in
+        let* types_outlive =
+          list_of_json
+            (outlives_pred_of_json ty_of_json region_of_json)
+            types_outlive
+        in
+        let* trait_type_constraints =
+          list_of_json trait_type_constraint_of_json trait_type_constraints
+        in
+        Ok
+          ({
+             regions;
+             types;
+             const_generics;
+             trait_clauses;
+             regions_outlive;
+             types_outlive;
+             trait_type_constraints;
+           }
+            : generic_params)
+    | _ -> Error "")
+
+and existential_predicate_of_json (js : json) :
+    (existential_predicate, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with `Null -> Ok () | _ -> Error "")
+
+and trait_clause_of_json (id_to_file : id_to_file_map) (js : json) :
+    (trait_clause, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("clause_id", clause_id);
+          ("span", span);
+          ("origin", _);
+          ("trait_", trait);
+        ] ->
+        let* clause_id = trait_clause_id_of_json clause_id in
+        let* span = option_of_json (span_of_json id_to_file) span in
+        let* trait = trait_decl_ref_of_json trait in
+        Ok ({ clause_id; span; trait } : trait_clause)
+    | _ -> Error "")
+
+and type_decl_of_json (id_to_file : id_to_file_map) (js : json) :
+    (type_decl, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("def_id", def_id);
+          ("item_meta", item_meta);
+          ("generics", generics);
+          ("kind", kind);
+        ] ->
+        let* def_id = type_decl_id_of_json def_id in
+        let* item_meta = item_meta_of_json id_to_file item_meta in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* kind = type_decl_kind_of_json id_to_file kind in
+        Ok ({ def_id; item_meta; generics; kind } : type_decl)
+    | _ -> Error "")
+
+and type_decl_kind_of_json (id_to_file : id_to_file_map) (js : json) :
+    (type_decl_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Struct", struct_) ] ->
+        let* struct_ =
+          vector_of_json field_id_of_json (field_of_json id_to_file) struct_
+        in
+        Ok (Struct struct_)
+    | `Assoc [ ("Enum", enum) ] ->
+        let* enum =
+          vector_of_json variant_id_of_json (variant_of_json id_to_file) enum
+        in
+        Ok (Enum enum)
+    | `Assoc [ ("Union", union) ] ->
+        let* union =
+          vector_of_json field_id_of_json (field_of_json id_to_file) union
+        in
+        Ok (Union union)
+    | `String "Opaque" -> Ok Opaque
+    | `Assoc [ ("Alias", alias) ] ->
+        let* alias = ty_of_json alias in
+        Ok (Alias alias)
+    | `Assoc [ ("Error", error) ] ->
+        let* error = string_of_json error in
+        Ok (Error error)
+    | _ -> Error "")
+
+and variant_of_json (id_to_file : id_to_file_map) (js : json) :
+    (variant, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("span", span);
+          ("attr_info", attr_info);
+          ("name", name);
+          ("fields", fields);
+          ("discriminant", discriminant);
+        ] ->
+        let* span = span_of_json id_to_file span in
+        let* attr_info = attr_info_of_json attr_info in
+        let* variant_name = string_of_json name in
+        let* fields =
+          vector_of_json field_id_of_json (field_of_json id_to_file) fields
+        in
+        let* discriminant = scalar_value_of_json discriminant in
+        Ok ({ span; attr_info; variant_name; fields; discriminant } : variant)
+    | _ -> Error "")
+
+and field_of_json (id_to_file : id_to_file_map) (js : json) :
+    (field, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [ ("span", span); ("attr_info", attr_info); ("name", name); ("ty", ty) ]
+      ->
+        let* span = span_of_json id_to_file span in
+        let* attr_info = attr_info_of_json attr_info in
+        let* field_name = option_of_json string_of_json name in
+        let* field_ty = ty_of_json ty in
+        Ok ({ span; attr_info; field_name; field_ty } : field)
+    | _ -> Error "")
+
+and integer_type_of_json (js : json) : (integer_type, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Isize" -> Ok Isize
+    | `String "I8" -> Ok I8
+    | `String "I16" -> Ok I16
+    | `String "I32" -> Ok I32
+    | `String "I64" -> Ok I64
+    | `String "I128" -> Ok I128
+    | `String "Usize" -> Ok Usize
+    | `String "U8" -> Ok U8
+    | `String "U16" -> Ok U16
+    | `String "U32" -> Ok U32
+    | `String "U64" -> Ok U64
+    | `String "U128" -> Ok U128
+    | _ -> Error "")
+
+and float_type_of_json (js : json) : (float_type, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "F16" -> Ok F16
+    | `String "F32" -> Ok F32
+    | `String "F64" -> Ok F64
+    | `String "F128" -> Ok F128
+    | _ -> Error "")
+
+and ref_kind_of_json (js : json) : (ref_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Mut" -> Ok RMut
+    | `String "Shared" -> Ok RShared
+    | _ -> Error "")
+
+and type_id_of_json (js : json) : (type_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Adt", adt) ] ->
+        let* adt = type_decl_id_of_json adt in
+        Ok (TAdtId adt)
+    | `String "Tuple" -> Ok TTuple
+    | `Assoc [ ("Builtin", builtin) ] ->
+        let* builtin = assumed_ty_of_json builtin in
+        Ok (TAssumed builtin)
+    | _ -> Error "")
+
+and literal_type_of_json (js : json) : (literal_type, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Integer", integer) ] ->
+        let* integer = integer_type_of_json integer in
+        Ok (TInteger integer)
+    | `Assoc [ ("Float", float_) ] ->
+        let* float_ = float_type_of_json float_ in
+        Ok (TFloat float_)
+    | `String "Bool" -> Ok TBool
+    | `String "Char" -> Ok TChar
+    | _ -> Error "")
+
+and const_generic_of_json (js : json) : (const_generic, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Global", global) ] ->
+        let* global = global_decl_id_of_json global in
+        Ok (CgGlobal global)
+    | `Assoc [ ("Var", var) ] ->
+        let* var = const_generic_var_id_of_json var in
+        Ok (CgVar var)
+    | `Assoc [ ("Value", value) ] ->
+        let* value = literal_of_json value in
+        Ok (CgValue value)
+    | _ -> Error "")
+
+and ty_of_json (js : json) : (ty, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Adt", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = type_id_of_json x_0 in
+        let* x_1 = generic_args_of_json x_1 in
+        Ok (TAdt (x_0, x_1))
+    | `Assoc [ ("TypeVar", type_var) ] ->
+        let* type_var = type_var_id_of_json type_var in
+        Ok (TVar type_var)
+    | `Assoc [ ("Literal", literal) ] ->
+        let* literal = literal_type_of_json literal in
+        Ok (TLiteral literal)
+    | `String "Never" -> Ok TNever
+    | `Assoc [ ("Ref", `List [ x_0; x_1; x_2 ]) ] ->
+        let* x_0 = region_of_json x_0 in
+        let* x_1 = ty_of_json x_1 in
+        let* x_2 = ref_kind_of_json x_2 in
+        Ok (TRef (x_0, x_1, x_2))
+    | `Assoc [ ("RawPtr", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = ty_of_json x_0 in
+        let* x_1 = ref_kind_of_json x_1 in
+        Ok (TRawPtr (x_0, x_1))
+    | `Assoc [ ("TraitType", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = trait_ref_of_json x_0 in
+        let* x_1 = trait_item_name_of_json x_1 in
+        Ok (TTraitType (x_0, x_1))
+    | `Assoc [ ("DynTrait", dyn_trait) ] ->
+        let* dyn_trait = existential_predicate_of_json dyn_trait in
+        Ok (TDynTrait dyn_trait)
+    | `Assoc [ ("Arrow", `List [ x_0; x_1; x_2 ]) ] ->
+        let* x_0 = vector_of_json region_id_of_json region_var_of_json x_0 in
+        let* x_1 = list_of_json ty_of_json x_1 in
+        let* x_2 = ty_of_json x_2 in
+        Ok (TArrow (x_0, x_1, x_2))
+    | _ -> Error "")
+
+and assumed_ty_of_json (js : json) : (assumed_ty, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Box" -> Ok TBox
+    | `String "Array" -> Ok TArray
+    | `String "Slice" -> Ok TSlice
+    | `String "Str" -> Ok TStr
+    | _ -> Error "")
+
+and params_info_of_json (js : json) : (params_info, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("num_region_params", num_region_params);
+          ("num_type_params", num_type_params);
+          ("num_const_generic_params", num_const_generic_params);
+          ("num_trait_clauses", num_trait_clauses);
+          ("num_regions_outlive", num_regions_outlive);
+          ("num_types_outlive", num_types_outlive);
+          ("num_trait_type_constraints", num_trait_type_constraints);
+        ] ->
+        let* num_region_params = int_of_json num_region_params in
+        let* num_type_params = int_of_json num_type_params in
+        let* num_const_generic_params = int_of_json num_const_generic_params in
+        let* num_trait_clauses = int_of_json num_trait_clauses in
+        let* num_regions_outlive = int_of_json num_regions_outlive in
+        let* num_types_outlive = int_of_json num_types_outlive in
+        let* num_trait_type_constraints =
+          int_of_json num_trait_type_constraints
+        in
+        Ok
+          ({
+             num_region_params;
+             num_type_params;
+             num_const_generic_params;
+             num_trait_clauses;
+             num_regions_outlive;
+             num_types_outlive;
+             num_trait_type_constraints;
+           }
+            : params_info)
+    | _ -> Error "")
+
+and closure_kind_of_json (js : json) : (closure_kind, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Fn" -> Ok Fn
+    | `String "FnMut" -> Ok FnMut
+    | `String "FnOnce" -> Ok FnOnce
+    | _ -> Error "")
+
+and closure_info_of_json (js : json) : (closure_info, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("kind", kind); ("state", state) ] ->
+        let* kind = closure_kind_of_json kind in
+        let* state = vector_of_json type_var_id_of_json ty_of_json state in
+        Ok ({ kind; state } : closure_info)
+    | _ -> Error "")
+
+and fun_sig_of_json (id_to_file : id_to_file_map) (js : json) :
+    (fun_sig, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("is_unsafe", is_unsafe);
+          ("is_closure", is_closure);
+          ("closure_info", closure_info);
+          ("generics", generics);
+          ("parent_params_info", parent_params_info);
+          ("inputs", inputs);
+          ("output", output);
+        ] ->
+        let* is_unsafe = bool_of_json is_unsafe in
+        let* is_closure = bool_of_json is_closure in
+        let* closure_info = option_of_json closure_info_of_json closure_info in
+        let* generics = generic_params_of_json id_to_file generics in
+        let* parent_params_info =
+          option_of_json params_info_of_json parent_params_info
+        in
+        let* inputs = list_of_json ty_of_json inputs in
+        let* output = ty_of_json output in
+        Ok
+          ({
+             is_unsafe;
+             is_closure;
+             closure_info;
+             generics;
+             parent_params_info;
+             inputs;
+             output;
+           }
+            : fun_sig)
+    | _ -> Error "")
+
+and literal_of_json (js : json) : (literal, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Scalar", scalar) ] ->
+        let* scalar = scalar_value_of_json scalar in
+        Ok (VScalar scalar)
+    | `Assoc [ ("Float", float_) ] ->
+        let* float_ = float_value_of_json float_ in
+        Ok (VFloat float_)
+    | `Assoc [ ("Bool", bool_) ] ->
+        let* bool_ = bool_of_json bool_ in
+        Ok (VBool bool_)
+    | `Assoc [ ("Char", char_) ] ->
+        let* char_ = char_of_json char_ in
+        Ok (VChar char_)
+    | `Assoc [ ("ByteStr", byte_str) ] ->
+        let* byte_str = list_of_json int_of_json byte_str in
+        Ok (VByteStr byte_str)
+    | `Assoc [ ("Str", str) ] ->
+        let* str = string_of_json str in
+        Ok (VStr str)
+    | _ -> Error "")
+
+and float_value_of_json (js : json) : (float_value, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("value", value); ("ty", ty) ] ->
+        let* float_value = string_of_json value in
+        let* float_ty = float_type_of_json ty in
+        Ok ({ float_value; float_ty } : float_value)
     | _ -> Error "")
 
 and declaration_group_of_json (js : json) : (declaration_group, string) result =
@@ -1432,24 +1436,20 @@ and declaration_group_of_json (js : json) : (declaration_group, string) result =
         Ok (MixedGroup mixed)
     | _ -> Error "")
 
-and any_decl_id_of_json (js : json) : (any_decl_id, string) result =
+and g_declaration_group_of_json :
+      'a0.
+      (json -> ('a0, string) result) ->
+      json ->
+      ('a0 g_declaration_group, string) result =
+ fun arg0_of_json js ->
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Type", type_) ] ->
-        let* type_ = type_decl_id_of_json type_ in
-        Ok (IdType type_)
-    | `Assoc [ ("Fun", fun_) ] ->
-        let* fun_ = fun_decl_id_of_json fun_ in
-        Ok (IdFun fun_)
-    | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_id_of_json global in
-        Ok (IdGlobal global)
-    | `Assoc [ ("TraitDecl", trait_decl) ] ->
-        let* trait_decl = trait_decl_id_of_json trait_decl in
-        Ok (IdTraitDecl trait_decl)
-    | `Assoc [ ("TraitImpl", trait_impl) ] ->
-        let* trait_impl = trait_impl_id_of_json trait_impl in
-        Ok (IdTraitImpl trait_impl)
+    | `Assoc [ ("NonRec", non_rec) ] ->
+        let* non_rec = arg0_of_json non_rec in
+        Ok (NonRecGroup non_rec)
+    | `Assoc [ ("Rec", rec_) ] ->
+        let* rec_ = list_of_json arg0_of_json rec_ in
+        Ok (RecGroup rec_)
     | _ -> Error "")
 
 (* This is written by hand because the corresponding rust type is not type-generic. *)

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -191,12 +191,6 @@ and place_of_json (js : json) : (place, string) result =
         Ok ({ var_id; projection } : place)
     | _ -> Error "")
 
-and projection_of_json (js : json) : (projection, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> list_of_json projection_elem_of_json x
-    | _ -> Error "")
-
 and projection_elem_of_json (js : json) : (projection_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -960,18 +954,6 @@ and outlives_pred_of_json :
         let* x_0 = arg0_of_json x_0 in
         let* x_1 = arg1_of_json x_1 in
         Ok (x_0, x_1)
-    | _ -> Error "")
-
-and region_outlives_of_json (js : json) : (region_outlives, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> outlives_pred_of_json region_of_json region_of_json x
-    | _ -> Error "")
-
-and type_outlives_of_json (js : json) : (type_outlives, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> outlives_pred_of_json ty_of_json region_of_json x
     | _ -> Error "")
 
 and trait_type_constraint_of_json (js : json) :

--- a/charon-ml/src/Identifiers.ml
+++ b/charon-ml/src/Identifiers.ml
@@ -142,13 +142,7 @@ module IdGen () : Id = struct
   let to_string = string_of_int
   let to_int x = x
   let of_int x = x
-
-  let id_of_json js =
-    (* TODO: check boundaries ? *)
-    match js with
-    | `Int i -> Ok i
-    | _ -> Error ("id_of_json: failed on " ^ Yojson.Basic.show js)
-
+  let id_of_json = OfJsonBasic.int_of_json
   let compare_id = compare
   let max id0 id1 = if id0 > id1 then id0 else id1
   let min id0 id1 = if id0 < id1 then id0 else id1

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -72,16 +72,14 @@ and switch =
         name = "iter_statement";
         variety = "iter";
         ancestors = [ "iter_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_statement";
         variety = "map";
         ancestors = [ "map_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 type expr_body = statement gexpr_body [@@deriving show]

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -67,6 +67,7 @@ and switch =
        *)
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_statement";

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -4,7 +4,7 @@ open Values
 open Expressions
 open Meta
 
-(* Hand-written because we encode sequences differently. *)
+(** A raw statement: a statement without meta data. *)
 type raw_statement =
   | Assign of place * rvalue
   | FakeRead of place
@@ -17,13 +17,13 @@ type raw_statement =
   | Return
   | Break of int
       (** Break to (outer) loop. The [int] identifies the loop to break to:
-          * 0: break to the first outer loop (the current loop)
-          * 1: break to the second outer loop
-          * ...
-          *)
+        * 0: break to the first outer loop (the current loop)
+        * 1: break to the second outer loop
+        * ...
+        *)
   | Continue of int
       (** Continue to (outer) loop. The loop identifier works
-          the same way as for {!Break} *)
+        the same way as for {!Break} *)
   | Nop
   | Sequence of statement * statement
   | Switch of switch

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -10,51 +10,6 @@ open LlbcAst
 
 let rec ___ = ()
 
-and statement_of_json (id_to_file : id_to_file_map) (js : json) :
-    (statement, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("span", span); ("content", content) ] ->
-        let* span = span_of_json id_to_file span in
-        let* content = raw_statement_of_json id_to_file content in
-        Ok ({ span; content } : statement)
-    | _ -> Error "")
-
-and switch_of_json (id_to_file : id_to_file_map) (js : json) :
-    (switch, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("If", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = operand_of_json x_0 in
-        let* x_1 = (statement_of_json id_to_file) x_1 in
-        let* x_2 = (statement_of_json id_to_file) x_2 in
-        Ok (If (x_0, x_1, x_2))
-    | `Assoc [ ("SwitchInt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
-        let* x_0 = operand_of_json x_0 in
-        let* x_1 = integer_type_of_json x_1 in
-        let* x_2 =
-          list_of_json
-            (pair_of_json
-               (list_of_json scalar_value_of_json)
-               (statement_of_json id_to_file))
-            x_2
-        in
-        let* x_3 = (statement_of_json id_to_file) x_3 in
-        Ok (SwitchInt (x_0, x_1, x_2, x_3))
-    | `Assoc [ ("Match", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 =
-          list_of_json
-            (pair_of_json
-               (list_of_json variant_id_of_json)
-               (statement_of_json id_to_file))
-            x_1
-        in
-        let* x_2 = option_of_json (statement_of_json id_to_file) x_2 in
-        Ok (Match (x_0, x_1, x_2))
-    | _ -> Error "")
-
-(* Hand-written because we change the `Sequence` representation *)
 and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
     (raw_statement, string) result =
   combine_error_msgs js __FUNCTION__
@@ -112,6 +67,50 @@ and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
     | `Assoc [ ("Error", s) ] ->
         let* s = string_of_json s in
         Ok (Error s)
+    | _ -> Error "")
+
+and statement_of_json (id_to_file : id_to_file_map) (js : json) :
+    (statement, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("span", span); ("content", content) ] ->
+        let* span = span_of_json id_to_file span in
+        let* content = raw_statement_of_json id_to_file content in
+        Ok ({ span; content } : statement)
+    | _ -> Error "")
+
+and switch_of_json (id_to_file : id_to_file_map) (js : json) :
+    (switch, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("If", `List [ x_0; x_1; x_2 ]) ] ->
+        let* x_0 = operand_of_json x_0 in
+        let* x_1 = (statement_of_json id_to_file) x_1 in
+        let* x_2 = (statement_of_json id_to_file) x_2 in
+        Ok (If (x_0, x_1, x_2))
+    | `Assoc [ ("SwitchInt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
+        let* x_0 = operand_of_json x_0 in
+        let* x_1 = integer_type_of_json x_1 in
+        let* x_2 =
+          list_of_json
+            (pair_of_json
+               (list_of_json scalar_value_of_json)
+               (statement_of_json id_to_file))
+            x_2
+        in
+        let* x_3 = (statement_of_json id_to_file) x_3 in
+        Ok (SwitchInt (x_0, x_1, x_2, x_3))
+    | `Assoc [ ("Match", `List [ x_0; x_1; x_2 ]) ] ->
+        let* x_0 = place_of_json x_0 in
+        let* x_1 =
+          list_of_json
+            (pair_of_json
+               (list_of_json variant_id_of_json)
+               (statement_of_json id_to_file))
+            x_1
+        in
+        let* x_2 = option_of_json (statement_of_json id_to_file) x_2 in
+        Ok (Match (x_0, x_1, x_2))
     | _ -> Error "")
 
 let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -17,17 +17,8 @@ type loc = {
   col : int;  (** The (0-based) column offset. *)
 }
 
-(** A filename. *)
-and file_name =
-  | Virtual of path_buf  (** A remapped path (namely paths into stdlib) *)
-  | Local of path_buf
-      (** A local path (a file coming from the current crate for instance) *)
-[@@deriving show, ord]
-
-(** Span data *)
-
 (** Span information *)
-type raw_span = { file : file_name; beg_loc : loc; end_loc : loc }
+and raw_span = { file : file_name; beg_loc : loc; end_loc : loc }
 
 (** Meta information about a piece of code (block, statement, etc.) *)
 and span = {
@@ -120,4 +111,10 @@ and attr_info = {
         true`; computing item reachability is harder.
      *)
 }
+
+(** A filename. *)
+and file_name =
+  | Virtual of path_buf  (** A remapped path (namely paths into stdlib) *)
+  | Local of path_buf
+      (** A local path (a file coming from the current crate for instance) *)
 [@@deriving show, ord]

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -24,14 +24,13 @@ and file_name =
       (** A local path (a file coming from the current crate for instance) *)
 [@@deriving show, ord]
 
-(* Hand-written because doesn't match the rust type *)
-
 (** Span data *)
+
+(** Span information *)
 type raw_span = { file : file_name; beg_loc : loc; end_loc : loc }
-[@@deriving show, ord]
 
 (** Meta information about a piece of code (block, statement, etc.) *)
-type span = {
+and span = {
   span : raw_span;
       (** The source code span.
 

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -48,7 +48,6 @@ type ('id, 'name) indexed_var = {
 [@@deriving show, ord]
 
 type fun_decl_id = FunDeclId.id
-and trait_item_name = string
 and disambiguator = Disambiguator.id
 and type_var_id = TypeVarId.id
 and type_decl_id = TypeDeclId.id
@@ -59,8 +58,7 @@ and const_generic_var_id = ConstGenericVarId.id
 and global_decl_id = GlobalDeclId.id
 and trait_clause_id = TraitClauseId.id
 and trait_decl_id = TraitDeclId.id
-and trait_impl_id = TraitImplId.id
-and ref_kind = RMut | RShared [@@deriving show, ord]
+and trait_impl_id = TraitImplId.id [@@deriving show, ord]
 
 let all_signed_int_types = [ Isize; I8; I16; I32; I64; I128 ]
 let all_unsigned_int_types = [ Usize; U8; U16; U32; U64; U128 ]
@@ -76,55 +74,134 @@ let option_some_id = VariantId.of_int 1
 class ['self] iter_const_generic_base =
   object (self : 'self)
     inherit [_] iter_literal
-    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
-    method visit_global_decl_id : 'env -> global_decl_id -> unit = fun _ _ -> ()
 
     method visit_const_generic_var_id : 'env -> const_generic_var_id -> unit =
       fun _ _ -> ()
+
+    method visit_fun_decl_id : 'env -> fun_decl_id -> unit = fun _ _ -> ()
+    method visit_global_decl_id : 'env -> global_decl_id -> unit = fun _ _ -> ()
+    method visit_region_db_id : 'env -> region_db_id -> unit = fun _ _ -> ()
+    method visit_region_id : 'env -> region_id -> unit = fun _ _ -> ()
+    method visit_region_var_id : 'env -> region_var_id -> unit = fun _ _ -> ()
+
+    method visit_trait_clause_id : 'env -> trait_clause_id -> unit =
+      fun _ _ -> ()
+
+    method visit_trait_decl_id : 'env -> trait_decl_id -> unit = fun _ _ -> ()
+    method visit_trait_impl_id : 'env -> trait_impl_id -> unit = fun _ _ -> ()
+    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
+    method visit_type_var_id : 'env -> type_var_id -> unit = fun _ _ -> ()
   end
 
 class ['self] map_const_generic_base =
   object (self : 'self)
     inherit [_] map_literal
 
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
+    method visit_const_generic_var_id
+        : 'env -> const_generic_var_id -> const_generic_var_id =
       fun _ x -> x
+
+    method visit_fun_decl_id : 'env -> fun_decl_id -> fun_decl_id = fun _ x -> x
 
     method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id =
       fun _ x -> x
 
-    method visit_const_generic_var_id
-        : 'env -> const_generic_var_id -> const_generic_var_id =
+    method visit_region_db_id : 'env -> region_db_id -> region_db_id =
       fun _ x -> x
+
+    method visit_region_id : 'env -> region_id -> region_id = fun _ x -> x
+
+    method visit_region_var_id : 'env -> region_var_id -> region_var_id =
+      fun _ x -> x
+
+    method visit_trait_clause_id : 'env -> trait_clause_id -> trait_clause_id =
+      fun _ x -> x
+
+    method visit_trait_decl_id : 'env -> trait_decl_id -> trait_decl_id =
+      fun _ x -> x
+
+    method visit_trait_impl_id : 'env -> trait_impl_id -> trait_impl_id =
+      fun _ x -> x
+
+    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
+      fun _ x -> x
+
+    method visit_type_var_id : 'env -> type_var_id -> type_var_id = fun _ x -> x
   end
 
 class virtual ['self] reduce_const_generic_base =
   object (self : 'self)
     inherit [_] reduce_literal
 
-    method visit_type_decl_id : 'env -> type_decl_id -> 'a =
+    method visit_const_generic_var_id : 'env -> const_generic_var_id -> 'a =
       fun _ _ -> self#zero
+
+    method visit_fun_decl_id : 'env -> fun_decl_id -> 'a = fun _ _ -> self#zero
 
     method visit_global_decl_id : 'env -> global_decl_id -> 'a =
       fun _ _ -> self#zero
 
-    method visit_const_generic_var_id : 'env -> const_generic_var_id -> 'a =
+    method visit_region_db_id : 'env -> region_db_id -> 'a =
       fun _ _ -> self#zero
+
+    method visit_region_id : 'env -> region_id -> 'a = fun _ _ -> self#zero
+
+    method visit_region_var_id : 'env -> region_var_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_trait_clause_id : 'env -> trait_clause_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_trait_decl_id : 'env -> trait_decl_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_trait_impl_id : 'env -> trait_impl_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_type_decl_id : 'env -> type_decl_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_type_var_id : 'env -> type_var_id -> 'a = fun _ _ -> self#zero
   end
 
 class virtual ['self] mapreduce_const_generic_base =
   object (self : 'self)
     inherit [_] mapreduce_literal
 
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id * 'a =
+    method visit_const_generic_var_id
+        : 'env -> const_generic_var_id -> const_generic_var_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_fun_decl_id : 'env -> fun_decl_id -> fun_decl_id * 'a =
       fun _ x -> (x, self#zero)
 
     method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id * 'a
         =
       fun _ x -> (x, self#zero)
 
-    method visit_const_generic_var_id
-        : 'env -> const_generic_var_id -> const_generic_var_id * 'a =
+    method visit_region_db_id : 'env -> region_db_id -> region_db_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_region_id : 'env -> region_id -> region_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_region_var_id : 'env -> region_var_id -> region_var_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_trait_clause_id
+        : 'env -> trait_clause_id -> trait_clause_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_trait_decl_id : 'env -> trait_decl_id -> trait_decl_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_trait_impl_id : 'env -> trait_impl_id -> trait_impl_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_type_var_id : 'env -> type_var_id -> type_var_id * 'a =
       fun _ x -> (x, self#zero)
   end
 
@@ -227,61 +304,13 @@ class virtual ['self] map_ty_base_base =
         (left, right)
   end
 
-(* Ancestors for the ty visitors *)
-class ['self] iter_ty_base =
-  object (self : 'self)
-    inherit [_] iter_ty_base_base
-    method visit_region_db_id : 'env -> region_db_id -> unit = fun _ _ -> ()
-    method visit_region_var_id : 'env -> region_var_id -> unit = fun _ _ -> ()
-    method visit_region_id : 'env -> region_id -> unit = fun _ _ -> ()
-    method visit_type_var_id : 'env -> type_var_id -> unit = fun _ _ -> ()
-    method visit_ref_kind : 'env -> ref_kind -> unit = fun _ _ -> ()
-
-    method visit_trait_item_name : 'env -> trait_item_name -> unit =
-      fun _ _ -> ()
-
-    method visit_fun_decl_id : 'env -> fun_decl_id -> unit = fun _ _ -> ()
-    method visit_trait_decl_id : 'env -> trait_decl_id -> unit = fun _ _ -> ()
-    method visit_trait_impl_id : 'env -> trait_impl_id -> unit = fun _ _ -> ()
-
-    method visit_trait_clause_id : 'env -> trait_clause_id -> unit =
-      fun _ _ -> ()
-  end
-
-class ['self] map_ty_base =
-  object (self : 'self)
-    inherit [_] map_ty_base_base
-
-    method visit_region_db_id : 'env -> region_db_id -> region_db_id =
-      fun _ x -> x
-
-    method visit_region_var_id : 'env -> region_var_id -> region_var_id =
-      fun _ x -> x
-
-    method visit_region_id : 'env -> region_id -> region_id = fun _ x -> x
-    method visit_type_var_id : 'env -> type_var_id -> type_var_id = fun _ x -> x
-    method visit_ref_kind : 'env -> ref_kind -> ref_kind = fun _ x -> x
-
-    method visit_trait_item_name : 'env -> trait_item_name -> trait_item_name =
-      fun _ x -> x
-
-    method visit_fun_decl_id : 'env -> fun_decl_id -> fun_decl_id = fun _ x -> x
-
-    method visit_trait_decl_id : 'env -> trait_decl_id -> trait_decl_id =
-      fun _ x -> x
-
-    method visit_trait_impl_id : 'env -> trait_impl_id -> trait_impl_id =
-      fun _ x -> x
-
-    method visit_trait_clause_id : 'env -> trait_clause_id -> trait_clause_id =
-      fun _ x -> x
-  end
-
 (** Reference to a global declaration. *)
 type global_decl_ref = {
   global_id : global_decl_id;
   global_generics : generic_args;
 }
+
+and trait_item_name = string
 
 (** Region variable. *)
 and region_var = (region_var_id, string option) indexed_var
@@ -347,6 +376,8 @@ and generic_args = {
     TODO: store something useful here
  *)
 and existential_predicate = unit
+
+and ref_kind = RMut | RShared
 
 (** Type identifier.
 
@@ -453,14 +484,14 @@ and assumed_ty =
       {
         name = "iter_ty";
         variety = "iter";
-        ancestors = [ "iter_ty_base" ];
+        ancestors = [ "iter_ty_base_base" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_ty";
         variety = "map";
-        ancestors = [ "map_ty_base" ];
+        ancestors = [ "map_ty_base_base" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
@@ -623,28 +654,7 @@ and impl_elem =
 
     Also note that the first path element in the name is always the crate name.
  *)
-and name = path_elem list [@@deriving show, ord]
-
-(* Hand-written because these don't exist on the rust side *)
-
-(** A group of regions.
-
-    Results from a lifetime analysis: we group the regions with the same
-    lifetime together, and compute the hierarchy between the regions.
-    This is necessary to introduce the proper abstraction with the
-    proper constraints, when evaluating a function call in symbolic mode.
-*)
-type ('rid, 'id) g_region_group = {
-  id : 'id;
-  regions : 'rid list;
-  parents : 'id list;
-}
-[@@deriving show]
-
-type region_var_group = (RegionVarId.id, RegionGroupId.id) g_region_group
-[@@deriving show]
-
-type region_var_groups = region_var_group list [@@deriving show]
+and name = path_elem list
 
 (** A type declaration.
 
@@ -660,7 +670,7 @@ type region_var_groups = region_var_group list [@@deriving show]
     A type can only be an ADT (structure or enumeration), as type aliases are
     inlined in MIR.
  *)
-type type_decl = {
+and type_decl = {
   def_id : type_decl_id;
   item_meta : item_meta;  (** Meta information associated with the item. *)
   generics : generic_params;
@@ -702,7 +712,28 @@ and field = {
   field_name : string option;
   field_ty : ty;
 }
+[@@deriving show, ord]
+
+(* Hand-written because these don't exist on the rust side *)
+
+(** A group of regions.
+
+    Results from a lifetime analysis: we group the regions with the same
+    lifetime together, and compute the hierarchy between the regions.
+    This is necessary to introduce the proper abstraction with the
+    proper constraints, when evaluating a function call in symbolic mode.
+*)
+type ('rid, 'id) g_region_group = {
+  id : 'id;
+  regions : 'rid list;
+  parents : 'id list;
+}
 [@@deriving show]
+
+type region_var_group = (RegionVarId.id, RegionGroupId.id) g_region_group
+[@@deriving show]
+
+type region_var_groups = region_var_group list [@@deriving show]
 
 (** Type with erased regions (this only has an informative purpose) *)
 type ety = ty

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -25,10 +25,8 @@ class ['self] map_statement_base =
     method visit_block_id : 'env -> block_id -> block_id = fun _ x -> x
   end
 
-type statement = { span : span; content : raw_statement }
-
 (** A raw statement: a statement without meta data. *)
-and raw_statement =
+type raw_statement =
   | Assign of place * rvalue
   | Call of call
       (** A call. For now, we don't support dynamic calls (i.e. to a function pointer in memory). *)
@@ -44,6 +42,8 @@ and raw_statement =
           checks, over/underflow checks, div/rem by zero checks, pointer alignement check.
        *)
   | Nop  (** Does nothing. Useful for passes. *)
+
+and statement = { span : span; content : raw_statement }
 [@@deriving
   show,
     visitors
@@ -89,10 +89,8 @@ type switch =
         concrete = true;
       }]
 
-type terminator = { span : span; content : raw_terminator }
-
 (** A raw terminator: a terminator without meta data. *)
-and raw_terminator =
+type raw_terminator =
   | Goto of block_id  (** 
           Fields:
           - [target]
@@ -105,6 +103,8 @@ and raw_terminator =
        *)
   | Abort of abort_kind  (** Handles panics and impossible cases. *)
   | Return
+
+and terminator = { span : span; content : raw_terminator }
 [@@deriving
   show,
     visitors
@@ -124,8 +124,10 @@ and raw_terminator =
         concrete = true;
       }]
 
-type block = { statements : statement list; terminator : terminator }
-and blocks = block list [@@deriving show]
+type blocks = block list
+
+and block = { statements : statement list; terminator : terminator }
+[@@deriving show]
 
 type expr_body = blocks gexpr_body [@@deriving show]
 type fun_body = expr_body [@@deriving show]

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -53,6 +53,7 @@ and switch =
        *)
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_statement";
@@ -90,6 +91,7 @@ and terminator = { span : span; content : raw_terminator }
 and block = { statements : statement list; terminator : terminator }
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_ullbc_ast";

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -11,16 +11,15 @@ module BlockId = IdGen ()
   *)
 type block_id = BlockId.id [@@deriving show, ord]
 
-(** Ancestor for {!UllbcAst.statement} iter visitor *)
+(* Ancestors for the statement visitors *)
 class ['self] iter_statement_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] GAst.iter_statement_base
     method visit_block_id : 'env -> block_id -> unit = fun _ _ -> ()
   end
 
-(** Ancestor for {!UllbcAst.statement} map visitor *)
 class ['self] map_statement_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] GAst.map_statement_base
     method visit_block_id : 'env -> block_id -> block_id = fun _ x -> x
   end
@@ -51,16 +50,14 @@ and statement = { span : span; content : raw_statement }
         name = "iter_statement";
         variety = "iter";
         ancestors = [ "iter_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_statement";
         variety = "map";
         ancestors = [ "map_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 type switch =
@@ -77,16 +74,14 @@ type switch =
         name = "iter_switch";
         variety = "iter";
         ancestors = [ "iter_statement" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_switch";
         variety = "map";
         ancestors = [ "map_statement" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 (** A raw terminator: a terminator without meta data. *)
@@ -112,16 +107,14 @@ and terminator = { span : span; content : raw_terminator }
         name = "iter_terminator";
         variety = "iter";
         ancestors = [ "iter_switch" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_terminator";
         variety = "map";
         ancestors = [ "map_switch" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
 type blocks = block list

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -43,6 +43,14 @@ type raw_statement =
   | Nop  (** Does nothing. Useful for passes. *)
 
 and statement = { span : span; content : raw_statement }
+
+and switch =
+  | If of block_id * block_id  (** Gives the `if` block and the `else` block *)
+  | SwitchInt of integer_type * (scalar_value * block_id) list * block_id
+      (** Gives the integer type, a map linking values to switch branches, and the
+          otherwise block. Note that matches over enumerations are performed by
+          switching over the discriminant, which is an integer.
+       *)
 [@@deriving
   show,
     visitors
@@ -60,32 +68,10 @@ and statement = { span : span; content : raw_statement }
         nude = true (* Don't inherit VisitorsRuntime *);
       }]
 
-type switch =
-  | If of block_id * block_id  (** Gives the `if` block and the `else` block *)
-  | SwitchInt of integer_type * (scalar_value * block_id) list * block_id
-      (** Gives the integer type, a map linking values to switch branches, and the
-          otherwise block. Note that matches over enumerations are performed by
-          switching over the discriminant, which is an integer.
-       *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_switch";
-        variety = "iter";
-        ancestors = [ "iter_statement" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      },
-    visitors
-      {
-        name = "map_switch";
-        variety = "map";
-        ancestors = [ "map_statement" ];
-        nude = true (* Don't inherit VisitorsRuntime *);
-      }]
+type blocks = block list
 
 (** A raw terminator: a terminator without meta data. *)
-type raw_terminator =
+and raw_terminator =
   | Goto of block_id  (** 
           Fields:
           - [target]
@@ -100,27 +86,24 @@ type raw_terminator =
   | Return
 
 and terminator = { span : span; content : raw_terminator }
+
+and block = { statements : statement list; terminator : terminator }
 [@@deriving
   show,
     visitors
       {
-        name = "iter_terminator";
+        name = "iter_ullbc_ast";
         variety = "iter";
-        ancestors = [ "iter_switch" ];
+        ancestors = [ "iter_statement" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
-        name = "map_terminator";
+        name = "map_ullbc_ast";
         variety = "map";
-        ancestors = [ "map_switch" ];
+        ancestors = [ "map_statement" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       }]
-
-type blocks = block list
-
-and block = { statements : statement list; terminator : terminator }
-[@@deriving show]
 
 type expr_body = blocks gexpr_body [@@deriving show]
 type fun_body = expr_body [@@deriving show]

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -13,14 +13,11 @@ let block_id_of_json = BlockId.id_of_json
 
 let rec ___ = ()
 
-and statement_of_json (id_to_file : id_to_file_map) (js : json) :
-    (statement, string) result =
+and blocks_of_json (id_to_file : id_to_file_map) (js : json) :
+    (blocks, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("span", span); ("content", content) ] ->
-        let* span = span_of_json id_to_file span in
-        let* content = raw_statement_of_json content in
-        Ok ({ span; content } : statement)
+    | x -> vector_of_json block_id_of_json (block_of_json id_to_file) x
     | _ -> Error "")
 
 and raw_statement_of_json (js : json) : (raw_statement, string) result =
@@ -55,6 +52,16 @@ and raw_statement_of_json (js : json) : (raw_statement, string) result =
     | `String "Nop" -> Ok Nop
     | _ -> Error "")
 
+and statement_of_json (id_to_file : id_to_file_map) (js : json) :
+    (statement, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("span", span); ("content", content) ] ->
+        let* span = span_of_json id_to_file span in
+        let* content = raw_statement_of_json content in
+        Ok ({ span; content } : statement)
+    | _ -> Error "")
+
 and switch_of_json (js : json) : (switch, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -69,16 +76,6 @@ and switch_of_json (js : json) : (switch, string) result =
         in
         let* x_2 = block_id_of_json x_2 in
         Ok (SwitchInt (x_0, x_1, x_2))
-    | _ -> Error "")
-
-and terminator_of_json (id_to_file : id_to_file_map) (js : json) :
-    (terminator, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("span", span); ("content", content) ] ->
-        let* span = span_of_json id_to_file span in
-        let* content = raw_terminator_of_json id_to_file content in
-        Ok ({ span; content } : terminator)
     | _ -> Error "")
 
 and raw_terminator_of_json (id_to_file : id_to_file_map) (js : json) :
@@ -99,6 +96,16 @@ and raw_terminator_of_json (id_to_file : id_to_file_map) (js : json) :
     | `String "Return" -> Ok Return
     | _ -> Error "")
 
+and terminator_of_json (id_to_file : id_to_file_map) (js : json) :
+    (terminator, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("span", span); ("content", content) ] ->
+        let* span = span_of_json id_to_file span in
+        let* content = raw_terminator_of_json id_to_file content in
+        Ok ({ span; content } : terminator)
+    | _ -> Error "")
+
 and block_of_json (id_to_file : id_to_file_map) (js : json) :
     (block, string) result =
   combine_error_msgs js __FUNCTION__
@@ -109,13 +116,6 @@ and block_of_json (id_to_file : id_to_file_map) (js : json) :
         in
         let* terminator = terminator_of_json id_to_file terminator in
         Ok ({ statements; terminator } : block)
-    | _ -> Error "")
-
-and blocks_of_json (id_to_file : id_to_file_map) (js : json) :
-    (blocks, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> vector_of_json block_id_of_json (block_of_json id_to_file) x
     | _ -> Error "")
 
 let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -9,9 +9,11 @@ open Types
 open Expressions
 open UllbcAst
 
-let block_id_of_json = BlockId.id_of_json
-
 let rec ___ = ()
+
+and block_id_of_json (js : json) : (block_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with x -> BlockId.id_of_json x | _ -> Error "")
 
 and blocks_of_json (id_to_file : id_to_file_map) (js : json) :
     (blocks, string) result =

--- a/charon-ml/src/Values.ml
+++ b/charon-ml/src/Values.ml
@@ -66,12 +66,6 @@ type integer_type =
 
 and float_type = F16 | F32 | F64 | F128
 
-(** This is simlar to the Scalar value above. However, instead of storing
-    the float value itself, we store its String representation. This allows
-    to derive the Eq and Ord traits, which are not implemented for floats
- *)
-and float_value = { float_value : string; float_ty : float_type }
-
 (** Types of primitive values. Either an integer, bool, char *)
 and literal_type =
   | TInteger of integer_type
@@ -90,6 +84,12 @@ and literal =
   | VChar of char
   | VByteStr of int list
   | VStr of string
+
+(** This is simlar to the Scalar value above. However, instead of storing
+    the float value itself, we store its String representation. This allows
+    to derive the Eq and Ord traits, which are not implemented for floats
+ *)
+and float_value = { float_value : string; float_ty : float_type }
 
 (** A scalar value
 

--- a/charon-ml/src/Values.ml
+++ b/charon-ml/src/Values.ml
@@ -20,28 +20,25 @@ let pp_big_int (fmt : Format.formatter) (bi : big_int) : unit =
 let compare_big_int (bi0 : big_int) (bi1 : big_int) : int = Z.compare bi0 bi1
 let show_big_int (bi : big_int) : string = Z.to_string bi
 
-(** Ancestor the literal iter visitor *)
+(* Ancestors for the literal visitors *)
 class ['self] iter_literal_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] VisitorsRuntime.iter
     method visit_big_int : 'env -> big_int -> unit = fun _ _ -> ()
   end
 
-(** Ancestor the literal map visitor *)
 class ['self] map_literal_base =
-  object (_self : 'self)
+  object (self : 'self)
     inherit [_] VisitorsRuntime.map
     method visit_big_int : 'env -> big_int -> big_int = fun _ x -> x
   end
 
-(** Ancestor the literal reduce visitor *)
 class virtual ['self] reduce_literal_base =
   object (self : 'self)
     inherit [_] VisitorsRuntime.reduce
     method visit_big_int : 'env -> big_int -> 'a = fun _ _ -> self#zero
   end
 
-(** Ancestor the literal mapreduce visitor *)
 class virtual ['self] mapreduce_literal_base =
   object (self : 'self)
     inherit [_] VisitorsRuntime.mapreduce
@@ -50,16 +47,7 @@ class virtual ['self] mapreduce_literal_base =
       fun _ x -> (x, self#zero)
   end
 
-(** A scalar value
-
-    Note that we use unbounded integers everywhere.
-    We then harcode the boundaries for the different types.
-
-    Hand-written because the rust version is an enum with custom (de)serialization functions.
- *)
-type scalar_value = { value : big_int; int_ty : integer_type }
-
-and integer_type =
+type integer_type =
   | Isize
   | I8
   | I16
@@ -93,6 +81,15 @@ and literal =
   | VChar of char
   | VByteStr of int list
   | VStr of string
+
+(** A scalar value. *)
+and scalar_value = {
+  (* Note that we use unbounded integers everywhere.
+     We then harcode the boundaries for the different types.
+  *)
+  value : big_int;
+  int_ty : integer_type;
+}
 
 (** This is simlar to the Scalar value above. However, instead of storing
     the float value itself, we store its String representation. This allows

--- a/charon-ml/src/Values.ml
+++ b/charon-ml/src/Values.ml
@@ -50,7 +50,16 @@ class virtual ['self] mapreduce_literal_base =
       fun _ x -> (x, self#zero)
   end
 
-type integer_type =
+(** A scalar value
+
+    Note that we use unbounded integers everywhere.
+    We then harcode the boundaries for the different types.
+
+    Hand-written because the rust version is an enum with custom (de)serialization functions.
+ *)
+type scalar_value = { value : big_int; int_ty : integer_type }
+
+and integer_type =
   | Isize
   | I8
   | I16
@@ -90,15 +99,6 @@ and literal =
     to derive the Eq and Ord traits, which are not implemented for floats
  *)
 and float_value = { float_value : string; float_ty : float_type }
-
-(** A scalar value
-
-    Note that we use unbounded integers everywhere.
-    We then harcode the boundaries for the different types.
-
-    Hand-written because the rust version is an enum with custom (de)serialization functions.
- *)
-and scalar_value = { value : big_int; int_ty : integer_type }
 [@@deriving
   show,
     ord,
@@ -107,28 +107,26 @@ and scalar_value = { value : big_int; int_ty : integer_type }
         name = "iter_literal";
         variety = "iter";
         ancestors = [ "iter_literal_base" ];
-        nude = true;
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "map_literal";
         variety = "map";
         ancestors = [ "map_literal_base" ];
-        nude = true;
-        concrete = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "reduce_literal";
         variety = "reduce";
         ancestors = [ "reduce_literal_base" ];
-        nude = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
         name = "mapreduce_literal";
         variety = "mapreduce";
         ancestors = [ "mapreduce_literal_base" ];
-        nude = true;
+        nude = true (* Don't inherit VisitorsRuntime *);
       }]

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -132,8 +132,8 @@ pub struct TranslatedCrate {
 }
 
 impl TranslatedCrate {
-    pub fn get_item(&self, trans_id: AnyTransId) -> Option<AnyTransItem<'_>> {
-        match trans_id {
+    pub fn get_item(&self, trans_id: impl Into<AnyTransId>) -> Option<AnyTransItem<'_>> {
+        match trans_id.into() {
             AnyTransId::Type(id) => self.type_decls.get(id).map(AnyTransItem::Type),
             AnyTransId::Fun(id) => self.fun_decls.get(id).map(AnyTransItem::Fun),
             AnyTransId::Global(id) => self.global_decls.get(id).map(AnyTransItem::Global),

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -43,14 +43,9 @@ pub enum Literal {
     Str(String),
 }
 
-/// It might be a good idea to use a structure:
-/// `{ value: ??; int_ty: IntegerTy; }`
-/// But then it is not obvious how to naturally store the integer (for instance,
-/// in OCaml it is possible to use big integers).
-///
-/// Also, we don't automatically derive the serializer, because it would serialize
-/// the values to integers, leading to potential overflows: we implement a custom
-/// serialization, which serializes the values to strings.
+/// A scalar value.
+// We encode it as `{ value: ??; int_ty: IntegerTy; }` in json and on the ocaml side. We therefore
+// use a custom (de)serializer.
 #[derive(
     Debug,
     PartialEq,

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -621,6 +621,7 @@ impl GenerateCodeFor<'_> {
                         .get(*name)
                         .expect(&format!("Name not found: `{name}`"))
                 })
+                .sorted_by_key(|tdecl| tdecl.def_id)
                 .enumerate()
                 .map(|(i, ty)| match kind {
                     GenerationKind::OfJson => type_decl_to_json_deserializer(&ctx, ty),

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -927,9 +927,13 @@ fn main() -> Result<()> {
         CrateData::deserialize(deserializer)?.translated
     };
 
+    generate_ml(crate_data, dir)
+}
+
+fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Result<()> {
     let ctx = GenerateCtx::new(&crate_data);
 
-    // Compute the sets of type to be put in each module.
+    // Compute the sets of types to be put in each module.
     let manually_implemented: HashSet<_> = [
         "Vector",
         "ScalarValue",
@@ -979,8 +983,8 @@ fn main() -> Result<()> {
     #[rustfmt::skip]
     let generate_code_for = vec![
         GenerateCodeFor {
-            template: dir.join("templates/GAst.ml"),
-            target: dir.join("generated/GAst.ml"),
+            template: output_dir.join("templates/GAst.ml"),
+            target: output_dir.join("generated/GAst.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(false, Some(DeriveVisitors {
                     name: "call",
@@ -1008,8 +1012,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/Expressions.ml"),
-            target: dir.join("generated/Expressions.ml"),
+            template: output_dir.join("templates/Expressions.ml"),
+            target: output_dir.join("generated/Expressions.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(false, None), &[
                     "BuiltinFunId",
@@ -1066,8 +1070,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/Meta.ml"),
-            target: dir.join("generated/Meta.ml"),
+            template: output_dir.join("templates/Meta.ml"),
+            target: output_dir.join("generated/Meta.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(false, None), &[
                     "Loc",
@@ -1083,8 +1087,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/Types.ml"),
-            target: dir.join("generated/Types.ml"),
+            template: output_dir.join("templates/Types.ml"),
+            target: output_dir.join("generated/Types.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(false, None), &[
                     "BuiltinTy",
@@ -1134,8 +1138,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/Values.ml"),
-            target: dir.join("generated/Values.ml"),
+            template: output_dir.join("templates/Values.ml"),
+            target: output_dir.join("generated/Values.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(true, Some(DeriveVisitors {
                     name: "literal",
@@ -1153,8 +1157,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/LlbcAst.ml"),
-            target: dir.join("generated/LlbcAst.ml"),
+            template: output_dir.join("templates/LlbcAst.ml"),
+            target: output_dir.join("generated/LlbcAst.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(true, Some(DeriveVisitors {
                     name: "statement",
@@ -1169,8 +1173,8 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/UllbcAst.ml"),
-            target: dir.join("generated/UllbcAst.ml"),
+            template: output_dir.join("templates/UllbcAst.ml"),
+            target: output_dir.join("generated/UllbcAst.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(false, Some(DeriveVisitors {
                     name: "statement",
@@ -1210,18 +1214,18 @@ fn main() -> Result<()> {
             ]),
         },
         GenerateCodeFor {
-            template: dir.join("templates/GAstOfJson.ml"),
-            target: dir.join("generated/GAstOfJson.ml"),
+            template: output_dir.join("templates/GAstOfJson.ml"),
+            target: output_dir.join("generated/GAstOfJson.ml"),
             markers: vec![(GenerationKind::OfJson, gast_types)],
         },
         GenerateCodeFor {
-            template: dir.join("templates/LlbcOfJson.ml"),
-            target: dir.join("generated/LlbcOfJson.ml"),
+            template: output_dir.join("templates/LlbcOfJson.ml"),
+            target: output_dir.join("generated/LlbcOfJson.ml"),
             markers: vec![(GenerationKind::OfJson, llbc_types)],
         },
         GenerateCodeFor {
-            template: dir.join("templates/UllbcOfJson.ml"),
-            target: dir.join("generated/UllbcOfJson.ml"),
+            template: output_dir.join("templates/UllbcOfJson.ml"),
+            target: output_dir.join("generated/UllbcOfJson.ml"),
             markers: vec![(GenerationKind::OfJson, ullbc_types)],
         },
     ];

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -769,6 +769,19 @@ fn main() -> Result<()> {
             ],
         },
         GenerateCodeFor {
+            template: dir.join("templates/Values.ml"),
+            target: dir.join("generated/Values.ml"),
+            markers: &[
+                (GenerationKind::TypeDecl(false), &[
+                    "IntegerTy",
+                    "FloatTy",
+                    "FloatValue",
+                    "LiteralTy",
+                    "Literal",
+                ]),
+            ],
+        },
+        GenerateCodeFor {
             template: dir.join("templates/LlbcAst.ml"),
             target: dir.join("generated/LlbcAst.ml"),
             markers: &[

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -814,7 +814,6 @@ fn generate_visitor_bases(
 struct DeriveVisitors {
     name: &'static str,
     ancestor: Option<&'static str>,
-    ord: bool,
     reduce: bool,
     extra_types: &'static [&'static str],
 }
@@ -866,7 +865,6 @@ impl GenerateCodeFor {
                         let DeriveVisitors {
                             name,
                             mut ancestor,
-                            ord,
                             reduce,
                             extra_types,
                         } = visitors;
@@ -916,8 +914,7 @@ impl GenerateCodeFor {
                                 )
                             })
                             .format(", ");
-                        let ord = if *ord { ", ord" } else { "" };
-                        let _ = write!(&mut decls, "\n[@@deriving show {ord}, {visitors}]");
+                        let _ = write!(&mut decls, "\n[@@deriving show, ord, {visitors}]");
                     };
                     decls
                 }
@@ -1224,7 +1221,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "statement_base",
                     ancestor: Some("rvalue"),
                     reduce: false,
-                    ord: false,
                     extra_types: &[
                         "abort_kind",
                     ],
@@ -1261,7 +1257,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "rvalue",
                     ancestor: Some("generic_params"),
                     reduce: false,
-                    ord: true,
                     extra_types: &[
                         "var_id",
                         "variant_id",
@@ -1328,7 +1323,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "const_generic",
                     ancestor: Some("literal"),
                     reduce: true,
-                    ord: true,
                     extra_types: &[
                         "const_generic_var_id",
                         "fun_decl_id",
@@ -1351,7 +1345,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "ty",
                     ancestor: Some("ty_base_base"),
                     reduce: false,
-                    ord: true,
                     extra_types: &[],
                 })), &[
                     "TraitItemName",
@@ -1373,7 +1366,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "generic_params",
                     ancestor: Some("ty"),
                     reduce: false,
-                    ord: true,
                     extra_types: &[
                         "span",
                     ],
@@ -1406,7 +1398,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "literal",
                     ancestor: None,
                     reduce: true,
-                    ord: true,
                     extra_types: &[
                         "big_int",
                     ],
@@ -1428,7 +1419,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "statement",
                     ancestor: Some("statement_base"),
                     reduce: false,
-                    ord: false,
                     extra_types: &[],
                 })), &[
                     "charon_lib::ast::llbc_ast::RawStatement",
@@ -1445,7 +1435,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "statement",
                     ancestor: Some("GAst.statement_base"),
                     reduce: false,
-                    ord: false,
                     extra_types: &[
                         "block_id",
                     ],
@@ -1459,7 +1448,6 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                     name: "ullbc_ast",
                     ancestor: Some("statement"),
                     reduce: false,
-                    ord: false,
                     extra_types: &[],
                 })), &[
                     "charon_lib::ast::ullbc_ast::Terminator",

--- a/charon/src/bin/generate-ml/templates/Expressions.ml
+++ b/charon/src/bin/generate-ml/templates/Expressions.ml
@@ -22,49 +22,7 @@ type var_id = VarId.id [@@deriving show, ord]
 (* __REPLACE0__ *)
 [@@deriving show, ord]
 
-(** Ancestor the field_proj_kind iter visitor *)
-class ['self] iter_place_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.iter
-    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
-    method visit_var_id : 'env -> var_id -> unit = fun _ _ -> ()
-    method visit_variant_id : 'env -> variant_id -> unit = fun _ _ -> ()
-    method visit_field_id : 'env -> field_id -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor the field_proj_kind map visitor *)
-class ['self] map_place_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.map
-
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
-      fun _ x -> x
-
-    method visit_var_id : 'env -> var_id -> var_id = fun _ x -> x
-    method visit_variant_id : 'env -> variant_id -> variant_id = fun _ x -> x
-    method visit_field_id : 'env -> field_id -> field_id = fun _ x -> x
-  end
-
 (* __REPLACE1__ *)
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_place";
-        variety = "iter";
-        ancestors = [ "iter_place_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_place";
-        variety = "map";
-        ancestors = [ "map_place_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 (* __REPLACE2__ *)
 [@@deriving show, ord]
@@ -89,77 +47,6 @@ let all_binops =
     Shr;
   ]
 
-(** Ancestor for the constant_expr iter visitor *)
-class ['self] iter_constant_expr_base =
-  object (_self : 'self)
-    inherit [_] iter_place
-    inherit! [_] iter_ty
-    method visit_assumed_fun_id : 'env -> assumed_fun_id -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor the constant_expr map visitor *)
-class ['self] map_constant_expr_base =
-  object (_self : 'self)
-    inherit [_] map_place
-    inherit! [_] map_ty
-
-    method visit_assumed_fun_id : 'env -> assumed_fun_id -> assumed_fun_id =
-      fun _ x -> x
-  end
-
 (* __REPLACE3__ *)
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_constant_expr";
-        variety = "iter";
-        ancestors = [ "iter_constant_expr_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_constant_expr";
-        variety = "map";
-        ancestors = [ "map_constant_expr_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
-
-(** Ancestor the operand iter visitor *)
-class ['self] iter_rvalue_base =
-  object (_self : 'self)
-    inherit [_] iter_constant_expr
-    method visit_binop : 'env -> binop -> unit = fun _ _ -> ()
-    method visit_borrow_kind : 'env -> borrow_kind -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor the operand map visitor *)
-class ['self] map_rvalue_base =
-  object (_self : 'self)
-    inherit [_] map_constant_expr
-    method visit_binop : 'env -> binop -> binop = fun _ x -> x
-    method visit_borrow_kind : 'env -> borrow_kind -> borrow_kind = fun _ x -> x
-  end
 
 (* __REPLACE4__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_rvalue";
-        variety = "iter";
-        ancestors = [ "iter_rvalue_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_rvalue";
-        variety = "map";
-        ancestors = [ "map_rvalue_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]

--- a/charon/src/bin/generate-ml/templates/Expressions.ml
+++ b/charon/src/bin/generate-ml/templates/Expressions.ml
@@ -14,11 +14,6 @@ module VarId = IdGen ()
 module GlobalDeclId = Types.GlobalDeclId
 module FunDeclId = Types.FunDeclId
 
-(** We define this type to control the name of the visitor functions
-    (see e.g., {!Charon.UllbcAst.iter_statement_base}).
-  *)
-type var_id = VarId.id [@@deriving show, ord]
-
 (* __REPLACE0__ *)
 [@@deriving show, ord]
 

--- a/charon/src/bin/generate-ml/templates/Expressions.ml
+++ b/charon/src/bin/generate-ml/templates/Expressions.ml
@@ -19,9 +19,6 @@ module FunDeclId = Types.FunDeclId
 
 (* __REPLACE1__ *)
 
-(* __REPLACE2__ *)
-[@@deriving show, ord]
-
 let all_binops =
   [
     BitXor;
@@ -41,7 +38,3 @@ let all_binops =
     Shl;
     Shr;
   ]
-
-(* __REPLACE3__ *)
-
-(* __REPLACE4__ *)

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -48,28 +48,7 @@ class ['self] map_ast_base =
     inherit! [_] map_generic_params
   end
 
-(* Below: the types need not be mutually recursive, but it makes it easier
-   to derive the visitors *)
-
 (* __REPLACE0__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_call";
-        variety = "iter";
-        ancestors = [ "iter_ast_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_call";
-        variety = "map";
-        ancestors = [ "map_ast_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 (** Ancestor the {!LlbcAst.statement} and {!Charon.UllbcAst.statement} iter visitors *)
 class ['self] iter_statement_base =

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -24,57 +24,12 @@ type assumed_fun_id = Expressions.assumed_fun_id [@@deriving show, ord]
 type fun_id = Expressions.fun_id [@@deriving show, ord]
 type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref [@@deriving show, ord]
 
-(* __REPLACE5__ *)
+(* __REPLACE2__ *)
 [@@deriving show, ord]
-
-(* __REPLACE4__ *)
-[@@deriving show]
-
-(** Ancestor the AST iter visitors *)
-class ['self] iter_ast_base =
-  object (_self : 'self)
-    inherit [_] iter_rvalue
-    inherit! [_] iter_generic_params
-  end
-
-(** Ancestor the AST map visitors *)
-class ['self] map_ast_base =
-  object (_self : 'self)
-    inherit [_] map_rvalue
-    inherit! [_] map_generic_params
-  end
 
 (* __REPLACE0__ *)
 
-(** Ancestor the {!LlbcAst.statement} and {!Charon.UllbcAst.statement} iter visitors *)
-class ['self] iter_statement_base =
-  object (_self : 'self)
-    inherit [_] iter_call
-    method visit_abort_kind : 'env -> abort_kind -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor the {!LlbcAst.statement} and {!Charon.UllbcAst.statement} map visitors *)
-class ['self] map_statement_base =
-  object (_self : 'self)
-    inherit [_] map_call
-    method visit_abort_kind : 'env -> abort_kind -> abort_kind = fun _ x -> x
-  end
-
 (* __REPLACE1__ *)
-[@@deriving show]
-
-(* Hand-written because the rust equivalent isn't generic *)
-type 'body gfun_decl = {
-  def_id : FunDeclId.id;
-  item_meta : item_meta;
-  signature : fun_sig;
-  kind : item_kind;
-  body : 'body gexpr_body option;
-  is_global_decl_body : bool;
-}
-[@@deriving show]
-
-(* __REPLACE2__ *)
 [@@deriving show]
 
 (* Hand-written because they don't exist in rust *)
@@ -92,7 +47,15 @@ type trait_declaration_group = TraitDeclId.id g_declaration_group
 type trait_impl_group = TraitImplId.id g_declaration_group [@@deriving show]
 type mixed_declaration_group = any_decl_id g_declaration_group [@@deriving show]
 
-(* __REPLACE3__ *)
+(* Hand-written because the rust equivalent isn't generic *)
+type 'body gfun_decl = {
+  def_id : FunDeclId.id;
+  item_meta : item_meta;
+  signature : fun_sig;
+  kind : item_kind;
+  body : 'body gexpr_body option;
+  is_global_decl_body : bool;
+}
 [@@deriving show]
 
 (* Hand-written because the rust equivalent isn't generic *)

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -19,16 +19,12 @@ module TraitDeclId = Types.TraitDeclId
 module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
 
-(* Note: this is duplicated in `Types.ml` but re-exported here to not break dependent projects. *)
-type fun_decl_id = FunDeclId.id [@@deriving show, ord]
-
-(* __REPLACE5__ *)
-[@@deriving show, ord]
-
+(* Imports *)
 type assumed_fun_id = Expressions.assumed_fun_id [@@deriving show, ord]
 type fun_id = Expressions.fun_id [@@deriving show, ord]
+type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref [@@deriving show, ord]
 
-type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref
+(* __REPLACE5__ *)
 [@@deriving show, ord]
 
 (* __REPLACE4__ *)

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -38,21 +38,7 @@ type id_to_file_map = file_name FileId.Map.t
 
 let de_bruijn_id_of_json = int_of_json
 let path_buf_of_json = string_of_json
-let trait_item_name_of_json = string_of_json
-let const_generic_var_id_of_json = ConstGenericVarId.id_of_json
-let disambiguator_of_json = Disambiguator.id_of_json
-let field_id_of_json = FieldId.id_of_json
-let fun_decl_id_of_json = FunDeclId.id_of_json
-let global_decl_id_of_json = GlobalDeclId.id_of_json
-let file_id_of_json = FileId.id_of_json
 let region_id_of_json = RegionVarId.id_of_json
-let trait_clause_id_of_json = TraitClauseId.id_of_json
-let trait_decl_id_of_json = TraitDeclId.id_of_json
-let trait_impl_id_of_json = TraitImplId.id_of_json
-let type_decl_id_of_json = TypeDeclId.id_of_json
-let type_var_id_of_json = TypeVarId.id_of_json
-let variant_id_of_json = VariantId.id_of_json
-let var_id_of_json = VarId.id_of_json
 
 (* A vector can contain empty slots. We filter them out. *)
 let vector_of_json _ item_of_json js =

--- a/charon/src/bin/generate-ml/templates/LlbcAst.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcAst.ml
@@ -4,32 +4,6 @@ open Values
 open Expressions
 open Meta
 
-(* Hand-written because we encode sequences differently. *)
-type raw_statement =
-  | Assign of place * rvalue
-  | FakeRead of place
-  | SetDiscriminant of place * variant_id
-  | Drop of place
-  | Assert of assertion
-  | Call of call
-  (* FIXME: rename to `Abort` *)
-  | Panic
-  | Return
-  | Break of int
-      (** Break to (outer) loop. The [int] identifies the loop to break to:
-          * 0: break to the first outer loop (the current loop)
-          * 1: break to the second outer loop
-          * ...
-          *)
-  | Continue of int
-      (** Continue to (outer) loop. The loop identifier works
-          the same way as for {!Break} *)
-  | Nop
-  | Sequence of statement * statement
-  | Switch of switch
-  | Loop of statement
-  | Error of string
-
 (* __REPLACE0__ *)
 
 type expr_body = statement gexpr_body [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/LlbcAst.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcAst.ml
@@ -31,24 +31,6 @@ type raw_statement =
   | Error of string
 
 (* __REPLACE0__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_statement";
-        variety = "iter";
-        ancestors = [ "iter_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_statement";
-        variety = "map";
-        ancestors = [ "map_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 type expr_body = statement gexpr_body [@@deriving show]
 type fun_body = expr_body [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/Meta.ml
+++ b/charon/src/bin/generate-ml/templates/Meta.ml
@@ -16,9 +16,5 @@ type path_buf = string
 [@@deriving show, ord]
 
 (** Span data *)
-(* Hand-written because doesn't match the rust type *)
-type raw_span = { file : file_name; beg_loc : loc; end_loc : loc }
-[@@deriving show, ord]
-
 (* __REPLACE1__ *)
 [@@deriving show, ord]

--- a/charon/src/bin/generate-ml/templates/Meta.ml
+++ b/charon/src/bin/generate-ml/templates/Meta.ml
@@ -14,7 +14,3 @@ type path_buf = string
 
 (* __REPLACE0__ *)
 [@@deriving show, ord]
-
-(** Span data *)
-(* __REPLACE1__ *)
-[@@deriving show, ord]

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -48,7 +48,7 @@ type ('id, 'name) indexed_var = {
 }
 [@@deriving show, ord]
 
-(* __REPLACE6__ *)
+(* __REPLACE0__ *)
 [@@deriving show, ord]
 
 let all_signed_int_types = [ Isize; I8; I16; I32; I64; I128 ]
@@ -61,7 +61,7 @@ let option_none_id = VariantId.of_int 0
 (** The variant id for [Option::Some] *)
 let option_some_id = VariantId.of_int 1
 
-(* __REPLACE5__ *)
+(* __REPLACE1__ *)
 
 (** Ancestor for iter visitor for {!type: Types.ty} *)
 class ['self] iter_ty_base_base =
@@ -125,11 +125,11 @@ class virtual ['self] map_ty_base_base =
         (left, right)
   end
 
-(* __REPLACE0__ *)
-
-(* __REPLACE1__ *)
+(* __REPLACE2__ *)
 
 (* __REPLACE3__ *)
+
+(* __REPLACE4__ *)
 [@@deriving show, ord]
 
 (** A group of regions.
@@ -151,9 +151,6 @@ type region_var_group = (RegionVarId.id, RegionGroupId.id) g_region_group
 [@@deriving show]
 
 type region_var_groups = region_var_group list [@@deriving show]
-
-(* __REPLACE4__ *)
-[@@deriving show]
 
 (** Type with erased regions (this only has an informative purpose) *)
 type ety = ty

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -31,53 +31,26 @@ module BodyId = IdGen ()
 type ('a, 'b) outlives_pred = 'a * 'b
 type ('id, 'x) vector = 'x list [@@deriving show, ord]
 
-(** We define this type to control the name of the visitor functions
-    (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
-  *)
-type type_var_id = TypeVarId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
-type const_generic_var_id = ConstGenericVarId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
-type global_decl_id = GlobalDeclId.id [@@deriving show, ord]
-
 type integer_type = Values.integer_type [@@deriving show, ord]
 type float_type = Values.float_type [@@deriving show, ord]
 
-(** Same remark as for {!type_var_id} *)
+(** We define these types to control the name of the visitor functions
+    (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
+  *)
+type type_var_id = TypeVarId.id [@@deriving show, ord]
+type const_generic_var_id = ConstGenericVarId.id [@@deriving show, ord]
+type global_decl_id = GlobalDeclId.id [@@deriving show, ord]
 type variant_id = VariantId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type field_id = FieldId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type type_decl_id = TypeDeclId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type fun_decl_id = FunDeclId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type trait_decl_id = TraitDeclId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type trait_impl_id = TraitImplId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type trait_clause_id = TraitClauseId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type region_var_id = RegionVarId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type region_id = RegionId.id [@@deriving show, ord]
-
-(** Same remark as for {!type_var_id} *)
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
-
 type disambiguator = Disambiguator.id [@@deriving show, ord]
-
-(** Region DeBruijn identifiers *)
 type region_db_id = int [@@deriving show, ord]
 
 type ('id, 'name) indexed_var = {
@@ -112,108 +85,7 @@ let option_none_id = VariantId.of_int 0
 (** The variant id for [Option::Some] *)
 let option_some_id = VariantId.of_int 1
 
-(** Ancestor for iter visitor for {!Types.const_generic} *)
-class ['self] iter_const_generic_base =
-  object (_self : 'self)
-    inherit [_] iter_literal
-    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
-    method visit_global_decl_id : 'env -> global_decl_id -> unit = fun _ _ -> ()
-
-    method visit_const_generic_var_id : 'env -> const_generic_var_id -> unit =
-      fun _ _ -> ()
-  end
-
-(** Ancestor for map visitor for {!Types.const_generic} *)
-class ['self] map_const_generic_base =
-  object (_self : 'self)
-    inherit [_] map_literal
-
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
-      fun _ x -> x
-
-    method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id =
-      fun _ x -> x
-
-    method visit_const_generic_var_id
-        : 'env -> const_generic_var_id -> const_generic_var_id =
-      fun _ x -> x
-  end
-
-(** Ancestor for reduce visitor for {!Types.const_generic} *)
-class virtual ['self] reduce_const_generic_base =
-  object (self : 'self)
-    inherit [_] reduce_literal
-
-    method visit_type_decl_id : 'env -> type_decl_id -> 'a =
-      fun _ _ -> self#zero
-
-    method visit_global_decl_id : 'env -> global_decl_id -> 'a =
-      fun _ _ -> self#zero
-
-    method visit_const_generic_var_id : 'env -> const_generic_var_id -> 'a =
-      fun _ _ -> self#zero
-  end
-
-(** Ancestor for mapreduce visitor for {!Types.const_generic} *)
-class virtual ['self] mapreduce_const_generic_base =
-  object (self : 'self)
-    inherit [_] mapreduce_literal
-
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id * 'a =
-      fun _ x -> (x, self#zero)
-
-    method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id * 'a
-        =
-      fun _ x -> (x, self#zero)
-
-    method visit_const_generic_var_id
-        : 'env -> const_generic_var_id -> const_generic_var_id * 'a =
-      fun _ x -> (x, self#zero)
-  end
-
-(** Remark: we have to use long names because otherwise we have collisions in
-    the functions derived for the visitors. *)
-type const_generic =
-  | CgGlobal of global_decl_id
-  | CgVar of const_generic_var_id
-  | CgValue of literal
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_const_generic";
-        variety = "iter";
-        ancestors = [ "iter_const_generic_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-        polymorphic = false;
-      },
-    visitors
-      {
-        name = "map_const_generic";
-        variety = "map";
-        ancestors = [ "map_const_generic_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.map} *);
-        concrete = true;
-        polymorphic = false;
-      },
-    visitors
-      {
-        name = "reduce_const_generic";
-        variety = "reduce";
-        ancestors = [ "reduce_const_generic_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.reduce} *);
-        polymorphic = false;
-      },
-    visitors
-      {
-        name = "mapreduce_const_generic";
-        variety = "mapreduce";
-        ancestors = [ "mapreduce_const_generic_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.mapreduce} *);
-        polymorphic = false;
-      }]
+(* __REPLACE5__ *)
 
 type trait_item_name = string [@@deriving show, ord]
 
@@ -319,27 +191,7 @@ and region =
   | RFVar of region_id
       (** Free region. We use those during the symbolic execution. *)
   | RErased  (** Erased region *)
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_ty";
-        variety = "iter";
-        ancestors = [ "iter_ty_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-        polymorphic = false;
-      },
-    visitors
-      {
-        name = "map_ty";
-        variety = "map";
-        ancestors = [ "map_ty_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.map} *);
-        concrete = false;
-        polymorphic = false;
-      }]
+(* __REPLACE6__ *)
 
 (** Ancestor for iter visitor for {!type: Types.generic_params} *)
 class ['self] iter_generic_params_base =
@@ -424,27 +276,6 @@ and region_outlives = region * region
 and type_outlives = ty * region
 
 (* __REPLACE2__ *)
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_generic_params";
-        variety = "iter";
-        ancestors = [ "iter_generic_params_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-        polymorphic = false;
-      },
-    visitors
-      {
-        name = "map_generic_params";
-        variety = "map";
-        ancestors = [ "map_generic_params_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.map} *);
-        concrete = false;
-        polymorphic = false;
-      }]
 
 (* __REPLACE3__ *)
 [@@deriving show, ord]

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -28,30 +28,19 @@ module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
 module BodyId = IdGen ()
 
-type ('a, 'b) outlives_pred = 'a * 'b
+type ('a, 'b) outlives_pred = 'a * 'b [@@deriving show, ord]
 type ('id, 'x) vector = 'x list [@@deriving show, ord]
 
 type integer_type = Values.integer_type [@@deriving show, ord]
 type float_type = Values.float_type [@@deriving show, ord]
+type literal_type = Values.literal_type [@@deriving show, ord]
+type region_db_id = int [@@deriving show, ord]
 
 (** We define these types to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
-type type_var_id = TypeVarId.id [@@deriving show, ord]
-type const_generic_var_id = ConstGenericVarId.id [@@deriving show, ord]
-type global_decl_id = GlobalDeclId.id [@@deriving show, ord]
-type variant_id = VariantId.id [@@deriving show, ord]
-type field_id = FieldId.id [@@deriving show, ord]
-type type_decl_id = TypeDeclId.id [@@deriving show, ord]
-type fun_decl_id = FunDeclId.id [@@deriving show, ord]
-type trait_decl_id = TraitDeclId.id [@@deriving show, ord]
-type trait_impl_id = TraitImplId.id [@@deriving show, ord]
-type trait_clause_id = TraitClauseId.id [@@deriving show, ord]
 type region_var_id = RegionVarId.id [@@deriving show, ord]
-type region_id = RegionId.id [@@deriving show, ord]
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
-type disambiguator = Disambiguator.id [@@deriving show, ord]
-type region_db_id = int [@@deriving show, ord]
 
 type ('id, 'name) indexed_var = {
   index : 'id;  (** Unique index identifying the variable *)
@@ -59,25 +48,12 @@ type ('id, 'name) indexed_var = {
 }
 [@@deriving show, ord]
 
-type type_var = (TypeVarId.id, string) indexed_var [@@deriving show, ord]
-
-type region_var = (RegionVarId.id, string option) indexed_var
-[@@deriving show, ord]
-
-type literal_type = Values.literal_type [@@deriving show, ord]
-
-type const_generic_var = {
-  index : ConstGenericVarId.id;
-  name : string;
-  ty : literal_type;
-}
+(* __REPLACE6__ *)
 [@@deriving show, ord]
 
 let all_signed_int_types = [ Isize; I8; I16; I32; I64; I128 ]
 let all_unsigned_int_types = [ Usize; U8; U16; U32; U64; U128 ]
 let all_int_types = List.append all_signed_int_types all_unsigned_int_types
-
-type ref_kind = RMut | RShared [@@deriving show, ord]
 
 (** The variant id for [Option::None] *)
 let option_none_id = VariantId.of_int 0
@@ -87,195 +63,71 @@ let option_some_id = VariantId.of_int 1
 
 (* __REPLACE5__ *)
 
-type trait_item_name = string [@@deriving show, ord]
-
 (** Ancestor for iter visitor for {!type: Types.ty} *)
-class ['self] iter_ty_base =
+class ['self] iter_ty_base_base =
   object (self : 'self)
     inherit [_] iter_const_generic
-    method visit_region_db_id : 'env -> region_db_id -> unit = fun _ _ -> ()
-    method visit_region_var_id : 'env -> region_var_id -> unit = fun _ _ -> ()
-    method visit_region_id : 'env -> region_id -> unit = fun _ _ -> ()
-    method visit_type_var_id : 'env -> type_var_id -> unit = fun _ _ -> ()
-    method visit_ref_kind : 'env -> ref_kind -> unit = fun _ _ -> ()
 
-    method visit_trait_item_name : 'env -> trait_item_name -> unit =
-      fun _ _ -> ()
+    method visit_indexed_var
+        : 'id 'name.
+          ('env -> 'id -> unit) ->
+          ('env -> 'name -> unit) ->
+          'env ->
+          ('id, 'name) indexed_var ->
+          unit =
+      fun visit_index visit_name env x ->
+        let { index; name } = x in
+        visit_index env index;
+        visit_name env name
 
-    method visit_fun_decl_id : 'env -> fun_decl_id -> unit = fun _ _ -> ()
-    method visit_trait_decl_id : 'env -> trait_decl_id -> unit = fun _ _ -> ()
-    method visit_trait_impl_id : 'env -> trait_impl_id -> unit = fun _ _ -> ()
-
-    method visit_trait_clause_id : 'env -> trait_clause_id -> unit =
-      fun _ _ -> ()
-
-    method visit_region_var : 'env -> region_var -> unit =
-      fun env x ->
-        let { index; name } : region_var = x in
-        self#visit_region_var_id env index;
-        self#visit_option self#visit_string env name
+    method visit_outlives_pred
+        : 'l 'r.
+          ('env -> 'l -> unit) ->
+          ('env -> 'r -> unit) ->
+          'env ->
+          ('l, 'r) outlives_pred ->
+          unit =
+      fun visit_left visit_right env x ->
+        let (left, right) = x in
+        visit_left env left;
+        visit_right env right
   end
 
 (** Ancestor for map visitor for {!type: Types.ty} *)
-class virtual ['self] map_ty_base =
+class virtual ['self] map_ty_base_base =
   object (self : 'self)
     inherit [_] map_const_generic
 
-    method visit_region_db_id : 'env -> region_db_id -> region_db_id =
-      fun _ id -> id
-
-    method visit_region_var_id : 'env -> region_var_id -> region_var_id =
-      fun _ id -> id
-
-    method visit_region_id : 'env -> region_id -> region_id = fun _ id -> id
-
-    method visit_type_var_id : 'env -> type_var_id -> type_var_id =
-      fun _ id -> id
-
-    method visit_ref_kind : 'env -> ref_kind -> ref_kind = fun _ rk -> rk
-
-    method visit_trait_item_name : 'env -> trait_item_name -> trait_item_name =
-      fun _ x -> x
-
-    method visit_fun_decl_id : 'env -> fun_decl_id -> fun_decl_id = fun _ x -> x
-
-    method visit_trait_decl_id : 'env -> trait_decl_id -> trait_decl_id =
-      fun _ x -> x
-
-    method visit_trait_impl_id : 'env -> trait_impl_id -> trait_impl_id =
-      fun _ x -> x
-
-    method visit_trait_clause_id : 'env -> trait_clause_id -> trait_clause_id =
-      fun _ x -> x
-
-    method visit_region_var : 'env -> region_var -> region_var =
-      fun env x ->
-        let { index; name } : region_var = x in
-        let index = self#visit_region_var_id env index in
-        let name = self#visit_option self#visit_string env name in
+    method visit_indexed_var
+        : 'id 'name.
+          ('env -> 'id -> 'id) ->
+          ('env -> 'name -> 'name) ->
+          'env ->
+          ('id, 'name) indexed_var ->
+          ('id, 'name) indexed_var =
+      fun visit_index visit_name env x ->
+        let { index; name } = x in
+        let index = visit_index env index in
+        let name = visit_name env name in
         { index; name }
+
+    method visit_outlives_pred
+        : 'l 'r.
+          ('env -> 'l -> 'l) ->
+          ('env -> 'r -> 'r) ->
+          'env ->
+          ('l, 'r) outlives_pred ->
+          ('l, 'r) outlives_pred =
+      fun visit_left visit_right env x ->
+        let (left, right) = x in
+        let left = visit_left env left in
+        let right = visit_right env right in
+        (left, right)
   end
 
 (* __REPLACE0__ *)
 
-(* Hand-written because we add an extra variant not present on the rust side *)
-and trait_instance_id =
-  | Self
-      (** Reference to *self*, in case of trait declarations/implementations *)
-  | TraitImpl of trait_impl_id * generic_args  (** A specific implementation *)
-  | BuiltinOrAuto of trait_decl_ref
-  | Clause of trait_clause_id
-  | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
-  | FnPointer of ty
-  | Closure of fun_decl_id * generic_args
-  | Dyn of trait_decl_ref
-  | Unsolved of trait_decl_id * generic_args
-  | UnknownTrait of string
-      (** Not present in the Rust version of Charon.
-
-          We use this in the substitutions, to substitute [Self] when [Self] shouldn't
-          appear: this allows us to track errors by making sure [Self] indeed did not
-          appear.
-       *)
-
-(** A region.
-
-    This definition doesn't need to be mutually recursive with the others, but
-    this allows us to factor out the visitors.
- *)
-(* Hand-written because we add an extra variant not present on the rust side *)
-and region =
-  | RStatic  (** Static region *)
-  | RBVar of region_db_id * region_var_id
-      (** Bound region. We use those in function signatures, type definitions, etc. *)
-  | RFVar of region_id
-      (** Free region. We use those during the symbolic execution. *)
-  | RErased  (** Erased region *)
-(* __REPLACE6__ *)
-
-(** Ancestor for iter visitor for {!type: Types.generic_params} *)
-class ['self] iter_generic_params_base =
-  object (self : 'self)
-    inherit [_] iter_ty
-    method visit_span : 'env -> span -> unit = fun _ _ -> ()
-
-    method visit_type_var : 'env -> type_var -> unit =
-      fun env x ->
-        let { index; name } : type_var = x in
-        self#visit_type_var_id env index;
-        self#visit_string env name
-
-    method visit_const_generic_var : 'env -> const_generic_var -> unit =
-      fun env x ->
-        let { index; name; ty } : const_generic_var = x in
-        self#visit_const_generic_var_id env index;
-        self#visit_string env name;
-        self#visit_literal_type env ty
-  end
-
-(** Ancestor for map visitor for {!type: Types.generic_params} *)
-class virtual ['self] map_generic_params_base =
-  object (self : 'self)
-    inherit [_] map_ty
-    method visit_span : 'env -> span -> span = fun _ x -> x
-
-    method visit_type_var : 'env -> type_var -> type_var =
-      fun env x ->
-        let { index; name } : type_var = x in
-        let index = self#visit_type_var_id env index in
-        let name = self#visit_string env name in
-        { index; name }
-
-    method visit_const_generic_var
-        : 'env -> const_generic_var -> const_generic_var =
-      fun env x ->
-        let { index; name; ty } : const_generic_var = x in
-        let index = self#visit_const_generic_var_id env index in
-        let name = self#visit_string env name in
-        let ty = self#visit_literal_type env ty in
-        { index; name; ty }
-  end
-
-(** Type with erased regions (this only has an informative purpose) *)
-type ety = ty
-
-(** Type with non-erased regions (this only has an informative purpose) *)
-and rty = ty
-
 (* __REPLACE1__ *)
-
-(* Hand-written because visitors can't handle `outlives_pred` *)
-and generic_params = {
-  regions : region_var list;
-  types : type_var list;
-      (** The type parameters can be indexed with {!Types.TypeVarId.id}.
-
-          See {!Identifiers.Id.mapi} for instance.
-       *)
-  const_generics : const_generic_var list;
-      (** The const generic parameters can be indexed with {!Types.ConstGenericVarId.id}.
-
-          See {!Identifiers.Id.mapi} for instance.
-       *)
-  trait_clauses : trait_clause list;
-      (** **REMARK:**:
-          The indices used by the trait clauses may not be contiguous
-          (e.g., we may have the list: `[clause 0; clause 2; clause3; clause 5]`).
-          because of the way the clauses are resolved in hax (see the comments
-          in Charon).
-        *)
-  regions_outlive : region_outlives list;
-  types_outlive : type_outlives list;
-  trait_type_constraints : trait_type_constraint list;
-}
-
-(** ('long, 'short) means that 'long outlives 'short *)
-and region_outlives = region * region
-
-(** (T, 'a) means that T outlives 'a *)
-and type_outlives = ty * region
-
-(* __REPLACE2__ *)
 
 (* __REPLACE3__ *)
 [@@deriving show, ord]
@@ -302,3 +154,10 @@ type region_var_groups = region_var_group list [@@deriving show]
 
 (* __REPLACE4__ *)
 [@@deriving show]
+
+(** Type with erased regions (this only has an informative purpose) *)
+type ety = ty
+
+(** Type with non-erased regions (this only has an informative purpose) *)
+and rty = ty
+[@@deriving show, ord]

--- a/charon/src/bin/generate-ml/templates/UllbcAst.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcAst.ml
@@ -11,79 +11,11 @@ module BlockId = IdGen ()
   *)
 type block_id = BlockId.id [@@deriving show, ord]
 
-(** Ancestor for {!UllbcAst.statement} iter visitor *)
-class ['self] iter_statement_base =
-  object (_self : 'self)
-    inherit [_] GAst.iter_statement_base
-    method visit_block_id : 'env -> block_id -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor for {!UllbcAst.statement} map visitor *)
-class ['self] map_statement_base =
-  object (_self : 'self)
-    inherit [_] GAst.map_statement_base
-    method visit_block_id : 'env -> block_id -> block_id = fun _ x -> x
-  end
-
 (* __REPLACE0__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_statement";
-        variety = "iter";
-        ancestors = [ "iter_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_statement";
-        variety = "map";
-        ancestors = [ "map_statement_base" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 (* __REPLACE1__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_switch";
-        variety = "iter";
-        ancestors = [ "iter_statement" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_switch";
-        variety = "map";
-        ancestors = [ "map_statement" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 (* __REPLACE2__ *)
-[@@deriving
-  show,
-    visitors
-      {
-        name = "iter_terminator";
-        variety = "iter";
-        ancestors = [ "iter_switch" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_terminator";
-        variety = "map";
-        ancestors = [ "map_switch" ];
-        nude = true (* Don't inherit {!VisitorsRuntime.iter} *);
-        concrete = true;
-      }]
 
 (* __REPLACE3__ *)
 [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/UllbcAst.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcAst.ml
@@ -15,11 +15,6 @@ type block_id = BlockId.id [@@deriving show, ord]
 
 (* __REPLACE1__ *)
 
-(* __REPLACE2__ *)
-
-(* __REPLACE3__ *)
-[@@deriving show]
-
 type expr_body = blocks gexpr_body [@@deriving show]
 type fun_body = expr_body [@@deriving show]
 type fun_decl = blocks gfun_decl [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
@@ -9,8 +9,6 @@ open Types
 open Expressions
 open UllbcAst
 
-let block_id_of_json = BlockId.id_of_json
-
 let rec ___ = ()
 
 (* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
@@ -9,8 +9,6 @@ open Types
 open Expressions
 open UllbcAst
 
-let rec ___ = ()
-
 (* __REPLACE0__ *)
 
 let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :

--- a/charon/src/bin/generate-ml/templates/Values.ml
+++ b/charon/src/bin/generate-ml/templates/Values.ml
@@ -50,46 +50,7 @@ class virtual ['self] mapreduce_literal_base =
       fun _ x -> (x, self#zero)
   end
 
-type integer_type =
-  | Isize
-  | I8
-  | I16
-  | I32
-  | I64
-  | I128
-  | Usize
-  | U8
-  | U16
-  | U32
-  | U64
-  | U128
-
-and float_type = F16 | F32 | F64 | F128
-
-(** This is simlar to the Scalar value above. However, instead of storing
-    the float value itself, we store its String representation. This allows
-    to derive the Eq and Ord traits, which are not implemented for floats
- *)
-and float_value = { float_value : string; float_ty : float_type }
-
-(** Types of primitive values. Either an integer, bool, char *)
-and literal_type =
-  | TInteger of integer_type
-  | TFloat of float_type
-  | TBool
-  | TChar
-
-(** A primitive value.
-
-    Those are for instance used for the constant operands [crate::expressions::Operand::Const]
- *)
-and literal =
-  | VScalar of scalar_value
-  | VFloat of float_value
-  | VBool of bool
-  | VChar of char
-  | VByteStr of int list
-  | VStr of string
+(* __REPLACE0__ *)
 
 (** A scalar value
 

--- a/charon/src/bin/generate-ml/templates/Values.ml
+++ b/charon/src/bin/generate-ml/templates/Values.ml
@@ -50,8 +50,6 @@ class virtual ['self] mapreduce_literal_base =
       fun _ x -> (x, self#zero)
   end
 
-(* __REPLACE0__ *)
-
 (** A scalar value
 
     Note that we use unbounded integers everywhere.
@@ -59,37 +57,6 @@ class virtual ['self] mapreduce_literal_base =
 
     Hand-written because the rust version is an enum with custom (de)serialization functions.
  *)
-and scalar_value = { value : big_int; int_ty : integer_type }
-[@@deriving
-  show,
-    ord,
-    visitors
-      {
-        name = "iter_literal";
-        variety = "iter";
-        ancestors = [ "iter_literal_base" ];
-        nude = true;
-        concrete = true;
-      },
-    visitors
-      {
-        name = "map_literal";
-        variety = "map";
-        ancestors = [ "map_literal_base" ];
-        nude = true;
-        concrete = true;
-      },
-    visitors
-      {
-        name = "reduce_literal";
-        variety = "reduce";
-        ancestors = [ "reduce_literal_base" ];
-        nude = true;
-      },
-    visitors
-      {
-        name = "mapreduce_literal";
-        variety = "mapreduce";
-        ancestors = [ "mapreduce_literal_base" ];
-        nude = true;
-      }]
+type scalar_value = { value : big_int; int_ty : integer_type }
+
+(* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/templates/Values.ml
+++ b/charon/src/bin/generate-ml/templates/Values.ml
@@ -20,43 +20,4 @@ let pp_big_int (fmt : Format.formatter) (bi : big_int) : unit =
 let compare_big_int (bi0 : big_int) (bi1 : big_int) : int = Z.compare bi0 bi1
 let show_big_int (bi : big_int) : string = Z.to_string bi
 
-(** Ancestor the literal iter visitor *)
-class ['self] iter_literal_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.iter
-    method visit_big_int : 'env -> big_int -> unit = fun _ _ -> ()
-  end
-
-(** Ancestor the literal map visitor *)
-class ['self] map_literal_base =
-  object (_self : 'self)
-    inherit [_] VisitorsRuntime.map
-    method visit_big_int : 'env -> big_int -> big_int = fun _ x -> x
-  end
-
-(** Ancestor the literal reduce visitor *)
-class virtual ['self] reduce_literal_base =
-  object (self : 'self)
-    inherit [_] VisitorsRuntime.reduce
-    method visit_big_int : 'env -> big_int -> 'a = fun _ _ -> self#zero
-  end
-
-(** Ancestor the literal mapreduce visitor *)
-class virtual ['self] mapreduce_literal_base =
-  object (self : 'self)
-    inherit [_] VisitorsRuntime.mapreduce
-
-    method visit_big_int : 'env -> big_int -> big_int * 'a =
-      fun _ x -> (x, self#zero)
-  end
-
-(** A scalar value
-
-    Note that we use unbounded integers everywhere.
-    We then harcode the boundaries for the different types.
-
-    Hand-written because the rust version is an enum with custom (de)serialization functions.
- *)
-type scalar_value = { value : big_int; int_ty : integer_type }
-
 (* __REPLACE0__ *)

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,7 @@
           cp ${./charon-ml/src}/Expressions.ml committed
           cp ${./charon-ml/src}/Meta.ml committed
           cp ${./charon-ml/src}/Types.ml committed
+          cp ${./charon-ml/src}/Values.ml committed
           cp ${./charon-ml/src}/GAstOfJson.ml committed
           cp ${./charon-ml/src}/LlbcOfJson.ml committed
           cp ${./charon-ml/src}/UllbcOfJson.ml committed


### PR DESCRIPTION
This PR greatly cleans up `charon-ml`:
- we now generate all the boilerplate visitors code;
- we no longer have to list which types to generate json code for (we still do for type declarations because of visitors);
- this removes many unneeded intermediate visitors;
- overall the template files are much more legible now.

There are visitors I would like to merge but cannot because of limitations in the `visitors` library. This is an issue for `dyn` support, as this requires `GenericParams` and `GenericArgs` to be in the same group of mutual recursion.