### PR TITLE
Use `FullDef` to explore the crate

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
+source = "git+https://github.com/hacspec/hax?branch=main#5ca1c13023200dee0cca6237901a3b5a69ad345a"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
+source = "git+https://github.com/hacspec/hax?branch=main#5ca1c13023200dee0cca6237901a3b5a69ad345a"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#5b781f6fb7ed46708dbe3d499e82bc069b958d1e"
+source = "git+https://github.com/hacspec/hax?branch=main#5ca1c13023200dee0cca6237901a3b5a69ad345a"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -5,7 +5,6 @@ use charon_lib::transform::ctx::TransformOptions;
 use charon_lib::transform::TransformCtx;
 use hax_frontend_exporter as hax;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{ForeignItemKind, ItemId, ItemKind};
 use rustc_middle::ty::TyCtxt;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -13,14 +12,11 @@ use std::path::PathBuf;
 impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Register a HIR item and all its children. We call this on the crate root items and end up
     /// exploring the whole crate.
-    fn register_local_hir_item(&mut self, item_id: ItemId) {
+    fn register_local_item(&mut self, def_id: DefId) {
         let mut ctx_ref = std::panic::AssertUnwindSafe(&mut *self);
         // Catch panics that could happen during registration.
-        let res = std::panic::catch_unwind(move || ctx_ref.register_local_hir_item_inner(item_id));
+        let res = std::panic::catch_unwind(move || ctx_ref.register_local_item_inner(def_id));
         if res.is_err() {
-            let hir_map = self.tcx.hir();
-            let item = hir_map.item(item_id);
-            let def_id = item.owner_id.to_def_id();
             let span = self.tcx.def_span(def_id);
             self.errors
                 .span_err_no_register(span, &format!("panicked while registering `{def_id:?}`"));
@@ -28,43 +24,38 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         }
     }
 
-    fn register_local_hir_item_inner(&mut self, item_id: ItemId) {
-        let hir_map = self.tcx.hir();
-        let item = hir_map.item(item_id);
-        let def_id = item.owner_id.to_def_id();
+    fn register_local_item_inner(&mut self, def_id: DefId) {
+        use hax::FullDefKind;
         trace!("Registering {:?}", def_id);
 
         let Ok(def) = self.hax_def(def_id) else {
             return; // Error has already been emitted
         };
-        // Case disjunction on the item kind.
-        match &item.kind {
-            ItemKind::Enum(..)
-            | ItemKind::Struct(..)
-            | ItemKind::Union(..)
-            | ItemKind::TyAlias(..) => {
+
+        match def.kind() {
+            FullDefKind::Enum { .. }
+            | FullDefKind::Struct { .. }
+            | FullDefKind::Union { .. }
+            | FullDefKind::TyAlias { .. }
+            | FullDefKind::ForeignTy => {
                 let _ = self.register_type_decl_id(&None, def_id);
             }
-            ItemKind::Fn(..) => {
+            FullDefKind::Fn { .. } => {
                 let _ = self.register_fun_decl_id(&None, def_id);
             }
-            ItemKind::Trait(..) => {
-                let _ = self.register_trait_decl_id(&None, def_id);
-            }
-            ItemKind::Const(..) | ItemKind::Static(..) => {
+            FullDefKind::Const { .. } | FullDefKind::Static { .. } => {
                 let _ = self.register_global_decl_id(&None, def_id);
             }
-            ItemKind::Impl(..) => {
-                trace!("impl");
-                let hax::FullDefKind::Impl {
-                    items,
-                    impl_subject,
-                    ..
-                } = &def.kind
-                else {
-                    unreachable!()
-                };
 
+            FullDefKind::Trait { .. } => {
+                let _ = self.register_trait_decl_id(&None, def_id);
+            }
+            FullDefKind::Impl {
+                items,
+                impl_subject,
+                ..
+            } => {
+                trace!("impl");
                 match impl_subject {
                     hax::ImplSubject::Trait { .. } => {
                         let _ = self.register_trait_impl_id(&None, def_id);
@@ -107,15 +98,16 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                     }
                 }
             }
-            ItemKind::Mod(module) => {
-                trace!("module");
+            // TODO: trait aliases (https://github.com/AeneasVerif/charon/issues/366)
+            FullDefKind::TraitAlias { .. } => {}
 
+            FullDefKind::Mod { items, .. } => {
+                trace!("module");
                 // Explore the module, only if it was not marked as "opaque"
-                // TODO: we may want to accumulate the set of modules we found,
-                // to check that all the opaque modules given as arguments actually
-                // exist
+                // TODO: we may want to accumulate the set of modules we found, to check that all
+                // the opaque modules given as arguments actually exist
                 trace!("{:?}", def_id);
-                let Ok(name) = self.def_id_to_name(def_id) else {
+                let Ok(name) = self.hax_def_id_to_name(&def.def_id) else {
                     return; // Error has already been emitted
                 };
                 let opacity = self.opacity_for_name(&name);
@@ -131,35 +123,46 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 } else {
                     trace!("Diving into module [{:?}]", def_id);
                     // Lookup and register the items
-                    for item_id in module.item_ids {
-                        self.register_local_hir_item(*item_id);
+                    for def_id in items {
+                        self.register_local_item(def_id.into());
                     }
                 }
             }
-            ItemKind::ForeignMod { items, .. } => {
-                trace!("Diving into `extern` block [{:?}]", def_id);
-                for item in *items {
-                    // Lookup and register the item
-                    let item = hir_map.foreign_item(item.id);
-                    let def_id = item.owner_id.to_def_id();
-                    match item.kind {
-                        ForeignItemKind::Fn(..) => {
-                            let _ = self.register_fun_decl_id(&None, def_id);
-                        }
-                        ForeignItemKind::Static(..) => {
-                            let _ = self.register_global_decl_id(&None, def_id);
-                        }
-                        ForeignItemKind::Type => {
-                            let _ = self.register_type_decl_id(&None, def_id);
-                        }
-                    }
+            FullDefKind::ForeignMod { items, .. } => {
+                for def_id in items {
+                    self.register_local_item(def_id.into());
                 }
             }
-            // TODO: trait aliases (https://github.com/AeneasVerif/charon/issues/366)
-            ItemKind::TraitAlias(..) => {}
-            // Macros are already expanded.
-            ItemKind::Macro(..) => {}
-            ItemKind::ExternCrate(..) | ItemKind::GlobalAsm(..) | ItemKind::Use(..) => {}
+
+            // We skip these
+            FullDefKind::ExternCrate { .. }
+            | FullDefKind::GlobalAsm { .. }
+            | FullDefKind::Macro { .. }
+            | FullDefKind::Use { .. } => {}
+            // We cannot encounter these since they're not top-level items.
+            FullDefKind::AnonConst { .. }
+            | FullDefKind::AssocConst { .. }
+            | FullDefKind::AssocFn { .. }
+            | FullDefKind::AssocTy { .. }
+            | FullDefKind::Closure { .. }
+            | FullDefKind::ConstParam { .. }
+            | FullDefKind::Ctor { .. }
+            | FullDefKind::Field { .. }
+            | FullDefKind::InlineConst { .. }
+            | FullDefKind::LifetimeParam { .. }
+            | FullDefKind::OpaqueTy { .. }
+            | FullDefKind::SyntheticCoroutineBody { .. }
+            | FullDefKind::TyParam { .. }
+            | FullDefKind::Variant { .. } => {
+                let span = self.def_span(def_id);
+                self.errors.span_err(
+                    span,
+                    &format!(
+                        "Cannot register this item: `{def_id:?}` with kind `{:?}`",
+                        def.kind()
+                    ),
+                );
+            }
         }
     }
 
@@ -333,13 +336,11 @@ pub fn translate<'tcx, 'ctx>(
         cached_names: Default::default(),
     };
 
-    // Recursively register all the items in the crate, starting from the root module. We could
+    // Recursively register all the items in the crate, starting from the crate root. We could
     // instead ask rustc for the plain list of all items in the crate, but we wouldn't be able to
     // skip items inside modules annotated with `#[charon::opaque]`.
-    let hir = tcx.hir();
-    for item_id in hir.root_module().item_ids {
-        ctx.register_local_hir_item(*item_id);
-    }
+    let crate_def_id = rustc_span::def_id::CRATE_DEF_ID.to_def_id();
+    ctx.register_local_item(crate_def_id);
 
     trace!(
         "Queue after we explored the crate:\n{:?}",

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -13,18 +13,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
     /// Register a HIR item and all its children. We call this on the crate root items and end up
     /// exploring the whole crate.
     fn register_local_item(&mut self, def_id: DefId) {
-        let mut ctx_ref = std::panic::AssertUnwindSafe(&mut *self);
-        // Catch panics that could happen during registration.
-        let res = std::panic::catch_unwind(move || ctx_ref.register_local_item_inner(def_id));
-        if res.is_err() {
-            let span = self.tcx.def_span(def_id);
-            self.errors
-                .span_err_no_register(span, &format!("panicked while registering `{def_id:?}`"));
-            self.errors.error_count += 1;
-        }
-    }
-
-    fn register_local_item_inner(&mut self, def_id: DefId) {
         use hax::FullDefKind;
         trace!("Registering {:?}", def_id);
 

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -34,6 +34,9 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
         let def_id = item.owner_id.to_def_id();
         trace!("Registering {:?}", def_id);
 
+        let Ok(def) = self.hax_def(def_id) else {
+            return; // Error has already been emitted
+        };
         // Case disjunction on the item kind.
         match &item.kind {
             ItemKind::Enum(..)
@@ -53,9 +56,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
             }
             ItemKind::Impl(..) => {
                 trace!("impl");
-                let Ok(def) = self.hax_def(def_id) else {
-                    return; // Error has already been emitted
-                };
                 let hax::FullDefKind::Impl {
                     items,
                     impl_subject,
@@ -116,9 +116,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx, 'ctx> {
                 // exist
                 trace!("{:?}", def_id);
                 let Ok(name) = self.def_id_to_name(def_id) else {
-                    return; // Error has already been emitted
-                };
-                let Ok(def) = self.hax_def(def_id) else {
                     return; // Error has already been emitted
                 };
                 let opacity = self.opacity_for_name(&name);

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -130,5 +130,24 @@ fn test_crate::module::dont_translate_body()
 
 fn test_crate::exclude_me()
 
+struct test_crate::Struct = {}
+
+fn test_crate::{test_crate::Struct}::method()
+{
+    let @0: (); // return
+    let @1: i32; // anonymous local
+    let @2: (); // anonymous local
+
+    @1 := const (0 : i32)
+    @fake_read(@1)
+    drop @1
+    @2 := ()
+    @0 := move (@2)
+    @0 := ()
+    return
+}
+
+unsafe fn test_crate::extern_fn(@1: i32)
+
 
 

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -132,21 +132,6 @@ fn test_crate::exclude_me()
 
 struct test_crate::Struct = {}
 
-fn test_crate::{test_crate::Struct}::method()
-{
-    let @0: (); // return
-    let @1: i32; // anonymous local
-    let @2: (); // anonymous local
-
-    @1 := const (0 : i32)
-    @fake_read(@1)
-    drop @1
-    @2 := ()
-    @0 := move (@2)
-    @0 := ()
-    return
-}
-
 unsafe fn test_crate::extern_fn(@1: i32)
 
 

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -12,6 +12,8 @@
 //@ charon-args=--include crate::keep_names_of_excluded::{crate::keep_names_of_excluded::Trait<_>}
 // Note: we don't use the `impl Trait for T` syntax above because we can't have spaces in these
 // options.
+#![feature(register_tool)]
+#![register_tool(charon)]
 
 fn foo() {
     let _ = Some(0).is_some();
@@ -46,4 +48,18 @@ mod keep_names_of_excluded {
             let _ = 0;
         }
     }
+}
+
+struct Struct;
+
+#[charon::opaque]
+impl Struct {
+    fn method() {
+        let _ = 0;
+    }
+}
+
+#[charon::opaque]
+extern "C" {
+    fn extern_fn(x: i32);
 }

--- a/charon/tests/ui/opacity.rs
+++ b/charon/tests/ui/opacity.rs
@@ -59,6 +59,7 @@ impl Struct {
     }
 }
 
+// Foreign modules can't be named or have attributes, so we can't mark them opaque.
 #[charon::opaque]
 extern "C" {
     fn extern_fn(x: i32);

--- a/charon/tests/ui/rename_attribute_failure.out
+++ b/charon/tests/ui/rename_attribute_failure.out
@@ -36,4 +36,4 @@ error: Error parsing attribute: Unrecognized attribute: `charon::something_else(
 
 error: aborting due to 6 previous errors
 
-ERROR Compilation encountered 6 errors
+ERROR Compilation encountered 12 errors

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,15 +1,3 @@
-error: Constant parameters of non-literal type are not supported
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
-   |
-14 | fn foo<const X: Foo>() -> Foo {
-   |        ^^^^^^^^^^^^
-
-error: Ignoring the following item due to a previous error: test_crate::foo
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
-   |
-14 | fn foo<const X: Foo>() -> Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 disabled backtrace
 error[E9999]: Supposely unreachable place in the Rust AST. The label is "TranslateUneval".
               This error report happend because some assumption about the Rust AST was broken.
@@ -40,14 +28,18 @@ error: Hax panicked when translating `test_crate::bar`.
 20 | |     [(); N + 1]:,
    | |_________________^
 
-error: Ignoring the following item due to a previous error: test_crate::bar
-  --> tests/ui/unsupported/advanced-const-generics.rs:18:1
+error: Constant parameters of non-literal type are not supported
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
    |
-18 | / fn bar<const N: usize>()
-19 | | where
-20 | |     [(); N + 1]:,
-   | |_________________^
+14 | fn foo<const X: Foo>() -> Foo {
+   |        ^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: Ignoring the following item due to a previous error: test_crate::foo
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ERROR Compilation encountered 4 errors
+error: aborting due to 4 previous errors
+
+ERROR Compilation encountered 3 errors


### PR DESCRIPTION
This considerably simplifies initial item registration, now that we don't fear stealing issues anymore and our queries don't panic as much.