### PR TITLE
A few clippy fixes

### DIFF
--- a/charon/macros/src/enum_helpers.rs
+++ b/charon/macros/src/enum_helpers.rs
@@ -19,7 +19,7 @@ fn to_snake_case(s: &str) -> String {
     // "I32" -> "I3_2"
     let mut last_is_lowercase = false;
 
-    for (_, c) in s.chars().enumerate() {
+    for c in s.chars() {
         if c.is_uppercase() {
             if last_is_lowercase {
                 snake_case.push('_');

--- a/charon/macros/src/lib.rs
+++ b/charon/macros/src/lib.rs
@@ -26,6 +26,7 @@ pub fn derive_variant_index_arity(item: TokenStream) -> TokenStream {
 }
 
 /// Macro `EnumIsA`
+///
 /// Derives functions of the form `fn is_{variant_name}(&self) -> bool` returning true
 /// if an enumeration instance is of some variant. For lists, it would generate
 /// `is_cons` and `is_nil`.
@@ -40,6 +41,7 @@ pub fn derive_enum_is_a(item: TokenStream) -> TokenStream {
 }
 
 /// Macro `EnumAsGetters`
+///
 /// Derives functions of the form `fn as_{variant_name}(&self) -> ...` checking
 /// that an enumeration instance is of the proper variant and returning shared
 /// borrows to its fields.
@@ -59,6 +61,7 @@ pub fn derive_enum_as_getters(item: TokenStream) -> TokenStream {
 }
 
 /// Macro `EnumToGetters`
+///
 /// Derives functions of the form `fn to_{variant_name}(self) -> ...` checking
 /// that an enumeration instance is of the proper variant and returning its
 /// fields (while consuming the instance).


### PR DESCRIPTION
A few minor clippy fixes found while integrating with Kani (https://github.com/model-checking/kani/pull/3514):
```
$ cargo clippy --all -- -D warnings 
   Compiling serde_derive v1.0.210
   Compiling zerocopy-derive v0.7.35
   Compiling tracing-attributes v0.1.27
   Compiling thiserror-impl v1.0.64
   Compiling strum_macros v0.26.4
   Compiling clap_derive v4.5.18
   Compiling kani_macros v0.55.0 (/home/ubuntu/git/kani/library/kani_macros)
   Compiling macros v0.1.0 (/home/ubuntu/git/kani/charon/charon/macros)
error: you seem to use `.enumerate()` and immediately discard the index
  --> charon/charon/macros/src/enum_helpers.rs:22:19
   |
22 |     for (_, c) in s.chars().enumerate() {
   |                   ^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
   = note: `-D clippy::unused-enumerate-index` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unused_enumerate_index)]`
help: remove the `.enumerate()` call
   |
22 |     for c in s.chars() {
   |         ~    ~~~~~~~~~

error: first doc comment paragraph is too long
  --> charon/charon/macros/src/lib.rs:28:1
   |
28 | / /// Macro `EnumIsA`
29 | | /// Derives functions of the form `fn is_{variant_name}(&self) -> bool` returning true
30 | | /// if an enumeration instance is of some variant. For lists, it would generate
31 | | /// `is_cons` and `is_nil`.
...  |
35 | | /// dead (a PR from 2019 has never been merged), so it seems better to maintain
36 | | /// our own code here (which is small) rather than doing PRs for this crate.
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
   = note: `-D clippy::too-long-first-doc-paragraph` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`

error: first doc comment paragraph is too long
  --> charon/charon/macros/src/lib.rs:42:1
   |
42 | / /// Macro `EnumAsGetters`
43 | | /// Derives functions of the form `fn as_{variant_name}(&self) -> ...` checking
44 | | /// that an enumeration instance is of the proper variant and returning shared
45 | | /// borrows to its fields.
46 | | /// Also see the comments for [crate::derive_enum_is_a]
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

error: first doc comment paragraph is too long
  --> charon/charon/macros/src/lib.rs:61:1
   |
61 | / /// Macro `EnumToGetters`
62 | | /// Derives functions of the form `fn to_{variant_name}(self) -> ...` checking
63 | | /// that an enumeration instance is of the proper variant and returning its
64 | | /// fields (while consuming the instance).
65 | | /// Also see the comments for [crate::derive_enum_is_a]
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

error: could not compile `macros` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `macros` (lib) due to 4 previous errors
```