### PR TITLE
Use `hax` for item name translation

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#fdb0664bf77153977a2fa8ac4ab3d96cbced92ce"
+source = "git+https://github.com/hacspec/hax?branch=main#291e34e51a0182c0f1b29f27cbafe3d40490e39a"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#fdb0664bf77153977a2fa8ac4ab3d96cbced92ce"
+source = "git+https://github.com/hacspec/hax?branch=main#291e34e51a0182c0f1b29f27cbafe3d40490e39a"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/hacspec/hax?branch=main#fdb0664bf77153977a2fa8ac4ab3d96cbced92ce"
+source = "git+https://github.com/hacspec/hax?branch=main#291e34e51a0182c0f1b29f27cbafe3d40490e39a"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -102,7 +102,7 @@ impl Callbacks for CharonCallbacks {
     /// For this reason, and as we may want to plug ourselves at different
     /// phases of the compilation process, we query the context as early as
     /// possible (i.e., after parsing). See [charon_lib::get_mir].
-    fn after_crate_root_parsing<'tcx>(
+    fn after_expansion<'tcx>(
         &mut self,
         _c: &Compiler,
         queries: &'tcx Queries<'tcx>,

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -275,7 +275,6 @@ pub fn translate<'tcx, 'ctx>(
         reverse_id_map: Default::default(),
         items_to_translate: Default::default(),
         translate_stack: Default::default(),
-        cached_path_elems: Default::default(),
         cached_names: Default::default(),
     };
 


### PR DESCRIPTION
Thanks to https://github.com/hacspec/hax/pull/1054 we can now use hax's `DefId`s to compute names instead of doing queries ourselves.

This also fixes #449 as a drive-by.