### PR TITLE
fix(hax api): `ConstantLiteral::Float` now carries a string

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#381bd0f7b09f50c02f0ac2ee028a1b6c16dad456"
+source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#381bd0f7b09f50c02f0ac2ee028a1b6c16dad456"
+source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#381bd0f7b09f50c02f0ac2ee028a1b6c16dad456"
+source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -41,27 +41,15 @@ impl<'tcx, 'ctx, 'ctx1> BodyTransCtx<'tcx, 'ctx, 'ctx1> {
                 };
                 Literal::Scalar(scalar)
             }
-            hax::ConstantLiteral::Float(bits, float_type) => {
-                use rustc_apfloat::Float;
-                let value = match float_type {
-                    hax::FloatTy::F16 => FloatValue {
-                        value: rustc_apfloat::ieee::Half::from_bits(*bits).to_string(),
-                        ty: FloatTy::F16,
-                    },
-                    hax::FloatTy::F32 => FloatValue {
-                        value: rustc_apfloat::ieee::Single::from_bits(*bits).to_string(),
-                        ty: FloatTy::F32,
-                    },
-                    hax::FloatTy::F64 => FloatValue {
-                        value: rustc_apfloat::ieee::Double::from_bits(*bits).to_string(),
-                        ty: FloatTy::F64,
-                    },
-                    hax::FloatTy::F128 => FloatValue {
-                        value: rustc_apfloat::ieee::Quad::from_bits(*bits).to_string(),
-                        ty: FloatTy::F128,
-                    },
+            hax::ConstantLiteral::Float(value, float_type) => {
+                let value = value.clone();
+                let ty = match float_type {
+                    hax::FloatTy::F16 => FloatTy::F16,
+                    hax::FloatTy::F32 => FloatTy::F32,
+                    hax::FloatTy::F64 => FloatTy::F64,
+                    hax::FloatTy::F128 => FloatTy::F128,
                 };
-                Literal::Float(value)
+                Literal::Float(FloatValue { value, ty })
             }
         };
         Ok(RawConstantExpr::Literal(lit))


### PR DESCRIPTION
Companion PR for hacspec/hax#1061