### PR TITLE
Cleanup the translation of generics

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -94,36 +94,7 @@ impl TranslateOptions {
                 opacities.push((pat.to_string(), Invisible));
             }
 
-            // Hide some methods that have signatures we don't handle yet.
-            // TODO: handle these signatures.
-            let tricky_iterator_methods = &[
-                "filter",
-                "find",
-                "inspect",
-                "is_sorted_by",
-                "map_windows",
-                "max_by",
-                "max_by_key",
-                "min_by",
-                "min_by_key",
-                "partition",
-                "partition_in_place",
-                "rposition",
-                "scan",
-                "skip_while",
-                "take_while",
-                "try_find",
-            ];
-            for method in tricky_iterator_methods {
-                opacities.push((
-                    format!("core::iter::traits::iterator::Iterator::{method}"),
-                    Invisible,
-                ));
-            }
-            opacities.push((
-                format!("core::iter::traits::double_ended::DoubleEndedIterator::rfind"),
-                Invisible,
-            ));
+            // We always hide this trait.
             opacities.push((format!("core::alloc::Allocator"), Invisible));
             opacities.push((
                 format!("alloc::alloc::{{impl core::alloc::Allocator for _}}"),

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -349,10 +349,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                         // substs and bounds. In order to properly do so, we introduce
                         // a body translation context.
                         let mut bt_ctx = BodyTransCtx::new(def_id, self);
-
-                        bt_ctx.push_generics_for_def(span, &def)?;
-                        let generics = bt_ctx.get_generics();
-
+                        let generics = bt_ctx.translate_def_generics(span, &def)?;
                         let ty = bt_ctx.translate_ty(span, erase_regions, &ty)?;
                         ImplElem::Ty(generics, ty)
                     }
@@ -1091,22 +1088,6 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     pub(crate) fn push_block(&mut self, id: ast::BlockId, block: ast::BlockData) {
         self.blocks.insert(id, block);
-    }
-
-    pub(crate) fn get_generics(&mut self) -> GenericParams {
-        // Sanity checks
-        self.check_generics();
-        assert!(self.region_vars.len() == 1);
-        let mut generic_params = self.generic_params.clone();
-        assert!(generic_params.regions.is_empty());
-        generic_params.regions = self.region_vars[0].clone();
-        assert!(generic_params
-            .trait_clauses
-            .iter()
-            .enumerate()
-            .all(|(i, c)| c.clause_id.index() == i));
-        trace!("Translated generics: {generic_params:?}");
-        generic_params
     }
 
     pub(crate) fn make_dep_source(&self, span: rustc_span::Span) -> Option<DepSource> {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1387,8 +1387,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         let erase_regions = false;
         let span = item_meta.span.rust_span();
 
-        self.push_generics_for_def(span, &def)?;
-        let generics = self.get_generics();
+        let generics = self.translate_def_generics(span, def)?;
 
         let signature = match &def.kind {
             hax::FullDefKind::Closure { args, .. } => &args.sig,
@@ -1558,8 +1557,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         //   const LEN : usize = N;
         // }
         // ```
-        bt_ctx.push_generics_for_def(span, def)?;
-        let generics = bt_ctx.get_generics();
+        let generics = bt_ctx.translate_def_generics(span, def)?;
 
         trace!("Translating global type");
         let ty = match &def.kind {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1387,31 +1387,15 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         let erase_regions = false;
         let span = item_meta.span.rust_span();
 
+        self.push_generics_for_def(span, &def)?;
+        let generics = self.get_generics();
+
         let signature = match &def.kind {
             hax::FullDefKind::Closure { args, .. } => &args.sig,
             hax::FullDefKind::Fn { sig, .. } => sig,
             hax::FullDefKind::AssocFn { sig, .. } => sig,
             _ => panic!("Unexpected definition for function: {def:?}"),
         };
-
-        // The parameters (and in particular the lifetimes) are split between
-        // early bound and late bound parameters. See those blog posts for explanations:
-        // https://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
-        // https://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-        // Note that only lifetimes can be late bound.
-        //
-        // [TyCtxt.generics_of] gives us the early-bound parameters
-        // The late-bounds parameters are bound in the [Binder] returned by
-        // [TyCtxt.type_of].
-
-        // Add the early bound parameters and predicates.
-        self.push_generics_for_def(span, &def)?;
-
-        // Add the *late-bound* parameters (bound in the signature, can only be lifetimes).
-        let binder = signature.rebind(());
-        self.set_first_bound_regions_group(span, binder)?;
-
-        let generics = self.get_generics();
 
         // Translate the signature
         trace!("signature of {def_id:?}:\n{:?}", signature.value);

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -91,7 +91,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         item_meta: ItemMeta,
         def: &hax::FullDef,
     ) -> Result<TraitDecl, Error> {
-        use hax::AssocKind;
         trace!("About to translate trait decl:\n{:?}", rust_id);
         trace!("Trait decl id:\n{:?}", def_id);
 
@@ -106,19 +105,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let hax::FullDefKind::Trait { items, .. } = &def.kind else {
             error_or_panic!(self, span, &format!("Unexpected definition: {def:?}"));
         };
-        let items: Vec<(TraitItemName, &hax::AssocItem, Option<Arc<hax::FullDef>>)> = items
+        let items: Vec<(TraitItemName, &hax::AssocItem, Arc<hax::FullDef>)> = items
             .iter()
             .map(|item| {
                 let name = TraitItemName(item.name.clone());
-                // Warning: don't call `hax_def` on associated functions because this triggers
-                // hax crashes on functions with higher-kinded predicates like
-                // `Iterator::scan`.
-                let def = if matches!(item.kind, AssocKind::Type | AssocKind::Const) {
-                    let def = bt_ctx.t_ctx.hax_def(&item.def_id);
-                    Some(def)
-                } else {
-                    None
-                };
+                let def = bt_ctx.t_ctx.hax_def(&item.def_id);
                 (name, item, def)
             })
             .collect_vec();
@@ -128,27 +119,18 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
 
         // Gather the associated type clauses
         let mut type_clauses = Vec::new();
-        for (name, item, def) in &items {
-            match &item.kind {
-                AssocKind::Type => {
-                    let hax::FullDefKind::AssocTy { predicates, .. } =
-                        &def.as_deref().unwrap().kind
-                    else {
-                        unreachable!()
-                    };
-                    // TODO: handle generics (i.e. GATs).
-                    // Register the trait clauses as item trait clauses
-                    bt_ctx.register_predicates(
-                        &predicates,
-                        PredicateOrigin::TraitItem(name.clone()),
-                        &PredicateLocation::Item(name.clone()),
-                    )?;
-                    if let Some(clauses) = bt_ctx.item_trait_clauses.get(name) {
-                        type_clauses.push((name.clone(), clauses.clone()));
-                    }
+        for (name, _, def) in &items {
+            if let hax::FullDefKind::AssocTy { predicates, .. } = &def.kind {
+                // TODO: handle generics (i.e. GATs).
+                // Register the trait clauses as item trait clauses
+                bt_ctx.register_predicates(
+                    &predicates,
+                    PredicateOrigin::TraitItem(name.clone()),
+                    &PredicateLocation::Item(name.clone()),
+                )?;
+                if let Some(clauses) = bt_ctx.item_trait_clauses.get(name) {
+                    type_clauses.push((name.clone(), clauses.clone()));
                 }
-                AssocKind::Fn => {}
-                AssocKind::Const => {}
             }
         }
 
@@ -165,36 +147,22 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let mut type_defaults = HashMap::new();
         let mut required_methods = Vec::new();
         let mut provided_methods = Vec::new();
-        for (item_name, hax_item, opt_hax_def) in &items {
+        for (item_name, hax_item, hax_def) in &items {
             let rust_item_id = DefId::from(&hax_item.def_id);
             let item_span = bt_ctx.t_ctx.tcx.def_span(rust_item_id);
-            match &hax_item.kind {
-                AssocKind::Fn => {
+            match &hax_def.kind {
+                hax::FullDefKind::AssocFn { .. } => {
+                    let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
                     if hax_item.has_value {
-                        // This is a *provided* method,
-                        // Hack: To avoid having a trait that lists methods that aren't translated,
-                        // we filter out invisible methods early. FIXME: remove this once we can
-                        // translate all `Iterator` method signatures.
-                        let fun_name = bt_ctx.t_ctx.def_id_to_name(rust_item_id)?;
-                        if !bt_ctx.t_ctx.opacity_for_name(&fun_name).is_invisible() {
-                            let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
-                            provided_methods.push((item_name.clone(), fun_id));
-                        }
+                        // This is a provided method,
+                        provided_methods.push((item_name.clone(), fun_id));
                     } else {
                         // This is a required method (no default implementation)
-                        let fun_id = bt_ctx.register_fun_decl_id(item_span, rust_item_id);
                         required_methods.push((item_name.clone(), fun_id));
                     }
                 }
-                AssocKind::Const => {
+                hax::FullDefKind::AssocConst { ty, .. } => {
                     // Check if the constant has a value (i.e., a body).
-                    // We are handling a trait *declaration* so we need to
-                    // check whether the constant has a default value.
-                    let hax::FullDefKind::AssocConst { ty, .. } =
-                        &opt_hax_def.as_deref().unwrap().kind
-                    else {
-                        unreachable!()
-                    };
                     if hax_item.has_value {
                         // The parameters of the constant are the same as those of the item that
                         // declares them.
@@ -207,18 +175,14 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     let ty = bt_ctx.translate_ty(item_span, erase_regions, ty)?;
                     consts.push((item_name.clone(), ty));
                 }
-                AssocKind::Type => {
-                    let hax::FullDefKind::AssocTy { value, .. } =
-                        &opt_hax_def.as_deref().unwrap().kind
-                    else {
-                        unreachable!()
-                    };
+                hax::FullDefKind::AssocTy { value, .. } => {
                     if let Some(ty) = value {
                         let ty = bt_ctx.translate_ty(item_span, erase_regions, &ty)?;
                         type_defaults.insert(item_name.clone(), ty);
                     };
                     types.push(item_name.clone());
                 }
+                _ => panic!("Unexpected definition for trait item: {hax_def:?}"),
             }
         }
 

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -115,11 +115,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             .collect_vec();
 
         // Translate the generics
-        // Note that in the generics returned by [get_generics], the trait refs only contain the
-        // local trait clauses. The parent clauses are stored in `bt_ctx.parent_trait_clauses`.
+        // Note that in the generics returned by [translate_def_generics], the trait refs only
+        // contain the local trait clauses. The parent clauses are stored in
+        // `bt_ctx.parent_trait_clauses`.
         // TODO: Distinguish between required and implied trait clauses?
-        bt_ctx.push_generics_for_def(span, def)?;
-        let generics = bt_ctx.get_generics();
+        let generics = bt_ctx.translate_def_generics(span, def)?;
 
         // Translate the associated items
         // We do something subtle here: TODO: explain
@@ -232,8 +232,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let erase_regions = false;
         let mut bt_ctx = BodyTransCtx::new(rust_id, self);
 
-        bt_ctx.push_generics_for_def(span, def)?;
-        let generics = bt_ctx.get_generics();
+        let generics = bt_ctx.translate_def_generics(span, def)?;
 
         let hax::FullDefKind::Impl {
             impl_subject: hax::ImplSubject::Trait(trait_pred),

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -615,16 +615,34 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         }
     }
 
-    /// Add the generics and predicates of this item and its parents to the current context.
-    pub(crate) fn push_generics_for_def(
+    /// Translate the generics and predicates of this item and its parents.
+    pub(crate) fn translate_def_generics(
         &mut self,
         span: rustc_span::Span,
         def: &hax::FullDef,
-    ) -> Result<(), Error> {
-        self.push_generics_for_def_inner(span, def, false)
+    ) -> Result<GenericParams, Error> {
+        self.push_generics_for_def(span, def, false)?;
+        let mut generic_params = self.generic_params.clone();
+
+        // Sanity checks
+        self.check_generics();
+        assert!(generic_params
+            .trait_clauses
+            .iter()
+            .enumerate()
+            .all(|(i, c)| c.clause_id.index() == i));
+
+        // The regons were tracked separately, we add them back here.
+        assert!(generic_params.regions.is_empty());
+        assert!(self.region_vars.len() == 1);
+        generic_params.regions = self.region_vars[0].clone();
+
+        trace!("Translated generics: {generic_params:?}");
+        Ok(generic_params)
     }
 
-    fn push_generics_for_def_inner(
+    /// Add the generics and predicates of this item and its parents to the current context.
+    fn push_generics_for_def(
         &mut self,
         span: rustc_span::Span,
         def: &hax::FullDef,
@@ -639,7 +657,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             | FullDefKind::AssocConst { parent, .. }
             | FullDefKind::Closure { parent, .. } => {
                 let parent_def = self.t_ctx.hax_def(parent);
-                self.push_generics_for_def_inner(span, &parent_def, true)?;
+                self.push_generics_for_def(span, &parent_def, true)?;
             }
             _ => {}
         }
@@ -796,8 +814,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let span = item_meta.span.rust_span();
 
         // Translate generics and predicates
-        bt_ctx.push_generics_for_def(span, def)?;
-        let generics = bt_ctx.get_generics();
+        let generics = bt_ctx.translate_def_generics(span, def)?;
 
         // Translate type body
         let kind = match &def.kind {

--- a/charon/tests/ui/generic-associated-types.out
+++ b/charon/tests/ui/generic-associated-types.out
@@ -1,3 +1,18 @@
+thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:151:9:
+Normalizing <<Self as LendingIterator>::Item<'a> as std::marker::Sized> without wrapping in a `Binder`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Thread panicked when extracting item `test_crate::LendingIterator`.
+ --> tests/ui/generic-associated-types.rs:2:1
+  |
+2 | trait LendingIterator {
+  | ^^^^^^^^^^^^^^^^^^^^^
+
+error: Ignoring the following item due to an error: test_crate::LendingIterator
+ --> tests/ui/generic-associated-types.rs:2:1
+  |
+2 | trait LendingIterator {
+  | ^^^^^^^^^^^^^^^^^^^^^
+
 error: Could not find region: Region { kind: ReEarlyParam(EarlyParamRegion { index: 2, name: "'b" }) }
        
        Region vars map:
@@ -15,21 +30,6 @@ error: Ignoring the following item due to an error: test_crate::{impl#0}
    |
 10 | impl<'a, T> LendingIterator for Option<&'a T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-thread 'rustc' panicked at compiler/rustc_trait_selection/src/traits/normalize.rs:151:9:
-Normalizing <<Self as LendingIterator>::Item<'a> as std::marker::Sized> without wrapping in a `Binder`
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: Thread panicked when extracting item `test_crate::LendingIterator::next`.
- --> tests/ui/generic-associated-types.rs:7:5
-  |
-7 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ignoring the following item due to an error: test_crate::LendingIterator::next
- --> tests/ui/generic-associated-types.rs:7:5
-  |
-7 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 thread 'rustc' panicked at /rustc/730d5d4095a264ef5f7c0a0781eea68c15431d45/compiler/rustc_type_ir/src/binder.rs:783:9:
 const parameter `'a/#1` ('a/#1/1) out of range when instantiating args=[I/#0]

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -139,9 +139,15 @@ opaque type core::iter::adapters::zip::Zip<A, B>
 
 opaque type core::iter::adapters::map::Map<I, F>
 
+opaque type core::iter::adapters::filter::Filter<I, P>
+
 opaque type core::iter::adapters::filter_map::FilterMap<I, F>
 
 opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::skip_while::SkipWhile<I, P>
+
+opaque type core::iter::adapters::take_while::TakeWhile<I, P>
 
 opaque type core::iter::adapters::map_while::MapWhile<I, P>
 
@@ -149,7 +155,11 @@ opaque type core::iter::adapters::skip::Skip<I>
 
 opaque type core::iter::adapters::take::Take<I>
 
+opaque type core::iter::adapters::scan::Scan<I, St, F>
+
 opaque type core::iter::adapters::fuse::Fuse<I>
+
+opaque type core::iter::adapters::inspect::Inspect<I, F>
 
 trait core::ops::try_trait::FromResidual<Self, R>
 {
@@ -178,6 +188,11 @@ where
     parent_clause_1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
     parent_clause_2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
     type TryType
+}
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
@@ -220,11 +235,6 @@ trait core::cmp::Ord<Self>
 
 opaque type core::iter::adapters::rev::Rev<T>
 
-trait core::default::Default<Self>
-{
-    fn default : core::default::Default::default
-}
-
 opaque type core::iter::adapters::copied::Copied<I>
 
 opaque type core::iter::adapters::cloned::Cloned<I>
@@ -248,19 +258,27 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
     fn map : core::iter::traits::iterator::Iterator::map
     fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : core::iter::traits::iterator::Iterator::filter
     fn filter_map : core::iter::traits::iterator::Iterator::filter_map
     fn enumerate : core::iter::traits::iterator::Iterator::enumerate
     fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
+    fn take_while : core::iter::traits::iterator::Iterator::take_while
     fn map_while : core::iter::traits::iterator::Iterator::map_while
     fn skip : core::iter::traits::iterator::Iterator::skip
     fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : core::iter::traits::iterator::Iterator::scan
     fn flat_map : core::iter::traits::iterator::Iterator::flat_map
     fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
     fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : core::iter::traits::iterator::Iterator::inspect
     fn by_ref : core::iter::traits::iterator::Iterator::by_ref
     fn collect : core::iter::traits::iterator::Iterator::collect
     fn try_collect : core::iter::traits::iterator::Iterator::try_collect
     fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : core::iter::traits::iterator::Iterator::partition
+    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
     fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
     fn try_fold : core::iter::traits::iterator::Iterator::try_fold
     fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
@@ -269,10 +287,17 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
     fn all : core::iter::traits::iterator::Iterator::all
     fn any : core::iter::traits::iterator::Iterator::any
+    fn find : core::iter::traits::iterator::Iterator::find
     fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : core::iter::traits::iterator::Iterator::try_find
     fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : core::iter::traits::iterator::Iterator::rposition
     fn max : core::iter::traits::iterator::Iterator::max
     fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
+    fn max_by : core::iter::traits::iterator::Iterator::max_by
+    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
+    fn min_by : core::iter::traits::iterator::Iterator::min_by
     fn rev : core::iter::traits::iterator::Iterator::rev
     fn unzip : core::iter::traits::iterator::Iterator::unzip
     fn copied : core::iter::traits::iterator::Iterator::copied
@@ -293,6 +318,7 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn gt : core::iter::traits::iterator::Iterator::gt
     fn ge : core::iter::traits::iterator::Iterator::ge
     fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
     fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
     fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
 }
@@ -329,6 +355,10 @@ opaque type core::iter::adapters::flatten::Flatten<I>
       [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
       [@TraitClause2]: core::iter::traits::collect::IntoIterator<@TraitClause1::Item>,
 
+opaque type core::iter::adapters::map_windows::MapWindows<I, F, const N : usize>
+  where
+      [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
+
 trait core::iter::traits::collect::FromIterator<Self, A>
 {
     fn from_iter : core::iter::traits::collect::FromIterator::from_iter
@@ -350,6 +380,14 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
     fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
     fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
     fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+}
+
+trait core::iter::traits::exact_size::ExactSizeIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
+    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -791,6 +829,11 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
+fn core::iter::traits::iterator::Iterator::filter<Self, P>(@1: Self, @2: P) -> core::iter::adapters::filter::Filter<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -800,6 +843,16 @@ fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::it
 
 fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
 
+fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::skip_while::SkipWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::take_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::take_while::TakeWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>,
@@ -808,6 +861,11 @@ where
 fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
 
 fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(@1: Self, @2: St, @3: F) -> core::iter::adapters::scan::Scan<Self, St, F>
+where
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 mut (St), Self::Item)>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = core::option::Option<B>,
 
 fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause3>
 where
@@ -819,7 +877,17 @@ fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter
 where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(@1: Self, @2: F) -> core::iter::adapters::map_windows::MapWindows<Self, F, const N : usize, Self>
+where
+    [@TraitClause3]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Array<Self::Item, const N : usize>))>,
+    for<'_1_0> (parents(@TraitClause3)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::inspect<Self, F>(@1: Self, @2: F) -> core::iter::adapters::inspect::Inspect<Self, F>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
 fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
 
@@ -836,6 +904,21 @@ where
 fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
 where
     [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::partition<Self, B, F>(@1: Self, @2: F) -> (B, B)
+where
+    [@TraitClause3]: core::default::Default<B>,
+    [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>(@1: Self, @2: P) -> usize
+where
+    [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (T))>,
+    T : 'a,
+    Self::Item = &'a mut (T),
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
 where
@@ -884,15 +967,35 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
 
+fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = core::option::Option<B>,
 
+fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, impl FnMut(&Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(&Self::Item) -> R) -> @TraitClause4::TryType
+where
+    [@TraitClause3]: core::ops::try_trait::Try<R>,
+    [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause3::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_1_0 (Self::Item))>,
+    @TraitClause3::Output = bool,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::rposition<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>,
+    [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>,
+    [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
@@ -901,6 +1004,28 @@ where
 fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
     [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::max_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::min_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
 
 fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
 where
@@ -1006,6 +1131,11 @@ fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
 where
     [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -1054,6 +1184,8 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 
+fn core::default::Default::default<Self>() -> Self
+
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
@@ -1072,7 +1204,14 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = B,
 
-fn core::default::Default::default<Self>() -> Self
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 ((parents(Self)::[@TraitClause0])::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
+
+fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
 where

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -869,9 +869,15 @@ trait core::ops::function::FnMut<Self, Args>
 
 opaque type core::iter::adapters::map::Map<I, F>
 
+opaque type core::iter::adapters::filter::Filter<I, P>
+
 opaque type core::iter::adapters::filter_map::FilterMap<I, F>
 
 opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::skip_while::SkipWhile<I, P>
+
+opaque type core::iter::adapters::take_while::TakeWhile<I, P>
 
 opaque type core::iter::adapters::map_while::MapWhile<I, P>
 
@@ -879,7 +885,11 @@ opaque type core::iter::adapters::skip::Skip<I>
 
 opaque type core::iter::adapters::take::Take<I>
 
+opaque type core::iter::adapters::scan::Scan<I, St, F>
+
 opaque type core::iter::adapters::fuse::Fuse<I>
+
+opaque type core::iter::adapters::inspect::Inspect<I, F>
 
 trait core::ops::try_trait::FromResidual<Self, R>
 {
@@ -908,6 +918,11 @@ where
     parent_clause_1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
     parent_clause_2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
     type TryType
+}
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
@@ -950,11 +965,6 @@ trait core::cmp::Ord<Self>
 
 opaque type core::iter::adapters::rev::Rev<T>
 
-trait core::default::Default<Self>
-{
-    fn default : core::default::Default::default
-}
-
 opaque type core::iter::adapters::copied::Copied<I>
 
 opaque type core::iter::adapters::cloned::Cloned<I>
@@ -978,19 +988,27 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
     fn map : core::iter::traits::iterator::Iterator::map
     fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : core::iter::traits::iterator::Iterator::filter
     fn filter_map : core::iter::traits::iterator::Iterator::filter_map
     fn enumerate : core::iter::traits::iterator::Iterator::enumerate
     fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
+    fn take_while : core::iter::traits::iterator::Iterator::take_while
     fn map_while : core::iter::traits::iterator::Iterator::map_while
     fn skip : core::iter::traits::iterator::Iterator::skip
     fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : core::iter::traits::iterator::Iterator::scan
     fn flat_map : core::iter::traits::iterator::Iterator::flat_map
     fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
     fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : core::iter::traits::iterator::Iterator::inspect
     fn by_ref : core::iter::traits::iterator::Iterator::by_ref
     fn collect : core::iter::traits::iterator::Iterator::collect
     fn try_collect : core::iter::traits::iterator::Iterator::try_collect
     fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : core::iter::traits::iterator::Iterator::partition
+    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
     fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
     fn try_fold : core::iter::traits::iterator::Iterator::try_fold
     fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
@@ -999,10 +1017,17 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
     fn all : core::iter::traits::iterator::Iterator::all
     fn any : core::iter::traits::iterator::Iterator::any
+    fn find : core::iter::traits::iterator::Iterator::find
     fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : core::iter::traits::iterator::Iterator::try_find
     fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : core::iter::traits::iterator::Iterator::rposition
     fn max : core::iter::traits::iterator::Iterator::max
     fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
+    fn max_by : core::iter::traits::iterator::Iterator::max_by
+    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
+    fn min_by : core::iter::traits::iterator::Iterator::min_by
     fn rev : core::iter::traits::iterator::Iterator::rev
     fn unzip : core::iter::traits::iterator::Iterator::unzip
     fn copied : core::iter::traits::iterator::Iterator::copied
@@ -1023,6 +1048,7 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn gt : core::iter::traits::iterator::Iterator::gt
     fn ge : core::iter::traits::iterator::Iterator::ge
     fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
     fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
     fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
 }
@@ -1059,6 +1085,10 @@ opaque type core::iter::adapters::flatten::Flatten<I>
       [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
       [@TraitClause2]: core::iter::traits::collect::IntoIterator<@TraitClause1::Item>,
 
+opaque type core::iter::adapters::map_windows::MapWindows<I, F, const N : usize>
+  where
+      [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
+
 trait core::iter::traits::collect::FromIterator<Self, A>
 {
     fn from_iter : core::iter::traits::collect::FromIterator::from_iter
@@ -1080,6 +1110,14 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
     fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
     fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
     fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+}
+
+trait core::iter::traits::exact_size::ExactSizeIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
+    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -2069,6 +2107,11 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
+fn core::iter::traits::iterator::Iterator::filter<Self, P>(@1: Self, @2: P) -> core::iter::adapters::filter::Filter<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -2078,6 +2121,16 @@ fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::it
 
 fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
 
+fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::skip_while::SkipWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::take_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::take_while::TakeWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>,
@@ -2086,6 +2139,11 @@ where
 fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
 
 fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(@1: Self, @2: St, @3: F) -> core::iter::adapters::scan::Scan<Self, St, F>
+where
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 mut (St), Self::Item)>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = core::option::Option<B>,
 
 fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause3>
 where
@@ -2097,7 +2155,17 @@ fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter
 where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(@1: Self, @2: F) -> core::iter::adapters::map_windows::MapWindows<Self, F, const N : usize, Self>
+where
+    [@TraitClause3]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Array<Self::Item, const N : usize>))>,
+    for<'_1_0> (parents(@TraitClause3)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::inspect<Self, F>(@1: Self, @2: F) -> core::iter::adapters::inspect::Inspect<Self, F>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
 fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
 
@@ -2114,6 +2182,21 @@ where
 fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
 where
     [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::partition<Self, B, F>(@1: Self, @2: F) -> (B, B)
+where
+    [@TraitClause3]: core::default::Default<B>,
+    [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>(@1: Self, @2: P) -> usize
+where
+    [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (T))>,
+    T : 'a,
+    Self::Item = &'a mut (T),
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
 where
@@ -2162,15 +2245,35 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
 
+fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = core::option::Option<B>,
 
+fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, impl FnMut(&Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(&Self::Item) -> R) -> @TraitClause4::TryType
+where
+    [@TraitClause3]: core::ops::try_trait::Try<R>,
+    [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause3::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_1_0 (Self::Item))>,
+    @TraitClause3::Output = bool,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::rposition<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>,
+    [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>,
+    [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
@@ -2179,6 +2282,28 @@ where
 fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
     [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::max_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::min_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
 
 fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
 where
@@ -2284,6 +2409,11 @@ fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
 where
     [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -2350,6 +2480,8 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 
+fn core::default::Default::default<Self>() -> Self
+
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
@@ -2368,7 +2500,14 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = B,
 
-fn core::default::Default::default<Self>() -> Self
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 ((parents(Self)::[@TraitClause0])::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
+
+fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
 where

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -120,9 +120,15 @@ trait core::ops::function::FnMut<Self, Args>
 
 opaque type core::iter::adapters::map::Map<I, F>
 
+opaque type core::iter::adapters::filter::Filter<I, P>
+
 opaque type core::iter::adapters::filter_map::FilterMap<I, F>
 
 opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::skip_while::SkipWhile<I, P>
+
+opaque type core::iter::adapters::take_while::TakeWhile<I, P>
 
 opaque type core::iter::adapters::map_while::MapWhile<I, P>
 
@@ -130,7 +136,11 @@ opaque type core::iter::adapters::skip::Skip<I>
 
 opaque type core::iter::adapters::take::Take<I>
 
+opaque type core::iter::adapters::scan::Scan<I, St, F>
+
 opaque type core::iter::adapters::fuse::Fuse<I>
+
+opaque type core::iter::adapters::inspect::Inspect<I, F>
 
 trait core::ops::try_trait::FromResidual<Self, R>
 {
@@ -159,6 +169,11 @@ where
     parent_clause_1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
     parent_clause_2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
     type TryType
+}
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
@@ -201,11 +216,6 @@ trait core::cmp::Ord<Self>
 
 opaque type core::iter::adapters::rev::Rev<T>
 
-trait core::default::Default<Self>
-{
-    fn default : core::default::Default::default
-}
-
 opaque type core::iter::adapters::copied::Copied<I>
 
 opaque type core::iter::adapters::cloned::Cloned<I>
@@ -239,19 +249,27 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
     fn map : core::iter::traits::iterator::Iterator::map
     fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : core::iter::traits::iterator::Iterator::filter
     fn filter_map : core::iter::traits::iterator::Iterator::filter_map
     fn enumerate : core::iter::traits::iterator::Iterator::enumerate
     fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
+    fn take_while : core::iter::traits::iterator::Iterator::take_while
     fn map_while : core::iter::traits::iterator::Iterator::map_while
     fn skip : core::iter::traits::iterator::Iterator::skip
     fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : core::iter::traits::iterator::Iterator::scan
     fn flat_map : core::iter::traits::iterator::Iterator::flat_map
     fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
     fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : core::iter::traits::iterator::Iterator::inspect
     fn by_ref : core::iter::traits::iterator::Iterator::by_ref
     fn collect : core::iter::traits::iterator::Iterator::collect
     fn try_collect : core::iter::traits::iterator::Iterator::try_collect
     fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : core::iter::traits::iterator::Iterator::partition
+    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
     fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
     fn try_fold : core::iter::traits::iterator::Iterator::try_fold
     fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
@@ -260,10 +278,17 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
     fn all : core::iter::traits::iterator::Iterator::all
     fn any : core::iter::traits::iterator::Iterator::any
+    fn find : core::iter::traits::iterator::Iterator::find
     fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : core::iter::traits::iterator::Iterator::try_find
     fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : core::iter::traits::iterator::Iterator::rposition
     fn max : core::iter::traits::iterator::Iterator::max
     fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
+    fn max_by : core::iter::traits::iterator::Iterator::max_by
+    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
+    fn min_by : core::iter::traits::iterator::Iterator::min_by
     fn rev : core::iter::traits::iterator::Iterator::rev
     fn unzip : core::iter::traits::iterator::Iterator::unzip
     fn copied : core::iter::traits::iterator::Iterator::copied
@@ -284,6 +309,7 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn gt : core::iter::traits::iterator::Iterator::gt
     fn ge : core::iter::traits::iterator::Iterator::ge
     fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
     fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
     fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
 }
@@ -310,6 +336,10 @@ opaque type core::iter::adapters::flatten::Flatten<I>
       [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
       [@TraitClause2]: core::iter::traits::collect::IntoIterator<@TraitClause1::Item>,
 
+opaque type core::iter::adapters::map_windows::MapWindows<I, F, const N : usize>
+  where
+      [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
+
 trait core::iter::traits::collect::FromIterator<Self, A>
 {
     fn from_iter : core::iter::traits::collect::FromIterator::from_iter
@@ -331,6 +361,14 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
     fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
     fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
     fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+}
+
+trait core::iter::traits::exact_size::ExactSizeIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
+    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -459,13 +497,6 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (&'_ (T))>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = bool,
-
-trait core::iter::traits::exact_size::ExactSizeIterator<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
-}
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
@@ -912,6 +943,11 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
+fn core::iter::traits::iterator::Iterator::filter<Self, P>(@1: Self, @2: P) -> core::iter::adapters::filter::Filter<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -921,6 +957,16 @@ fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::it
 
 fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
 
+fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::skip_while::SkipWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::take_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::take_while::TakeWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>,
@@ -929,6 +975,11 @@ where
 fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
 
 fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(@1: Self, @2: St, @3: F) -> core::iter::adapters::scan::Scan<Self, St, F>
+where
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 mut (St), Self::Item)>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = core::option::Option<B>,
 
 fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause3>
 where
@@ -940,7 +991,17 @@ fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter
 where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(@1: Self, @2: F) -> core::iter::adapters::map_windows::MapWindows<Self, F, const N : usize, Self>
+where
+    [@TraitClause3]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Array<Self::Item, const N : usize>))>,
+    for<'_1_0> (parents(@TraitClause3)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::inspect<Self, F>(@1: Self, @2: F) -> core::iter::adapters::inspect::Inspect<Self, F>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
 fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
 
@@ -957,6 +1018,21 @@ where
 fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
 where
     [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::partition<Self, B, F>(@1: Self, @2: F) -> (B, B)
+where
+    [@TraitClause3]: core::default::Default<B>,
+    [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>(@1: Self, @2: P) -> usize
+where
+    [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (T))>,
+    T : 'a,
+    Self::Item = &'a mut (T),
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
 where
@@ -1005,15 +1081,35 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
 
+fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = core::option::Option<B>,
 
+fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, impl FnMut(&Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(&Self::Item) -> R) -> @TraitClause4::TryType
+where
+    [@TraitClause3]: core::ops::try_trait::Try<R>,
+    [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause3::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_1_0 (Self::Item))>,
+    @TraitClause3::Output = bool,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::rposition<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>,
+    [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>,
+    [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
@@ -1022,6 +1118,28 @@ where
 fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
     [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::max_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::min_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
 
 fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
 where
@@ -1127,6 +1245,11 @@ fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
 where
     [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -1167,6 +1290,35 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 
+fn core::default::Default::default<Self>() -> Self
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause4]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    [@TraitClause5]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause4)::[@TraitClause0])::Output = R,
+    @TraitClause5::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    (parents(@TraitClause3)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 ((parents(Self)::[@TraitClause0])::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
+
+fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
+
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
 fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
@@ -1193,26 +1345,6 @@ fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs
 
 fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
-fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
-where
-    [@TraitClause4]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
-    [@TraitClause5]: core::ops::try_trait::Try<R>,
-    (parents(@TraitClause4)::[@TraitClause0])::Output = R,
-    @TraitClause5::Output = B,
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
-where
-    [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
-    (parents(@TraitClause3)::[@TraitClause0])::Output = B,
-
-fn core::default::Default::default<Self>() -> Self
-
 fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
 where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
@@ -1226,10 +1358,6 @@ where
 fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
-
-fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
-
-fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 
 

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:772:42:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:788:42:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::foo`.

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:753:42:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:772:42:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::foo`.

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:721:42:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:753:42:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::foo`.

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -102,9 +102,15 @@ trait core::ops::function::FnMut<Self, Args>
 
 opaque type core::iter::adapters::map::Map<I, F>
 
+opaque type core::iter::adapters::filter::Filter<I, P>
+
 opaque type core::iter::adapters::filter_map::FilterMap<I, F>
 
 opaque type core::iter::adapters::enumerate::Enumerate<I>
+
+opaque type core::iter::adapters::skip_while::SkipWhile<I, P>
+
+opaque type core::iter::adapters::take_while::TakeWhile<I, P>
 
 opaque type core::iter::adapters::map_while::MapWhile<I, P>
 
@@ -112,7 +118,11 @@ opaque type core::iter::adapters::skip::Skip<I>
 
 opaque type core::iter::adapters::take::Take<I>
 
+opaque type core::iter::adapters::scan::Scan<I, St, F>
+
 opaque type core::iter::adapters::fuse::Fuse<I>
+
+opaque type core::iter::adapters::inspect::Inspect<I, F>
 
 trait core::ops::try_trait::FromResidual<Self, R>
 {
@@ -141,6 +151,11 @@ where
     parent_clause_1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
     parent_clause_2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
     type TryType
+}
+
+trait core::default::Default<Self>
+{
+    fn default : core::default::Default::default
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
@@ -183,11 +198,6 @@ trait core::cmp::Ord<Self>
 
 opaque type core::iter::adapters::rev::Rev<T>
 
-trait core::default::Default<Self>
-{
-    fn default : core::default::Default::default
-}
-
 opaque type core::iter::adapters::copied::Copied<I>
 
 opaque type core::iter::adapters::cloned::Cloned<I>
@@ -211,19 +221,27 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
     fn map : core::iter::traits::iterator::Iterator::map
     fn for_each : core::iter::traits::iterator::Iterator::for_each
+    fn filter : core::iter::traits::iterator::Iterator::filter
     fn filter_map : core::iter::traits::iterator::Iterator::filter_map
     fn enumerate : core::iter::traits::iterator::Iterator::enumerate
     fn peekable : core::iter::traits::iterator::Iterator::peekable
+    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
+    fn take_while : core::iter::traits::iterator::Iterator::take_while
     fn map_while : core::iter::traits::iterator::Iterator::map_while
     fn skip : core::iter::traits::iterator::Iterator::skip
     fn take : core::iter::traits::iterator::Iterator::take
+    fn scan : core::iter::traits::iterator::Iterator::scan
     fn flat_map : core::iter::traits::iterator::Iterator::flat_map
     fn flatten : core::iter::traits::iterator::Iterator::flatten
+    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
     fn fuse : core::iter::traits::iterator::Iterator::fuse
+    fn inspect : core::iter::traits::iterator::Iterator::inspect
     fn by_ref : core::iter::traits::iterator::Iterator::by_ref
     fn collect : core::iter::traits::iterator::Iterator::collect
     fn try_collect : core::iter::traits::iterator::Iterator::try_collect
     fn collect_into : core::iter::traits::iterator::Iterator::collect_into
+    fn partition : core::iter::traits::iterator::Iterator::partition
+    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
     fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
     fn try_fold : core::iter::traits::iterator::Iterator::try_fold
     fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
@@ -232,10 +250,17 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
     fn all : core::iter::traits::iterator::Iterator::all
     fn any : core::iter::traits::iterator::Iterator::any
+    fn find : core::iter::traits::iterator::Iterator::find
     fn find_map : core::iter::traits::iterator::Iterator::find_map
+    fn try_find : core::iter::traits::iterator::Iterator::try_find
     fn position : core::iter::traits::iterator::Iterator::position
+    fn rposition : core::iter::traits::iterator::Iterator::rposition
     fn max : core::iter::traits::iterator::Iterator::max
     fn min : core::iter::traits::iterator::Iterator::min
+    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
+    fn max_by : core::iter::traits::iterator::Iterator::max_by
+    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
+    fn min_by : core::iter::traits::iterator::Iterator::min_by
     fn rev : core::iter::traits::iterator::Iterator::rev
     fn unzip : core::iter::traits::iterator::Iterator::unzip
     fn copied : core::iter::traits::iterator::Iterator::copied
@@ -256,6 +281,7 @@ trait core::iter::traits::iterator::Iterator<Self>
     fn gt : core::iter::traits::iterator::Iterator::gt
     fn ge : core::iter::traits::iterator::Iterator::ge
     fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
+    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
     fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
     fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
 }
@@ -292,6 +318,10 @@ opaque type core::iter::adapters::flatten::Flatten<I>
       [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
       [@TraitClause2]: core::iter::traits::collect::IntoIterator<@TraitClause1::Item>,
 
+opaque type core::iter::adapters::map_windows::MapWindows<I, F, const N : usize>
+  where
+      [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
+
 trait core::iter::traits::collect::FromIterator<Self, A>
 {
     fn from_iter : core::iter::traits::collect::FromIterator::from_iter
@@ -313,6 +343,14 @@ trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
     fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
     fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
     fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
+    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+}
+
+trait core::iter::traits::exact_size::ExactSizeIterator<Self>
+{
+    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
+    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
+    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -381,13 +419,6 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (&'_ (T))>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = bool,
-
-trait core::iter::traits::exact_size::ExactSizeIterator<Self>
-{
-    parent_clause_0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
-}
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>}#182::rposition<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>), @2: P) -> core::option::Option<usize>
 where
@@ -505,6 +536,11 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
+fn core::iter::traits::iterator::Iterator::filter<Self, P>(@1: Self, @2: P) -> core::iter::adapters::filter::Filter<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::filter_map::FilterMap<Self, F>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -514,6 +550,16 @@ fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::it
 
 fn core::iter::traits::iterator::Iterator::peekable<Self>(@1: Self) -> core::iter::adapters::peekable::Peekable<Self, Self>
 
+fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::skip_while::SkipWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::take_while<Self, P>(@1: Self, @2: P) -> core::iter::adapters::take_while::TakeWhile<Self, P>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(@1: Self, @2: P) -> core::iter::adapters::map_while::MapWhile<Self, P>
 where
     [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>,
@@ -522,6 +568,11 @@ where
 fn core::iter::traits::iterator::Iterator::skip<Self>(@1: Self, @2: usize) -> core::iter::adapters::skip::Skip<Self>
 
 fn core::iter::traits::iterator::Iterator::take<Self>(@1: Self, @2: usize) -> core::iter::adapters::take::Take<Self>
+
+fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(@1: Self, @2: St, @3: F) -> core::iter::adapters::scan::Scan<Self, St, F>
+where
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 mut (St), Self::Item)>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = core::option::Option<B>,
 
 fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(@1: Self, @2: F) -> core::iter::adapters::flatten::FlatMap<Self, U, F, @TraitClause3>
 where
@@ -533,7 +584,17 @@ fn core::iter::traits::iterator::Iterator::flatten<Self>(@1: Self) -> core::iter
 where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(@1: Self, @2: F) -> core::iter::adapters::map_windows::MapWindows<Self, F, const N : usize, Self>
+where
+    [@TraitClause3]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Array<Self::Item, const N : usize>))>,
+    for<'_1_0> (parents(@TraitClause3)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::fuse<Self>(@1: Self) -> core::iter::adapters::fuse::Fuse<Self>
+
+fn core::iter::traits::iterator::Iterator::inspect<Self, F>(@1: Self, @2: F) -> core::iter::adapters::inspect::Inspect<Self, F>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = (),
 
 fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self)
 
@@ -550,6 +611,21 @@ where
 fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(@1: Self, @2: &'_0 mut (E)) -> &'_0 mut (E)
 where
     [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::partition<Self, B, F>(@1: Self, @2: F) -> (B, B)
+where
+    [@TraitClause3]: core::default::Default<B>,
+    [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>(@1: Self, @2: P) -> usize
+where
+    [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (T))>,
+    T : 'a,
+    Self::Item = &'a mut (T),
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(@1: Self, @2: P) -> bool
 where
@@ -598,15 +674,35 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
 
+fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(@1: &'_0 mut (Self), @2: F) -> core::option::Option<B>
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     (parents(@TraitClause3)::[@TraitClause0])::Output = core::option::Option<B>,
 
+fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, impl FnMut(&Self::Item) -> R>(@1: &'_0 mut (Self), @2: impl FnMut(&Self::Item) -> R) -> @TraitClause4::TryType
+where
+    [@TraitClause3]: core::ops::try_trait::Try<R>,
+    [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause3::Residual, core::option::Option<Self::Item>>,
+    [@TraitClause5]: for<'_1_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_1_0 (Self::Item))>,
+    @TraitClause3::Output = bool,
+    for<'_1_0> (parents(@TraitClause5)::[@TraitClause0])::Output = R,
+
 fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
 where
     [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>,
     (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::iterator::Iterator::rposition<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<usize>
+where
+    [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>,
+    [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>,
+    [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
+    (parents(@TraitClause1)::[@TraitClause0])::Output = bool,
 
 fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
@@ -615,6 +711,28 @@ where
 fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>
 where
     [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::max_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
+
+fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: core::cmp::Ord<B>,
+    [@TraitClause4]: for<'_1_0> core::ops::function::FnMut<F, (&'_1_0 (Self::Item))>,
+    for<'_1_0> (parents(@TraitClause4)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::iterator::Iterator::min_by<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = core::cmp::Ordering,
 
 fn core::iter::traits::iterator::Iterator::rev<Self>(@1: Self) -> core::iter::adapters::rev::Rev<Self>
 where
@@ -720,6 +838,11 @@ fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
 where
     [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
 
+fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
+where
+    [@TraitClause2]: for<'_1_0, '_1_1> core::ops::function::FnMut<F, (&'_1_0 (Self::Item), &'_1_1 (Self::Item))>,
+    for<'_1_0, '_1_1> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
 fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(@1: Self, @2: F) -> bool
 where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
@@ -762,6 +885,35 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 
+fn core::default::Default::default<Self>() -> Self
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
+where
+    [@TraitClause4]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    [@TraitClause5]: core::ops::try_trait::Try<R>,
+    (parents(@TraitClause4)::[@TraitClause0])::Output = R,
+    @TraitClause5::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
+    (parents(@TraitClause3)::[@TraitClause0])::Output = B,
+
+fn core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0, Self, P>(@1: &'_0 mut (Self), @2: P) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
+where
+    [@TraitClause2]: for<'_1_0> core::ops::function::FnMut<P, (&'_1_0 ((parents(Self)::[@TraitClause0])::Item))>,
+    for<'_1_0> (parents(@TraitClause2)::[@TraitClause0])::Output = bool,
+
+fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
+
+fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
+
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
 fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
@@ -788,26 +940,6 @@ fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs
 
 fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
-fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26>>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<(parents(Self)::[@TraitClause0])::Item>
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0, Self, B, F, R>(@1: &'_0 mut (Self), @2: B, @3: F) -> R
-where
-    [@TraitClause4]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
-    [@TraitClause5]: core::ops::try_trait::Try<R>,
-    (parents(@TraitClause4)::[@TraitClause0])::Output = R,
-    @TraitClause5::Output = B,
-
-fn core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
-where
-    [@TraitClause3]: core::ops::function::FnMut<F, (B, (parents(Self)::[@TraitClause0])::Item)>,
-    (parents(@TraitClause3)::[@TraitClause0])::Output = B,
-
-fn core::default::Default::default<Self>() -> Self
-
 fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
 where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
@@ -821,10 +953,6 @@ where
 fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
-
-fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
-
-fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
 
 
 


### PR DESCRIPTION
This replaces the "push_generics"/"get_generics" split with a single `translate_generics` function that centralizes handling of generic parameters and precidates. This also removes the hacks we introduced to circumvent binder errors; we can now translate all `Iterator` methods!