### PR TITLE
Don't use optimized_mir for constants

### DIFF
--- a/charon/tests/ui/stealing.out
+++ b/charon/tests/ui/stealing.out
@@ -1,12 +1,39 @@
-thread 'rustc' panicked at compiler/rustc_mir_transform/src/lib.rs:649:24:
-do not use `optimized_mir` for constants: Const { inline: false }
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: Thread panicked when extracting body.
-  --> tests/ui/stealing.rs:13:1
-   |
-13 | const FOO: usize = 42;
-   | ^^^^^^^^^^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-error: aborting due to 1 previous error
+global test_crate::SLICE  {
+    let @0: Array<(), 4 : usize>; // return
+    let @1: (); // anonymous local
 
-Error: Charon driver exited with code 101
+    @1 := ()
+    @0 := @ArrayRepeat<'_, (), 4 : usize>(move (@1))
+    drop @1
+    return
+}
+
+fn test_crate::four() -> usize
+{
+    let @0: usize; // return
+
+    @0 := const (4 : usize)
+    return
+}
+
+global test_crate::BAR  {
+    let @0: Array<(), 42 : usize>; // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := @ArrayRepeat<'_, (), 42 : usize>(move (@1))
+    drop @1
+    return
+}
+
+global test_crate::FOO  {
+    let @0: usize; // return
+
+    @0 := const (42 : usize)
+    return
+}
+
+
+

--- a/charon/tests/ui/stealing.out
+++ b/charon/tests/ui/stealing.out
@@ -1,22 +1,12 @@
-# Final LLBC before serialization:
+thread 'rustc' panicked at compiler/rustc_mir_transform/src/lib.rs:649:24:
+do not use `optimized_mir` for constants: Const { inline: false }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Thread panicked when extracting body.
+  --> tests/ui/stealing.rs:13:1
+   |
+13 | const FOO: usize = 42;
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
-global test_crate::SLICE  {
-    let @0: Array<(), 4 : usize>; // return
-    let @1: (); // anonymous local
+error: aborting due to 1 previous error
 
-    @1 := ()
-    @0 := @ArrayRepeat<'_, (), 4 : usize>(move (@1))
-    drop @1
-    return
-}
-
-fn test_crate::four() -> usize
-{
-    let @0: usize; // return
-
-    @0 := const (4 : usize)
-    return
-}
-
-
-
+Error: Charon driver exited with code 101

--- a/charon/tests/ui/stealing.rs
+++ b/charon/tests/ui/stealing.rs
@@ -1,3 +1,5 @@
+//@ known-failure
+
 // Translating this needs the evaluatable MIR of `fn four()`, which steals its `mir_built` body.
 // There's no simple ordering of the translation of items that can avoid all stealing.
 static SLICE: [(); four()] = [(); 4];
@@ -5,3 +7,7 @@ static SLICE: [(); four()] = [(); 4];
 const fn four() -> usize {
     2 + 2
 }
+
+// The order counts, we want to translate `BAR` first to steal `FOO`.
+const BAR: [(); FOO] = [(); FOO];
+const FOO: usize = 42;

--- a/charon/tests/ui/stealing.rs
+++ b/charon/tests/ui/stealing.rs
@@ -1,5 +1,3 @@
-//@ known-failure
-
 // Translating this needs the evaluatable MIR of `fn four()`, which steals its `mir_built` body.
 // There's no simple ordering of the translation of items that can avoid all stealing.
 static SLICE: [(); four()] = [(); 4];


### PR DESCRIPTION
This fixes the "do not use `optimized_mir` for constants" ICE we sometimes get.