### PR TITLE
Hash-cons `Ty`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.44"
+let supported_charon_version = "0.1.45"

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -436,7 +436,6 @@ and type_id =
           for more uniform treatment throughout the codebase.
        *)
 
-(** A type. *)
 and ty =
   | TAdt of type_id * generic_args
       (** An ADT.

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.44"
+version = "0.1.45"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -65,7 +65,7 @@ rustc_version = "0.4"
 serde_json = { version = "1.0.91", features = ["unbounded_depth"] }
 serde-map-to-array = { version = "1.1.1", features = ["std"] }
 serde_stacker = "0.1.11"
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive", "rc"] }
 stacker = "0.1"
 take_mut = "0.2.2"
 toml = { version = "0.8", features = ["parse"] }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,10 +1,9 @@
-use crate::ast::*;
 use crate::ids::Vector;
+use crate::{ast::*, common::hash_consing::HashConsed};
 use derivative::Derivative;
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 pub type FieldName = String;
 
@@ -649,22 +648,16 @@ pub enum ConstGeneric {
 }
 
 /// A type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive)]
-pub struct Ty(Arc<TyKind>);
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+pub struct Ty(HashConsed<TyKind>);
 
 impl Ty {
     pub fn new(kind: TyKind) -> Self {
-        Ty(Arc::new(kind))
+        Ty(HashConsed::new(kind))
     }
 
     pub fn kind(&self) -> &TyKind {
-        self.0.as_ref()
-    }
-
-    /// Clones if needed to get mutable access to the type kind.
-    pub fn with_kind_mut<T>(&mut self, f: impl FnOnce(&mut TyKind) -> T) -> T {
-        let kind = Arc::make_mut(&mut self.0);
-        f(kind)
+        self.0.inner()
     }
 }
 

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -355,15 +355,6 @@ impl RefKind {
     }
 }
 
-/// Note: this destroys all sharing
-impl DriveMut for Ty {
-    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        self.with_kind_mut(|kind| kind.drive_mut(visitor));
-        visitor.visit(self, Event::Exit);
-    }
-}
-
 // The derive macro doesn't handle generics.
 impl<T: Drive> Drive for RegionBinder<T> {
     fn drive<V: Visitor>(&self, visitor: &mut V) {

--- a/charon/src/ast/values_utils.rs
+++ b/charon/src/ast/values_utils.rs
@@ -230,7 +230,7 @@ impl ScalarValue {
     pub fn to_constant(self) -> ConstantExpr {
         ConstantExpr {
             value: RawConstantExpr::Literal(Literal::Scalar(self)),
-            ty: Ty::Literal(LiteralTy::Integer(self.get_integer_ty())),
+            ty: TyKind::Literal(LiteralTy::Integer(self.get_integer_ty())).into_ty(),
         }
     }
 }

--- a/charon/src/bin/charon-driver/translate/get_mir.rs
+++ b/charon/src/bin/charon-driver/translate/get_mir.rs
@@ -18,7 +18,7 @@ pub fn extract_constants_at_top_level(level: MirLevel) -> bool {
 }
 
 /// Are boxe manipulations desugared to very low-level code using raw pointers,
-/// unique and non-null pointers? See [crate::types::Ty::RawPtr] for detailed explanations.
+/// unique and non-null pointers? See [crate::types::TyKind::RawPtr] for detailed explanations.
 pub fn boxes_are_desugared(level: MirLevel) -> bool {
     match level {
         MirLevel::Built => false,

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -122,41 +122,41 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         ty: &hax::Ty,
     ) -> Result<Ty, Error> {
         trace!("{:?}", ty);
-        match ty.kind() {
-            hax::TyKind::Bool => Ok(Ty::Literal(LiteralTy::Bool)),
-            hax::TyKind::Char => Ok(Ty::Literal(LiteralTy::Char)),
+        let kind = match ty.kind() {
+            hax::TyKind::Bool => TyKind::Literal(LiteralTy::Bool),
+            hax::TyKind::Char => TyKind::Literal(LiteralTy::Char),
             hax::TyKind::Int(int_ty) => {
                 use hax::IntTy;
-                Ok(Ty::Literal(LiteralTy::Integer(match int_ty {
+                TyKind::Literal(LiteralTy::Integer(match int_ty {
                     IntTy::Isize => IntegerTy::Isize,
                     IntTy::I8 => IntegerTy::I8,
                     IntTy::I16 => IntegerTy::I16,
                     IntTy::I32 => IntegerTy::I32,
                     IntTy::I64 => IntegerTy::I64,
                     IntTy::I128 => IntegerTy::I128,
-                })))
+                }))
             }
             hax::TyKind::Uint(int_ty) => {
                 use hax::UintTy;
-                Ok(Ty::Literal(LiteralTy::Integer(match int_ty {
+                TyKind::Literal(LiteralTy::Integer(match int_ty {
                     UintTy::Usize => IntegerTy::Usize,
                     UintTy::U8 => IntegerTy::U8,
                     UintTy::U16 => IntegerTy::U16,
                     UintTy::U32 => IntegerTy::U32,
                     UintTy::U64 => IntegerTy::U64,
                     UintTy::U128 => IntegerTy::U128,
-                })))
+                }))
             }
             hax::TyKind::Float(float_ty) => {
                 use hax::FloatTy;
-                Ok(Ty::Literal(LiteralTy::Float(match float_ty {
+                TyKind::Literal(LiteralTy::Float(match float_ty {
                     FloatTy::F16 => charon_lib::ast::types::FloatTy::F16,
                     FloatTy::F32 => charon_lib::ast::types::FloatTy::F32,
                     FloatTy::F64 => charon_lib::ast::types::FloatTy::F64,
                     FloatTy::F128 => charon_lib::ast::types::FloatTy::F128,
-                })))
+                }))
             }
-            hax::TyKind::Never => Ok(Ty::Never),
+            hax::TyKind::Never => TyKind::Never,
 
             hax::TyKind::Alias(alias) => match &alias.kind {
                 hax::AliasKind::Projection {
@@ -169,7 +169,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     // ignore) has associated types.
                     let trait_ref = trait_ref.unwrap();
                     let name = TraitItemName(assoc_item.name.clone().into());
-                    Ok(Ty::TraitType(trait_ref, name))
+                    TyKind::TraitType(trait_ref, name)
                 }
                 _ => {
                     error_or_panic!(self, span, format!("Unimplemented: {:?}", ty))
@@ -203,13 +203,13 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 )?;
 
                 // Return the instantiated ADT
-                Ok(Ty::Adt(type_id, generics))
+                TyKind::Adt(type_id, generics)
             }
             hax::TyKind::Str => {
                 trace!("Str");
 
                 let id = TypeId::Builtin(BuiltinTy::Str);
-                Ok(Ty::Adt(id, GenericArgs::empty()))
+                TyKind::Adt(id, GenericArgs::empty())
             }
             hax::TyKind::Array(ty, const_param) => {
                 trace!("Array");
@@ -218,17 +218,14 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let tys = vec![self.translate_ty(span, erase_regions, ty)?].into();
                 let cgs = vec![c].into();
                 let id = TypeId::Builtin(BuiltinTy::Array);
-                Ok(Ty::Adt(
-                    id,
-                    GenericArgs::new(Vector::new(), tys, cgs, Vector::new()),
-                ))
+                TyKind::Adt(id, GenericArgs::new(Vector::new(), tys, cgs, Vector::new()))
             }
             hax::TyKind::Slice(ty) => {
                 trace!("Slice");
 
                 let tys = vec![self.translate_ty(span, erase_regions, ty)?].into();
                 let id = TypeId::Builtin(BuiltinTy::Slice);
-                Ok(Ty::Adt(id, GenericArgs::new_from_types(tys)))
+                TyKind::Adt(id, GenericArgs::new_from_types(tys))
             }
             hax::TyKind::Ref(region, ty, mutability) => {
                 trace!("Ref");
@@ -240,7 +237,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 } else {
                     RefKind::Shared
                 };
-                Ok(Ty::Ref(region, Box::new(ty), kind))
+                TyKind::Ref(region, ty, kind)
             }
             hax::TyKind::RawPtr(ty, mutbl) => {
                 trace!("RawPtr: {:?}", (ty, mutbl));
@@ -250,7 +247,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 } else {
                     RefKind::Shared
                 };
-                Ok(Ty::RawPtr(Box::new(ty), kind))
+                TyKind::RawPtr(ty, kind)
             }
             hax::TyKind::Tuple(substs) => {
                 trace!("Tuple");
@@ -261,7 +258,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                     params.push(param_ty);
                 }
 
-                Ok(Ty::Adt(TypeId::Tuple, GenericArgs::new_from_types(params)))
+                TyKind::Adt(TypeId::Tuple, GenericArgs::new_from_types(params))
             }
 
             hax::TyKind::Param(param) => {
@@ -284,14 +281,14 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                             param.name, param.index
                         )
                     ),
-                    Some(var_id) => Ok(Ty::TypeVar(*var_id)),
+                    Some(var_id) => TyKind::TypeVar(*var_id),
                 }
             }
 
             hax::TyKind::Foreign(def_id) => {
                 trace!("Foreign");
                 let def_id = self.translate_type_id(span, def_id)?;
-                Ok(Ty::Adt(def_id, GenericArgs::empty()))
+                TyKind::Adt(def_id, GenericArgs::empty())
             }
             hax::TyKind::Infer(_) => {
                 trace!("Infer");
@@ -302,7 +299,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 // TODO: we don't translate the predicates yet because our machinery can't handle
                 // it.
                 trace!("Dynamic");
-                Ok(Ty::DynTrait(ExistentialPredicate))
+                TyKind::DynTrait(ExistentialPredicate)
             }
 
             hax::TyKind::Coroutine(..) => {
@@ -333,8 +330,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                         .map(|x| ctx.translate_ty(span, erase_regions, x))
                         .try_collect()?;
                     let output = ctx.translate_ty(span, erase_regions, &sig.value.output)?;
-                    Ok(Ty::Arrow(regions, inputs, Box::new(output)))
-                })
+                    Ok(TyKind::Arrow(regions, inputs, output))
+                })?
             }
             hax::TyKind::Error => {
                 trace!("Error");
@@ -344,7 +341,8 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 trace!("Todo: {s}");
                 error_or_panic!(self, span, format!("Unsupported type: {:?}", s))
             }
-        }
+        };
+        Ok(kind.into_ty())
     }
 
     #[allow(clippy::type_complexity)]
@@ -584,7 +582,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         discr: &hax::DiscriminantValue,
     ) -> Result<ScalarValue, Error> {
         let ty = self.translate_ty(def_span, true, &discr.ty)?;
-        let int_ty = *ty.as_literal().unwrap().as_integer().unwrap();
+        let int_ty = *ty.kind().as_literal().unwrap().as_integer().unwrap();
         Ok(ScalarValue::from_bits(int_ty, discr.val))
     }
 
@@ -781,7 +779,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 // The type should be primitive, meaning it shouldn't contain variables,
                 // non-primitive adts, etc. As a result, we can use an empty context.
                 let ty = self.translate_ty(span, false, ty)?;
-                let ty = ty.to_literal().unwrap();
+                let ty = *ty.kind().as_literal().unwrap();
                 self.push_const_generic_var(param.index, ty, param.name.clone());
             }
         }

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -216,6 +216,38 @@ pub mod hash_consing {
     }
 }
 
+pub mod hash_by_addr {
+    use std::{
+        hash::{Hash, Hasher},
+        ops::Deref,
+    };
+
+    /// A wrapper around a smart pointer that hashes and compares the contents by the address of
+    /// the pointee.
+    #[derive(Debug, Clone)]
+    pub struct HashByAddr<T>(pub T);
+
+    impl<T: Deref> HashByAddr<T> {
+        fn addr(&self) -> *const T::Target {
+            self.0.deref()
+        }
+    }
+
+    impl<T: Eq + Deref> Eq for HashByAddr<T> {}
+
+    impl<T: PartialEq + Deref> PartialEq for HashByAddr<T> {
+        fn eq(&self, other: &Self) -> bool {
+            std::ptr::addr_eq(self.addr(), other.addr())
+        }
+    }
+
+    impl<T: Hash + Deref> Hash for HashByAddr<T> {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.addr().hash(state);
+        }
+    }
+}
+
 // This is the amount of bytes that need to be left on the stack before increasing the size. It
 // must be at least as large as the stack required by any code that does not call
 // `ensure_sufficient_stack`.

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -55,6 +55,167 @@ pub fn write_vec<T>(
     write_iterator(write_t, f, v.iter())
 }
 
+pub mod type_map {
+    use std::{
+        any::{Any, TypeId},
+        collections::HashMap,
+        marker::PhantomData,
+    };
+
+    pub trait Mappable = Any + Send + Sync;
+
+    pub trait Mapper {
+        type Value<T: Mappable>: Mappable;
+    }
+
+    /// A map that maps types to values in a generic manner: we store for each type `T` a value of
+    /// type `M::Value<T>`.
+    pub struct TypeMap<M> {
+        data: HashMap<TypeId, Box<dyn Mappable>>,
+        phantom: PhantomData<M>,
+    }
+
+    impl<M: Mapper> TypeMap<M> {
+        pub fn get<T: Mappable>(&self) -> Option<&M::Value<T>> {
+            self.data
+                .get(&TypeId::of::<T>())
+                // We must be careful to not accidentally cast the box itself as `dyn Any`.
+                .map(|val: &Box<dyn Mappable>| &**val)
+                .and_then(|val: &dyn Mappable| (val as &dyn Any).downcast_ref())
+        }
+
+        pub fn get_mut<T: Mappable>(&mut self) -> Option<&mut M::Value<T>> {
+            self.data
+                .get_mut(&TypeId::of::<T>())
+                // We must be careful to not accidentally cast the box itself as `dyn Any`.
+                .map(|val: &mut Box<dyn Mappable>| &mut **val)
+                .and_then(|val: &mut dyn Mappable| (val as &mut dyn Any).downcast_mut())
+        }
+
+        pub fn insert<T: Mappable>(&mut self, val: M::Value<T>) -> Option<Box<M::Value<T>>> {
+            self.data
+                .insert(TypeId::of::<T>(), Box::new(val))
+                .and_then(|val: Box<dyn Mappable>| (val as Box<dyn Any>).downcast().ok())
+        }
+    }
+
+    impl<M> Default for TypeMap<M> {
+        fn default() -> Self {
+            Self {
+                data: Default::default(),
+                phantom: Default::default(),
+            }
+        }
+    }
+}
+
+pub mod hash_consing {
+    use super::type_map::{Mappable, Mapper, TypeMap};
+    use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
+    use itertools::Either;
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+    use std::hash::Hash;
+    use std::sync::{Arc, LazyLock, RwLock};
+
+    /// Hash-consed data structure: a reference-counted wrapper that guarantees that two equal
+    /// value will be stored at the same address. This makes it possible to use the pointer address
+    /// as a hash value.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HashConsed<T>(Arc<T>);
+
+    impl<T> HashConsed<T> {
+        pub fn inner(&self) -> &T {
+            self.0.as_ref()
+        }
+    }
+
+    impl<T> HashConsed<T>
+    where
+        T: Hash + PartialEq + Eq + Clone + Mappable,
+    {
+        pub fn new(inner: T) -> Self {
+            Self::intern(Either::Left(inner))
+        }
+
+        /// Clones if needed to get mutable access to the inner value.
+        pub fn with_inner_mut<R>(&mut self, f: impl FnOnce(&mut T) -> R) -> R {
+            let kind = Arc::make_mut(&mut self.0);
+            let ret = f(kind);
+            // Re-establish sharing, crucial for the hashing function to be correct.
+            *self = Self::intern(Either::Right(self.0.clone()));
+            ret
+        }
+
+        /// Deduplicate the valuess by hashing them. This deduplication is crucial for the hashing
+        /// function to be correct. This is the only function allowed to create `Self` values.
+        fn intern(inner: Either<T, Arc<T>>) -> Self {
+            struct InternMapper;
+            impl Mapper for InternMapper {
+                type Value<T: Mappable> = HashMap<T, Arc<T>>;
+            }
+            static INTERNED: LazyLock<RwLock<TypeMap<InternMapper>>> =
+                LazyLock::new(|| Default::default());
+
+            if INTERNED.read().unwrap().get::<T>().is_none() {
+                INTERNED.write().unwrap().insert::<T>(Default::default());
+            }
+            let read_guard = INTERNED.read().unwrap();
+            if let Some(inner) = (*read_guard)
+                .get::<T>()
+                .unwrap()
+                .get(inner.as_ref().either(|x| x, |x| x.as_ref()))
+            {
+                Self(inner.clone())
+            } else {
+                drop(read_guard);
+                // We clone the value here in the slow path, which makes it possible to avoid an
+                // allocation in the fast path.
+                let raw_val: T = inner.as_ref().either(T::clone, |x| x.as_ref().clone());
+                let arc: Arc<T> = inner.either(Arc::new, |x| x);
+                INTERNED
+                    .write()
+                    .unwrap()
+                    .get_mut::<T>()
+                    .unwrap()
+                    .insert(raw_val, arc.clone());
+                Self(arc)
+            }
+        }
+    }
+
+    /// Hash the pointer; this is only correct if two identical values of `Self` are guaranteed to
+    /// point to the same memory location, which we carefully enforce above.
+    impl<T> std::hash::Hash for HashConsed<T> {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            Arc::as_ptr(&self.0).hash(state);
+        }
+    }
+
+    impl<T> Drive for HashConsed<T>
+    where
+        T: Drive,
+    {
+        fn drive<V: Visitor>(&self, visitor: &mut V) {
+            visitor.visit(self, Event::Enter);
+            self.inner().drive(visitor);
+            visitor.visit(self, Event::Exit);
+        }
+    }
+
+    /// Note: this explores the full tree mutably by cloning and re-hashing afterwards.
+    impl<T> DriveMut for HashConsed<T>
+    where
+        T: DriveMut + Hash + PartialEq + Eq + Clone + Mappable,
+    {
+        fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
+            visitor.visit(self, Event::Enter);
+            self.with_inner_mut(|inner| inner.drive_mut(visitor));
+            visitor.visit(self, Event::Exit);
+        }
+    }
+}
+
 // This is the amount of bytes that need to be left on the stack before increasing the size. It
 // must be at least as large as the stack required by any code that does not call
 // `ensure_sufficient_stack`.

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -15,6 +15,7 @@
 // For rustdoc: prevents overflows
 #![recursion_limit = "256"]
 #![feature(box_patterns)]
+#![feature(deref_pure_trait)]
 #![feature(extract_if)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -84,26 +84,26 @@ impl Pattern {
         if let [PatElem::Glob] = self.elems.as_slice() {
             return true;
         }
-        match ty {
-            Ty::Adt(TypeId::Adt(type_id), args) => {
+        match ty.kind() {
+            TyKind::Adt(TypeId::Adt(type_id), args) => {
                 let Some(type_name) = ctx.item_names.get(&(*type_id).into()) else {
                     return false;
                 };
                 self.matches_with_generics(ctx, type_name, args)
             }
-            Ty::Adt(TypeId::Builtin(builtin_ty), args) => {
+            TyKind::Adt(TypeId::Builtin(builtin_ty), args) => {
                 let name = builtin_ty.get_name();
                 self.matches_with_generics(ctx, &name, args)
             }
-            Ty::Adt(TypeId::Tuple, _)
-            | Ty::TypeVar(_)
-            | Ty::Literal(_)
-            | Ty::Never
-            | Ty::Ref(_, _, _)
-            | Ty::RawPtr(_, _)
-            | Ty::TraitType(_, _)
-            | Ty::DynTrait(_)
-            | Ty::Arrow(_, _, _) => false,
+            TyKind::Adt(TypeId::Tuple, _)
+            | TyKind::TypeVar(_)
+            | TyKind::Literal(_)
+            | TyKind::Never
+            | TyKind::Ref(_, _, _)
+            | TyKind::RawPtr(_, _)
+            | TyKind::TraitType(_, _)
+            | TyKind::DynTrait(_)
+            | TyKind::Arrow(_, _, _) => false,
         }
     }
 
@@ -209,9 +209,9 @@ impl PatTy {
     }
 
     pub fn matches_ty(&self, ctx: &TranslatedCrate, ty: &Ty) -> bool {
-        match (self, ty) {
+        match (self, ty.kind()) {
             (PatTy::Pat(p), _) => p.matches_ty(ctx, ty),
-            (PatTy::Ref(pat_mtbl, p_ty), Ty::Ref(_, ty, ty_mtbl)) => {
+            (PatTy::Ref(pat_mtbl, p_ty), TyKind::Ref(_, ty, ty_mtbl)) => {
                 pat_mtbl == ty_mtbl && p_ty.matches_ty(ctx, ty)
             }
             _ => false,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1364,8 +1364,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitTypeConstraint {
 
 impl<C: AstFormatter> FmtWithCtx<C> for Ty {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        match self {
-            Ty::Adt(id, generics) => {
+        match self.kind() {
+            TyKind::Adt(id, generics) => {
                 let adt_ident = id.fmt_with_ctx(ctx);
 
                 if id.is_tuple() {
@@ -1377,10 +1377,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                     format!("{adt_ident}{generics}")
                 }
             }
-            Ty::TypeVar(id) => ctx.format_object(*id),
-            Ty::Literal(kind) => kind.to_string(),
-            Ty::Never => "!".to_string(),
-            Ty::Ref(r, ty, kind) => match kind {
+            TyKind::TypeVar(id) => ctx.format_object(*id),
+            TyKind::Literal(kind) => kind.to_string(),
+            TyKind::Never => "!".to_string(),
+            TyKind::Ref(r, ty, kind) => match kind {
                 RefKind::Mut => {
                     format!("&{} mut ({})", r.fmt_with_ctx(ctx), ty.fmt_with_ctx(ctx))
                 }
@@ -1388,15 +1388,15 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                     format!("&{} ({})", r.fmt_with_ctx(ctx), ty.fmt_with_ctx(ctx))
                 }
             },
-            Ty::RawPtr(ty, kind) => match kind {
+            TyKind::RawPtr(ty, kind) => match kind {
                 RefKind::Shared => format!("*const {}", ty.fmt_with_ctx(ctx)),
                 RefKind::Mut => format!("*mut {}", ty.fmt_with_ctx(ctx)),
             },
-            Ty::TraitType(trait_ref, name) => {
+            TyKind::TraitType(trait_ref, name) => {
                 format!("{}::{name}", trait_ref.fmt_with_ctx(ctx),)
             }
-            Ty::DynTrait(pred) => format!("dyn ({})", pred.with_ctx(ctx)),
-            Ty::Arrow(regions, inputs, box output) => {
+            TyKind::DynTrait(pred) => format!("dyn ({})", pred.with_ctx(ctx)),
+            TyKind::Arrow(regions, inputs, output) => {
                 // Update the bound regions
                 let ctx = &ctx.push_bound_regions(regions);
 

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -115,7 +115,7 @@ impl CheckGenericsVisitor<'_, '_> {
         }
     }
     fn enter_ty(&mut self, ty: &Ty) {
-        if let Ty::Adt(kind, args) = ty {
+        if let TyKind::Adt(kind, args) = ty.kind() {
             self.check_typeid_generics(args, kind);
         }
     }

--- a/charon/src/transform/prettify_cfg.rs
+++ b/charon/src/transform/prettify_cfg.rs
@@ -28,7 +28,7 @@ impl Transform {
             content: second_abort @ RawStatement::Abort(_),
             ..
         }, ..] = seq
-            && locals[call.dest.var_id].ty.is_never()
+            && locals[call.dest.var_id].ty.kind().is_never()
         {
             *second_abort = RawStatement::Nop;
             return Vec::new();

--- a/charon/src/transform/reconstruct_boxes.rs
+++ b/charon/src/transform/reconstruct_boxes.rs
@@ -52,7 +52,8 @@ impl Transform {
                 && call_malloc.dest == *alloc_use
                 && box_make.projection.is_empty()
                 && let var_id = box_make.var_id
-                && let Ty::Adt(TypeId::Builtin(BuiltinTy::Box), generics) = &locals[var_id].ty
+                && let TyKind::Adt(TypeId::Builtin(BuiltinTy::Box), generics) =
+                    locals[var_id].ty.kind()
             {
                 // Find the assignment into the box.
                 for i in 0..rest.len() {

--- a/charon/src/transform/remove_drop_never.rs
+++ b/charon/src/transform/remove_drop_never.rs
@@ -20,7 +20,7 @@ impl LlbcPass for Transform {
                 // `x` has type `Never`. Otherwise leave it unchanged.
                 if let RawStatement::Drop(p) = &st.content
                     && p.projection.is_empty()
-                    && locals.get(p.var_id).unwrap().ty.is_never()
+                    && locals.get(p.var_id).unwrap().ty.kind().is_never()
                 {
                     st.content = RawStatement::Nop;
                 }

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -138,7 +138,7 @@ fn transform_constant_expr<F: FnMut(Ty) -> VarId>(
 
             // Introduce an intermediate assignment for the aggregated ADT
             let rval = {
-                let (adt_kind, generics) = val.ty.as_adt().unwrap();
+                let (adt_kind, generics) = val.ty.kind().as_adt().unwrap();
                 let aggregate_kind = AggregateKind::Adt(*adt_kind, variant, None, generics.clone());
                 Rvalue::Aggregate(aggregate_kind, fields)
             };

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -30,13 +30,13 @@ impl<'a> InsertRegions<'a> {
     }
 
     fn enter_ty(&mut self, ty: &mut Ty) {
-        if let Ty::Arrow(..) = ty {
+        if let TyKind::Arrow(..) = ty.kind() {
             self.depth += 1;
         }
     }
 
     fn exit_ty(&mut self, ty: &mut Ty) {
-        if let Ty::Arrow(..) = ty {
+        if let TyKind::Arrow(..) = ty.kind() {
             self.depth -= 1;
         }
     }
@@ -65,10 +65,11 @@ fn transform_function(
 
         // Group the types into a tuple
         let num_fields = info.state.len();
-        let state = Ty::Adt(
+        let state = TyKind::Adt(
             TypeId::Tuple,
             GenericArgs::new_from_types(info.state.clone()),
-        );
+        )
+        .into_ty();
         // Depending on the kind of the closure, add a reference
         let mut state = match &info.kind {
             ClosureKind::FnOnce => state,
@@ -83,7 +84,7 @@ fn transform_function(
                     RefKind::Mut
                 };
                 //let r = Region::BVar(DeBruijnId::new(0), index);
-                Ty::Ref(Region::Erased, Box::new(state), mutability)
+                TyKind::Ref(Region::Erased, state, mutability).into_ty()
             }
         };
 

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -20,7 +20,7 @@ error[E9999]: Supposely unreachable place in the Rust AST. The label is "Transla
    = note: ⚠️ This is a bug in Hax's frontend.
            Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:784:42:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:782:50:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::foo`.

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -20,7 +20,7 @@ error[E9999]: Supposely unreachable place in the Rust AST. The label is "Transla
    = note: ⚠️ This is a bug in Hax's frontend.
            Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:782:50:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_types.rs:790:50:
 called `Option::unwrap()` on a `None` value
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::foo`.


### PR DESCRIPTION
This PR hash-conses `Ty`. This builds on https://github.com/hacspec/hax/pull/996 to avoid runaway memory consumption in the presence of heavily-redundant types (which happens n particular with `Sized` trait resolution of nested types). This makes charon able to compile rust-crypto crates.

Fixes https://github.com/AeneasVerif/charon/issues/325