### PR TITLE
Re-add the top-level `catch_unwind`

### DIFF
--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -237,11 +237,16 @@ fn main() {
                 log::warn!("{}", msg);
             }
         }
-        Err(err) => {
+        Err(err) if errors_as_warnings => {
             log::error!("{err}");
-            if !errors_as_warnings {
-                std::process::exit(1);
-            }
+        }
+        Err(CharonFailure::Panic) => {
+            // Standard rust panic error code.
+            std::process::exit(101);
+        }
+        Err(err @ (CharonFailure::RustcError(_) | CharonFailure::Serialize)) => {
+            log::error!("{err}");
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
This reverts https://github.com/AeneasVerif/charon/pull/362. It turns out that rustc re-throws any ICEs, so this catch-unwind is required to generate an llbc file when we caught some ICEs during translation.

Possibly fIxes https://github.com/AeneasVerif/charon/issues/401