### PR TITLE
Don't visit inside types by default

### DIFF
--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -648,7 +648,11 @@ pub enum ConstGeneric {
 }
 
 /// A type.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+///
+/// Warning: for performance reasons, the `Drive` and `DriveMut` impls of `Ty` don't explore the
+/// contents of the type, they only yield a pointer to the type itself. To recurse into the type,
+/// use `drive_inner{_mut}` or `visit_inside`.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Ty(HashConsed<TyKind>);
 
 impl Ty {
@@ -658,6 +662,13 @@ impl Ty {
 
     pub fn kind(&self) -> &TyKind {
         self.0.inner()
+    }
+
+    pub fn drive_inner<V: Visitor>(&self, visitor: &mut V) {
+        self.0.drive(visitor)
+    }
+    pub fn drive_inner_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
+        self.0.drive_mut(visitor)
     }
 }
 

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,8 +1,8 @@
 //! This file groups everything which is linked to implementations about [crate::types]
-use crate::ids::Vector;
 use crate::types::*;
+use crate::{common::visitor_event::VisitEvent, ids::Vector};
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
-use std::iter::Iterator;
+use std::{collections::HashMap, iter::Iterator};
 
 impl DeBruijnId {
     pub fn new(index: usize) -> Self {
@@ -289,7 +289,20 @@ impl Ty {
 
     /// Wrap a visitor to make it visit the contents of types it encounters.
     pub fn visit_inside<V>(visitor: V) -> VisitInsideTy<V> {
-        VisitInsideTy(visitor)
+        VisitInsideTy {
+            visitor,
+            cache: None,
+        }
+    }
+    /// Wrap a stateless visitor to make it visit the contents of types it encounters. This will
+    /// only visit each type once and cache the results. For this to behave as expecte, the visitor
+    /// must be stateless.
+    /// The performance impact does not appear to be significant.
+    pub fn visit_inside_stateless<V>(visitor: V) -> VisitInsideTy<V> {
+        VisitInsideTy {
+            visitor,
+            cache: Some(Default::default()),
+        }
     }
 }
 
@@ -395,23 +408,79 @@ impl DriveMut for Ty {
     }
 }
 
-pub struct VisitInsideTy<V>(pub V);
+pub struct VisitInsideTy<V> {
+    visitor: V,
+    /// If `Some`, record the effected visits and don't do them again. Only valid if the wrapped
+    /// visitor is stateless.
+    cache: Option<HashMap<(Ty, VisitEvent), Ty>>,
+}
+
+impl<V> VisitInsideTy<V> {
+    pub fn into_inner(self) -> V {
+        self.visitor
+    }
+}
 
 impl<V: Visitor> Visitor for VisitInsideTy<V> {
     fn visit(&mut self, item: &dyn std::any::Any, event: Event) {
-        let is_enter = matches!(event, Event::Enter);
-        self.0.visit(item, event);
-        if is_enter && let Some(ty) = item.downcast_ref::<Ty>() {
-            ty.drive_inner(self)
+        match item.downcast_ref::<Ty>() {
+            Some(ty) => {
+                let visit_event: VisitEvent = (&event).into();
+
+                // Shortcut if we already visited this.
+                if let Some(cache) = &self.cache
+                    && cache.contains_key(&(ty.clone(), visit_event))
+                {
+                    return;
+                }
+
+                // Recursively visit the type.
+                self.visitor.visit(ty, event);
+                if matches!(visit_event, VisitEvent::Enter) {
+                    ty.drive_inner(self);
+                }
+
+                // Remember we just visited that.
+                if let Some(cache) = &mut self.cache {
+                    cache.insert((ty.clone(), visit_event), ty.clone());
+                }
+            }
+            None => {
+                self.visitor.visit(item, event);
+            }
         }
     }
 }
 impl<V: VisitorMut> VisitorMut for VisitInsideTy<V> {
     fn visit(&mut self, item: &mut dyn std::any::Any, event: Event) {
-        let is_enter = matches!(event, Event::Enter);
-        self.0.visit(item, event);
-        if is_enter && let Some(ty) = item.downcast_mut::<Ty>() {
-            ty.drive_inner_mut(self)
+        match item.downcast_mut::<Ty>() {
+            Some(ty) => {
+                let visit_event: VisitEvent = (&event).into();
+
+                // Shortcut if we already visited this.
+                if let Some(cache) = &self.cache
+                    && let Some(new_ty) = cache.get(&(ty.clone(), visit_event))
+                {
+                    *ty = new_ty.clone();
+                    return;
+                }
+
+                // Recursively visit the type.
+                let pre_visit = ty.clone();
+                self.visitor.visit(ty, event);
+                if matches!(visit_event, VisitEvent::Enter) {
+                    ty.drive_inner_mut(self);
+                }
+
+                // Cache the visit we just did.
+                if let Some(cache) = &mut self.cache {
+                    let post_visit = ty.clone();
+                    cache.insert((pre_visit, visit_event), post_visit);
+                }
+            }
+            None => {
+                self.visitor.visit(item, event);
+            }
         }
     }
 }
@@ -419,11 +488,11 @@ impl<V: VisitorMut> VisitorMut for VisitInsideTy<V> {
 impl<V> std::ops::Deref for VisitInsideTy<V> {
     type Target = V;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.visitor
     }
 }
 impl<V> std::ops::DerefMut for VisitInsideTy<V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.visitor
     }
 }

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -248,6 +248,33 @@ pub mod hash_by_addr {
     }
 }
 
+pub mod visitor_event {
+    /// `derive_visitor::Event` doesn't derive all the useful traits so we use this instead.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum VisitEvent {
+        Enter,
+        Exit,
+    }
+
+    impl From<&derive_visitor::Event> for VisitEvent {
+        fn from(value: &derive_visitor::Event) -> Self {
+            match value {
+                derive_visitor::Event::Enter => VisitEvent::Enter,
+                derive_visitor::Event::Exit => VisitEvent::Exit,
+            }
+        }
+    }
+
+    impl From<VisitEvent> for derive_visitor::Event {
+        fn from(value: VisitEvent) -> Self {
+            match value {
+                VisitEvent::Enter => derive_visitor::Event::Enter,
+                VisitEvent::Exit => derive_visitor::Event::Exit,
+            }
+        }
+    }
+}
+
 // This is the amount of bytes that need to be left on the stack before increasing the size. It
 // must be at least as large as the stack required by any code that does not call
 // `ensure_sufficient_stack`.

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -161,7 +161,7 @@ pub struct Check;
 impl TransformPass for Check {
     fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
         for item in ctx.translated.all_items() {
-            let mut visitor = Ty::visit_inside(CheckGenericsVisitor {
+            let mut visitor = Ty::visit_inside_stateless(CheckGenericsVisitor {
                 translated: &ctx.translated,
                 error_ctx: &mut ctx.errors,
                 discharged_args: 0,

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -161,12 +161,12 @@ pub struct Check;
 impl TransformPass for Check {
     fn transform_ctx(&self, ctx: &mut TransformCtx<'_>) {
         for item in ctx.translated.all_items() {
-            let mut visitor = CheckGenericsVisitor {
+            let mut visitor = Ty::visit_inside(CheckGenericsVisitor {
                 translated: &ctx.translated,
                 error_ctx: &mut ctx.errors,
                 discharged_args: 0,
                 item_span: item.item_meta().span,
-            };
+            });
             item.drive(&mut visitor);
             assert_eq!(
                 visitor.discharged_args, 0,

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -103,6 +103,6 @@ impl TransformPass for Transform {
         }
 
         ctx.translated
-            .drive_mut(&mut Ty::visit_inside(Visitor { exclude }));
+            .drive_mut(&mut Ty::visit_inside_stateless(Visitor { exclude }));
     }
 }

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -102,6 +102,7 @@ impl TransformPass for Transform {
             ctx.translated.trait_decls.remove(id);
         }
 
-        ctx.translated.drive_mut(&mut Visitor { exclude });
+        ctx.translated
+            .drive_mut(&mut Ty::visit_inside(Visitor { exclude }));
     }
 }

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -46,7 +46,7 @@ impl TransformPass for Transform {
 
         // Update trait refs.
         ctx.translated
-            .drive_mut(&mut Ty::visit_inside(visitor_enter_fn_mut(
+            .drive_mut(&mut Ty::visit_inside_stateless(visitor_enter_fn_mut(
                 |trkind: &mut TraitRefKind| {
                     use TraitRefKind::*;
                     if let ItemClause(..) = trkind {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -126,7 +126,8 @@ impl Display for DeclarationGroup {
     GlobalDeclId(enter),
     TraitImplId(enter),
     TraitDeclId(enter),
-    BodyId(enter)
+    BodyId(enter),
+    Ty(enter)
 )]
 pub struct Deps<'tcx, 'ctx> {
     ctx: &'tcx TransformCtx<'ctx>,
@@ -279,6 +280,11 @@ impl Deps<'_, '_> {
         if let Some(body) = self.ctx.translated.bodies.get(*id) {
             body.drive(self);
         }
+    }
+
+    fn enter_ty(&mut self, ty: &Ty) {
+        // Recurse into the type, which doesn't happen by default.
+        ty.drive_inner(self);
     }
 }
 

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -90,10 +90,10 @@ fn transform_function(
 
         // Explore the state and introduce fresh regions for the erased
         // regions we find.
-        let mut visitor = InsertRegions {
+        let mut visitor = Ty::visit_inside(InsertRegions {
             regions: &mut generics.regions,
             depth: 0,
-        };
+        });
         state.drive_mut(&mut visitor);
 
         // Update the inputs (slightly annoying to push to the front of


### PR DESCRIPTION
This PR makes it so the `Drive`/`DriveMut` impls for `Ty` don't look into it. I added some helpers to recover the normal behavior that visits everything. This should save a lot of unnecessary visits in most passes.

Fixes #427.