### PR TITLE
Cleanup iteration over crate items

### DIFF
--- a/charon/src/bin/charon-driver/translate/get_mir.rs
+++ b/charon/src/bin/charon-driver/translate/get_mir.rs
@@ -6,18 +6,7 @@ use rustc_middle::ty::TyCtxt;
 
 use crate::translate::translate_ctx::MirLevel;
 
-/// Indicates if the constants should be extracted in their own identifier,
-/// or if they must be evaluated to a constant value, depending on the
-/// MIR level which we extract.
-pub fn extract_constants_at_top_level(level: MirLevel) -> bool {
-    match level {
-        MirLevel::Built => true,
-        MirLevel::Promoted => true,
-        MirLevel::Optimized => false,
-    }
-}
-
-/// Are boxe manipulations desugared to very low-level code using raw pointers,
+/// Are box manipulations desugared to very low-level code using raw pointers,
 /// unique and non-null pointers? See [crate::types::TyKind::RawPtr] for detailed explanations.
 pub fn boxes_are_desugared(level: MirLevel) -> bool {
     match level {

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -9,7 +9,6 @@ use rustc_hir::{ForeignItemKind, ItemId, ItemKind};
 use rustc_middle::ty::TyCtxt;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Register a HIR item and all its children. We call this on the crate root items and end up
@@ -57,7 +56,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
             ItemKind::Impl(..) => {
                 trace!("impl");
-                let def = self.hax_def(def_id);
+                let def = self
+                    .hax_def(def_id)
+                    .expect("hax failed when registering impl block");
                 let hax::FullDefKind::Impl {
                     items,
                     impl_subject,
@@ -117,7 +118,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 // to check that all the opaque modules given as arguments actually
                 // exist
                 trace!("{:?}", def_id);
-                let def = self.hax_def(def_id);
+                let def = self
+                    .hax_def(def_id)
+                    .expect("hax failed when registering module");
                 let opacity = self.opacity_for_name(&name);
                 // Go through `item_meta` to get take into account the `charon::opaque` attribute.
                 let item_meta = self.translate_item_meta(&def, name, opacity);
@@ -231,7 +234,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             // Don't even start translating the item. In particular don't call `hax_def` on it.
             return Ok(());
         }
-        let def: Arc<hax::FullDef> = self.hax_def(rust_id);
+        let def = self.hax_def(rust_id)?;
         let item_meta = self.translate_item_meta(&def, name, opacity);
 
         // Initialize the body translation context

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -1,4 +1,3 @@
-use super::get_mir::extract_constants_at_top_level;
 use super::translate_ctx::*;
 use charon_lib::ast::*;
 use charon_lib::options::CliOpts;
@@ -48,11 +47,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 let _ = self.register_trait_decl_id(&None, def_id);
             }
             ItemKind::Const(..) | ItemKind::Static(..) => {
-                if extract_constants_at_top_level(self.options.mir_level) {
-                    let _ = self.register_global_decl_id(&None, def_id);
-                } else {
-                    // Avoid registering globals in optimized MIR (they will be inlined)
-                }
+                let _ = self.register_global_decl_id(&None, def_id);
             }
             ItemKind::Impl(..) => {
                 trace!("impl");

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -697,7 +697,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     }
 
     pub(crate) fn def_span(&mut self, def_id: impl Into<DefId>) -> Span {
-        let span = &self.hax_def(def_id).span;
+        let span = self.tcx.def_span(def_id.into());
+        let span = span.sinto(&self.hax_state);
         self.translate_span_from_hax(&span)
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -538,7 +538,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         def: &hax::FullDef,
         name: Name,
         opacity: ItemOpacity,
-    ) -> Result<ItemMeta, Error> {
+    ) -> ItemMeta {
         let def_id = def.rust_def_id();
         let span = def.source_span.as_ref().unwrap_or(&def.span);
         let span = self.translate_span_from_hax(span);
@@ -554,14 +554,14 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             opacity
         };
 
-        Ok(ItemMeta {
+        ItemMeta {
             name,
             span,
             source_text: def.source_text.clone(),
             attr_info,
             is_local,
             opacity,
-        })
+        }
     }
 
     pub fn translate_filename(&mut self, name: &hax::FileName) -> meta::FileName {

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -16,7 +16,7 @@ use charon_lib::ids::Vector;
 use charon_lib::pretty::FmtWithCtx;
 use charon_lib::ullbc_ast::*;
 use hax_frontend_exporter as hax;
-use hax_frontend_exporter::{HasMirSetter, HasOwnerIdSetter, SInto};
+use hax_frontend_exporter::{HasMirSetter, HasOwnerIdSetter};
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::START_BLOCK;
@@ -775,7 +775,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
         trait_refs: &Vec<hax::ImplExpr>,
         trait_info: &Option<hax::ImplExpr>,
     ) -> Result<SubstFunIdOrPanic, Error> {
-        let fun_def = self.t_ctx.hax_def(def_id);
+        let fun_def = self.t_ctx.hax_def(def_id)?;
         let builtin_fun = self.recognize_builtin_fun(&fun_def)?;
         if matches!(builtin_fun, Some(BuiltinFun::Panic)) {
             let name = self.t_ctx.hax_def_id_to_name(def_id)?;
@@ -1314,7 +1314,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             .with_owner_id(rust_id)
             .with_mir(Rc::new(body.clone()));
         // Translate
-        let body: hax::MirBody<()> = body.sinto(&state);
+        let body: hax::MirBody<()> = self.t_ctx.catch_sinto(&state, item_meta.span, &body)?;
 
         // Initialize the local variables
         trace!("Translating the body locals");
@@ -1424,7 +1424,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 associated_item,
                 ..
             } => {
-                let parent_def = self.t_ctx.hax_def(parent);
+                let parent_def = self.t_ctx.hax_def(parent)?;
                 let (parent_generics, parent_predicates) = parent_def.generics().unwrap();
                 let mut params_info = self.count_generics(parent_generics, parent_predicates)?;
                 // If this is a trait decl method, we need to adjust the number of parent clauses

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -6,7 +6,6 @@ use charon_lib::meta::ItemMeta;
 use charon_lib::pretty::FmtWithCtx;
 use charon_lib::ullbc_ast as ast;
 use hax_frontend_exporter as hax;
-use hax_frontend_exporter::SInto;
 use itertools::Itertools;
 use rustc_hir::def_id::DefId;
 use std::collections::HashMap;
@@ -250,7 +249,7 @@ impl BodyTransCtx<'_, '_, '_> {
             unreachable!()
         };
         let implemented_trait_id = &trait_pred.trait_ref.def_id;
-        let trait_def = self.t_ctx.hax_def(implemented_trait_id);
+        let trait_def = self.t_ctx.hax_def(implemented_trait_id)?;
         let hax::FullDefKind::Trait {
             items: decl_items, ..
         } = trait_def.kind()
@@ -396,8 +395,8 @@ impl BodyTransCtx<'_, '_, '_> {
                             // define a default value.
                             let ty = tcx
                                 .type_of(item_def_id)
-                                .instantiate(tcx, rust_implemented_trait_ref.args)
-                                .sinto(&self.hax_state);
+                                .instantiate(tcx, rust_implemented_trait_ref.args);
+                            let ty = self.t_ctx.catch_sinto(&self.hax_state, span, &ty)?;
                             self.translate_ty(item_span, erase_regions, &ty)?
                         }
                     };

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -429,7 +429,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
 
     /// Checks whether the given id corresponds to a built-in type.
     fn recognize_builtin_type(&mut self, def_id: &hax::DefId) -> Result<Option<BuiltinTy>, Error> {
-        let def = self.t_ctx.hax_def(def_id);
+        let def = self.t_ctx.hax_def(def_id)?;
         let ty = if def.lang_item.as_deref() == Some("owned_box") {
             Some(BuiltinTy::Box)
         } else {
@@ -511,7 +511,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 let field_span = self.t_ctx.translate_span_from_hax(&field_def.span);
                 // Translate the field type
                 let ty = self.translate_ty(field_span, erase_regions, &field_def.ty)?;
-                let field_full_def = self.t_ctx.hax_def(&field_def.did);
+                let field_full_def = self.t_ctx.hax_def(&field_def.did)?;
                 let field_attrs = self.t_ctx.translate_attr_info(&field_full_def);
 
                 // Retrieve the field name.
@@ -542,7 +542,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             let discriminant = self.translate_discriminant(def_span, &var_def.discr_val)?;
             let variant_span = self.t_ctx.translate_span_from_hax(&var_def.span);
             let variant_name = var_def.name.clone();
-            let variant_full_def = self.t_ctx.hax_def(&var_def.def_id);
+            let variant_full_def = self.t_ctx.hax_def(&var_def.def_id)?;
             let variant_attrs = self.t_ctx.translate_attr_info(&variant_full_def);
 
             let mut variant = Variant {
@@ -660,7 +660,7 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
             | FullDefKind::AssocFn { parent, .. }
             | FullDefKind::AssocConst { parent, .. }
             | FullDefKind::Closure { parent, .. } => {
-                let parent_def = self.t_ctx.hax_def(parent);
+                let parent_def = self.t_ctx.hax_def(parent)?;
                 self.push_generics_for_def(span, &parent_def, true)?;
             }
             _ => {}

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -100,9 +100,9 @@ impl ErrorCtx<'_> {
 
     /// Report an error without registering anything.
     #[cfg(feature = "rustc")]
-    pub(crate) fn span_err_no_register<S: Into<rustc_error_messages::MultiSpan>>(
+    pub fn span_err_no_register(
         &self,
-        span: S,
+        span: impl Into<rustc_error_messages::MultiSpan>,
         msg: &str,
     ) {
         let msg = msg.to_string();

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -492,7 +492,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[2]
+        crate_data.fun_decls[1]
             .item_meta
             .attr_info
             .rename
@@ -501,7 +501,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[3]
+        crate_data.fun_decls[2]
             .item_meta
             .attr_info
             .rename
@@ -519,7 +519,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[1]
+        crate_data.fun_decls[0]
             .item_meta
             .attr_info
             .rename

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -128,5 +128,7 @@ fn test_crate::foo()
 
 fn test_crate::module::dont_translate_body()
 
+fn test_crate::exclude_me()
+
 
 

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -32,7 +32,7 @@ error[E9999]: Supposely unreachable place in the Rust AST. The label is "Transla
    = note: ⚠️ This is a bug in Hax's frontend.
            Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-error: Thread panicked when extracting item `test_crate::bar`.
+error: Hax panicked when translating `test_crate::bar`.
   --> tests/ui/unsupported/advanced-const-generics.rs:18:1
    |
 18 | / fn bar<const N: usize>()

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -34,4 +34,4 @@ error: Ignoring the following item due to a previous error: test_crate::foo
 
 error: aborting due to 3 previous errors
 
-ERROR Compilation encountered 2 errors
+ERROR Compilation encountered 3 errors

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -20,6 +20,14 @@ error[E9999]: Supposely unreachable place in the Rust AST. The label is "Transla
    = note: ⚠️ This is a bug in Hax's frontend.
            Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
+error: panicked while registering `test_crate::bar`
+  --> tests/ui/unsupported/advanced-const-generics.rs:18:1
+   |
+18 | / fn bar<const N: usize>()
+19 | | where
+20 | |     [(); N + 1]:,
+   | |_________________^
+
 error: Constant parameters of non-literal type are not supported
   --> tests/ui/unsupported/advanced-const-generics.rs:14:8
    |
@@ -32,6 +40,6 @@ error: Ignoring the following item due to a previous error: test_crate::foo
 14 | fn foo<const X: Foo>() -> Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 ERROR Compilation encountered 3 errors

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,3 +1,15 @@
+error: Constant parameters of non-literal type are not supported
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   |        ^^^^^^^^^^^^
+
+error: Ignoring the following item due to a previous error: test_crate::foo
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 disabled backtrace
 error[E9999]: Supposely unreachable place in the Rust AST. The label is "TranslateUneval".
               This error report happend because some assumption about the Rust AST was broken.
@@ -20,7 +32,7 @@ error[E9999]: Supposely unreachable place in the Rust AST. The label is "Transla
    = note: ⚠️ This is a bug in Hax's frontend.
            Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-error: panicked while registering `test_crate::bar`
+error: Thread panicked when extracting item `test_crate::bar`.
   --> tests/ui/unsupported/advanced-const-generics.rs:18:1
    |
 18 | / fn bar<const N: usize>()
@@ -28,18 +40,14 @@ error: panicked while registering `test_crate::bar`
 20 | |     [(); N + 1]:,
    | |_________________^
 
-error: Constant parameters of non-literal type are not supported
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+error: Ignoring the following item due to a previous error: test_crate::bar
+  --> tests/ui/unsupported/advanced-const-generics.rs:18:1
    |
-14 | fn foo<const X: Foo>() -> Foo {
-   |        ^^^^^^^^^^^^
+18 | / fn bar<const N: usize>()
+19 | | where
+20 | |     [(); N + 1]:,
+   | |_________________^
 
-error: Ignoring the following item due to a previous error: test_crate::foo
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
-   |
-14 | fn foo<const X: Foo>() -> Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error: aborting due to 5 previous errors
 
-error: aborting due to 4 previous errors
-
-ERROR Compilation encountered 3 errors
+ERROR Compilation encountered 4 errors


### PR DESCRIPTION
In particular this clarifies panic handling quite a bit. We now catch panics on every interaction with `hax` and turn them into normal errors. Once #181 and #409 are done, this may become the only place we need to catch panics.