### PR TITLE
Remove the top-level `catch_unwind`

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -10,7 +10,6 @@ use rustc_interface::{interface::Compiler, Queries};
 use rustc_middle::ty::TyCtxt;
 use std::fmt;
 use std::ops::Deref;
-use std::panic::{self, AssertUnwindSafe};
 
 /// The callbacks for Charon
 pub struct CharonCallbacks {
@@ -22,7 +21,6 @@ pub struct CharonCallbacks {
 
 pub enum CharonFailure {
     RustcError(usize),
-    Panic,
     Serialize,
 }
 
@@ -32,7 +30,6 @@ impl fmt::Display for CharonFailure {
             CharonFailure::RustcError(error_count) => {
                 write!(f, "Compilation encountered {} errors", error_count)?
             }
-            CharonFailure::Panic => write!(f, "Compilation panicked")?,
             CharonFailure::Serialize => write!(f, "Could not serialize output file")?,
         }
         Ok(())
@@ -54,13 +51,8 @@ impl CharonCallbacks {
         // Arguments list always start with the executable name. We put a silly value to ensure
         // it's not used for anything.
         args.insert(0, "__CHARON_MYSTERIOUS_FIRST_ARG__".to_string());
-        let mut this = AssertUnwindSafe(self);
-        panic::catch_unwind(move || {
-            let res = rustc_driver::RunCompiler::new(&args, *this).run();
-            res.map_err(|_| CharonFailure::RustcError(this.error_count))
-        })
-        .map_err(|_| CharonFailure::Panic)??;
-        Ok(())
+        let res = rustc_driver::RunCompiler::new(&args, self).run();
+        res.map_err(|_| CharonFailure::RustcError(self.error_count))
     }
 }
 

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -237,16 +237,11 @@ fn main() {
                 log::warn!("{}", msg);
             }
         }
-        Err(err) if errors_as_warnings => {
+        Err(err) => {
             log::error!("{err}");
-        }
-        Err(CharonFailure::Panic) => {
-            // Standard rust panic error code.
-            std::process::exit(101);
-        }
-        Err(err @ (CharonFailure::RustcError(_) | CharonFailure::Serialize)) => {
-            log::error!("{err}");
-            std::process::exit(1);
+            if !errors_as_warnings {
+                std::process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
We can't really recover from it anyway and it muddles stack traces.