### PR TITLE
fix(hax api): `Ty` is now a type alias to `Node<TyKind>`

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -160,25 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
-dependencies = [
- "bincode_derive",
- "serde",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,7 +796,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#21672cd0da2f036b0f5f0def1afd2bfc9f7bf5b5"
+source = "git+https://github.com/hacspec/hax?branch=main#f1f094f100da29794ceae9342ea0239173a50a01"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -826,9 +807,8 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#21672cd0da2f036b0f5f0def1afd2bfc9f7bf5b5"
+source = "git+https://github.com/hacspec/hax?branch=main#f1f094f100da29794ceae9342ea0239173a50a01"
 dependencies = [
- "bincode",
  "extension-traits",
  "hax-adt-into",
  "hax-frontend-exporter-options",
@@ -844,9 +824,8 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#21672cd0da2f036b0f5f0def1afd2bfc9f7bf5b5"
+source = "git+https://github.com/hacspec/hax?branch=main#f1f094f100da29794ceae9342ea0239173a50a01"
 dependencies = [
- "bincode",
  "hax-adt-into",
  "schemars",
  "serde",
@@ -2392,12 +2371,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "virtue"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "wait-timeout"

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -123,7 +123,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         ty: &hax::Ty,
     ) -> Result<Ty, Error> {
         trace!("{:?}", ty);
-        let cache_key = HashByAddr(ty.kind.clone());
+        let cache_key = HashByAddr(ty.inner().clone());
         if let Some(ty) = self.type_trans_cache.get(&cache_key) {
             return Ok(ty.clone());
         }


### PR DESCRIPTION
This PR follows https://github.com/hacspec/hax/pull/1029.