### PR TITLE
feat: deploy charon rustdoc on Github Pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,3 +1,5 @@
+name: Deploy Doc
+
 on:
   push:
     branches: [ main ]
@@ -25,10 +27,13 @@ jobs:
   deploy:
     environment:
       name: github-pages
-
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build static files
+        env:
+          CARGO_TERM_COLOR: always
         id: build
         run: |
           cd charon

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  # Build job
+  build:
+    # Specify runner +  build & upload the static files as an artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build static files
+        id: build
+        run: |
+          cd charon
+          make doc
+
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
+        with:
+          path: charon/target/doc/
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
close https://github.com/AeneasVerif/charon/issues/445

If the deployment is successful[^1], the default site `https://AeneasVerif.github.io/charon` will be 404 since there is no index.html under `target/doc/`, so the entry point should be

https://AeneasVerif.github.io/charon/charon

[^1]: maybe Github Pages source should be set to Github Actions to make it work