### PR TITLE
Add a micro-pass to fix borrow-checking issues introduced by `index_to_function_calls`

### DIFF
--- a/charon-ml/src/Collections.ml
+++ b/charon-ml/src/Collections.ml
@@ -116,6 +116,16 @@ module List = struct
   let filter_mapi (f : int -> 'a -> 'b option) (l : 'a list) : 'b list =
     let l = mapi f l in
     filter_map (fun x -> x) l
+
+  (** Monadic map function *)
+  let rec mmap (f : 'a -> 'b option) (l : 'a list) : 'b list option =
+    match l with
+    | [] -> Some []
+    | hd :: tl -> (
+        match f hd with
+        | None -> None
+        | Some hd -> (
+            match mmap f tl with None -> None | Some tl -> Some (hd :: tl)))
 end
 
 module type OrderedType = sig

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -1,5 +1,6 @@
 //! This file groups everything which is linked to implementations about [crate::expressions]
 use crate::ast::*;
+use crate::ids::Vector;
 
 impl Place {
     pub fn new(var_id: VarId) -> Place {
@@ -17,5 +18,79 @@ impl BorrowKind {
         } else {
             Self::Shared
         }
+    }
+}
+
+impl Place {
+    /// Compute the type of a place.
+    pub fn compute_projected_type(
+        &self,
+        type_decls: &Vector<TypeDeclId, TypeDecl>,
+        locals: &Vector<VarId, Var>,
+    ) -> Result<Ty, ()> {
+        // Lookup the local
+        let mut cur_ty = locals.get(self.var_id).ok_or(())?.ty.clone();
+
+        // Apply the projection
+        use ProjectionElem::*;
+        for pe in &self.projection {
+            cur_ty = match pe {
+                Deref => {
+                    use TyKind::*;
+                    match cur_ty.kind() {
+                        Ref(_, ty, _) | RawPtr(ty, _) => ty.clone(),
+                        Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(_)
+                        | Arrow(..) => {
+                            // Unreachable
+                            return Err(());
+                        }
+                    }
+                }
+                Field(pkind, field_id) => {
+                    // Lookup the type decl
+                    use FieldProjKind::*;
+                    match pkind {
+                        Adt(type_decl_id, variant_id) => {
+                            let type_decl = type_decls.get(*type_decl_id).ok_or(())?;
+                            use TypeDeclKind::*;
+                            match &type_decl.kind {
+                                Struct(fields) => {
+                                    if variant_id.is_some() {
+                                        return Err(());
+                                    };
+                                    fields.get(*field_id).ok_or(())?.ty.clone()
+                                }
+                                Enum(variants) => {
+                                    let variant_id = variant_id.ok_or(())?;
+                                    let variant = variants.get(variant_id).ok_or(())?;
+                                    variant.fields.get(*field_id).ok_or(())?.ty.clone()
+                                }
+                                Union(_) | Opaque | Alias(_) | Error(_) => return Err(()),
+                            }
+                        }
+                        Tuple(_) => cur_ty
+                            .as_tuple()
+                            .ok_or(())?
+                            .get(TypeVarId::from(usize::from(*field_id)))
+                            .ok_or(())?
+                            .clone(),
+                        ClosureState => return Err(()),
+                    }
+                }
+                Index { ty, .. } | Subslice { ty, .. } => {
+                    // We could check that that the current type is compatible with
+                    // the type of the
+                    let cur_ty = cur_ty.as_array_or_slice().ok_or(())?;
+                    let ty = ty.as_array_or_slice().ok_or(())?;
+                    if cur_ty == ty {
+                        ty.clone()
+                    } else {
+                        return Err(());
+                    }
+                }
+            };
+        }
+
+        Ok(cur_ty)
     }
 }

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -52,18 +52,34 @@ impl Place {
                     match pkind {
                         Adt(type_decl_id, variant_id) => {
                             let type_decl = type_decls.get(*type_decl_id).ok_or(())?;
+                            let (type_id, generics) = cur_ty.as_adt().ok_or(())?;
+                            assert!(TypeId::Adt(*type_decl_id) == type_id);
+                            assert!(generics.regions.len() == type_decl.generics.regions.len());
+                            assert!(generics.types.len() == type_decl.generics.types.len());
+                            assert!(
+                                generics.const_generics.len()
+                                    == type_decl.generics.const_generics.len()
+                            );
+                            assert!(
+                                generics.trait_refs.len() == type_decl.generics.trait_clauses.len()
+                            );
                             use TypeDeclKind::*;
                             match &type_decl.kind {
                                 Struct(fields) => {
                                     if variant_id.is_some() {
                                         return Err(());
                                     };
-                                    fields.get(*field_id).ok_or(())?.ty.clone()
+                                    let mut ty = fields.get(*field_id).ok_or(())?.ty.clone();
+                                    ty.substitute(generics);
+                                    ty
                                 }
                                 Enum(variants) => {
                                     let variant_id = variant_id.ok_or(())?;
                                     let variant = variants.get(variant_id).ok_or(())?;
-                                    variant.fields.get(*field_id).ok_or(())?.ty.clone()
+                                    let mut ty =
+                                        variant.fields.get(*field_id).ok_or(())?.ty.clone();
+                                    ty.substitute(generics);
+                                    ty
                                 }
                                 Union(_) | Opaque | Alias(_) | Error(_) => return Err(()),
                             }

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -39,6 +39,9 @@ impl Place {
                     use TyKind::*;
                     match cur_ty.kind() {
                         Ref(_, ty, _) | RawPtr(ty, _) => ty.clone(),
+                        Adt(TypeId::Builtin(BuiltinTy::Box), args) => {
+                            args.types.get(TypeVarId::new(0)).unwrap().clone()
+                        }
                         Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(_)
                         | Arrow(..) => {
                             // Unreachable
@@ -65,7 +68,7 @@ impl Place {
                             );
                             use TypeDeclKind::*;
                             match &type_decl.kind {
-                                Struct(fields) => {
+                                Struct(fields) | Union(fields) => {
                                     if variant_id.is_some() {
                                         return Err(());
                                     };
@@ -81,7 +84,7 @@ impl Place {
                                     ty.substitute(generics);
                                     ty
                                 }
-                                Union(_) | Opaque | Alias(_) | Error(_) => return Err(()),
+                                Opaque | Alias(_) | Error(_) => return Err(()),
                             }
                         }
                         Tuple(_) => cur_ty

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -94,10 +94,9 @@ impl Place {
                     }
                 }
                 Index { ty, .. } | Subslice { ty, .. } => {
-                    // We could check that that the current type is compatible with
-                    // the type of the
                     let cur_ty = cur_ty.as_array_or_slice().ok_or(())?;
                     let ty = ty.as_array_or_slice().ok_or(())?;
+                    // Sanity check: ensure we're using the same types.
                     if cur_ty == ty {
                         ty.clone()
                     } else {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -541,7 +541,6 @@ struct Subst<'a> {
 }
 
 impl<'a> Subst<'a> {
-    /// Returns [true] if the item is a binder (we use this to skip some checks)
     fn enter_poly_trait_decl_ref(&mut self, _: &mut PolyTraitDeclRef) {
         self.current_level.index += 1;
     }
@@ -585,7 +584,7 @@ impl<'a> Subst<'a> {
 
 impl Ty {
     pub fn substitute(&mut self, generics: &GenericArgs) {
-        let mut subst = Subst {
+        let subst = Subst {
             current_level: DeBruijnId { index: 0 },
             generics,
         };

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -589,6 +589,6 @@ impl Ty {
             current_level: DeBruijnId { index: 0 },
             generics,
         };
-        self.drive_inner_mut(&mut subst);
+        self.drive_inner_mut(&mut Ty::visit_inside(subst));
     }
 }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -287,6 +287,28 @@ impl Ty {
         }
     }
 
+    pub fn as_array_or_slice(&self) -> Option<&Ty> {
+        match self.kind() {
+            TyKind::Adt(TypeId::Builtin(BuiltinTy::Array | BuiltinTy::Slice), generics) => {
+                assert!(generics.regions.is_empty());
+                assert!(generics.types.len() == 1);
+                Some(&generics.types[0])
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_tuple(&self) -> Option<&Vector<TypeVarId, Ty>> {
+        match self.kind() {
+            TyKind::Adt(TypeId::Tuple, generics) => {
+                assert!(generics.regions.is_empty());
+                assert!(generics.const_generics.is_empty());
+                Some(&generics.types)
+            }
+            _ => None,
+        }
+    }
+
     /// Wrap a visitor to make it visit the contents of types it encounters.
     pub fn visit_inside<V>(visitor: V) -> VisitInsideTy<V> {
         VisitInsideTy {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -561,7 +561,6 @@ impl<'a> Subst<'a> {
         }
     }
 
-    /// Returns [true] if the item is a binder (we use this to skip some checks)
     fn exit_ty(&mut self, ty: &mut Ty) {
         match ty.kind() {
             TyKind::TypeVar(id) => *ty = self.generics.types.get(*id).unwrap().clone(),

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -526,6 +526,12 @@ impl<V> std::ops::DerefMut for VisitInsideTy<V> {
     }
 }
 
+
+/// Visitor for the [Ty::substitute] function.
+///
+/// Important: [PolyTraitDeclRef] is the only occurrence of a [RegionBinder]
+/// which can appear in a type for now. There may be more in the future, which
+/// means that this visitor has to be carefully updated.
 #[derive(VisitorMut)]
 #[visitor(
     PolyTraitDeclRef(enter, exit),

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -526,7 +526,6 @@ impl<V> std::ops::DerefMut for VisitInsideTy<V> {
     }
 }
 
-
 /// Visitor for the [Ty::substitute] function.
 ///
 /// Important: [PolyTraitDeclRef] is the only occurrence of a [RegionBinder]

--- a/charon/src/transform/index_intermediate_assigns.rs
+++ b/charon/src/transform/index_intermediate_assigns.rs
@@ -3,7 +3,7 @@
 //!
 //! The problem comes from "and assignments" like in the snippet of code below:
 //! ```text
-//! x[0] += 1; // Desugards to: x[0] = copy x[0] + 1
+//! x[0] += 1; // Desugars to: x[0] = copy x[0] + 1
 //! ```
 //!
 //! If we don't introduce an intermediate assignment, then the micro-pass which
@@ -12,7 +12,7 @@
 //! ```text
 //! dest = &mut x[0];
 //! src = & x[0]; // Invalidates dest
-//! *dest = copy (*src) + 1; // Can't derefference dest!
+//! *dest = copy (*src) + 1; // Can't dereference dest!
 //! ```
 //! (also note that the problem remains if we introduce `src` *then* `dest`).
 //!

--- a/charon/src/transform/index_intermediate_assigns.rs
+++ b/charon/src/transform/index_intermediate_assigns.rs
@@ -1,0 +1,149 @@
+//! This micro-pass introduces intermediate assignments in preparation of
+//! [`index_to_function_calls`], so as to avoid borrow-checking errors.
+//!
+//! The problem comes from "and assignments" like in the snippet of code below:
+//! ```text
+//! x[0] += 1; // Desugards to: x[0] = copy x[0] + 1
+//! ```
+//!
+//! If we don't introduce an intermediate assignment, then the micro-pass which
+//! transforms the index operations into function calls generates the following
+//! LLBC:
+//! ```text
+//! dest = &mut x[0];
+//! src = & x[0]; // Invalidates dest
+//! *dest = copy (*src) + 1; // Can't derefference dest!
+//! ```
+//! (also note that the problem remains if we introduce `src` *then* `dest`).
+//!
+//! Our solution is to introduce a temporary variable for the assignment.
+//! We first transform the code to:
+//! ```text
+//! tmp = copy x[0] + 1;
+//! x[0] = move tmp;
+//! ```
+//!
+//! Which then allows us to transform it to:
+//! ```text
+//! // RHS:
+//! src = & x[0];
+//! tmp = copy (*src) + 1;
+//! // LHS:
+//! dest = &mut x[0];
+//! *dest = move tmp;
+//! ```
+
+use crate::ids::Vector;
+use crate::llbc_ast::*;
+use crate::transform::TransformCtx;
+use derive_visitor::{Drive, Visitor};
+
+use super::ctx::LlbcPass;
+
+impl Place {
+    fn contains_index(&self) -> bool {
+        for pe in &self.projection {
+            use ProjectionElem::*;
+            if let Index { .. } | Subslice { .. } = pe {
+                return true;
+            };
+        }
+        return false;
+    }
+}
+
+#[derive(Visitor)]
+#[visitor(Place(enter))]
+struct RvalueVisitor {
+    contains_index: bool,
+}
+
+impl RvalueVisitor {
+    fn enter_place(&mut self, p: &Place) {
+        self.contains_index = self.contains_index || p.contains_index();
+    }
+}
+
+impl Rvalue {
+    fn contains_index(&self) -> bool {
+        let mut v = RvalueVisitor {
+            contains_index: false,
+        };
+        self.drive(&mut v);
+        v.contains_index
+    }
+}
+
+fn introduce_intermediate_let_binding(
+    ctx: &mut TransformCtx<'_>,
+    span: Span,
+    comments_before: &mut Vec<String>,
+    locals: &mut Vector<VarId, Var>,
+    lhs: &mut Place,
+    rhs: &mut Rvalue,
+) -> Vec<Statement> {
+    // Compute the type of the lhs
+    let Ok(lhs_ty) = lhs.compute_projected_type(&ctx.translated.type_decls, locals) else {
+        use crate::pretty::fmt_with_ctx::FmtWithCtx;
+        use crate::pretty::formatter::IntoFormatter;
+        let msg = format!(
+            "Could not compute the type of place: {}",
+            lhs.fmt_with_ctx(&ctx.into_fmt())
+        );
+        crate::register_error_or_panic!(ctx, span, msg);
+        return vec![];
+    };
+
+    // Introduce a fresh local variable, for the temporary assignment
+    let tmp_var = locals.push_with(|index| Var {
+        index,
+        name: None,
+        ty: lhs_ty,
+    });
+
+    // Update the rhs
+    let tmp_rhs = std::mem::replace(rhs, Rvalue::Use(Operand::Move(Place::new(tmp_var))));
+
+    // Retrieve the "comments before" to move them to the new intermediate statement
+    let comments_before = std::mem::take(comments_before);
+
+    // Introduce the intermediate let-binding
+    vec![Statement {
+        span,
+        content: RawStatement::Assign(Place::new(tmp_var), tmp_rhs),
+        comments_before,
+    }]
+}
+
+pub struct Transform;
+
+impl LlbcPass for Transform {
+    fn transform_body(&self, ctx: &mut TransformCtx<'_>, b: &mut ExprBody) {
+        b.body.transform(&mut |st: &mut Statement| {
+            let locals = &mut b.locals;
+
+            //
+            match &mut st.content {
+                RawStatement::Assign(lhs, rhs) => {
+                    // Introduce an intermediate statement if and only
+                    // if both the rhs and the lhs contain an "index"
+                    // projection element (this way we avoid introducing
+                    // too many intermediate assignments).
+                    if lhs.contains_index() && rhs.contains_index() {
+                        introduce_intermediate_let_binding(
+                            ctx,
+                            st.span,
+                            &mut st.comments_before,
+                            locals,
+                            lhs,
+                            rhs,
+                        )
+                    } else {
+                        vec![]
+                    }
+                }
+                _ => vec![],
+            }
+        });
+    }
+}

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -3,6 +3,7 @@ pub mod ctx;
 pub mod filter_invisible_trait_impls;
 pub mod graphs;
 pub mod hide_marker_traits;
+pub mod index_intermediate_assigns;
 pub mod index_to_function_calls;
 pub mod inline_local_panic_functions;
 pub mod insert_assign_return_unit;
@@ -79,6 +80,9 @@ pub static LLBC_PASSES: &[Pass] = &[
     // # Micro-pass: `panic!()` expands to a new function definition each time. This pass cleans
     // those up.
     StructuredBody(&inline_local_panic_functions::Transform),
+    // # Micro-pass: introduce intermediate assignments in preparation of the
+    // [`index_to_function_calls`] pass.
+    StructuredBody(&index_intermediate_assigns::Transform),
     // # Micro-pass: replace the arrays/slices index operations with function
     // calls.
     // (introduces: ArrayIndexShared, ArrayIndexMut, etc.)

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -638,6 +638,58 @@ fn test_crate::update_update_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>
     return
 }
 
+fn test_crate::incr_array_self<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>))
+{
+    let @0: (); // return
+    let s@1: &'_ mut (Array<u32, 2 : usize>); // arg #1
+    let @2: usize; // anonymous local
+    let @3: (); // anonymous local
+    let @4: u32; // anonymous local
+    let @5: &'_ mut (Array<u32, 2 : usize>); // anonymous local
+    let @6: &'_ mut (u32); // anonymous local
+    let @7: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @8: &'_ (u32); // anonymous local
+
+    @2 := const (0 : usize)
+    @7 := &*(s@1)
+    @8 := @ArrayIndexShared<'_, u32, 2 : usize>(move (@7), copy (@2))
+    @4 := copy (*(@8)) + const (1 : u32)
+    @5 := &mut *(s@1)
+    @6 := @ArrayIndexMut<'_, u32, 2 : usize>(move (@5), copy (@2))
+    *(@6) := move (@4)
+    drop @2
+    @3 := ()
+    @0 := move (@3)
+    @0 := ()
+    return
+}
+
+fn test_crate::incr_slice_self<'_0>(@1: &'_0 mut (Slice<u32>))
+{
+    let @0: (); // return
+    let s@1: &'_ mut (Slice<u32>); // arg #1
+    let @2: usize; // anonymous local
+    let @3: (); // anonymous local
+    let @4: u32; // anonymous local
+    let @5: &'_ mut (Slice<u32>); // anonymous local
+    let @6: &'_ mut (u32); // anonymous local
+    let @7: &'_ (Slice<u32>); // anonymous local
+    let @8: &'_ (u32); // anonymous local
+
+    @2 := const (0 : usize)
+    @7 := &*(s@1)
+    @8 := @SliceIndexShared<'_, u32>(move (@7), copy (@2))
+    @4 := copy (*(@8)) + const (1 : u32)
+    @5 := &mut *(s@1)
+    @6 := @SliceIndexMut<'_, u32>(move (@5), copy (@2))
+    *(@6) := move (@4)
+    drop @2
+    @3 := ()
+    @0 := move (@3)
+    @0 := ()
+    return
+}
+
 fn test_crate::array_local_deep_copy<'_0>(@1: &'_0 (Array<u32, 32 : usize>))
 {
     let @0: (); // return

--- a/charon/tests/ui/arrays.rs
+++ b/charon/tests/ui/arrays.rs
@@ -115,6 +115,14 @@ pub fn update_update_array(mut s: [[u32; 32]; 32], i: usize, j: usize) {
     s[i][j] = 0;
 }
 
+pub fn incr_array_self(s: &mut [u32; 2]) {
+    s[0] += 1;
+}
+
+pub fn incr_slice_self(s: &mut [u32]) {
+    s[0] += 1;
+}
+
 pub fn array_local_deep_copy(x: &[u32; 32]) {
     let _y = *x;
 }


### PR DESCRIPTION
This fixes https://github.com/AeneasVerif/aeneas/issues/295.
The issue is that if you write `x[0] += 1`, the micro-pass `index_to_function_calls` transforms the code to (note that the problem remains if we introduce `src` before `dest`):
```rust
dest = &mut x[0];
src = & x[0]; // Invalidates dest
*dest = copy (*src) + 1; // Can't dereference dest!
```

This PR adds a micro-pass which introduces an intermediate assignment to prevent this issue.
We first do:
```rust
tmp = copy x[0] + 1;
x[0] = move tmp;
```

Which leads to:
```rust
// RHS:
src = & x[0];
tmp = copy (*src) + 1;
// LHS:
dest = &mut x[0];
*dest = move tmp;
```
