### PR TITLE
Switch from `derivative` to `derive-where`

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -225,8 +225,8 @@ dependencies = [
  "colored",
  "convert_case 0.6.0",
  "crates_io_api",
- "derivative",
  "derive-visitor",
+ "derive-where",
  "env_logger",
  "flate2",
  "hashlink",
@@ -423,17 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-visitor"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +442,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -226,7 +226,6 @@ dependencies = [
  "convert_case 0.6.0",
  "crates_io_api",
  "derive-visitor",
- "derive-where",
  "env_logger",
  "flate2",
  "hashlink",
@@ -442,17 +441,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
 ]
 
 [[package]]

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -46,7 +46,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
-derivative = "2.2.0"
+derive-where = "1.2.7"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -46,7 +46,6 @@ clap = { version = "4.0", features = ["derive", "env"] }
 colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
-derive-where = "1.2.7"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,7 +1,7 @@
 use crate::ids::Vector;
 use crate::{ast::*, common::hash_consing::HashConsed};
-use derive_where::derive_where;
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
+use derive_where::derive_where;
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 
@@ -354,11 +354,11 @@ pub struct TraitClause {
     /// to specific where clauses when the selected trait actually is linked
     /// to a parameter.
     pub clause_id: TraitClauseId,
-    #[drive_where(skip)]
+    #[derive_where(skip)]
     // TODO: does not need to be an option.
     pub span: Option<Span>,
     /// Where the predicate was written, relative to the item that requires it.
-    #[drive_where(skip)]
+    #[derive_where(skip)]
     #[charon::opaque]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,7 +1,6 @@
 use crate::ids::Vector;
 use crate::{ast::*, common::hash_consing::HashConsed};
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
-use derive_where::derive_where;
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 
@@ -348,22 +347,26 @@ generate_index_type!(TraitImplId, "TraitImpl");
 
 /// A predicate of the form `Type: Trait<Args>`.
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
-#[derive_where(PartialEq)]
 pub struct TraitClause {
     /// We use this id when solving trait constraints, to be able to refer
     /// to specific where clauses when the selected trait actually is linked
     /// to a parameter.
     pub clause_id: TraitClauseId,
-    #[derive_where(skip)]
     // TODO: does not need to be an option.
     pub span: Option<Span>,
     /// Where the predicate was written, relative to the item that requires it.
-    #[derive_where(skip)]
     #[charon::opaque]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.
     #[charon::rename("trait")]
     pub trait_: PolyTraitDeclRef,
+}
+
+impl PartialEq for TraitClause {
+    fn eq(&self, other: &Self) -> bool {
+        // Skip `span` and `origin`
+        self.clause_id == other.clause_id && self.trait_ == other.trait_
+    }
 }
 
 impl Eq for TraitClause {}

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,6 +1,6 @@
 use crate::ids::Vector;
 use crate::{ast::*, common::hash_consing::HashConsed};
-use derivative::Derivative;
+use derive_where::derive_where;
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
@@ -347,18 +347,18 @@ generate_index_type!(TraitDeclId, "TraitDecl");
 generate_index_type!(TraitImplId, "TraitImpl");
 
 /// A predicate of the form `Type: Trait<Args>`.
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative, Drive, DriveMut)]
-#[derivative(PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive_where(PartialEq)]
 pub struct TraitClause {
     /// We use this id when solving trait constraints, to be able to refer
     /// to specific where clauses when the selected trait actually is linked
     /// to a parameter.
     pub clause_id: TraitClauseId,
-    #[derivative(PartialEq = "ignore")]
+    #[drive_where(skip)]
     // TODO: does not need to be an option.
     pub span: Option<Span>,
     /// Where the predicate was written, relative to the item that requires it.
-    #[derivative(PartialEq = "ignore")]
+    #[drive_where(skip)]
     #[charon::opaque]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.
@@ -369,7 +369,7 @@ pub struct TraitClause {
 impl Eq for TraitClause {}
 
 /// Where a given predicate came from.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Derivative, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub enum PredicateOrigin {
     // Note: we use this for globals too, but that's only available with an unstable feature.
     // ```


### PR DESCRIPTION
Derivative has not been maintained in 3 years and recently been marked as unmaintained by RUSTSEC (https://rustsec.org/advisories/RUSTSEC-2024-0388).

This PR replaces `derivative` with `derive-where`, a not dead alternative. 