### PR TITLE
Add the source files in the translated crate

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.43"
+let supported_charon_version = "0.1.44"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -424,6 +424,6 @@ type ('fun_body, 'global_body) gcrate = {
   global_decls : 'global_body gglobal_decl GlobalDeclId.Map.t;
   trait_decls : trait_decl TraitDeclId.Map.t;
   trait_impls : trait_impl TraitImplId.Map.t;
-  source_files : string list FileNameMap.t;
+  source_files : string FileNameMap.t;
 }
 [@@deriving show]

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -424,5 +424,6 @@ type ('fun_body, 'global_body) gcrate = {
   global_decls : 'global_body gglobal_decl GlobalDeclId.Map.t;
   trait_decls : trait_decl TraitDeclId.Map.t;
   trait_impls : trait_impl TraitImplId.Map.t;
+  source_files : string list FileNameMap.t;
 }
 [@@deriving show]

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1520,6 +1520,7 @@ and gtranslated_crate_of_json
           ("crate_name", name);
           ("real_crate_name", _);
           ("id_to_file", id_to_file);
+          ("file_id_to_content", file_id_to_content);
           ("all_ids", _);
           ("item_names", _);
           ("type_decls", types);
@@ -1563,6 +1564,12 @@ and gtranslated_crate_of_json
             (trait_impl_of_json id_to_file)
             trait_impls
         in
+        let* source_files =
+          list_of_json
+            (key_value_pair_of_json file_id_of_json
+               (list_of_json string_of_json))
+            file_id_to_content
+        in
 
         let type_decls =
           TypeDeclId.Map.of_list
@@ -1586,6 +1593,15 @@ and gtranslated_crate_of_json
           TraitImplId.Map.of_list
             (List.map (fun (d : trait_impl) -> (d.def_id, d)) trait_impls)
         in
+        let source_files =
+          FileNameMap.of_list
+            (List.filter_map
+               (fun (file_id, content) ->
+                 Option.map
+                   (fun filename -> (filename, content))
+                   (FileId.Map.find_opt file_id id_to_file))
+               source_files)
+        in
 
         Ok
           {
@@ -1596,6 +1612,7 @@ and gtranslated_crate_of_json
             global_decls;
             trait_decls;
             trait_impls;
+            source_files;
           }
     | _ -> Error "")
 

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1566,8 +1566,7 @@ and gtranslated_crate_of_json
         in
         let* source_files =
           list_of_json
-            (key_value_pair_of_json file_id_of_json
-               (list_of_json string_of_json))
+            (key_value_pair_of_json file_id_of_json string_of_json)
             file_id_to_content
         in
 

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -232,5 +232,6 @@ let crate_of_json (js : json) : (crate, string) result =
         global_decls;
         trait_decls = crate.trait_decls;
         trait_impls = crate.trait_impls;
+        source_files = crate.source_files;
       }
   end

--- a/charon-ml/src/Meta.ml
+++ b/charon-ml/src/Meta.ml
@@ -118,3 +118,17 @@ and file_name =
   | Local of path_buf
       (** A local path (a file coming from the current crate for instance) *)
 [@@deriving show, ord]
+
+(** Ordered file name *)
+module OrderedFileName : Collections.OrderedType with type t = file_name =
+struct
+  type t = file_name
+
+  let compare = compare_file_name
+  let to_string s = show_file_name s
+  let pp_t fmt s = pp_file_name fmt s
+  let show_t s = show_file_name s
+end
+
+module FileNameSet = Collections.MakeSet (OrderedFileName)
+module FileNameMap = Collections.MakeMap (OrderedFileName)

--- a/charon-ml/src/OfJsonBasic.ml
+++ b/charon-ml/src/OfJsonBasic.ml
@@ -74,3 +74,13 @@ let option_of_json (a_of_json : json -> ('a, string) result) (js : json) :
 let string_option_of_json (js : json) : (string option, string) result =
   combine_error_msgs js "string_option_of_json"
     (option_of_json string_of_json js)
+
+let key_value_pair_of_json (a_of_json : json -> ('a, string) result)
+    (b_of_json : json -> ('b, string) result) (js : json) :
+    ('a * 'b, string) result =
+  match js with
+  | `Assoc [ ("key", a); ("value", b) ] ->
+      let* a = a_of_json a in
+      let* b = b_of_json b in
+      Ok (a, b)
+  | _ -> Error ("key_value_pair_of_json failed on: " ^ show js)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.43"
+version = "0.1.44"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -98,11 +98,10 @@ pub struct TranslatedCrate {
 
     /// File id to content.
     ///
-    /// Note that we leave the slots for the virtual files as empty: the non-empty slots
-    /// are for the "real" files that we managed to read.
+    /// Note that some files may be missing, if they are not "real" files.
     #[drive(skip)]
-    #[serde(with = "HashMapToArray::<FileId, Vec<String>>")]
-    pub file_id_to_content: HashMap<FileId, Vec<String>>,
+    #[serde(with = "HashMapToArray::<FileId, String>")]
+    pub file_id_to_content: HashMap<FileId, String>,
 
     /// All the ids, in the order in which we encountered them
     #[drive(skip)]

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -96,6 +96,14 @@ pub struct TranslatedCrate {
     #[charon::opaque]
     pub file_to_id: HashMap<FileName, FileId>,
 
+    /// File id to content.
+    ///
+    /// Note that we leave the slots for the virtual files as empty: the non-empty slots
+    /// are for the "real" files that we managed to read.
+    #[drive(skip)]
+    #[serde(with = "HashMapToArray::<FileId, Vec<String>>")]
+    pub file_id_to_content: HashMap<FileId, Vec<String>>,
+
     /// All the ids, in the order in which we encountered them
     #[drive(skip)]
     pub all_ids: LinkedHashSet<AnyTransId>,

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -206,8 +206,8 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
     // the mutually recursive groups - we do this in the next step.
     let mut ctx = translate_crate_to_ullbc::translate(options, tcx);
 
-    if options.print_ullbc {
-        info!("# ULLBC after translation from MIR:\n\n{ctx}\n");
+    if options.print_original_ullbc {
+        println!("# ULLBC after translation from MIR:\n\n{ctx}\n");
     } else {
         trace!("# ULLBC after translation from MIR:\n\n{ctx}\n");
     }
@@ -224,6 +224,17 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
     for pass in ULLBC_PASSES.iter() {
         trace!("# Starting pass {}", pass.name());
         pass.run(&mut ctx)
+    }
+
+    let next_phase = if options.ullbc {
+        "serialization"
+    } else {
+        "control-flow reconstruction"
+    };
+    if options.print_ullbc {
+        println!("# Final ULLBC before {next_phase}:\n\n{ctx}\n");
+    } else {
+        trace!("# Final ULLBC before {next_phase}:\n\n{ctx}\n");
     }
 
     // # There are two options:
@@ -250,7 +261,7 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
         // - compute the order in which to extract the definitions
         // - find the recursive definitions
         // - group the mutually recursive definitions
-        let reordered_decls = compute_reordered_decls(&mut ctx);
+        let reordered_decls = compute_reordered_decls(&ctx);
         ctx.translated.ordered_decls = Some(reordered_decls);
 
         if options.print_llbc {

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -361,15 +361,20 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     /// Return a map from source file name to file content.
+    ///
+    /// Note that we collect *all* the source files found in the session,
+    /// including the source files from the dependencies. We later filter
+    /// those to build a map from the file names we actually refer to in
+    /// the spans to the file contents (ignoring the other files). This
+    /// is the reason why here we build a map from file name to `Arc<String>`
+    /// and not directly to `String`: we don't want to clone too much data.
     fn read_source_files(&mut self) -> HashMap<FileName, Arc<String>> {
         // Retrieve the source map
         let source_map = self.tcx.sess.source_map();
 
         // Read all the files
-        use std::ops::Deref;
         source_map
             .files()
-            .deref()
             .iter()
             .filter_map(|file| {
                 // Convert the filename

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -70,6 +70,7 @@ type 'body gglobal_decl = {
 [@@deriving show]
 
 (* Hand-written because the rust equivalent isn't generic *)
+
 (** A crate *)
 type ('fun_body, 'global_body) gcrate = {
   name : string;
@@ -79,5 +80,6 @@ type ('fun_body, 'global_body) gcrate = {
   global_decls : 'global_body gglobal_decl GlobalDeclId.Map.t;
   trait_decls : trait_decl TraitDeclId.Map.t;
   trait_impls : trait_impl TraitImplId.Map.t;
+  source_files : string list FileNameMap.t;
 }
 [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -80,6 +80,6 @@ type ('fun_body, 'global_body) gcrate = {
   global_decls : 'global_body gglobal_decl GlobalDeclId.Map.t;
   trait_decls : trait_decl TraitDeclId.Map.t;
   trait_impls : trait_impl TraitImplId.Map.t;
-  source_files : string list FileNameMap.t;
+  source_files : string FileNameMap.t;
 }
 [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -142,6 +142,7 @@ and gtranslated_crate_of_json
           ("crate_name", name);
           ("real_crate_name", _);
           ("id_to_file", id_to_file);
+          ("file_id_to_content", file_id_to_content);
           ("all_ids", _);
           ("item_names", _);
           ("type_decls", types);
@@ -185,6 +186,11 @@ and gtranslated_crate_of_json
             (trait_impl_of_json id_to_file)
             trait_impls
         in
+        let* source_files =
+          list_of_json
+            (key_value_pair_of_json file_id_of_json (list_of_json string_of_json))
+            file_id_to_content
+        in
 
         let type_decls =
           TypeDeclId.Map.of_list
@@ -208,6 +214,15 @@ and gtranslated_crate_of_json
           TraitImplId.Map.of_list
             (List.map (fun (d : trait_impl) -> (d.def_id, d)) trait_impls)
         in
+        let source_files =
+          FileNameMap.of_list
+            (List.filter_map
+               (fun (file_id, content) ->
+                 Option.map
+                   (fun filename -> (filename, content))
+                   (FileId.Map.find_opt file_id id_to_file))
+               source_files)
+        in
 
         Ok
           {
@@ -218,6 +233,7 @@ and gtranslated_crate_of_json
             global_decls;
             trait_decls;
             trait_impls;
+            source_files;
           }
     | _ -> Error "")
 

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -188,7 +188,7 @@ and gtranslated_crate_of_json
         in
         let* source_files =
           list_of_json
-            (key_value_pair_of_json file_id_of_json (list_of_json string_of_json))
+            (key_value_pair_of_json file_id_of_json string_of_json)
             file_id_to_content
         in
 

--- a/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
@@ -112,5 +112,6 @@ let crate_of_json (js : json) : (crate, string) result =
         global_decls;
         trait_decls = crate.trait_decls;
         trait_impls = crate.trait_impls;
+        source_files = crate.source_files;
       }
   end

--- a/charon/src/bin/generate-ml/templates/Meta.ml
+++ b/charon/src/bin/generate-ml/templates/Meta.ml
@@ -14,3 +14,17 @@ type path_buf = string
 
 (* __REPLACE0__ *)
 [@@deriving show, ord]
+
+(** Ordered file name *)
+module OrderedFileName : Collections.OrderedType with type t = file_name =
+struct
+  type t = file_name
+
+  let compare = compare_file_name
+  let to_string s = show_file_name s
+  let pp_t fmt s = pp_file_name fmt s
+  let show_t s = show_file_name s
+end
+
+module FileNameSet = Collections.MakeSet (OrderedFileName)
+module FileNameMap = Collections.MakeMap (OrderedFileName)

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -187,8 +187,14 @@ pub struct CliOpts {
     #[serde(default)]
     pub no_serialize: bool,
     #[clap(
-        long = "print-ullbc",
+        long = "print-original-ullbc",
         help = "Print the ULLBC immediately after extraction from MIR."
+    )]
+    #[serde(default)]
+    pub print_original_ullbc: bool,
+    #[clap(
+        long = "print-ullbc",
+        help = "Print the ULLBC after applying the micro-passes (before serialization/control-flow reconstruction)."
     )]
     #[serde(default)]
     pub print_ullbc: bool,


### PR DESCRIPTION
Having the source code in the serialized files is extremely convenient.
Also, I checked the size of the serialized files: the increase in size of the JSON files is generally negligible (a few percent).