### PR TITLE
Distinguish statements and sequences of statements in rust llbc ast

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.40"
+let supported_charon_version = "0.1.41"

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -31,9 +31,10 @@ type raw_statement =
   | Error of string
 
 and statement = { span : span; content : raw_statement }
+and block = statement
 
 and switch =
-  | If of operand * statement * statement
+  | If of operand * block * block
       (** Gives the `if` block and the `else` block. The `Operand` is the condition of the `if`, e.g. `if (y == 0)` could become
           ```rust,ignore
           v@3 := copy y; // Represented as `Assign(v@3, Use(Copy(y))`
@@ -42,7 +43,7 @@ and switch =
           ```
        *)
   | SwitchInt of
-      operand * integer_type * (scalar_value list * statement) list * statement
+      operand * integer_type * (scalar_value list * block) list * block
       (** Gives the integer type, a map linking values to switch branches, and the
           otherwise block. Note that matches over enumerations are performed by
           switching over the discriminant, which is an integer.
@@ -58,7 +59,7 @@ and switch =
           }
           ```
        *)
-  | Match of place * (variant_id list * statement) list * statement option
+  | Match of place * (variant_id list * block) list * block option
       (** A match over an ADT.
 
           The match statement is introduced in [crate::remove_read_discriminant]

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.40"
+version = "0.1.41"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
@@ -16,7 +16,7 @@ let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
     (match js with
     | `Assoc [ ("Structured", body) ] ->
         let* body =
-          gexpr_body_of_json (statement_of_json id_to_file) id_to_file body
+          gexpr_body_of_json (block_of_json id_to_file) id_to_file body
         in
         Ok body
     | _ -> Error "")

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -76,6 +76,20 @@ impl<C: AstFormatter> FmtWithCtx<C> for Assert {
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for llbc::Block {
+    fn fmt_with_ctx(&self, ctx: &C) -> String {
+        // By default use a tab.
+        self.fmt_with_ctx_and_indent(TAB_INCR, ctx)
+    }
+
+    fn fmt_with_ctx_and_indent(&self, tab: &str, ctx: &C) -> String {
+        self.statements
+            .iter()
+            .map(|st| st.fmt_with_ctx_and_indent(tab, ctx))
+            .join("\n")
+    }
+}
+
 impl<C: AstFormatter> FmtWithCtx<C> for BlockData {
     fn fmt_with_ctx_and_indent(&self, tab: &str, ctx: &C) -> String {
         let mut out: Vec<String> = Vec::new();
@@ -1008,10 +1022,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for llbc::Statement {
             RawStatement::Break(index) => format!("{tab}break {index}"),
             RawStatement::Continue(index) => format!("{tab}continue {index}"),
             RawStatement::Nop => format!("{tab}nop"),
-            RawStatement::Sequence(vec) => vec
-                .iter()
-                .map(|st| st.fmt_with_ctx_and_indent(tab, ctx))
-                .join("\n"),
             RawStatement::Switch(switch) => match switch {
                 Switch::If(discr, true_st, false_st) => {
                     let inner_tab = format!("{tab}{TAB_INCR}");

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -182,7 +182,7 @@ pub trait AstFormatter = Formatter<TypeVarId>
     + for<'a> Formatter<&'a ImplElem>
     + for<'a> Formatter<&'a RegionVar>
     + for<'a> Formatter<&'a Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>>
-    + for<'a> Formatter<&'a llbc_ast::Statement>
+    + for<'a> Formatter<&'a llbc_ast::Block>
     + for<'a> SetGenerics<'a>
     + for<'a> SetLocals<'a>
     + for<'a> PushBoundRegions<'a>;
@@ -539,8 +539,8 @@ impl<'a> Formatter<VarId> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<&llbc_ast::Statement> for FmtCtx<'a> {
-    fn format_object(&self, x: &llbc_ast::Statement) -> String {
+impl<'a> Formatter<&llbc_ast::Block> for FmtCtx<'a> {
+    fn format_object(&self, x: &llbc_ast::Block) -> String {
         x.fmt_with_ctx(self)
     }
 }

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -29,7 +29,9 @@ impl LlbcPass for Transform {
             if let Ok(body) = body {
                 let body = body.as_structured().unwrap();
                 // If the whole body is only a call to this specific panic function.
-                if let RawStatement::Abort(AbortKind::Panic(name)) = &body.body.content {
+                if let [st] = body.body.statements.as_slice()
+                    && let RawStatement::Abort(AbortKind::Panic(name)) = &st.content
+                {
                     if name.equals_ref_name(builtins::EXPLICIT_PANIC_NAME) {
                         // FIXME: also check that the name of the function is
                         // `panic_cold_explicit`?

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -9,7 +9,7 @@ use crate::transform::TransformCtx;
 
 use super::ctx::LlbcPass;
 
-fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
+fn transform_st(st: &mut Statement) -> Vec<Statement> {
     if let RawStatement::Return = &mut st.content {
         let ret_place = Place {
             var_id: VarId::new(0),
@@ -20,10 +20,10 @@ fn transform_st(st: &mut Statement) -> Option<Vec<Statement>> {
             Vec::new(),
         );
         let assign_st = Statement::new(st.span, RawStatement::Assign(ret_place, unit_value));
-        let ret_st = Statement::new(st.span, RawStatement::Return);
-        st.content = assign_st.then(ret_st).content;
-    };
-    None
+        vec![assign_st]
+    } else {
+        Vec::new()
+    }
 }
 
 pub struct Transform;

--- a/charon/src/transform/ops_to_function_calls.rs
+++ b/charon/src/transform/ops_to_function_calls.rs
@@ -7,7 +7,7 @@ use crate::transform::TransformCtx;
 
 use super::ctx::LlbcPass;
 
-fn transform_st(s: &mut Statement) -> Option<Vec<Statement>> {
+fn transform_st(s: &mut Statement) {
     match &s.content {
         // Transform the ArrayToSlice unop
         RawStatement::Assign(p, Rvalue::UnaryOp(UnOp::ArrayToSlice(ref_kind, ty, cg), op)) => {
@@ -30,8 +30,6 @@ fn transform_st(s: &mut Statement) -> Option<Vec<Statement>> {
                 args: vec![op.clone()],
                 dest: p.clone(),
             });
-
-            None
         }
         // Transform the array aggregates to function calls
         RawStatement::Assign(p, Rvalue::Repeat(op, ty, cg)) => {
@@ -51,16 +49,14 @@ fn transform_st(s: &mut Statement) -> Option<Vec<Statement>> {
                 args: vec![op.clone()],
                 dest: p.clone(),
             });
-
-            None
         }
-        _ => None,
+        _ => {}
     }
 }
 
 pub struct Transform;
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx<'_>, b: &mut ExprBody) {
-        b.body.transform(&mut transform_st);
+        b.body.visit_statements(&mut transform_st);
     }
 }

--- a/charon/src/transform/remove_nops.rs
+++ b/charon/src/transform/remove_nops.rs
@@ -1,30 +1,21 @@
 //! Remove the useless no-ops.
 
-use crate::llbc_ast::{ExprBody, RawStatement, Statement};
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
+
+use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
-use take_mut::take;
 
 use super::ctx::LlbcPass;
-
-fn transform_st(s: &mut Statement) {
-    if let RawStatement::Sequence(seq) = &mut s.content {
-        // Remove all the `Nop`s from this sequence.
-        if seq.iter().any(|st| st.content.is_nop()) {
-            seq.retain(|st| !st.content.is_nop())
-        }
-        // Replace an empty sequence with a `Nop`.
-        if seq.is_empty() {
-            take(&mut s.content, |_| RawStatement::Nop)
-        }
-    }
-}
 
 pub struct Transform;
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx<'_>, b: &mut ExprBody) {
-        b.body.transform(&mut |st| {
-            transform_st(st);
-            None
-        });
+        b.body
+            .drive_mut(&mut visitor_enter_fn_mut(|blk: &mut Block| {
+                // Remove all the `Nop`s from this sequence.
+                if blk.statements.iter().any(|st| st.content.is_nop()) {
+                    blk.statements.retain(|st| !st.content.is_nop())
+                }
+            }));
     }
 }

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -120,7 +120,7 @@ fn test_cargo_dependencies::main()
     @14 := copy (*(right_val@11))
     @12 := move (@13) == move (@14)
     if move (@12) {
-        nop
+
     }
     else {
         drop @14

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -120,7 +120,6 @@ fn test_cargo_dependencies::main()
     @14 := copy (*(right_val@11))
     @12 := move (@13) == move (@14)
     if move (@12) {
-
     }
     else {
         drop @14

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -24,7 +24,7 @@ where
         },
         0 => {
             @0 := const (false)
-        }
+        },
     }
     return
 }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -134,8 +134,11 @@ fn spans() -> anyhow::Result<()> {
     let body = &crate_data.bodies[body_id].as_structured().unwrap().body;
     // The whole function declaration.
     assert_eq!(repr_span(body.span), "2:8-10:9");
-    let seq = body.clone().into_sequence();
-    let the_loop = seq.iter().find(|st| st.content.is_loop()).unwrap();
+    let the_loop = body
+        .statements
+        .iter()
+        .find(|st| st.content.is_loop())
+        .unwrap();
     // That's not a very precise span :/
     assert_eq!(repr_span(the_loop.span), "4:12-10:9");
     Ok(())

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -1204,7 +1204,7 @@ fn test_crate::sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u
     drop @9
     @5 := move (@6) == move (@8)
     if move (@5) {
-        nop
+
     }
     else {
         drop @8
@@ -1229,13 +1229,13 @@ fn test_crate::sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u
             drop @15
             drop @14
             @19 := copy (i@10)
-            @26 := &*(s@1)
-            @27 := @SliceIndexShared<'_, u32>(move (@26), copy (@19))
-            @18 := copy (*(@27))
+            @28 := &*(s@1)
+            @29 := @SliceIndexShared<'_, u32>(move (@28), copy (@19))
+            @18 := copy (*(@29))
             @21 := copy (i@10)
-            @28 := &*(s2@2)
-            @29 := @SliceIndexShared<'_, u32>(move (@28), copy (@21))
-            @20 := copy (*(@29))
+            @26 := &*(s2@2)
+            @27 := @SliceIndexShared<'_, u32>(move (@26), copy (@21))
+            @20 := copy (*(@27))
             @17 := move (@18) + move (@20)
             drop @20
             drop @18
@@ -1695,15 +1695,15 @@ fn test_crate::slice_pattern_2<'_0, T>(@1: Array<&'_0 mut (T), 3 : usize>)
     let @11: &'_ mut (&'_ mut (T)); // anonymous local
 
     @fake_read(x@1)
-    @6 := &mut x@1
-    @7 := @ArrayIndexMut<'_, &'_ mut (T), 3 : usize>(move (@6), const (0 : usize))
-    _a@2 := move (*(@7))
+    @10 := &mut x@1
+    @11 := @ArrayIndexMut<'_, &'_ mut (T), 3 : usize>(move (@10), const (0 : usize))
+    _a@2 := move (*(@11))
     @8 := &mut x@1
     @9 := @ArrayIndexMut<'_, &'_ mut (T), 3 : usize>(move (@8), const (1 : usize))
     _b@3 := move (*(@9))
-    @10 := &mut x@1
-    @11 := @ArrayIndexMut<'_, &'_ mut (T), 3 : usize>(move (@10), const (2 : usize))
-    _c@4 := move (*(@11))
+    @6 := &mut x@1
+    @7 := @ArrayIndexMut<'_, &'_ mut (T), 3 : usize>(move (@6), const (2 : usize))
+    _c@4 := move (*(@7))
     @5 := ()
     @0 := move (@5)
     drop _c@4

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -1204,7 +1204,6 @@ fn test_crate::sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u
     drop @9
     @5 := move (@6) == move (@8)
     if move (@5) {
-
     }
     else {
         drop @8

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -71,7 +71,7 @@ where
             drop @4
             drop x@3
             drop x@3
-        }
+        },
     }
     drop f@2
     drop x@1
@@ -104,7 +104,7 @@ fn test_crate::map_option_pointer_ref<'a, T, F>(@1: &'a (core::option::Option<T>
             drop @4
             drop @4
             drop x@3
-        }
+        },
     }
     return
 }

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -142,7 +142,7 @@ fn test_crate::list_nth<'a, T>(@1: &'a (test_crate::CList<T>), @2: u32) -> &'a (
     @fake_read(l@1)
     match *(l@1) {
         0 => {
-            nop
+
         },
         1 => {
             panic(core::panicking::panic_explicit)
@@ -196,7 +196,7 @@ fn test_crate::list_nth_mut<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) 
     @fake_read(l@1)
     match *(l@1) {
         0 => {
-            nop
+
         },
         1 => {
             panic(core::panicking::panic_explicit)
@@ -265,7 +265,7 @@ fn test_crate::list_nth_mut1<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32)
                 @9 := copy (i@2)
                 @8 := move (@9) == const (0 : u32)
                 if move (@8) {
-                    nop
+
                 }
                 else {
                     drop @9

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -142,11 +142,10 @@ fn test_crate::list_nth<'a, T>(@1: &'a (test_crate::CList<T>), @2: u32) -> &'a (
     @fake_read(l@1)
     match *(l@1) {
         0 => {
-
         },
         1 => {
             panic(core::panicking::panic_explicit)
-        }
+        },
     }
     x@3 := &(*(l@1) as variant @0).0
     tl@4 := &(*(l@1) as variant @0).1
@@ -196,11 +195,10 @@ fn test_crate::list_nth_mut<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32) 
     @fake_read(l@1)
     match *(l@1) {
         0 => {
-
         },
         1 => {
             panic(core::panicking::panic_explicit)
-        }
+        },
     }
     x@5 := &mut (*(l@1) as variant @0).0
     tl@6 := &mut (*(l@1) as variant @0).1
@@ -265,7 +263,6 @@ fn test_crate::list_nth_mut1<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32)
                 @9 := copy (i@2)
                 @8 := move (@9) == const (0 : u32)
                 if move (@8) {
-
                 }
                 else {
                     drop @9
@@ -298,7 +295,7 @@ fn test_crate::list_nth_mut1<'a, T>(@1: &'a mut (test_crate::CList<T>), @2: u32)
                 drop @11
                 drop @3
                 panic(core::panicking::panic_explicit)
-            }
+            },
         }
     }
 }
@@ -356,7 +353,7 @@ fn test_crate::list_tail<'a, T>(@1: &'a mut (test_crate::CList<T>)) -> &'a mut (
         },
         1 => {
             @3 := move (l@1)
-        }
+        },
     }
     @2 := &mut *(@3)
     @0 := &mut *(@2)

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -16,7 +16,7 @@ fn test_crate::discriminant_value<'_0, T>(@1: &'_0 (core::option::Option<T>)) ->
         },
         1 => {
             @0 := const (1 : isize)
-        }
+        },
     }
     return
 }
@@ -33,7 +33,7 @@ fn test_crate::is_some<T>(@1: core::option::Option<T>) -> bool
         },
         1 => {
             @2 := const (1 : isize)
-        }
+        },
     }
     @0 := move (@2) != const (0 : isize)
     drop @2
@@ -52,7 +52,7 @@ fn test_crate::my_is_some<T>(@1: core::option::Option<T>) -> isize
         },
         1 => {
             @0 := const (1 : isize)
-        }
+        },
     }
     drop opt@1
     return

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -117,7 +117,6 @@ fn test_crate::slice_pat3()
     @9 := const (2 : usize)
     @10 := move (@8) >= move (@9)
     if move (@10) {
-
     }
     else {
         drop _c@7

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -18,15 +18,15 @@ fn test_crate::slice_pat1()
     array@1 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
     @fake_read(array@1)
     @fake_read(array@1)
-    @6 := &array@1
-    @7 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@6), const (0 : usize))
-    _a@2 := copy (*(@7))
+    @10 := &array@1
+    @11 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@10), const (0 : usize))
+    _a@2 := copy (*(@11))
     @8 := &array@1
     @9 := @ArraySubSliceShared<'_, i32, 4 : usize>(move (@8), const (1 : usize), const (3 : usize))
     _b@3 := copy (*(@9))
-    @10 := &array@1
-    @11 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@10), const (3 : usize))
-    _c@4 := copy (*(@11))
+    @6 := &array@1
+    @7 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@6), const (3 : usize))
+    _c@4 := copy (*(@7))
     @5 := ()
     @0 := move (@5)
     drop _c@4
@@ -60,15 +60,15 @@ fn test_crate::slice_pat2()
     @fake_read(array_ref@1)
     drop @2
     @fake_read(array_ref@1)
-    @8 := &*(array_ref@1)
-    @9 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@8), const (0 : usize))
-    _a@4 := &*(@9)
+    @12 := &*(array_ref@1)
+    @13 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@12), const (0 : usize))
+    _a@4 := &*(@13)
     @10 := &*(array_ref@1)
     @11 := @ArraySubSliceShared<'_, i32, 4 : usize>(move (@10), const (1 : usize), const (3 : usize))
     _b@5 := &*(@11)
-    @12 := &*(array_ref@1)
-    @13 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@12), const (3 : usize))
-    _c@6 := &*(@13)
+    @8 := &*(array_ref@1)
+    @9 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@8), const (3 : usize))
+    _c@6 := &*(@9)
     @7 := ()
     @0 := move (@7)
     drop _c@6
@@ -95,14 +95,14 @@ fn test_crate::slice_pat3()
     let @10: bool; // anonymous local
     let @11: (); // anonymous local
     let @12: &'_ (Slice<i32>); // anonymous local
-    let @13: &'_ (i32); // anonymous local
-    let @14: &'_ (Slice<i32>); // anonymous local
-    let @15: usize; // anonymous local
-    let @16: usize; // anonymous local
-    let @17: &'_ (Slice<i32>); // anonymous local
-    let @18: &'_ (Slice<i32>); // anonymous local
-    let @19: usize; // anonymous local
-    let @20: usize; // anonymous local
+    let @13: usize; // anonymous local
+    let @14: usize; // anonymous local
+    let @15: &'_ (i32); // anonymous local
+    let @16: &'_ (Slice<i32>); // anonymous local
+    let @17: usize; // anonymous local
+    let @18: usize; // anonymous local
+    let @19: &'_ (Slice<i32>); // anonymous local
+    let @20: &'_ (Slice<i32>); // anonymous local
     let @21: &'_ (i32); // anonymous local
 
     @4 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
@@ -117,7 +117,7 @@ fn test_crate::slice_pat3()
     @9 := const (2 : usize)
     @10 := move (@8) >= move (@9)
     if move (@10) {
-        nop
+
     }
     else {
         drop _c@7
@@ -125,19 +125,19 @@ fn test_crate::slice_pat3()
         drop _a@5
         panic(core::panicking::panic_explicit)
     }
+    @20 := &*(slice@1)
+    @21 := @SliceIndexShared<'_, i32>(move (@20), const (0 : usize))
+    _a@5 := &*(@21)
+    @16 := &*(slice@1)
+    @17 := len(*(slice@1))
+    @18 := copy (@17) - const (1 : usize)
+    @19 := @SliceSubSliceShared<'_, i32>(move (@16), const (1 : usize), copy (@18))
+    _b@6 := &*(@19)
     @12 := &*(slice@1)
-    @13 := @SliceIndexShared<'_, i32>(move (@12), const (0 : usize))
-    _a@5 := &*(@13)
-    @14 := &*(slice@1)
-    @15 := len(*(slice@1))
-    @16 := copy (@15) - const (1 : usize)
-    @17 := @SliceSubSliceShared<'_, i32>(move (@14), const (1 : usize), copy (@16))
-    _b@6 := &*(@17)
-    @18 := &*(slice@1)
-    @19 := len(*(slice@1))
-    @20 := copy (@19) - const (1 : usize)
-    @21 := @SliceIndexShared<'_, i32>(move (@18), copy (@20))
-    _c@7 := &*(@21)
+    @13 := len(*(slice@1))
+    @14 := copy (@13) - const (1 : usize)
+    @15 := @SliceIndexShared<'_, i32>(move (@12), copy (@14))
+    _c@7 := &*(@15)
     @11 := ()
     @0 := move (@11)
     drop _c@7

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -595,7 +595,7 @@ fn test_crate::cbd(@1: Array<u8, 33 : usize>)
                 @15 := ()
                 @5 := move (@15)
                 continue 0
-            }
+            },
         }
     }
     @13 := ()

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -74,7 +74,7 @@ fn test_crate::main()
         },
         1 => {
             @4 := const (1 : isize)
-        }
+        },
     }
     @5 := cast<isize, u8>(copy (@4))
     @6 := copy (@5) <= const (1 : u8)
@@ -90,7 +90,7 @@ fn test_crate::main()
         },
         1 => {
             @9 := const (1 : isize)
-        }
+        },
     }
     @10 := cast<isize, u8>(copy (@9))
     @11 := copy (@10) <= const (1 : u8)
@@ -111,7 +111,7 @@ fn test_crate::main()
         },
         2 => {
             @15 := const (1 : isize)
-        }
+        },
     }
     @16 := cast<isize, u8>(copy (@15))
     @17 := copy (@16) >= const (255 : u8)

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.out
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.out
@@ -28,7 +28,7 @@ fn test_crate::main()
         2 => {
             @4 := ()
             @0 := move (@4)
-        }
+        },
     }
     drop @1
     @0 := ()

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -186,7 +186,7 @@ fn test_crate::test_loop3(@1: u32) -> u32
                     drop @17
                     @15 := move (@16) == const (17 : u32)
                     if move (@15) {
-                        nop
+
                     }
                     else {
                         drop @16
@@ -671,7 +671,7 @@ fn test_crate::test_loops()
     @4 := copy (x@1)
     @3 := move (@4) == const (2 : u32)
     if move (@3) {
-        nop
+
     }
     else {
         drop @4
@@ -687,7 +687,7 @@ fn test_crate::test_loops()
     @8 := copy (x@5)
     @7 := move (@8) == const (1 : u32)
     if move (@7) {
-        nop
+
     }
     else {
         drop @8
@@ -703,7 +703,7 @@ fn test_crate::test_loops()
     @12 := copy (x@9)
     @11 := move (@12) == const (3 : u32)
     if move (@11) {
-        nop
+
     }
     else {
         drop @12
@@ -719,7 +719,7 @@ fn test_crate::test_loops()
     @16 := copy (x@13)
     @15 := move (@16) == const (1 : u32)
     if move (@15) {
-        nop
+
     }
     else {
         drop @16
@@ -735,7 +735,7 @@ fn test_crate::test_loops()
     @20 := copy (x@17)
     @19 := move (@20) == const (2 : u32)
     if move (@19) {
-        nop
+
     }
     else {
         drop @20
@@ -751,7 +751,7 @@ fn test_crate::test_loops()
     @24 := copy (x@21)
     @23 := move (@24) == const (2 : u32)
     if move (@23) {
-        nop
+
     }
     else {
         drop @24
@@ -1914,7 +1914,7 @@ fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usi
                 @8 := copy (x@2)
                 @6 := move (@7) == move (@8)
                 if move (@6) {
-                    nop
+
                 }
                 else {
                     drop @8
@@ -1969,7 +1969,7 @@ fn test_crate::list_nth_mut_loop_with_id<'_0, T>(@1: &'_0 mut (test_crate::List<
                 @8 := copy (i@2)
                 @7 := move (@8) == const (0 : u32)
                 if move (@7) {
-                    nop
+
                 }
                 else {
                     drop @8

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -186,7 +186,6 @@ fn test_crate::test_loop3(@1: u32) -> u32
                     drop @17
                     @15 := move (@16) == const (17 : u32)
                     if move (@15) {
-
                     }
                     else {
                         drop @16
@@ -671,7 +670,6 @@ fn test_crate::test_loops()
     @4 := copy (x@1)
     @3 := move (@4) == const (2 : u32)
     if move (@3) {
-
     }
     else {
         drop @4
@@ -687,7 +685,6 @@ fn test_crate::test_loops()
     @8 := copy (x@5)
     @7 := move (@8) == const (1 : u32)
     if move (@7) {
-
     }
     else {
         drop @8
@@ -703,7 +700,6 @@ fn test_crate::test_loops()
     @12 := copy (x@9)
     @11 := move (@12) == const (3 : u32)
     if move (@11) {
-
     }
     else {
         drop @12
@@ -719,7 +715,6 @@ fn test_crate::test_loops()
     @16 := copy (x@13)
     @15 := move (@16) == const (1 : u32)
     if move (@15) {
-
     }
     else {
         drop @16
@@ -735,7 +730,6 @@ fn test_crate::test_loops()
     @20 := copy (x@17)
     @19 := move (@20) == const (2 : u32)
     if move (@19) {
-
     }
     else {
         drop @20
@@ -751,7 +745,6 @@ fn test_crate::test_loops()
     @24 := copy (x@21)
     @23 := move (@24) == const (2 : u32)
     if move (@23) {
-
     }
     else {
         drop @24
@@ -1402,7 +1395,7 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
                 @32 := ()
                 @8 := move (@32)
                 continue 0
-            }
+            },
         }
     }
     @30 := ()
@@ -1458,7 +1451,7 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
                             @37 := ()
                             @8 := move (@37)
                             continue 0
-                        }
+                        },
                     }
                 }
                 @34 := ()
@@ -1474,7 +1467,7 @@ fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
                 @35 := ()
                 @8 := move (@35)
                 continue 0
-            }
+            },
         }
     }
     @33 := ()
@@ -1612,7 +1605,7 @@ fn test_crate::loop_inside_if(@1: bool, @2: u32) -> u32
                     @19 := ()
                     @10 := move (@19)
                     continue 0
-                }
+                },
             }
         }
         @17 := ()
@@ -1914,7 +1907,6 @@ fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usi
                 @8 := copy (x@2)
                 @6 := move (@7) == move (@8)
                 if move (@6) {
-
                 }
                 else {
                     drop @8
@@ -1939,7 +1931,7 @@ fn test_crate::get_elem_mut<'_0>(@1: &'_0 mut (test_crate::List<usize>), @2: usi
             },
             1 => {
                 panic(core::panicking::panic_explicit)
-            }
+            },
         }
     }
 }
@@ -1969,7 +1961,6 @@ fn test_crate::list_nth_mut_loop_with_id<'_0, T>(@1: &'_0 mut (test_crate::List<
                 @8 := copy (i@2)
                 @7 := move (@8) == const (0 : u32)
                 if move (@7) {
-
                 }
                 else {
                     drop @8
@@ -1998,7 +1989,7 @@ fn test_crate::list_nth_mut_loop_with_id<'_0, T>(@1: &'_0 mut (test_crate::List<
                 drop @10
                 drop @3
                 panic(core::panicking::panic_explicit)
-            }
+            },
         }
     }
 }

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -18,7 +18,7 @@ fn test_crate::test1(@1: test_crate::E1) -> bool
         },
         2 => {
             @0 := const (false)
-        }
+        },
     }
     return
 }
@@ -59,7 +59,7 @@ fn test_crate::test2(@1: test_crate::E2) -> u32
         },
         2 => {
             @0 := const (0 : u32)
-        }
+        },
     }
     return
 }
@@ -92,7 +92,7 @@ fn test_crate::test3(@1: test_crate::E2) -> u32
         },
         2 => {
             y@3 := const (0 : u32)
-        }
+        },
     }
     @fake_read(y@3)
     z@5 := test_crate::id<u32>(const (3 : u32))

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -314,7 +314,7 @@ fn test_crate::test_box1()
     @8 := copy (*(x@4))
     @7 := move (@8) == const (1 : i32)
     if move (@7) {
-        nop
+
     }
     else {
         drop @8
@@ -353,7 +353,7 @@ fn test_crate::test_unreachable(@1: bool)
 
     @2 := copy (b@1)
     if move (@2) {
-        nop
+
     }
     else {
         @3 := ()
@@ -394,7 +394,7 @@ fn test_crate::split_list<T>(@1: test_crate::List<T>) -> (T, test_crate::List<T>
     @fake_read(l@1)
     match l@1 {
         0 => {
-            nop
+
         },
         _ => {
             panic(core::panicking::panic_explicit)
@@ -508,7 +508,7 @@ fn test_crate::test_even_odd()
 
     @2 := test_crate::even(const (0 : u32))
     if move (@2) {
-        nop
+
     }
     else {
         panic(core::panicking::panic)
@@ -519,7 +519,7 @@ fn test_crate::test_even_odd()
     drop @1
     @4 := test_crate::even(const (4 : u32))
     if move (@4) {
-        nop
+
     }
     else {
         panic(core::panicking::panic)
@@ -530,7 +530,7 @@ fn test_crate::test_even_odd()
     drop @3
     @6 := test_crate::odd(const (1 : u32))
     if move (@6) {
-        nop
+
     }
     else {
         panic(core::panicking::panic)
@@ -541,7 +541,7 @@ fn test_crate::test_even_odd()
     drop @5
     @8 := test_crate::odd(const (5 : u32))
     if move (@8) {
-        nop
+
     }
     else {
         panic(core::panicking::panic)

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -314,7 +314,6 @@ fn test_crate::test_box1()
     @8 := copy (*(x@4))
     @7 := move (@8) == const (1 : i32)
     if move (@7) {
-
     }
     else {
         drop @8
@@ -353,7 +352,6 @@ fn test_crate::test_unreachable(@1: bool)
 
     @2 := copy (b@1)
     if move (@2) {
-
     }
     else {
         @3 := ()
@@ -377,7 +375,7 @@ fn test_crate::is_cons<'_0, T>(@1: &'_0 (test_crate::List<T>)) -> bool
         },
         1 => {
             @0 := const (false)
-        }
+        },
     }
     return
 }
@@ -394,11 +392,10 @@ fn test_crate::split_list<T>(@1: test_crate::List<T>) -> (T, test_crate::List<T>
     @fake_read(l@1)
     match l@1 {
         0 => {
-
         },
         _ => {
             panic(core::panicking::panic_explicit)
-        }
+        },
     }
     hd@2 := move ((l@1 as variant @0).0)
     tl@3 := move ((l@1 as variant @0).1)
@@ -508,7 +505,6 @@ fn test_crate::test_even_odd()
 
     @2 := test_crate::even(const (0 : u32))
     if move (@2) {
-
     }
     else {
         panic(core::panicking::panic)
@@ -519,7 +515,6 @@ fn test_crate::test_even_odd()
     drop @1
     @4 := test_crate::even(const (4 : u32))
     if move (@4) {
-
     }
     else {
         panic(core::panicking::panic)
@@ -530,7 +525,6 @@ fn test_crate::test_even_odd()
     drop @3
     @6 := test_crate::odd(const (1 : u32))
     if move (@6) {
-
     }
     else {
         panic(core::panicking::panic)
@@ -541,7 +535,6 @@ fn test_crate::test_even_odd()
     drop @5
     @8 := test_crate::odd(const (5 : u32))
     if move (@8) {
-
     }
     else {
         panic(core::panicking::panic)

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -16,7 +16,7 @@ fn core::option::{core::option::Option<T>}::is_some<'_0, T>(@1: &'_0 (core::opti
         },
         0 => {
             @0 := const (false)
-        }
+        },
     }
     return
 }

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -68,7 +68,6 @@ fn test_crate::panic4()
 
     @2 := const (false)
     if move (@2) {
-
     }
     else {
         panic(core::panicking::panic)
@@ -97,7 +96,6 @@ fn test_crate::panic5()
 
     @2 := const (false)
     if move (@2) {
-
     }
     else {
         @6 := [const ("assert failed"); 1 : usize]

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -68,7 +68,7 @@ fn test_crate::panic4()
 
     @2 := const (false)
     if move (@2) {
-        nop
+
     }
     else {
         panic(core::panicking::panic)
@@ -97,7 +97,7 @@ fn test_crate::panic5()
 
     @2 := const (false)
     if move (@2) {
-        nop
+
     }
     else {
         @6 := [const ("assert failed"); 1 : usize]

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -220,7 +220,7 @@ fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map::Has
             v@7 := copy ((@2 as variant @1).0)
             @0 := &*(v@7)
             drop v@7
-        }
+        },
     }
     drop @6
     drop @5

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -52,7 +52,7 @@ where
 
     match self@1 {
         0 => {
-            nop
+
         },
         1 => {
             e@2 := move ((self@1 as variant @1).0)

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -52,14 +52,13 @@ where
 
     match self@1 {
         0 => {
-
         },
         1 => {
             e@2 := move ((self@1 as variant @1).0)
             @5 := &e@2
             @4 := unsize_cast<&'_ (E), &'_ (dyn (exists(TODO)))>(copy (@5))
             @3 := core::result::unwrap_failed(const ("called `Result::unwrap()` on an `Err` value"), move (@4))
-        }
+        },
     }
     t@0 := move ((self@1 as variant @0).0)
     return
@@ -134,13 +133,13 @@ fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1: &'
                 _ => {
                     drop @5
                     @0 := core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt(move (self@1), move (f@2))
-                }
+                },
             }
         },
         _ => {
             drop @3
             @0 := core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt(move (self@1), move (f@2))
-        }
+        },
     }
     return
 }

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -674,7 +674,7 @@ fn test_crate::main()
                 @68 := ()
                 @8 := move (@68)
                 continue 0
-            }
+            },
         }
     }
     @66 := ()
@@ -723,7 +723,7 @@ fn test_crate::main()
                 @71 := ()
                 @8 := move (@71)
                 continue 0
-            }
+            },
         }
     }
     @69 := ()
@@ -763,7 +763,7 @@ fn test_crate::main()
                 @74 := ()
                 @8 := move (@74)
                 continue 0
-            }
+            },
         }
     }
     @72 := ()
@@ -803,7 +803,7 @@ fn test_crate::main()
                 @77 := ()
                 @8 := move (@77)
                 continue 0
-            }
+            },
         }
     }
     @75 := ()
@@ -828,7 +828,6 @@ fn test_crate::main()
     @58 := copy (*(right_val@55))
     @56 := move (@57) == move (@58)
     if move (@56) {
-
     }
     else {
         drop @58

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -828,7 +828,7 @@ fn test_crate::main()
     @58 := copy (*(right_val@55))
     @56 := move (@57) == move (@58)
     if move (@56) {
-        nop
+
     }
     else {
         drop @58

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -72,7 +72,7 @@ fn test_crate::{impl test_crate::BoolTrait for core::option::Option<T>}#1::get_b
         },
         1 => {
             @0 := const (true)
-        }
+        },
     }
     return
 }


### PR DESCRIPTION
This removes `RawStatement::Sequence` and instead correctly tracks where lists of statements are allowed, namely in loops, switch branches, and function bodies. This makes operating on statements much easier. This does not affect the caml side.