### PR TITLE
Attempt to translate in-body comments

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.41"
+let supported_charon_version = "0.1.42"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -352,6 +352,7 @@ and gexpr_body_of_json :
           ("span", span);
           ("arg_count", arg_count);
           ("locals", locals);
+          ("comments", _);
           ("body", body);
         ] ->
         let* span = span_of_json id_to_file span in

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -30,7 +30,12 @@ type raw_statement =
   | Loop of statement
   | Error of string
 
-and statement = { span : span; content : raw_statement }
+and statement = {
+  span : span;
+  content : raw_statement;
+  comments_before : string list;  (** Comments that precede this statement. *)
+}
+
 and block = statement
 
 and switch =

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -42,7 +42,7 @@ let fun_decl_has_loops (fd : fun_decl) : bool =
 let mk_sequence (st1 : statement) (st2 : statement) : statement =
   let span = MetaUtils.combine_span st1.span st2.span in
   let content = Sequence (st1, st2) in
-  { span; content }
+  { span; content; comments_before = [] }
 
 (** Chain two statements into a sequence, by pushing the second statement
     at the end of the first one (diving into sequences, switches, etc.).
@@ -60,7 +60,7 @@ let rec chain_statements (st1 : statement) (st2 : statement) : statement =
       (* Insert inside the switch *)
       let span = MetaUtils.combine_span st1.span st2.span in
       let content = Switch (chain_statements_in_switch switch st2) in
-      { span; content }
+      { span; content; comments_before = [] }
   | Sequence (st3, st4) ->
       (* Insert at the end of the statement *)
       mk_sequence st3 (chain_statements st4 st2)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.41"
+version = "0.1.42"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -59,6 +59,10 @@ pub struct GExprBody<T> {
     /// - the input arguments
     /// - the remaining locals, used for the intermediate computations
     pub locals: Vector<VarId, Var>,
+    /// For each line inside the body, we record any whole-line `//` comments found before it. They
+    /// are added to statements in the late `recover_body_comments` pass.
+    #[charon::opaque]
+    pub comments: Vec<(usize, Vec<String>)>,
     pub body: T,
 }
 

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -54,6 +54,9 @@ pub enum RawStatement {
 pub struct Statement {
     pub span: Span,
     pub content: RawStatement,
+    /// Comments that precede this statement.
+    // This is filled in a late pass after all the control-flow manipulation.
+    pub comments_before: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -59,7 +59,11 @@ impl Switch {
 
 impl Statement {
     pub fn new(span: Span, content: RawStatement) -> Self {
-        Statement { span, content }
+        Statement {
+            span,
+            content,
+            comments_before: vec![],
+        }
     }
 
     pub fn into_box(self) -> Box<Self> {

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 generate_index_type!(FileId);
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Loc {
     /// The (1-based) line number.
     pub line: usize,
@@ -23,7 +23,7 @@ fn dummy_span_data() -> rustc_span::SpanData {
 }
 
 /// Span information
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct RawSpan {
     pub file_id: FileId,
     pub beg: Loc,
@@ -47,7 +47,7 @@ impl From<RawSpan> for rustc_error_messages::MultiSpan {
 }
 
 /// Meta information about a piece of code (block, statement, etc.)
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Span {
     /// The source code span.
     ///

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1164,11 +1164,11 @@ fn generate_ml(crate_data: TranslatedCrate, output_dir: PathBuf) -> anyhow::Resu
                       list_of_json (statement_of_json id_to_file) statements
                     in
                     match List.rev statements with
-                    | [] -> Ok { span; content = Nop }
+                    | [] -> Ok { span; content = Nop; comments_before = [] }
                     | last :: rest ->
                         let seq =
                           List.fold_left
-                            (fun acc st -> { span = st.span; content = Sequence (st, acc) })
+                            (fun acc st -> { span = st.span; content = Sequence (st, acc); comments_before = [] })
                             last rest
                         in
                         Ok seq

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -15,6 +15,7 @@
 // For rustdoc: prevents overflows
 #![recursion_limit = "256"]
 #![feature(box_patterns)]
+#![feature(extract_if)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iterator_try_collect)]

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -101,15 +101,11 @@ impl<'a> Visitor<'a> {
             //`tmp0 = &{mut}p`
             let input_var = {
                 let input_var = self.fresh_var(None, input_ty);
-                let borrow_st = RawStatement::Assign(
+                let kind = RawStatement::Assign(
                     Place::new(input_var),
                     Rvalue::Ref(p.clone(), BorrowKind::mutable(mut_access)),
                 );
-                let borrow_st = Statement {
-                    content: borrow_st,
-                    span: self.span,
-                };
-                self.statements.push(borrow_st);
+                self.statements.push(Statement::new(self.span, kind));
                 input_var
             };
 
@@ -132,26 +128,22 @@ impl<'a> Visitor<'a> {
             if from_end {
                 let usize_ty = Ty::Literal(LiteralTy::Integer(IntegerTy::Usize));
                 let len_var = self.fresh_var(None, usize_ty.clone());
-                self.statements.push(Statement {
-                    content: RawStatement::Assign(
-                        Place::new(len_var),
-                        Rvalue::Len(
-                            p.clone(),
-                            ty.clone(),
-                            generics.const_generics.get(0.into()).cloned(),
-                        ),
+                let kind = RawStatement::Assign(
+                    Place::new(len_var),
+                    Rvalue::Len(
+                        p.clone(),
+                        ty.clone(),
+                        generics.const_generics.get(0.into()).cloned(),
                     ),
-                    span: self.span,
-                });
+                );
+                self.statements.push(Statement::new(self.span, kind));
                 // `index_var = len(p) - last_arg`
                 let index_var = self.fresh_var(None, usize_ty);
-                self.statements.push(Statement {
-                    content: RawStatement::Assign(
-                        Place::new(index_var),
-                        Rvalue::BinaryOp(BinOp::Sub, Operand::Copy(Place::new(len_var)), last_arg),
-                    ),
-                    span: self.span,
-                });
+                let kind = RawStatement::Assign(
+                    Place::new(index_var),
+                    Rvalue::BinaryOp(BinOp::Sub, Operand::Copy(Place::new(len_var)), last_arg),
+                );
+                self.statements.push(Statement::new(self.span, kind));
                 args.push(Operand::Copy(Place::new(index_var)));
             } else {
                 args.push(last_arg);
@@ -166,10 +158,8 @@ impl<'a> Visitor<'a> {
                     args,
                     dest: Place::new(output_var),
                 };
-                self.statements.push(Statement {
-                    content: RawStatement::Call(index_call),
-                    span: self.span,
-                });
+                let kind = RawStatement::Call(index_call);
+                self.statements.push(Statement::new(self.span, kind));
                 output_var
             };
 

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -12,6 +12,7 @@ pub mod ops_to_function_calls;
 pub mod prettify_cfg;
 pub mod reconstruct_asserts;
 pub mod reconstruct_boxes;
+pub mod recover_body_comments;
 pub mod remove_arithmetic_overflow_checks;
 pub mod remove_drop_never;
 pub mod remove_dynamic_checks;
@@ -99,6 +100,10 @@ pub static LLBC_PASSES: &[Pass] = &[
     StructuredBody(&remove_unused_locals::Transform),
     // # Micro-pass: remove the useless `StatementKind::Nop`s.
     StructuredBody(&remove_nops::Transform),
+    // # Micro-pass: take all the comments found in the original body and assign them to
+    // statements. This must be last after all the statement-affecting passes to avoid losing
+    // comments.
+    StructuredBody(&recover_body_comments::Transform),
     // Check that all supplied generic types match the corresponding generic parameters.
     NonBody(&check_generics::Check),
 ];

--- a/charon/src/transform/recover_body_comments.rs
+++ b/charon/src/transform/recover_body_comments.rs
@@ -1,0 +1,30 @@
+//! Take all the comments found in the original body and assign them to statements.
+
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
+
+use crate::llbc_ast::*;
+use crate::transform::TransformCtx;
+
+use super::ctx::LlbcPass;
+
+pub struct Transform;
+impl LlbcPass for Transform {
+    fn transform_body(&self, _ctx: &mut TransformCtx<'_>, b: &mut ExprBody) {
+        // Constraints in the ideal case:
+        // - each comment should be assigned to exactly one statement;
+        // - the order of comments in the source should refine the partial order of control flow;
+        // - a comment should come before the statement it was applied to.
+        // Statement spans are way too imprecise for that.
+
+        // This is a pretty terrible heuristic but the spans are really terrible.
+        let mut comments: Vec<(usize, Vec<String>)> = b.comments.clone();
+        b.body
+            .drive_mut(&mut visitor_enter_fn_mut(|st: &mut Statement| {
+                let st_line = st.span.span.beg.line;
+                st.comments_before = comments
+                    .extract_if(|(i, _)| *i <= st_line)
+                    .flat_map(|(_, comments)| comments)
+                    .collect();
+            }));
+    }
+}

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -22,6 +22,7 @@ impl Transform {
             if let [Statement {
                 content: RawStatement::Assign(dest, Rvalue::Discriminant(p, adt_id)),
                 span: span1,
+                ..
             }, rest @ ..] = suffix
             {
                 // The destination should be a variable
@@ -122,10 +123,10 @@ impl Transform {
                             .map(|(id, variant)| {
                                 let discr_value =
                                     Rvalue::Use(Operand::Const(variant.discriminant.to_constant()));
-                                let statement = Statement {
-                                    span: *span1,
-                                    content: RawStatement::Assign(dest.clone(), discr_value),
-                                };
+                                let statement = Statement::new(
+                                    *span1,
+                                    RawStatement::Assign(dest.clone(), discr_value),
+                                );
                                 (vec![id], statement.into_block())
                             })
                             .collect();

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -1727,6 +1727,7 @@ fn translate_body_aux(no_code_duplication: bool, src_body: &src::ExprBody) -> tg
         span: src_body.span,
         arg_count: src_body.arg_count,
         locals: src_body.locals.clone(),
+        comments: src_body.comments.clone(),
         body: tgt_body,
     }
 }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -1,6 +1,9 @@
 use charon_lib::ast::{AnyTransItem, TranslatedCrate};
+use derive_visitor::{visitor_enter_fn, Drive};
+use indoc::indoc;
 use itertools::Itertools;
-use std::collections::HashMap;
+use llbc_ast::Statement;
+use std::collections::{HashMap, HashSet};
 
 use charon_lib::ast::*;
 
@@ -141,6 +144,73 @@ fn spans() -> anyhow::Result<()> {
         .unwrap();
     // That's not a very precise span :/
     assert_eq!(repr_span(the_loop.span), "4:12-10:9");
+    Ok(())
+}
+
+#[test]
+fn comments() -> anyhow::Result<()> {
+    let crate_data = translate(
+        "
+        pub fn sum(s: &[u32]) -> u32 {
+            // Comment1
+            let mut sum = 0;
+            // Comment2
+            let mut i = 0;
+            // Comment3
+            while i < s.len() {
+                // Comment4
+                sum += s[i];
+                // Comment5
+                i += 1;
+            }
+            // Comment6
+            sum = if sum > 10 {
+                // Comment7
+                sum + 100
+            } else {
+                // Comment8
+                sum
+            };
+            // Comment9
+            sum
+        }
+        ",
+    )?;
+    let function = &crate_data.fun_decls[0];
+    let body_id = function.body.unwrap();
+    let body = &crate_data.bodies[body_id].as_structured().unwrap();
+    assert_eq!(function.item_meta.span.span.beg.line, 2);
+
+    let mut statement_lines = HashSet::new();
+    body.body.drive(&mut visitor_enter_fn(|st: &Statement| {
+        statement_lines.insert(st.span.span.beg.line);
+    }));
+    // This is terrible, we only distinguish three lines out of so many.
+    assert_eq!(
+        statement_lines.into_iter().sorted().collect_vec(),
+        vec![2, 4, 6]
+    );
+
+    let comments = body
+        .comments
+        .iter()
+        .map(|(i, comments)| format!("{i}: {comments:?}"))
+        .join("\n");
+    assert_eq!(
+        comments,
+        indoc!(
+            r#"
+            4: ["Comment1"]
+            6: ["Comment2"]
+            8: ["Comment3"]
+            10: ["Comment4"]
+            12: ["Comment5"]
+            15: ["Comment6"]
+            17: ["Comment7"]
+            20: ["Comment8"]
+            23: ["Comment9"]"#
+        )
+    );
     Ok(())
 }
 

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -1,0 +1,90 @@
+# Final LLBC before serialization:
+
+fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
+
+fn test_crate::sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
+{
+    let @0: u32; // return
+    let s@1: &'_ (Slice<u32>); // arg #1
+    let sum@2: u32; // local
+    let i@3: usize; // local
+    let @4: (); // anonymous local
+    let @5: (); // anonymous local
+    let @6: bool; // anonymous local
+    let @7: usize; // anonymous local
+    let @8: usize; // anonymous local
+    let @9: &'_ (Slice<u32>); // anonymous local
+    let @10: u32; // anonymous local
+    let @11: usize; // anonymous local
+    let @12: (); // anonymous local
+    let @13: u32; // anonymous local
+    let @14: bool; // anonymous local
+    let @15: u32; // anonymous local
+    let @16: u32; // anonymous local
+    let @17: (); // anonymous local
+    let @18: (); // anonymous local
+    let @19: &'_ (Slice<u32>); // anonymous local
+    let @20: &'_ (u32); // anonymous local
+
+    sum@2 := const (0 : u32)
+    @fake_read(sum@2)
+    // Comment1
+    i@3 := const (0 : usize)
+    @fake_read(i@3)
+    // Comment2
+    loop {
+        @7 := copy (i@3)
+        @9 := &*(s@1)
+        @8 := core::slice::{Slice<T>}::len<u32>(move (@9))
+        drop @9
+        @6 := move (@7) < move (@8)
+        if move (@6) {
+            drop @8
+            drop @7
+            @11 := copy (i@3)
+            @19 := &*(s@1)
+            @20 := @SliceIndexShared<'_, u32>(move (@19), copy (@11))
+            @10 := copy (*(@20))
+            sum@2 := copy (sum@2) + move (@10)
+            drop @10
+            drop @11
+            i@3 := copy (i@3) + const (1 : usize)
+            @17 := ()
+            @5 := move (@17)
+            drop @6
+            continue 0
+        }
+        else {
+            break 0
+        }
+    }
+    drop @8
+    drop @7
+    @18 := ()
+    @4 := move (@18)
+    drop @12
+    drop @6
+    drop @4
+    @15 := copy (sum@2)
+    @14 := move (@15) > const (10 : u32)
+    if move (@14) {
+        drop @15
+        @16 := copy (sum@2)
+        @13 := move (@16) + const (100 : u32)
+        drop @16
+    }
+    else {
+        drop @15
+        @13 := copy (sum@2)
+    }
+    drop @14
+    sum@2 := move (@13)
+    drop @13
+    @0 := copy (sum@2)
+    drop i@3
+    drop sum@2
+    return
+}
+
+
+

--- a/charon/tests/ui/comments.rs
+++ b/charon/tests/ui/comments.rs
@@ -1,0 +1,23 @@
+pub fn sum(s: &[u32]) -> u32 {
+    // Comment1
+    let mut sum = 0;
+    // Comment2
+    let mut i = 0;
+    // Comment3
+    while i < s.len() {
+        // Comment4
+        sum += s[i];
+        // Comment5
+        i += 1;
+    }
+    // Comment6
+    sum = if sum > 10 {
+        // Comment7
+        sum + 100
+    } else {
+        // Comment8
+        sum
+    };
+    // Comment9
+    sum
+}

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -283,6 +283,7 @@ fn test_crate::nullary_ops<T>() -> usize
     let offset@3: usize; // local
     let @4: usize; // anonymous local
 
+    // This one seems to be optimized out.
     size@1 := size_of<T>
     align@2 := align_of<T>
     offset@3 := offset_of(?)<test_crate::nullary_ops::Struct<T>>

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -396,6 +396,11 @@ where
     x@3 := @TraitClause1::to_u64(move (@4))
     drop @4
     @fake_read(x@3)
+    // Remark: we can't write: impl TestTrait for TestType<T>,
+    // we have to use a *local* parameter (can't use the outer T).
+    // In other words: the parameters used in the items inside
+    // an impl must be bound by the impl block (can't come from outer
+    // blocks).
     y@5 := test_crate::{test_crate::TestType<T>}#6::test::TestType1 { 0: const (0 : u64) }
     @fake_read(y@5)
     @7 := copy (x@3)


### PR DESCRIPTION
Getting the comments is easy, however putting them in the right place is near-impossible because the statement spans are imprecise to the point of uselessness (#233).

cf #340 