### PR TITLE
Pass a context to all ml deserialization functions

### DIFF
--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -42,50 +42,54 @@ let region_id_of_json = RegionVarId.id_of_json
 
 let rec ___ = ()
 
-and place_of_json (js : json) : (place, string) result =
+and place_of_json (ctx : of_json_ctx) (js : json) : (place, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("kind", kind); ("ty", ty) ] ->
-        let* kind = place_kind_of_json kind in
-        let* ty = ty_of_json ty in
+        let* kind = place_kind_of_json ctx kind in
+        let* ty = ty_of_json ctx ty in
         Ok ({ kind; ty } : place)
     | _ -> Error "")
 
-and place_kind_of_json (js : json) : (place_kind, string) result =
+and place_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (place_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Base", base) ] ->
-        let* base = var_id_of_json base in
+        let* base = var_id_of_json ctx base in
         Ok (PlaceBase base)
     | `Assoc [ ("Projection", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = projection_elem_of_json x_1 in
+        let* x_0 = box_of_json (place_of_json ctx) ctx x_0 in
+        let* x_1 = projection_elem_of_json ctx x_1 in
         Ok (PlaceProjection (x_0, x_1))
     | _ -> Error "")
 
-and projection_elem_of_json (js : json) : (projection_elem, string) result =
+and projection_elem_of_json (ctx : of_json_ctx) (js : json) :
+    (projection_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Deref" -> Ok Deref
     | `Assoc [ ("Field", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = field_proj_kind_of_json x_0 in
-        let* x_1 = field_id_of_json x_1 in
+        let* x_0 = field_proj_kind_of_json ctx x_0 in
+        let* x_1 = field_id_of_json ctx x_1 in
         Ok (Field (x_0, x_1))
     | _ -> Error "")
 
-and field_proj_kind_of_json (js : json) : (field_proj_kind, string) result =
+and field_proj_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (field_proj_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Adt", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = type_decl_id_of_json x_0 in
-        let* x_1 = option_of_json variant_id_of_json x_1 in
+        let* x_0 = type_decl_id_of_json ctx x_0 in
+        let* x_1 = option_of_json (variant_id_of_json ctx) ctx x_1 in
         Ok (ProjAdt (x_0, x_1))
     | `Assoc [ ("Tuple", tuple) ] ->
-        let* tuple = int_of_json tuple in
+        let* tuple = int_of_json ctx tuple in
         Ok (ProjTuple tuple)
     | _ -> Error "")
 
-and borrow_kind_of_json (js : json) : (borrow_kind, string) result =
+and borrow_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (borrow_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Shared" -> Ok BShared
@@ -95,55 +99,58 @@ and borrow_kind_of_json (js : json) : (borrow_kind, string) result =
     | `String "UniqueImmutable" -> Ok BUniqueImmutable
     | _ -> Error "")
 
-and unop_of_json (js : json) : (unop, string) result =
+and unop_of_json (ctx : of_json_ctx) (js : json) : (unop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Not" -> Ok Not
     | `String "Neg" -> Ok Neg
     | `Assoc [ ("Cast", cast) ] ->
-        let* cast = cast_kind_of_json cast in
+        let* cast = cast_kind_of_json ctx cast in
         Ok (Cast cast)
     | _ -> Error "")
 
-and nullop_of_json (js : json) : (nullop, string) result =
+and nullop_of_json (ctx : of_json_ctx) (js : json) : (nullop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "SizeOf" -> Ok SizeOf
     | `String "AlignOf" -> Ok AlignOf
     | `Assoc [ ("OffsetOf", offset_of) ] ->
         let* offset_of =
-          list_of_json (pair_of_json int_of_json field_id_of_json) offset_of
+          list_of_json
+            (pair_of_json (int_of_json ctx) (field_id_of_json ctx) ctx)
+            ctx offset_of
         in
         Ok (OffsetOf offset_of)
     | `String "UbChecks" -> Ok UbChecks
     | _ -> Error "")
 
-and cast_kind_of_json (js : json) : (cast_kind, string) result =
+and cast_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (cast_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Scalar", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = literal_type_of_json x_0 in
-        let* x_1 = literal_type_of_json x_1 in
+        let* x_0 = literal_type_of_json ctx x_0 in
+        let* x_1 = literal_type_of_json ctx x_1 in
         Ok (CastScalar (x_0, x_1))
     | `Assoc [ ("RawPtr", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (CastRawPtr (x_0, x_1))
     | `Assoc [ ("FnPtr", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (CastFnPtr (x_0, x_1))
     | `Assoc [ ("Unsize", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (CastUnsize (x_0, x_1))
     | `Assoc [ ("Transmute", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (CastTransmute (x_0, x_1))
     | _ -> Error "")
 
-and binop_of_json (js : json) : (binop, string) result =
+and binop_of_json (ctx : of_json_ctx) (js : json) : (binop, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "BitXor" -> Ok BitXor
@@ -167,32 +174,33 @@ and binop_of_json (js : json) : (binop, string) result =
     | `String "Shr" -> Ok Shr
     | _ -> Error "")
 
-and operand_of_json (js : json) : (operand, string) result =
+and operand_of_json (ctx : of_json_ctx) (js : json) : (operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Copy", copy) ] ->
-        let* copy = place_of_json copy in
+        let* copy = place_of_json ctx copy in
         Ok (Copy copy)
     | `Assoc [ ("Move", move) ] ->
-        let* move = place_of_json move in
+        let* move = place_of_json ctx move in
         Ok (Move move)
     | `Assoc [ ("Const", const) ] ->
-        let* const = constant_expr_of_json const in
+        let* const = constant_expr_of_json ctx const in
         Ok (Constant const)
     | _ -> Error "")
 
-and fun_id_of_json (js : json) : (fun_id, string) result =
+and fun_id_of_json (ctx : of_json_ctx) (js : json) : (fun_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Regular", regular) ] ->
-        let* regular = fun_decl_id_of_json regular in
+        let* regular = fun_decl_id_of_json ctx regular in
         Ok (FRegular regular)
     | `Assoc [ ("Builtin", builtin) ] ->
-        let* builtin = builtin_fun_id_of_json builtin in
+        let* builtin = builtin_fun_id_of_json ctx builtin in
         Ok (FBuiltin builtin)
     | _ -> Error "")
 
-and builtin_fun_id_of_json (js : json) : (builtin_fun_id, string) result =
+and builtin_fun_id_of_json (ctx : of_json_ctx) (js : json) :
+    (builtin_fun_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "BoxNew" -> Ok BoxNew
@@ -200,11 +208,12 @@ and builtin_fun_id_of_json (js : json) : (builtin_fun_id, string) result =
     | `String "ArrayToSliceMut" -> Ok ArrayToSliceMut
     | `String "ArrayRepeat" -> Ok ArrayRepeat
     | `Assoc [ ("Index", index) ] ->
-        let* index = builtin_index_op_of_json index in
+        let* index = builtin_index_op_of_json ctx index in
         Ok (Index index)
     | _ -> Error "")
 
-and builtin_index_op_of_json (js : json) : (builtin_index_op, string) result =
+and builtin_index_op_of_json (ctx : of_json_ctx) (js : json) :
+    (builtin_index_op, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -213,146 +222,151 @@ and builtin_index_op_of_json (js : json) : (builtin_index_op, string) result =
           ("mutability", mutability);
           ("is_range", is_range);
         ] ->
-        let* is_array = bool_of_json is_array in
-        let* mutability = ref_kind_of_json mutability in
-        let* is_range = bool_of_json is_range in
+        let* is_array = bool_of_json ctx is_array in
+        let* mutability = ref_kind_of_json ctx mutability in
+        let* is_range = bool_of_json ctx is_range in
         Ok ({ is_array; mutability; is_range } : builtin_index_op)
     | _ -> Error "")
 
-and fun_id_or_trait_method_ref_of_json (js : json) :
+and fun_id_or_trait_method_ref_of_json (ctx : of_json_ctx) (js : json) :
     (fun_id_or_trait_method_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Fun", fun_) ] ->
-        let* fun_ = fun_id_of_json fun_ in
+        let* fun_ = fun_id_of_json ctx fun_ in
         Ok (FunId fun_)
     | `Assoc [ ("Trait", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = trait_ref_of_json x_0 in
-        let* x_1 = trait_item_name_of_json x_1 in
-        let* x_2 = fun_decl_id_of_json x_2 in
+        let* x_0 = trait_ref_of_json ctx x_0 in
+        let* x_1 = trait_item_name_of_json ctx x_1 in
+        let* x_2 = fun_decl_id_of_json ctx x_2 in
         Ok (TraitMethod (x_0, x_1, x_2))
     | _ -> Error "")
 
-and fn_ptr_of_json (js : json) : (fn_ptr, string) result =
+and fn_ptr_of_json (ctx : of_json_ctx) (js : json) : (fn_ptr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("func", func); ("generics", generics) ] ->
-        let* func = fun_id_or_trait_method_ref_of_json func in
-        let* generics = generic_args_of_json generics in
+        let* func = fun_id_or_trait_method_ref_of_json ctx func in
+        let* generics = generic_args_of_json ctx generics in
         Ok ({ func; generics } : fn_ptr)
     | _ -> Error "")
 
-and raw_constant_expr_of_json (js : json) : (raw_constant_expr, string) result =
+and raw_constant_expr_of_json (ctx : of_json_ctx) (js : json) :
+    (raw_constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Literal", literal) ] ->
-        let* literal = literal_of_json literal in
+        let* literal = literal_of_json ctx literal in
         Ok (CLiteral literal)
     | `Assoc [ ("TraitConst", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_ref_of_json x_0 in
-        let* x_1 = trait_item_name_of_json x_1 in
+        let* x_0 = trait_ref_of_json ctx x_0 in
+        let* x_1 = trait_item_name_of_json ctx x_1 in
         Ok (CTraitConst (x_0, x_1))
     | `Assoc [ ("Var", var) ] ->
-        let* var = const_generic_var_id_of_json var in
+        let* var = const_generic_var_id_of_json ctx var in
         Ok (CVar var)
     | `Assoc [ ("FnPtr", fn_ptr) ] ->
-        let* fn_ptr = fn_ptr_of_json fn_ptr in
+        let* fn_ptr = fn_ptr_of_json ctx fn_ptr in
         Ok (CFnPtr fn_ptr)
     | _ -> Error "")
 
-and constant_expr_of_json (js : json) : (constant_expr, string) result =
+and constant_expr_of_json (ctx : of_json_ctx) (js : json) :
+    (constant_expr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("value", value); ("ty", ty) ] ->
-        let* value = raw_constant_expr_of_json value in
-        let* ty = ty_of_json ty in
+        let* value = raw_constant_expr_of_json ctx value in
+        let* ty = ty_of_json ctx ty in
         Ok ({ value; ty } : constant_expr)
     | _ -> Error "")
 
-and rvalue_of_json (js : json) : (rvalue, string) result =
+and rvalue_of_json (ctx : of_json_ctx) (js : json) : (rvalue, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Use", use) ] ->
-        let* use = operand_of_json use in
+        let* use = operand_of_json ctx use in
         Ok (Use use)
     | `Assoc [ ("Ref", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = borrow_kind_of_json x_1 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = borrow_kind_of_json ctx x_1 in
         Ok (RvRef (x_0, x_1))
     | `Assoc [ ("RawPtr", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = ref_kind_of_json x_1 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = ref_kind_of_json ctx x_1 in
         Ok (RawPtr (x_0, x_1))
     | `Assoc [ ("BinaryOp", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = binop_of_json x_0 in
-        let* x_1 = operand_of_json x_1 in
-        let* x_2 = operand_of_json x_2 in
+        let* x_0 = binop_of_json ctx x_0 in
+        let* x_1 = operand_of_json ctx x_1 in
+        let* x_2 = operand_of_json ctx x_2 in
         Ok (BinaryOp (x_0, x_1, x_2))
     | `Assoc [ ("UnaryOp", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = unop_of_json x_0 in
-        let* x_1 = operand_of_json x_1 in
+        let* x_0 = unop_of_json ctx x_0 in
+        let* x_1 = operand_of_json ctx x_1 in
         Ok (UnaryOp (x_0, x_1))
     | `Assoc [ ("NullaryOp", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = nullop_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_0 = nullop_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (NullaryOp (x_0, x_1))
     | `Assoc [ ("Discriminant", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = type_decl_id_of_json x_1 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = type_decl_id_of_json ctx x_1 in
         Ok (Discriminant (x_0, x_1))
     | `Assoc [ ("Aggregate", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = aggregate_kind_of_json x_0 in
-        let* x_1 = list_of_json operand_of_json x_1 in
+        let* x_0 = aggregate_kind_of_json ctx x_0 in
+        let* x_1 = list_of_json (operand_of_json ctx) ctx x_1 in
         Ok (Aggregate (x_0, x_1))
     | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_ref_of_json global in
+        let* global = global_decl_ref_of_json ctx global in
         Ok (Global global)
     | `Assoc [ ("GlobalRef", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = global_decl_ref_of_json x_0 in
-        let* x_1 = ref_kind_of_json x_1 in
+        let* x_0 = global_decl_ref_of_json ctx x_0 in
+        let* x_1 = ref_kind_of_json ctx x_1 in
         Ok (GlobalRef (x_0, x_1))
     | `Assoc [ ("Len", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
-        let* x_2 = option_of_json const_generic_of_json x_2 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
+        let* x_2 = option_of_json (const_generic_of_json ctx) ctx x_2 in
         Ok (Len (x_0, x_1, x_2))
     | _ -> Error "")
 
-and aggregate_kind_of_json (js : json) : (aggregate_kind, string) result =
+and aggregate_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (aggregate_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Adt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
-        let* x_0 = type_id_of_json x_0 in
-        let* x_1 = option_of_json variant_id_of_json x_1 in
-        let* x_2 = option_of_json field_id_of_json x_2 in
-        let* x_3 = generic_args_of_json x_3 in
+        let* x_0 = type_id_of_json ctx x_0 in
+        let* x_1 = option_of_json (variant_id_of_json ctx) ctx x_1 in
+        let* x_2 = option_of_json (field_id_of_json ctx) ctx x_2 in
+        let* x_3 = generic_args_of_json ctx x_3 in
         Ok (AggregatedAdt (x_0, x_1, x_2, x_3))
     | `Assoc [ ("Array", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = const_generic_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = const_generic_of_json ctx x_1 in
         Ok (AggregatedArray (x_0, x_1))
     | `Assoc [ ("Closure", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = fun_decl_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
+        let* x_0 = fun_decl_id_of_json ctx x_0 in
+        let* x_1 = generic_args_of_json ctx x_1 in
         Ok (AggregatedClosure (x_0, x_1))
     | _ -> Error "")
 
-and var_of_json (js : json) : (var, string) result =
+and var_of_json (ctx : of_json_ctx) (js : json) : (var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = var_id_of_json index in
-        let* name = option_of_json string_of_json name in
-        let* var_ty = ty_of_json ty in
+        let* index = var_id_of_json ctx index in
+        let* name = option_of_json (string_of_json ctx) ctx name in
+        let* var_ty = ty_of_json ctx ty in
         Ok ({ index; name; var_ty } : var)
     | _ -> Error "")
 
-and locals_of_json (js : json) : (locals, string) result =
+and locals_of_json (ctx : of_json_ctx) (js : json) : (locals, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("arg_count", arg_count); ("vars", vars) ] ->
-        let* arg_count = int_of_json arg_count in
-        let* vars = vector_of_json var_id_of_json var_of_json vars in
+        let* arg_count = int_of_json ctx arg_count in
+        let* vars =
+          vector_of_json (var_id_of_json ctx) (var_of_json ctx) ctx vars
+        in
         Ok ({ arg_count; vars } : locals)
     | _ -> Error "")
 
@@ -369,12 +383,13 @@ and gexpr_body_of_json :
         [ ("span", span); ("locals", locals); ("comments", _); ("body", body) ]
       ->
         let* span = span_of_json ctx span in
-        let* locals = locals_of_json locals in
+        let* locals = locals_of_json ctx locals in
         let* body = arg0_of_json body in
         Ok ({ span; locals; body } : _ gexpr_body)
     | _ -> Error "")
 
-and item_kind_of_json (js : json) : (item_kind, string) result =
+and item_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (item_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Regular" -> Ok RegularItem
@@ -388,9 +403,9 @@ and item_kind_of_json (js : json) : (item_kind, string) result =
                 ("has_default", has_default);
               ] );
         ] ->
-        let* trait_id = trait_decl_id_of_json trait_id in
-        let* item_name = trait_item_name_of_json item_name in
-        let* has_default = bool_of_json has_default in
+        let* trait_id = trait_decl_id_of_json ctx trait_id in
+        let* item_name = trait_item_name_of_json ctx item_name in
+        let* has_default = bool_of_json ctx has_default in
         Ok (TraitDeclItem (trait_id, item_name, has_default))
     | `Assoc
         [
@@ -403,10 +418,10 @@ and item_kind_of_json (js : json) : (item_kind, string) result =
                 ("reuses_default", reuses_default);
               ] );
         ] ->
-        let* impl_id = trait_impl_id_of_json impl_id in
-        let* trait_id = trait_decl_id_of_json trait_id in
-        let* item_name = trait_item_name_of_json item_name in
-        let* reuses_default = bool_of_json reuses_default in
+        let* impl_id = trait_impl_id_of_json ctx impl_id in
+        let* trait_id = trait_decl_id_of_json ctx trait_id in
+        let* item_name = trait_item_name_of_json ctx item_name in
+        let* reuses_default = bool_of_json ctx reuses_default in
         Ok (TraitImplItem (impl_id, trait_id, item_name, reuses_default))
     | _ -> Error "")
 
@@ -423,27 +438,29 @@ and global_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("kind", kind);
           ("init", init);
         ] ->
-        let* def_id = global_decl_id_of_json def_id in
+        let* def_id = global_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* generics = generic_params_of_json ctx generics in
-        let* ty = ty_of_json ty in
-        let* kind = item_kind_of_json kind in
-        let* body = fun_decl_id_of_json init in
+        let* ty = ty_of_json ctx ty in
+        let* kind = item_kind_of_json ctx kind in
+        let* body = fun_decl_id_of_json ctx init in
         Ok ({ def_id; item_meta; generics; ty; kind; body } : global_decl)
     | _ -> Error "")
 
-and global_decl_ref_of_json (js : json) : (global_decl_ref, string) result =
+and global_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
+    (global_decl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* global_id = global_decl_id_of_json id in
-        let* global_generics = generic_args_of_json generics in
+        let* global_id = global_decl_id_of_json ctx id in
+        let* global_generics = generic_args_of_json ctx generics in
         Ok ({ global_id; global_generics } : global_decl_ref)
     | _ -> Error "")
 
-and trait_item_name_of_json (js : json) : (trait_item_name, string) result =
+and trait_item_name_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_item_name, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> string_of_json x | _ -> Error "")
+    (match js with x -> string_of_json ctx x | _ -> Error "")
 
 and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
     (trait_decl, string) result =
@@ -463,26 +480,33 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("required_methods", required_methods);
           ("provided_methods", provided_methods);
         ] ->
-        let* def_id = trait_decl_id_of_json def_id in
+        let* def_id = trait_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* generics = generic_params_of_json ctx generics in
         let* parent_clauses =
-          vector_of_json trait_clause_id_of_json (trait_clause_of_json ctx)
-            parent_clauses
+          vector_of_json
+            (trait_clause_id_of_json ctx)
+            (trait_clause_of_json ctx) ctx parent_clauses
         in
         let* consts =
-          list_of_json (pair_of_json trait_item_name_of_json ty_of_json) consts
+          list_of_json
+            (pair_of_json (trait_item_name_of_json ctx) (ty_of_json ctx) ctx)
+            ctx consts
         in
-        let* types = list_of_json trait_item_name_of_json types in
+        let* types = list_of_json (trait_item_name_of_json ctx) ctx types in
         let* required_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
-            required_methods
+            (pair_of_json
+               (trait_item_name_of_json ctx)
+               (fun_decl_id_of_json ctx) ctx)
+            ctx required_methods
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
-            provided_methods
+            (pair_of_json
+               (trait_item_name_of_json ctx)
+               (fun_decl_id_of_json ctx) ctx)
+            ctx provided_methods
         in
         Ok
           ({
@@ -515,31 +539,41 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
           ("required_methods", required_methods);
           ("provided_methods", provided_methods);
         ] ->
-        let* def_id = trait_impl_id_of_json def_id in
+        let* def_id = trait_impl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
-        let* impl_trait = trait_decl_ref_of_json impl_trait in
+        let* impl_trait = trait_decl_ref_of_json ctx impl_trait in
         let* generics = generic_params_of_json ctx generics in
         let* parent_trait_refs =
-          vector_of_json trait_clause_id_of_json trait_ref_of_json
-            parent_trait_refs
+          vector_of_json
+            (trait_clause_id_of_json ctx)
+            (trait_ref_of_json ctx) ctx parent_trait_refs
         in
         let* consts =
           list_of_json
-            (pair_of_json trait_item_name_of_json global_decl_ref_of_json)
-            consts
+            (pair_of_json
+               (trait_item_name_of_json ctx)
+               (global_decl_ref_of_json ctx)
+               ctx)
+            ctx consts
         in
         let* types =
-          list_of_json (pair_of_json trait_item_name_of_json ty_of_json) types
+          list_of_json
+            (pair_of_json (trait_item_name_of_json ctx) (ty_of_json ctx) ctx)
+            ctx types
         in
         let* required_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
-            required_methods
+            (pair_of_json
+               (trait_item_name_of_json ctx)
+               (fun_decl_id_of_json ctx) ctx)
+            ctx required_methods
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
-            provided_methods
+            (pair_of_json
+               (trait_item_name_of_json ctx)
+               (fun_decl_id_of_json ctx) ctx)
+            ctx provided_methods
         in
         Ok
           ({
@@ -556,24 +590,25 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
             : trait_impl)
     | _ -> Error "")
 
-and fn_operand_of_json (js : json) : (fn_operand, string) result =
+and fn_operand_of_json (ctx : of_json_ctx) (js : json) :
+    (fn_operand, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Regular", regular) ] ->
-        let* regular = fn_ptr_of_json regular in
+        let* regular = fn_ptr_of_json ctx regular in
         Ok (FnOpRegular regular)
     | `Assoc [ ("Move", move) ] ->
-        let* move = place_of_json move in
+        let* move = place_of_json ctx move in
         Ok (FnOpMove move)
     | _ -> Error "")
 
-and call_of_json (js : json) : (call, string) result =
+and call_of_json (ctx : of_json_ctx) (js : json) : (call, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("func", func); ("args", args); ("dest", dest) ] ->
-        let* func = fn_operand_of_json func in
-        let* args = list_of_json operand_of_json args in
-        let* dest = place_of_json dest in
+        let* func = fn_operand_of_json ctx func in
+        let* args = list_of_json (operand_of_json ctx) ctx args in
+        let* dest = place_of_json ctx dest in
         Ok ({ func; args; dest } : call)
     | _ -> Error "")
 
@@ -587,65 +622,72 @@ and abort_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `String "UndefinedBehavior" -> Ok UndefinedBehavior
     | _ -> Error "")
 
-and assertion_of_json (js : json) : (assertion, string) result =
+and assertion_of_json (ctx : of_json_ctx) (js : json) :
+    (assertion, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("cond", cond); ("expected", expected) ] ->
-        let* cond = operand_of_json cond in
-        let* expected = bool_of_json expected in
+        let* cond = operand_of_json ctx cond in
+        let* expected = bool_of_json ctx expected in
         Ok ({ cond; expected } : assertion)
     | _ -> Error "")
 
-and fun_decl_id_of_json (js : json) : (fun_decl_id, string) result =
+and fun_decl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (fun_decl_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> FunDeclId.id_of_json x | _ -> Error "")
+    (match js with x -> FunDeclId.id_of_json ctx x | _ -> Error "")
 
-and type_decl_id_of_json (js : json) : (type_decl_id, string) result =
+and type_decl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (type_decl_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> TypeDeclId.id_of_json x | _ -> Error "")
+    (match js with x -> TypeDeclId.id_of_json ctx x | _ -> Error "")
 
-and global_decl_id_of_json (js : json) : (global_decl_id, string) result =
+and global_decl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (global_decl_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> GlobalDeclId.id_of_json x | _ -> Error "")
+    (match js with x -> GlobalDeclId.id_of_json ctx x | _ -> Error "")
 
-and trait_decl_id_of_json (js : json) : (trait_decl_id, string) result =
+and trait_decl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_decl_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> TraitDeclId.id_of_json x | _ -> Error "")
+    (match js with x -> TraitDeclId.id_of_json ctx x | _ -> Error "")
 
-and trait_impl_id_of_json (js : json) : (trait_impl_id, string) result =
+and trait_impl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_impl_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> TraitImplId.id_of_json x | _ -> Error "")
+    (match js with x -> TraitImplId.id_of_json ctx x | _ -> Error "")
 
-and any_decl_id_of_json (js : json) : (any_decl_id, string) result =
+and any_decl_id_of_json (ctx : of_json_ctx) (js : json) :
+    (any_decl_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Type", type_) ] ->
-        let* type_ = type_decl_id_of_json type_ in
+        let* type_ = type_decl_id_of_json ctx type_ in
         Ok (IdType type_)
     | `Assoc [ ("Fun", fun_) ] ->
-        let* fun_ = fun_decl_id_of_json fun_ in
+        let* fun_ = fun_decl_id_of_json ctx fun_ in
         Ok (IdFun fun_)
     | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_id_of_json global in
+        let* global = global_decl_id_of_json ctx global in
         Ok (IdGlobal global)
     | `Assoc [ ("TraitDecl", trait_decl) ] ->
-        let* trait_decl = trait_decl_id_of_json trait_decl in
+        let* trait_decl = trait_decl_id_of_json ctx trait_decl in
         Ok (IdTraitDecl trait_decl)
     | `Assoc [ ("TraitImpl", trait_impl) ] ->
-        let* trait_impl = trait_impl_id_of_json trait_impl in
+        let* trait_impl = trait_impl_id_of_json ctx trait_impl in
         Ok (IdTraitImpl trait_impl)
     | _ -> Error "")
 
-and file_id_of_json (js : json) : (file_id, string) result =
+and file_id_of_json (ctx : of_json_ctx) (js : json) : (file_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> FileId.id_of_json x | _ -> Error "")
+    (match js with x -> FileId.id_of_json ctx x | _ -> Error "")
 
-and loc_of_json (js : json) : (loc, string) result =
+and loc_of_json (ctx : of_json_ctx) (js : json) : (loc, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("line", line); ("col", col) ] ->
-        let* line = int_of_json line in
-        let* col = int_of_json col in
+        let* line = int_of_json ctx line in
+        let* col = int_of_json ctx col in
         Ok ({ line; col } : loc)
     | _ -> Error "")
 
@@ -654,10 +696,10 @@ and raw_span_of_json (ctx : of_json_ctx) (js : json) : (raw_span, string) result
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("file_id", file_id); ("beg", beg_loc); ("end", end_loc) ] ->
-        let* file_id = file_id_of_json file_id in
+        let* file_id = file_id_of_json ctx file_id in
         let file = FileId.Map.find file_id ctx in
-        let* beg_loc = loc_of_json beg_loc in
-        let* end_loc = loc_of_json end_loc in
+        let* beg_loc = loc_of_json ctx beg_loc in
+        let* end_loc = loc_of_json ctx end_loc in
         Ok { file; beg_loc; end_loc }
     | _ -> Error "")
 
@@ -667,12 +709,13 @@ and span_of_json (ctx : of_json_ctx) (js : json) : (span, string) result =
     | `Assoc [ ("span", span); ("generated_from_span", generated_from_span) ] ->
         let* span = raw_span_of_json ctx span in
         let* generated_from_span =
-          option_of_json (raw_span_of_json ctx) generated_from_span
+          option_of_json (raw_span_of_json ctx) ctx generated_from_span
         in
         Ok ({ span; generated_from_span } : span)
     | _ -> Error "")
 
-and inline_attr_of_json (js : json) : (inline_attr, string) result =
+and inline_attr_of_json (ctx : of_json_ctx) (js : json) :
+    (inline_attr, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Hint" -> Ok Hint
@@ -680,37 +723,40 @@ and inline_attr_of_json (js : json) : (inline_attr, string) result =
     | `String "Always" -> Ok Always
     | _ -> Error "")
 
-and attribute_of_json (js : json) : (attribute, string) result =
+and attribute_of_json (ctx : of_json_ctx) (js : json) :
+    (attribute, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Opaque" -> Ok AttrOpaque
     | `Assoc [ ("Rename", rename) ] ->
-        let* rename = string_of_json rename in
+        let* rename = string_of_json ctx rename in
         Ok (AttrRename rename)
     | `Assoc [ ("VariantsPrefix", variants_prefix) ] ->
-        let* variants_prefix = string_of_json variants_prefix in
+        let* variants_prefix = string_of_json ctx variants_prefix in
         Ok (AttrVariantsPrefix variants_prefix)
     | `Assoc [ ("VariantsSuffix", variants_suffix) ] ->
-        let* variants_suffix = string_of_json variants_suffix in
+        let* variants_suffix = string_of_json ctx variants_suffix in
         Ok (AttrVariantsSuffix variants_suffix)
     | `Assoc [ ("DocComment", doc_comment) ] ->
-        let* doc_comment = string_of_json doc_comment in
+        let* doc_comment = string_of_json ctx doc_comment in
         Ok (AttrDocComment doc_comment)
     | `Assoc [ ("Unknown", unknown) ] ->
-        let* unknown = raw_attribute_of_json unknown in
+        let* unknown = raw_attribute_of_json ctx unknown in
         Ok (AttrUnknown unknown)
     | _ -> Error "")
 
-and raw_attribute_of_json (js : json) : (raw_attribute, string) result =
+and raw_attribute_of_json (ctx : of_json_ctx) (js : json) :
+    (raw_attribute, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("path", path); ("args", args) ] ->
-        let* path = string_of_json path in
-        let* args = option_of_json string_of_json args in
+        let* path = string_of_json ctx path in
+        let* args = option_of_json (string_of_json ctx) ctx args in
         Ok ({ path; args } : raw_attribute)
     | _ -> Error "")
 
-and attr_info_of_json (js : json) : (attr_info, string) result =
+and attr_info_of_json (ctx : of_json_ctx) (js : json) :
+    (attr_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -720,10 +766,10 @@ and attr_info_of_json (js : json) : (attr_info, string) result =
           ("rename", rename);
           ("public", public);
         ] ->
-        let* attributes = list_of_json attribute_of_json attributes in
-        let* inline = option_of_json inline_attr_of_json inline in
-        let* rename = option_of_json string_of_json rename in
-        let* public = bool_of_json public in
+        let* attributes = list_of_json (attribute_of_json ctx) ctx attributes in
+        let* inline = option_of_json (inline_attr_of_json ctx) ctx inline in
+        let* rename = option_of_json (string_of_json ctx) ctx rename in
+        let* public = bool_of_json ctx public in
         Ok ({ attributes; inline; rename; public } : attr_info)
     | _ -> Error "")
 
@@ -742,47 +788,51 @@ and item_meta_of_json (ctx : of_json_ctx) (js : json) :
         ] ->
         let* name = name_of_json ctx name in
         let* span = span_of_json ctx span in
-        let* source_text = option_of_json string_of_json source_text in
-        let* attr_info = attr_info_of_json attr_info in
-        let* is_local = bool_of_json is_local in
+        let* source_text =
+          option_of_json (string_of_json ctx) ctx source_text
+        in
+        let* attr_info = attr_info_of_json ctx attr_info in
+        let* is_local = bool_of_json ctx is_local in
         Ok ({ name; span; source_text; attr_info; is_local } : item_meta)
     | _ -> Error "")
 
-and file_name_of_json (js : json) : (file_name, string) result =
+and file_name_of_json (ctx : of_json_ctx) (js : json) :
+    (file_name, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Virtual", virtual_) ] ->
-        let* virtual_ = path_buf_of_json virtual_ in
+        let* virtual_ = path_buf_of_json ctx virtual_ in
         Ok (Virtual virtual_)
     | `Assoc [ ("Local", local) ] ->
-        let* local = path_buf_of_json local in
+        let* local = path_buf_of_json ctx local in
         Ok (Local local)
     | _ -> Error "")
 
-and file_of_json (js : json) : (file, string) result =
+and file_of_json (ctx : of_json_ctx) (js : json) : (file, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("name", name); ("contents", contents) ] ->
-        let* name = file_name_of_json name in
-        let* contents = option_of_json string_of_json contents in
+        let* name = file_name_of_json ctx name in
+        let* contents = option_of_json (string_of_json ctx) ctx contents in
         Ok ({ name; contents } : file)
     | _ -> Error "")
 
-and disambiguator_of_json (js : json) : (disambiguator, string) result =
+and disambiguator_of_json (ctx : of_json_ctx) (js : json) :
+    (disambiguator, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> Disambiguator.id_of_json x | _ -> Error "")
+    (match js with x -> Disambiguator.id_of_json ctx x | _ -> Error "")
 
 and path_elem_of_json (ctx : of_json_ctx) (js : json) :
     (path_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Ident", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = string_of_json x_0 in
-        let* x_1 = disambiguator_of_json x_1 in
+        let* x_0 = string_of_json ctx x_0 in
+        let* x_1 = disambiguator_of_json ctx x_1 in
         Ok (PeIdent (x_0, x_1))
     | `Assoc [ ("Impl", `List [ x_0; x_1 ]) ] ->
         let* x_0 = impl_elem_of_json ctx x_0 in
-        let* x_1 = disambiguator_of_json x_1 in
+        let* x_1 = disambiguator_of_json ctx x_1 in
         Ok (PeImpl (x_0, x_1))
     | _ -> Error "")
 
@@ -792,121 +842,130 @@ and impl_elem_of_json (ctx : of_json_ctx) (js : json) :
     (match js with
     | `Assoc [ ("Ty", `List [ x_0; x_1 ]) ] ->
         let* x_0 = generic_params_of_json ctx x_0 in
-        let* x_1 = ty_of_json x_1 in
+        let* x_1 = ty_of_json ctx x_1 in
         Ok (ImplElemTy (x_0, x_1))
     | `Assoc [ ("Trait", trait) ] ->
-        let* trait = trait_impl_id_of_json trait in
+        let* trait = trait_impl_id_of_json ctx trait in
         Ok (ImplElemTrait trait)
     | _ -> Error "")
 
 and name_of_json (ctx : of_json_ctx) (js : json) : (name, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | x -> list_of_json (path_elem_of_json ctx) x
+    | x -> list_of_json (path_elem_of_json ctx) ctx x
     | _ -> Error "")
 
-and type_var_id_of_json (js : json) : (type_var_id, string) result =
+and type_var_id_of_json (ctx : of_json_ctx) (js : json) :
+    (type_var_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> TypeVarId.id_of_json x | _ -> Error "")
+    (match js with x -> TypeVarId.id_of_json ctx x | _ -> Error "")
 
-and variant_id_of_json (js : json) : (variant_id, string) result =
+and variant_id_of_json (ctx : of_json_ctx) (js : json) :
+    (variant_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> VariantId.id_of_json x | _ -> Error "")
+    (match js with x -> VariantId.id_of_json ctx x | _ -> Error "")
 
-and field_id_of_json (js : json) : (field_id, string) result =
+and field_id_of_json (ctx : of_json_ctx) (js : json) : (field_id, string) result
+    =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> FieldId.id_of_json x | _ -> Error "")
+    (match js with x -> FieldId.id_of_json ctx x | _ -> Error "")
 
-and const_generic_var_id_of_json (js : json) :
+and const_generic_var_id_of_json (ctx : of_json_ctx) (js : json) :
     (const_generic_var_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> ConstGenericVarId.id_of_json x | _ -> Error "")
+    (match js with x -> ConstGenericVarId.id_of_json ctx x | _ -> Error "")
 
-and type_var_of_json (js : json) : (type_var, string) result =
+and type_var_of_json (ctx : of_json_ctx) (js : json) : (type_var, string) result
+    =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = type_var_id_of_json index in
-        let* name = string_of_json name in
+        let* index = type_var_id_of_json ctx index in
+        let* name = string_of_json ctx name in
         Ok ({ index; name } : type_var)
     | _ -> Error "")
 
-and region_var_of_json (js : json) : (region_var, string) result =
+and region_var_of_json (ctx : of_json_ctx) (js : json) :
+    (region_var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name) ] ->
-        let* index = region_id_of_json index in
-        let* name = option_of_json string_of_json name in
+        let* index = region_id_of_json ctx index in
+        let* name = option_of_json (string_of_json ctx) ctx name in
         Ok ({ index; name } : region_var)
     | _ -> Error "")
 
-and const_generic_var_of_json (js : json) : (const_generic_var, string) result =
+and const_generic_var_of_json (ctx : of_json_ctx) (js : json) :
+    (const_generic_var, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("index", index); ("name", name); ("ty", ty) ] ->
-        let* index = const_generic_var_id_of_json index in
-        let* name = string_of_json name in
-        let* ty = literal_type_of_json ty in
+        let* index = const_generic_var_id_of_json ctx index in
+        let* name = string_of_json ctx name in
+        let* ty = literal_type_of_json ctx ty in
         Ok ({ index; name; ty } : const_generic_var)
     | _ -> Error "")
 
-and region_of_json (js : json) : (region, string) result =
+and region_of_json (ctx : of_json_ctx) (js : json) : (region, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Static" -> Ok RStatic
     | `Assoc [ ("BVar", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = de_bruijn_id_of_json x_0 in
-        let* x_1 = region_id_of_json x_1 in
+        let* x_0 = de_bruijn_id_of_json ctx x_0 in
+        let* x_1 = region_id_of_json ctx x_1 in
         Ok (RBVar (x_0, x_1))
     | `String "Erased" -> Ok RErased
     | _ -> Error "")
 
-and trait_instance_id_of_json (js : json) : (trait_instance_id, string) result =
+and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_instance_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("TraitImpl", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_impl_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
+        let* x_0 = trait_impl_id_of_json ctx x_0 in
+        let* x_1 = generic_args_of_json ctx x_1 in
         Ok (TraitImpl (x_0, x_1))
     | `Assoc [ ("Clause", clause) ] ->
-        let* clause = trait_clause_id_of_json clause in
+        let* clause = trait_clause_id_of_json ctx clause in
         Ok (Clause clause)
     | `Assoc [ ("ParentClause", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = trait_instance_id_of_json x_0 in
-        let* x_1 = trait_decl_id_of_json x_1 in
-        let* x_2 = trait_clause_id_of_json x_2 in
+        let* x_0 = box_of_json (trait_instance_id_of_json ctx) ctx x_0 in
+        let* x_1 = trait_decl_id_of_json ctx x_1 in
+        let* x_2 = trait_clause_id_of_json ctx x_2 in
         Ok (ParentClause (x_0, x_1, x_2))
     | `String "SelfId" -> Ok Self
     | `Assoc [ ("BuiltinOrAuto", builtin_or_auto) ] ->
         let* builtin_or_auto =
-          region_binder_of_json trait_decl_ref_of_json builtin_or_auto
+          region_binder_of_json (trait_decl_ref_of_json ctx) ctx builtin_or_auto
         in
         Ok (BuiltinOrAuto builtin_or_auto)
     | `Assoc [ ("Dyn", dyn) ] ->
-        let* dyn = region_binder_of_json trait_decl_ref_of_json dyn in
+        let* dyn = region_binder_of_json (trait_decl_ref_of_json ctx) ctx dyn in
         Ok (Dyn dyn)
     | `Assoc [ ("Unknown", unknown) ] ->
-        let* unknown = string_of_json unknown in
+        let* unknown = string_of_json ctx unknown in
         Ok (UnknownTrait unknown)
     | _ -> Error "")
 
-and trait_ref_of_json (js : json) : (trait_ref, string) result =
+and trait_ref_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("kind", kind); ("trait_decl_ref", trait_decl_ref) ] ->
-        let* trait_id = trait_instance_id_of_json kind in
+        let* trait_id = trait_instance_id_of_json ctx kind in
         let* trait_decl_ref =
-          region_binder_of_json trait_decl_ref_of_json trait_decl_ref
+          region_binder_of_json (trait_decl_ref_of_json ctx) ctx trait_decl_ref
         in
         Ok ({ trait_id; trait_decl_ref } : trait_ref)
     | _ -> Error "")
 
-and trait_decl_ref_of_json (js : json) : (trait_decl_ref, string) result =
+and trait_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_decl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("trait_id", trait_id); ("generics", generics) ] ->
-        let* trait_decl_id = trait_decl_id_of_json trait_id in
-        let* decl_generics = generic_args_of_json generics in
+        let* trait_decl_id = trait_decl_id_of_json ctx trait_id in
+        let* decl_generics = generic_args_of_json ctx generics in
         Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
     | _ -> Error "")
 
@@ -914,9 +973,10 @@ and outlives_pred_of_json :
       'a0 'a1.
       (json -> ('a0, string) result) ->
       (json -> ('a1, string) result) ->
+      of_json_ctx ->
       json ->
       (('a0, 'a1) outlives_pred, string) result =
- fun arg0_of_json arg1_of_json js ->
+ fun arg0_of_json arg1_of_json ctx js ->
   combine_error_msgs js __FUNCTION__
     (match js with
     | `List [ x_0; x_1 ] ->
@@ -925,19 +985,20 @@ and outlives_pred_of_json :
         Ok (x_0, x_1)
     | _ -> Error "")
 
-and trait_type_constraint_of_json (js : json) :
+and trait_type_constraint_of_json (ctx : of_json_ctx) (js : json) :
     (trait_type_constraint, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("trait_ref", trait_ref); ("type_name", type_name); ("ty", ty) ]
       ->
-        let* trait_ref = trait_ref_of_json trait_ref in
-        let* type_name = trait_item_name_of_json type_name in
-        let* ty = ty_of_json ty in
+        let* trait_ref = trait_ref_of_json ctx trait_ref in
+        let* type_name = trait_item_name_of_json ctx type_name in
+        let* ty = ty_of_json ctx ty in
         Ok ({ trait_ref; type_name; ty } : trait_type_constraint)
     | _ -> Error "")
 
-and generic_args_of_json (js : json) : (generic_args, string) result =
+and generic_args_of_json (ctx : of_json_ctx) (js : json) :
+    (generic_args, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -948,15 +1009,22 @@ and generic_args_of_json (js : json) : (generic_args, string) result =
           ("trait_refs", trait_refs);
         ] ->
         let* regions =
-          vector_of_json region_id_of_json region_of_json regions
+          vector_of_json (region_id_of_json ctx) (region_of_json ctx) ctx
+            regions
         in
-        let* types = vector_of_json type_var_id_of_json ty_of_json types in
+        let* types =
+          vector_of_json (type_var_id_of_json ctx) (ty_of_json ctx) ctx types
+        in
         let* const_generics =
-          vector_of_json const_generic_var_id_of_json const_generic_of_json
-            const_generics
+          vector_of_json
+            (const_generic_var_id_of_json ctx)
+            (const_generic_of_json ctx)
+            ctx const_generics
         in
         let* trait_refs =
-          vector_of_json trait_clause_id_of_json trait_ref_of_json trait_refs
+          vector_of_json
+            (trait_clause_id_of_json ctx)
+            (trait_ref_of_json ctx) ctx trait_refs
         in
         Ok ({ regions; types; const_generics; trait_refs } : generic_args)
     | _ -> Error "")
@@ -964,14 +1032,16 @@ and generic_args_of_json (js : json) : (generic_args, string) result =
 and region_binder_of_json :
       'a0.
       (json -> ('a0, string) result) ->
+      of_json_ctx ->
       json ->
       ('a0 region_binder, string) result =
- fun arg0_of_json js ->
+ fun arg0_of_json ctx js ->
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("regions", regions); ("skip_binder", skip_binder) ] ->
         let* binder_regions =
-          vector_of_json region_id_of_json region_var_of_json regions
+          vector_of_json (region_id_of_json ctx) (region_var_of_json ctx) ctx
+            regions
         in
         let* binder_value = arg0_of_json skip_binder in
         Ok ({ binder_regions; binder_value } : _ region_binder)
@@ -992,35 +1062,43 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
           ("trait_type_constraints", trait_type_constraints);
         ] ->
         let* regions =
-          vector_of_json region_id_of_json region_var_of_json regions
+          vector_of_json (region_id_of_json ctx) (region_var_of_json ctx) ctx
+            regions
         in
         let* types =
-          vector_of_json type_var_id_of_json type_var_of_json types
+          vector_of_json (type_var_id_of_json ctx) (type_var_of_json ctx) ctx
+            types
         in
         let* const_generics =
-          vector_of_json const_generic_var_id_of_json const_generic_var_of_json
-            const_generics
+          vector_of_json
+            (const_generic_var_id_of_json ctx)
+            (const_generic_var_of_json ctx)
+            ctx const_generics
         in
         let* trait_clauses =
-          vector_of_json trait_clause_id_of_json (trait_clause_of_json ctx)
-            trait_clauses
+          vector_of_json
+            (trait_clause_id_of_json ctx)
+            (trait_clause_of_json ctx) ctx trait_clauses
         in
         let* regions_outlive =
           list_of_json
             (region_binder_of_json
-               (outlives_pred_of_json region_of_json region_of_json))
-            regions_outlive
+               (outlives_pred_of_json (region_of_json ctx) (region_of_json ctx)
+                  ctx)
+               ctx)
+            ctx regions_outlive
         in
         let* types_outlive =
           list_of_json
             (region_binder_of_json
-               (outlives_pred_of_json ty_of_json region_of_json))
-            types_outlive
+               (outlives_pred_of_json (ty_of_json ctx) (region_of_json ctx) ctx)
+               ctx)
+            ctx types_outlive
         in
         let* trait_type_constraints =
           list_of_json
-            (region_binder_of_json trait_type_constraint_of_json)
-            trait_type_constraints
+            (region_binder_of_json (trait_type_constraint_of_json ctx) ctx)
+            ctx trait_type_constraints
         in
         Ok
           ({
@@ -1035,14 +1113,15 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
             : generic_params)
     | _ -> Error "")
 
-and existential_predicate_of_json (js : json) :
+and existential_predicate_of_json (ctx : of_json_ctx) (js : json) :
     (existential_predicate, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with `Null -> Ok () | _ -> Error "")
 
-and trait_clause_id_of_json (js : json) : (trait_clause_id, string) result =
+and trait_clause_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_clause_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> TraitClauseId.id_of_json x | _ -> Error "")
+    (match js with x -> TraitClauseId.id_of_json ctx x | _ -> Error "")
 
 and trait_clause_of_json (ctx : of_json_ctx) (js : json) :
     (trait_clause, string) result =
@@ -1055,9 +1134,11 @@ and trait_clause_of_json (ctx : of_json_ctx) (js : json) :
           ("origin", _);
           ("trait_", trait);
         ] ->
-        let* clause_id = trait_clause_id_of_json clause_id in
-        let* span = option_of_json (span_of_json ctx) span in
-        let* trait = region_binder_of_json trait_decl_ref_of_json trait in
+        let* clause_id = trait_clause_id_of_json ctx clause_id in
+        let* span = option_of_json (span_of_json ctx) ctx span in
+        let* trait =
+          region_binder_of_json (trait_decl_ref_of_json ctx) ctx trait
+        in
         Ok ({ clause_id; span; trait } : trait_clause)
     | _ -> Error "")
 
@@ -1072,7 +1153,7 @@ and type_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("generics", generics);
           ("kind", kind);
         ] ->
-        let* def_id = type_decl_id_of_json def_id in
+        let* def_id = type_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* generics = generic_params_of_json ctx generics in
         let* kind = type_decl_kind_of_json ctx kind in
@@ -1085,25 +1166,25 @@ and type_decl_kind_of_json (ctx : of_json_ctx) (js : json) :
     (match js with
     | `Assoc [ ("Struct", struct_) ] ->
         let* struct_ =
-          vector_of_json field_id_of_json (field_of_json ctx) struct_
+          vector_of_json (field_id_of_json ctx) (field_of_json ctx) ctx struct_
         in
         Ok (Struct struct_)
     | `Assoc [ ("Enum", enum) ] ->
         let* enum =
-          vector_of_json variant_id_of_json (variant_of_json ctx) enum
+          vector_of_json (variant_id_of_json ctx) (variant_of_json ctx) ctx enum
         in
         Ok (Enum enum)
     | `Assoc [ ("Union", union) ] ->
         let* union =
-          vector_of_json field_id_of_json (field_of_json ctx) union
+          vector_of_json (field_id_of_json ctx) (field_of_json ctx) ctx union
         in
         Ok (Union union)
     | `String "Opaque" -> Ok Opaque
     | `Assoc [ ("Alias", alias) ] ->
-        let* alias = ty_of_json alias in
+        let* alias = ty_of_json ctx alias in
         Ok (Alias alias)
     | `Assoc [ ("Error", error) ] ->
-        let* error = string_of_json error in
+        let* error = string_of_json ctx error in
         Ok (Error error)
     | _ -> Error "")
 
@@ -1119,12 +1200,12 @@ and variant_of_json (ctx : of_json_ctx) (js : json) : (variant, string) result =
           ("discriminant", discriminant);
         ] ->
         let* span = span_of_json ctx span in
-        let* attr_info = attr_info_of_json attr_info in
-        let* variant_name = string_of_json name in
+        let* attr_info = attr_info_of_json ctx attr_info in
+        let* variant_name = string_of_json ctx name in
         let* fields =
-          vector_of_json field_id_of_json (field_of_json ctx) fields
+          vector_of_json (field_id_of_json ctx) (field_of_json ctx) ctx fields
         in
-        let* discriminant = scalar_value_of_json discriminant in
+        let* discriminant = scalar_value_of_json ctx discriminant in
         Ok ({ span; attr_info; variant_name; fields; discriminant } : variant)
     | _ -> Error "")
 
@@ -1135,13 +1216,14 @@ and field_of_json (ctx : of_json_ctx) (js : json) : (field, string) result =
         [ ("span", span); ("attr_info", attr_info); ("name", name); ("ty", ty) ]
       ->
         let* span = span_of_json ctx span in
-        let* attr_info = attr_info_of_json attr_info in
-        let* field_name = option_of_json string_of_json name in
-        let* field_ty = ty_of_json ty in
+        let* attr_info = attr_info_of_json ctx attr_info in
+        let* field_name = option_of_json (string_of_json ctx) ctx name in
+        let* field_ty = ty_of_json ctx ty in
         Ok ({ span; attr_info; field_name; field_ty } : field)
     | _ -> Error "")
 
-and integer_type_of_json (js : json) : (integer_type, string) result =
+and integer_type_of_json (ctx : of_json_ctx) (js : json) :
+    (integer_type, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Isize" -> Ok Isize
@@ -1158,7 +1240,8 @@ and integer_type_of_json (js : json) : (integer_type, string) result =
     | `String "U128" -> Ok U128
     | _ -> Error "")
 
-and float_type_of_json (js : json) : (float_type, string) result =
+and float_type_of_json (ctx : of_json_ctx) (js : json) :
+    (float_type, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "F16" -> Ok F16
@@ -1167,90 +1250,97 @@ and float_type_of_json (js : json) : (float_type, string) result =
     | `String "F128" -> Ok F128
     | _ -> Error "")
 
-and ref_kind_of_json (js : json) : (ref_kind, string) result =
+and ref_kind_of_json (ctx : of_json_ctx) (js : json) : (ref_kind, string) result
+    =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Mut" -> Ok RMut
     | `String "Shared" -> Ok RShared
     | _ -> Error "")
 
-and type_id_of_json (js : json) : (type_id, string) result =
+and type_id_of_json (ctx : of_json_ctx) (js : json) : (type_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Adt", adt) ] ->
-        let* adt = type_decl_id_of_json adt in
+        let* adt = type_decl_id_of_json ctx adt in
         Ok (TAdtId adt)
     | `String "Tuple" -> Ok TTuple
     | `Assoc [ ("Builtin", builtin) ] ->
-        let* builtin = builtin_ty_of_json builtin in
+        let* builtin = builtin_ty_of_json ctx builtin in
         Ok (TBuiltin builtin)
     | _ -> Error "")
 
-and literal_type_of_json (js : json) : (literal_type, string) result =
+and literal_type_of_json (ctx : of_json_ctx) (js : json) :
+    (literal_type, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Integer", integer) ] ->
-        let* integer = integer_type_of_json integer in
+        let* integer = integer_type_of_json ctx integer in
         Ok (TInteger integer)
     | `Assoc [ ("Float", float_) ] ->
-        let* float_ = float_type_of_json float_ in
+        let* float_ = float_type_of_json ctx float_ in
         Ok (TFloat float_)
     | `String "Bool" -> Ok TBool
     | `String "Char" -> Ok TChar
     | _ -> Error "")
 
-and const_generic_of_json (js : json) : (const_generic, string) result =
+and const_generic_of_json (ctx : of_json_ctx) (js : json) :
+    (const_generic, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_id_of_json global in
+        let* global = global_decl_id_of_json ctx global in
         Ok (CgGlobal global)
     | `Assoc [ ("Var", var) ] ->
-        let* var = const_generic_var_id_of_json var in
+        let* var = const_generic_var_id_of_json ctx var in
         Ok (CgVar var)
     | `Assoc [ ("Value", value) ] ->
-        let* value = literal_of_json value in
+        let* value = literal_of_json ctx value in
         Ok (CgValue value)
     | _ -> Error "")
 
-and ty_of_json (js : json) : (ty, string) result =
+and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Adt", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = type_id_of_json x_0 in
-        let* x_1 = generic_args_of_json x_1 in
+        let* x_0 = type_id_of_json ctx x_0 in
+        let* x_1 = generic_args_of_json ctx x_1 in
         Ok (TAdt (x_0, x_1))
     | `Assoc [ ("TypeVar", type_var) ] ->
-        let* type_var = type_var_id_of_json type_var in
+        let* type_var = type_var_id_of_json ctx type_var in
         Ok (TVar type_var)
     | `Assoc [ ("Literal", literal) ] ->
-        let* literal = literal_type_of_json literal in
+        let* literal = literal_type_of_json ctx literal in
         Ok (TLiteral literal)
     | `String "Never" -> Ok TNever
     | `Assoc [ ("Ref", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = region_of_json x_0 in
-        let* x_1 = ty_of_json x_1 in
-        let* x_2 = ref_kind_of_json x_2 in
+        let* x_0 = region_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
+        let* x_2 = ref_kind_of_json ctx x_2 in
         Ok (TRef (x_0, x_1, x_2))
     | `Assoc [ ("RawPtr", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = ty_of_json x_0 in
-        let* x_1 = ref_kind_of_json x_1 in
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ref_kind_of_json ctx x_1 in
         Ok (TRawPtr (x_0, x_1))
     | `Assoc [ ("TraitType", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_ref_of_json x_0 in
-        let* x_1 = trait_item_name_of_json x_1 in
+        let* x_0 = trait_ref_of_json ctx x_0 in
+        let* x_1 = trait_item_name_of_json ctx x_1 in
         Ok (TTraitType (x_0, x_1))
     | `Assoc [ ("DynTrait", dyn_trait) ] ->
-        let* dyn_trait = existential_predicate_of_json dyn_trait in
+        let* dyn_trait = existential_predicate_of_json ctx dyn_trait in
         Ok (TDynTrait dyn_trait)
     | `Assoc [ ("Arrow", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = vector_of_json region_id_of_json region_var_of_json x_0 in
-        let* x_1 = list_of_json ty_of_json x_1 in
-        let* x_2 = ty_of_json x_2 in
+        let* x_0 =
+          vector_of_json (region_id_of_json ctx) (region_var_of_json ctx) ctx
+            x_0
+        in
+        let* x_1 = list_of_json (ty_of_json ctx) ctx x_1 in
+        let* x_2 = ty_of_json ctx x_2 in
         Ok (TArrow (x_0, x_1, x_2))
     | _ -> Error "")
 
-and builtin_ty_of_json (js : json) : (builtin_ty, string) result =
+and builtin_ty_of_json (ctx : of_json_ctx) (js : json) :
+    (builtin_ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Box" -> Ok TBox
@@ -1259,7 +1349,8 @@ and builtin_ty_of_json (js : json) : (builtin_ty, string) result =
     | `String "Str" -> Ok TStr
     | _ -> Error "")
 
-and params_info_of_json (js : json) : (params_info, string) result =
+and params_info_of_json (ctx : of_json_ctx) (js : json) :
+    (params_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc
@@ -1272,14 +1363,16 @@ and params_info_of_json (js : json) : (params_info, string) result =
           ("num_types_outlive", num_types_outlive);
           ("num_trait_type_constraints", num_trait_type_constraints);
         ] ->
-        let* num_region_params = int_of_json num_region_params in
-        let* num_type_params = int_of_json num_type_params in
-        let* num_const_generic_params = int_of_json num_const_generic_params in
-        let* num_trait_clauses = int_of_json num_trait_clauses in
-        let* num_regions_outlive = int_of_json num_regions_outlive in
-        let* num_types_outlive = int_of_json num_types_outlive in
+        let* num_region_params = int_of_json ctx num_region_params in
+        let* num_type_params = int_of_json ctx num_type_params in
+        let* num_const_generic_params =
+          int_of_json ctx num_const_generic_params
+        in
+        let* num_trait_clauses = int_of_json ctx num_trait_clauses in
+        let* num_regions_outlive = int_of_json ctx num_regions_outlive in
+        let* num_types_outlive = int_of_json ctx num_types_outlive in
         let* num_trait_type_constraints =
-          int_of_json num_trait_type_constraints
+          int_of_json ctx num_trait_type_constraints
         in
         Ok
           ({
@@ -1294,7 +1387,8 @@ and params_info_of_json (js : json) : (params_info, string) result =
             : params_info)
     | _ -> Error "")
 
-and closure_kind_of_json (js : json) : (closure_kind, string) result =
+and closure_kind_of_json (ctx : of_json_ctx) (js : json) :
+    (closure_kind, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Fn" -> Ok Fn
@@ -1302,12 +1396,15 @@ and closure_kind_of_json (js : json) : (closure_kind, string) result =
     | `String "FnOnce" -> Ok FnOnce
     | _ -> Error "")
 
-and closure_info_of_json (js : json) : (closure_info, string) result =
+and closure_info_of_json (ctx : of_json_ctx) (js : json) :
+    (closure_info, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("kind", kind); ("state", state) ] ->
-        let* kind = closure_kind_of_json kind in
-        let* state = vector_of_json type_var_id_of_json ty_of_json state in
+        let* kind = closure_kind_of_json ctx kind in
+        let* state =
+          vector_of_json (type_var_id_of_json ctx) (ty_of_json ctx) ctx state
+        in
         Ok ({ kind; state } : closure_info)
     | _ -> Error "")
 
@@ -1324,15 +1421,17 @@ and fun_sig_of_json (ctx : of_json_ctx) (js : json) : (fun_sig, string) result =
           ("inputs", inputs);
           ("output", output);
         ] ->
-        let* is_unsafe = bool_of_json is_unsafe in
-        let* is_closure = bool_of_json is_closure in
-        let* closure_info = option_of_json closure_info_of_json closure_info in
+        let* is_unsafe = bool_of_json ctx is_unsafe in
+        let* is_closure = bool_of_json ctx is_closure in
+        let* closure_info =
+          option_of_json (closure_info_of_json ctx) ctx closure_info
+        in
         let* generics = generic_params_of_json ctx generics in
         let* parent_params_info =
-          option_of_json params_info_of_json parent_params_info
+          option_of_json (params_info_of_json ctx) ctx parent_params_info
         in
-        let* inputs = list_of_json ty_of_json inputs in
-        let* output = ty_of_json output in
+        let* inputs = list_of_json (ty_of_json ctx) ctx inputs in
+        let* output = ty_of_json ctx output in
         Ok
           ({
              is_unsafe;
@@ -1346,34 +1445,35 @@ and fun_sig_of_json (ctx : of_json_ctx) (js : json) : (fun_sig, string) result =
             : fun_sig)
     | _ -> Error "")
 
-and var_id_of_json (js : json) : (var_id, string) result =
+and var_id_of_json (ctx : of_json_ctx) (js : json) : (var_id, string) result =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> VarId.id_of_json x | _ -> Error "")
+    (match js with x -> VarId.id_of_json ctx x | _ -> Error "")
 
-and literal_of_json (js : json) : (literal, string) result =
+and literal_of_json (ctx : of_json_ctx) (js : json) : (literal, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Scalar", scalar) ] ->
-        let* scalar = scalar_value_of_json scalar in
+        let* scalar = scalar_value_of_json ctx scalar in
         Ok (VScalar scalar)
     | `Assoc [ ("Float", float_) ] ->
-        let* float_ = float_value_of_json float_ in
+        let* float_ = float_value_of_json ctx float_ in
         Ok (VFloat float_)
     | `Assoc [ ("Bool", bool_) ] ->
-        let* bool_ = bool_of_json bool_ in
+        let* bool_ = bool_of_json ctx bool_ in
         Ok (VBool bool_)
     | `Assoc [ ("Char", char_) ] ->
-        let* char_ = char_of_json char_ in
+        let* char_ = char_of_json ctx char_ in
         Ok (VChar char_)
     | `Assoc [ ("ByteStr", byte_str) ] ->
-        let* byte_str = list_of_json int_of_json byte_str in
+        let* byte_str = list_of_json (int_of_json ctx) ctx byte_str in
         Ok (VByteStr byte_str)
     | `Assoc [ ("Str", str) ] ->
-        let* str = string_of_json str in
+        let* str = string_of_json ctx str in
         Ok (VStr str)
     | _ -> Error "")
 
-and scalar_value_of_json (js : json) : (scalar_value, string) result =
+and scalar_value_of_json (ctx : of_json_ctx) (js : json) :
+    (scalar_value, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ (ty, bi) ] ->
@@ -1385,19 +1485,20 @@ and scalar_value_of_json (js : json) : (scalar_value, string) result =
             | _ -> Error "")
         in
         let* value = big_int_of_json bi in
-        let* int_ty = integer_type_of_json (`String ty) in
+        let* int_ty = integer_type_of_json ctx (`String ty) in
         let sv = { value; int_ty } in
         if not (check_scalar_value_in_range sv) then
           raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv));
         Ok sv
     | _ -> Error "")
 
-and float_value_of_json (js : json) : (float_value, string) result =
+and float_value_of_json (ctx : of_json_ctx) (js : json) :
+    (float_value, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("value", value); ("ty", ty) ] ->
-        let* float_value = string_of_json value in
-        let* float_ty = float_type_of_json ty in
+        let* float_value = string_of_json ctx value in
+        let* float_ty = float_type_of_json ctx ty in
         Ok ({ float_value; float_ty } : float_value)
     | _ -> Error "")
 
@@ -1405,67 +1506,76 @@ and vector_of_json :
       'a0 'a1.
       (json -> ('a0, string) result) ->
       (json -> ('a1, string) result) ->
+      of_json_ctx ->
       json ->
       (('a0, 'a1) vector, string) result =
- fun arg0_of_json arg1_of_json js ->
+ fun arg0_of_json arg1_of_json ctx js ->
   combine_error_msgs js __FUNCTION__
     (match js with
     | js ->
-        let* list = list_of_json (option_of_json arg1_of_json) js in
+        let* list = list_of_json (option_of_json arg1_of_json ctx) ctx js in
         Ok (List.filter_map (fun x -> x) list)
     | _ -> Error "")
 
-and declaration_group_of_json (js : json) : (declaration_group, string) result =
+and declaration_group_of_json (ctx : of_json_ctx) (js : json) :
+    (declaration_group, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Type", type_) ] ->
-        let* type_ = g_declaration_group_of_json type_decl_id_of_json type_ in
+        let* type_ =
+          g_declaration_group_of_json (type_decl_id_of_json ctx) ctx type_
+        in
         Ok (TypeGroup type_)
     | `Assoc [ ("Fun", fun_) ] ->
-        let* fun_ = g_declaration_group_of_json fun_decl_id_of_json fun_ in
+        let* fun_ =
+          g_declaration_group_of_json (fun_decl_id_of_json ctx) ctx fun_
+        in
         Ok (FunGroup fun_)
     | `Assoc [ ("Global", global) ] ->
         let* global =
-          g_declaration_group_of_json global_decl_id_of_json global
+          g_declaration_group_of_json (global_decl_id_of_json ctx) ctx global
         in
         Ok (GlobalGroup global)
     | `Assoc [ ("TraitDecl", trait_decl) ] ->
         let* trait_decl =
-          g_declaration_group_of_json trait_decl_id_of_json trait_decl
+          g_declaration_group_of_json (trait_decl_id_of_json ctx) ctx trait_decl
         in
         Ok (TraitDeclGroup trait_decl)
     | `Assoc [ ("TraitImpl", trait_impl) ] ->
         let* trait_impl =
-          g_declaration_group_of_json trait_impl_id_of_json trait_impl
+          g_declaration_group_of_json (trait_impl_id_of_json ctx) ctx trait_impl
         in
         Ok (TraitImplGroup trait_impl)
     | `Assoc [ ("Mixed", mixed) ] ->
-        let* mixed = g_declaration_group_of_json any_decl_id_of_json mixed in
+        let* mixed =
+          g_declaration_group_of_json (any_decl_id_of_json ctx) ctx mixed
+        in
         Ok (MixedGroup mixed)
     | _ -> Error "")
 
 and g_declaration_group_of_json :
       'a0.
       (json -> ('a0, string) result) ->
+      of_json_ctx ->
       json ->
       ('a0 g_declaration_group, string) result =
- fun arg0_of_json js ->
+ fun arg0_of_json ctx js ->
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("NonRec", non_rec) ] ->
         let* non_rec = arg0_of_json non_rec in
         Ok (NonRecGroup non_rec)
     | `Assoc [ ("Rec", rec_) ] ->
-        let* rec_ = list_of_json arg0_of_json rec_ in
+        let* rec_ = list_of_json arg0_of_json ctx rec_ in
         Ok (RecGroup rec_)
     | _ -> Error "")
 
 and maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
-    (js : json) : ('body gexpr_body option, string) result =
+    (ctx : of_json_ctx) (js : json) : ('body gexpr_body option, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Ok", body) ] ->
-        let* body_id = BodyId.id_of_json body in
+        let* body_id = BodyId.id_of_json ctx body in
         let body = List.nth bodies (BodyId.to_int body_id) in
         Ok body
     | `Assoc [ ("Err", `Null) ] -> Ok None
@@ -1485,14 +1595,14 @@ and gfun_decl_of_json (bodies : 'body gexpr_body option list)
           ("is_global_initializer", is_global_initializer);
           ("body", body);
         ] ->
-        let* def_id = FunDeclId.id_of_json def_id in
+        let* def_id = FunDeclId.id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* signature = fun_sig_of_json ctx signature in
-        let* kind = item_kind_of_json kind in
+        let* kind = item_kind_of_json ctx kind in
         let* is_global_initializer =
-          option_of_json global_decl_id_of_json is_global_initializer
+          option_of_json (global_decl_id_of_json ctx) ctx is_global_initializer
         in
-        let* body = maybe_opaque_body_of_json bodies body in
+        let* body = maybe_opaque_body_of_json bodies ctx body in
         Ok { def_id; item_meta; signature; kind; is_global_initializer; body }
     | _ -> Error "")
 
@@ -1508,7 +1618,9 @@ and id_to_file_of_json (js : json) : (of_json_ctx, string) result =
   combine_error_msgs js __FUNCTION__
     ((* The map is stored as a list of pairs (key, value): we deserialize
       * this list then convert it to a map *)
-     let* files = list_of_json (option_of_json file_of_json) js in
+     let* files =
+       list_of_json (option_of_json (file_of_json FileId.Map.empty) ()) () js
+     in
      let files_with_ids =
        List.filter_map
          (fun (i, file) ->
@@ -1538,33 +1650,38 @@ and gtranslated_crate_of_json
           ("trait_impls", trait_impls);
           ("ordered_decls", declarations);
         ] ->
-        let* name = string_of_json name in
         let* ctx = id_to_file_of_json files in
+        let* name = string_of_json ctx name in
 
         let* declarations =
-          list_of_json declaration_group_of_json declarations
+          list_of_json (declaration_group_of_json ctx) ctx declarations
         in
 
-        let* bodies = list_of_json (option_of_json (body_of_json ctx)) bodies in
+        let* bodies =
+          list_of_json (option_of_json (body_of_json ctx) ctx) ctx bodies
+        in
         let* types =
-          vector_of_json type_id_of_json (type_decl_of_json ctx) types
+          vector_of_json (type_id_of_json ctx) (type_decl_of_json ctx) ctx types
         in
         let* functions =
-          vector_of_json fun_decl_id_of_json
+          vector_of_json (fun_decl_id_of_json ctx)
             (gfun_decl_of_json bodies ctx)
-            functions
+            ctx functions
         in
         let* globals =
-          vector_of_json global_decl_id_of_json (global_decl_of_json ctx)
-            globals
+          vector_of_json
+            (global_decl_id_of_json ctx)
+            (global_decl_of_json ctx) ctx globals
         in
         let* trait_decls =
-          vector_of_json trait_decl_id_of_json (trait_decl_of_json ctx)
-            trait_decls
+          vector_of_json
+            (trait_decl_id_of_json ctx)
+            (trait_decl_of_json ctx) ctx trait_decls
         in
         let* trait_impls =
-          vector_of_json trait_impl_id_of_json (trait_impl_of_json ctx)
-            trait_impls
+          vector_of_json
+            (trait_impl_id_of_json ctx)
+            (trait_impl_of_json ctx) ctx trait_impls
         in
 
         let type_decls =
@@ -1606,7 +1723,7 @@ and gcrate_of_json
   match js with
   | `Assoc [ ("charon_version", charon_version); ("translated", translated) ] ->
       (* Ensure the version is the one we support. *)
-      let* charon_version = string_of_json charon_version in
+      let* charon_version = string_of_json () charon_version in
       if
         not (String.equal charon_version CharonVersion.supported_charon_version)
       then

--- a/charon-ml/src/Identifiers.ml
+++ b/charon-ml/src/Identifiers.ml
@@ -56,7 +56,7 @@ module type Id = sig
   val to_string : id -> string
   val pp_id : Format.formatter -> id -> unit
   val show_id : id -> string
-  val id_of_json : Yojson.Basic.t -> (id, string) result
+  val id_of_json : 'ctx -> Yojson.Basic.t -> (id, string) result
   val compare_id : id -> id -> int
   val max : id -> id -> id
   val min : id -> id -> id

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -10,7 +10,7 @@ open LlbcAst
 
 let rec ___ = ()
 
-and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
+and raw_statement_of_json (ctx : of_json_ctx) (js : json) :
     (raw_statement, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -44,17 +44,17 @@ and raw_statement_of_json (id_to_file : id_to_file_map) (js : json) :
         Ok (Continue i)
     | `String "Nop" -> Ok Nop
     | `Assoc [ ("Switch", tgt) ] ->
-        let* switch = switch_of_json id_to_file tgt in
+        let* switch = switch_of_json ctx tgt in
         Ok (Switch switch)
     | `Assoc [ ("Loop", st) ] ->
-        let* st = block_of_json id_to_file st in
+        let* st = block_of_json ctx st in
         Ok (Loop st)
     | `Assoc [ ("Error", s) ] ->
         let* s = string_of_json s in
         Ok (Error s)
     | _ -> Error "")
 
-and statement_of_json (id_to_file : id_to_file_map) (js : json) :
+and statement_of_json (ctx : of_json_ctx) (js : json) :
     (statement, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -64,21 +64,18 @@ and statement_of_json (id_to_file : id_to_file_map) (js : json) :
           ("content", content);
           ("comments_before", comments_before);
         ] ->
-        let* span = span_of_json id_to_file span in
-        let* content = raw_statement_of_json id_to_file content in
+        let* span = span_of_json ctx span in
+        let* content = raw_statement_of_json ctx content in
         let* comments_before = list_of_json string_of_json comments_before in
         Ok ({ span; content; comments_before } : statement)
     | _ -> Error "")
 
-and block_of_json (id_to_file : id_to_file_map) (js : json) :
-    (block, string) result =
+and block_of_json (ctx : of_json_ctx) (js : json) : (block, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("span", span); ("statements", statements) ] -> begin
-        let* span = span_of_json id_to_file span in
-        let* statements =
-          list_of_json (statement_of_json id_to_file) statements
-        in
+        let* span = span_of_json ctx span in
+        let* statements = list_of_json (statement_of_json ctx) statements in
         match List.rev statements with
         | [] -> Ok { span; content = Nop; comments_before = [] }
         | last :: rest ->
@@ -96,14 +93,13 @@ and block_of_json (id_to_file : id_to_file_map) (js : json) :
       end
     | _ -> Error "")
 
-and switch_of_json (id_to_file : id_to_file_map) (js : json) :
-    (switch, string) result =
+and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("If", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = operand_of_json x_0 in
-        let* x_1 = block_of_json id_to_file x_1 in
-        let* x_2 = block_of_json id_to_file x_2 in
+        let* x_1 = block_of_json ctx x_1 in
+        let* x_2 = block_of_json ctx x_2 in
         Ok (If (x_0, x_1, x_2))
     | `Assoc [ ("SwitchInt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
         let* x_0 = operand_of_json x_0 in
@@ -112,32 +108,28 @@ and switch_of_json (id_to_file : id_to_file_map) (js : json) :
           list_of_json
             (pair_of_json
                (list_of_json scalar_value_of_json)
-               (block_of_json id_to_file))
+               (block_of_json ctx))
             x_2
         in
-        let* x_3 = block_of_json id_to_file x_3 in
+        let* x_3 = block_of_json ctx x_3 in
         Ok (SwitchInt (x_0, x_1, x_2, x_3))
     | `Assoc [ ("Match", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = place_of_json x_0 in
         let* x_1 =
           list_of_json
-            (pair_of_json
-               (list_of_json variant_id_of_json)
-               (block_of_json id_to_file))
+            (pair_of_json (list_of_json variant_id_of_json) (block_of_json ctx))
             x_1
         in
-        let* x_2 = option_of_json (block_of_json id_to_file) x_2 in
+        let* x_2 = option_of_json (block_of_json ctx) x_2 in
         Ok (Match (x_0, x_1, x_2))
     | _ -> Error "")
 
-let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
+let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     (expr_body, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Structured", body) ] ->
-        let* body =
-          gexpr_body_of_json (block_of_json id_to_file) id_to_file body
-        in
+        let* body = gexpr_body_of_json (block_of_json ctx) ctx body in
         Ok body
     | _ -> Error "")
 

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -15,32 +15,32 @@ and raw_statement_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Assign", `List [ place; rvalue ]) ] ->
-        let* place = place_of_json place in
-        let* rvalue = rvalue_of_json rvalue in
+        let* place = place_of_json ctx place in
+        let* rvalue = rvalue_of_json ctx rvalue in
         Ok (Assign (place, rvalue))
     | `Assoc [ ("FakeRead", place) ] ->
-        let* place = place_of_json place in
+        let* place = place_of_json ctx place in
         Ok (FakeRead place)
     | `Assoc [ ("SetDiscriminant", `List [ place; variant_id ]) ] ->
-        let* place = place_of_json place in
-        let* variant_id = VariantId.id_of_json variant_id in
+        let* place = place_of_json ctx place in
+        let* variant_id = VariantId.id_of_json ctx variant_id in
         Ok (SetDiscriminant (place, variant_id))
     | `Assoc [ ("Drop", place) ] ->
-        let* place = place_of_json place in
+        let* place = place_of_json ctx place in
         Ok (Drop place)
     | `Assoc [ ("Assert", assertion) ] ->
-        let* assertion = assertion_of_json assertion in
+        let* assertion = assertion_of_json ctx assertion in
         Ok (Assert assertion)
     | `Assoc [ ("Call", call) ] ->
-        let* call = call_of_json call in
+        let* call = call_of_json ctx call in
         Ok (Call call)
     | `Assoc [ ("Abort", _) ] -> Ok Panic
     | `String "Return" -> Ok Return
     | `Assoc [ ("Break", i) ] ->
-        let* i = int_of_json i in
+        let* i = int_of_json ctx i in
         Ok (Break i)
     | `Assoc [ ("Continue", i) ] ->
-        let* i = int_of_json i in
+        let* i = int_of_json ctx i in
         Ok (Continue i)
     | `String "Nop" -> Ok Nop
     | `Assoc [ ("Switch", tgt) ] ->
@@ -50,7 +50,7 @@ and raw_statement_of_json (ctx : of_json_ctx) (js : json) :
         let* st = block_of_json ctx st in
         Ok (Loop st)
     | `Assoc [ ("Error", s) ] ->
-        let* s = string_of_json s in
+        let* s = string_of_json ctx s in
         Ok (Error s)
     | _ -> Error "")
 
@@ -66,7 +66,9 @@ and statement_of_json (ctx : of_json_ctx) (js : json) :
         ] ->
         let* span = span_of_json ctx span in
         let* content = raw_statement_of_json ctx content in
-        let* comments_before = list_of_json string_of_json comments_before in
+        let* comments_before =
+          list_of_json (string_of_json ctx) ctx comments_before
+        in
         Ok ({ span; content; comments_before } : statement)
     | _ -> Error "")
 
@@ -75,7 +77,7 @@ and block_of_json (ctx : of_json_ctx) (js : json) : (block, string) result =
     (match js with
     | `Assoc [ ("span", span); ("statements", statements) ] -> begin
         let* span = span_of_json ctx span in
-        let* statements = list_of_json (statement_of_json ctx) statements in
+        let* statements = list_of_json (statement_of_json ctx) ctx statements in
         match List.rev statements with
         | [] -> Ok { span; content = Nop; comments_before = [] }
         | last :: rest ->
@@ -97,30 +99,32 @@ and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("If", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = operand_of_json x_0 in
+        let* x_0 = operand_of_json ctx x_0 in
         let* x_1 = block_of_json ctx x_1 in
         let* x_2 = block_of_json ctx x_2 in
         Ok (If (x_0, x_1, x_2))
     | `Assoc [ ("SwitchInt", `List [ x_0; x_1; x_2; x_3 ]) ] ->
-        let* x_0 = operand_of_json x_0 in
-        let* x_1 = integer_type_of_json x_1 in
+        let* x_0 = operand_of_json ctx x_0 in
+        let* x_1 = integer_type_of_json ctx x_1 in
         let* x_2 =
           list_of_json
             (pair_of_json
-               (list_of_json scalar_value_of_json)
-               (block_of_json ctx))
-            x_2
+               (list_of_json (scalar_value_of_json ctx) ctx)
+               (block_of_json ctx) ctx)
+            ctx x_2
         in
         let* x_3 = block_of_json ctx x_3 in
         Ok (SwitchInt (x_0, x_1, x_2, x_3))
     | `Assoc [ ("Match", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = place_of_json x_0 in
+        let* x_0 = place_of_json ctx x_0 in
         let* x_1 =
           list_of_json
-            (pair_of_json (list_of_json variant_id_of_json) (block_of_json ctx))
-            x_1
+            (pair_of_json
+               (list_of_json (variant_id_of_json ctx) ctx)
+               (block_of_json ctx) ctx)
+            ctx x_1
         in
-        let* x_2 = option_of_json (block_of_json ctx) x_2 in
+        let* x_2 = option_of_json (block_of_json ctx) ctx x_2 in
         Ok (Match (x_0, x_1, x_2))
     | _ -> Error "")
 

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -67,7 +67,7 @@ and statement_of_json (ctx : of_json_ctx) (js : json) :
         let* span = span_of_json ctx span in
         let* content = raw_statement_of_json ctx content in
         let* comments_before =
-          list_of_json (string_of_json ctx) ctx comments_before
+          list_of_json string_of_json ctx comments_before
         in
         Ok ({ span; content; comments_before } : statement)
     | _ -> Error "")
@@ -77,7 +77,7 @@ and block_of_json (ctx : of_json_ctx) (js : json) : (block, string) result =
     (match js with
     | `Assoc [ ("span", span); ("statements", statements) ] -> begin
         let* span = span_of_json ctx span in
-        let* statements = list_of_json (statement_of_json ctx) ctx statements in
+        let* statements = list_of_json statement_of_json ctx statements in
         match List.rev statements with
         | [] -> Ok { span; content = Nop; comments_before = [] }
         | last :: rest ->
@@ -108,9 +108,7 @@ and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
         let* x_1 = integer_type_of_json ctx x_1 in
         let* x_2 =
           list_of_json
-            (pair_of_json
-               (list_of_json (scalar_value_of_json ctx) ctx)
-               (block_of_json ctx) ctx)
+            (pair_of_json (list_of_json scalar_value_of_json) block_of_json)
             ctx x_2
         in
         let* x_3 = block_of_json ctx x_3 in
@@ -119,12 +117,10 @@ and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
         let* x_0 = place_of_json ctx x_0 in
         let* x_1 =
           list_of_json
-            (pair_of_json
-               (list_of_json (variant_id_of_json ctx) ctx)
-               (block_of_json ctx) ctx)
+            (pair_of_json (list_of_json variant_id_of_json) block_of_json)
             ctx x_1
         in
-        let* x_2 = option_of_json (block_of_json ctx) ctx x_2 in
+        let* x_2 = option_of_json block_of_json ctx x_2 in
         Ok (Match (x_0, x_1, x_2))
     | _ -> Error "")
 
@@ -133,7 +129,7 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Structured", body) ] ->
-        let* body = gexpr_body_of_json (block_of_json ctx) ctx body in
+        let* body = gexpr_body_of_json block_of_json ctx body in
         Ok body
     | _ -> Error "")
 

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -11,44 +11,46 @@ open UllbcAst
 
 let rec ___ = ()
 
-and block_id_of_json (js : json) : (block_id, string) result =
+and block_id_of_json (ctx : of_json_ctx) (js : json) : (block_id, string) result
+    =
   combine_error_msgs js __FUNCTION__
-    (match js with x -> BlockId.id_of_json x | _ -> Error "")
+    (match js with x -> BlockId.id_of_json ctx x | _ -> Error "")
 
 and blocks_of_json (ctx : of_json_ctx) (js : json) : (blocks, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | x -> vector_of_json block_id_of_json (block_of_json ctx) x
+    | x -> vector_of_json (block_id_of_json ctx) (block_of_json ctx) ctx x
     | _ -> Error "")
 
-and raw_statement_of_json (js : json) : (raw_statement, string) result =
+and raw_statement_of_json (ctx : of_json_ctx) (js : json) :
+    (raw_statement, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Assign", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = rvalue_of_json x_1 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = rvalue_of_json ctx x_1 in
         Ok (Assign (x_0, x_1))
     | `Assoc [ ("Call", call) ] ->
-        let* call = call_of_json call in
+        let* call = call_of_json ctx call in
         Ok (Call call)
     | `Assoc [ ("FakeRead", fake_read) ] ->
-        let* fake_read = place_of_json fake_read in
+        let* fake_read = place_of_json ctx fake_read in
         Ok (FakeRead fake_read)
     | `Assoc [ ("SetDiscriminant", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = place_of_json x_0 in
-        let* x_1 = variant_id_of_json x_1 in
+        let* x_0 = place_of_json ctx x_0 in
+        let* x_1 = variant_id_of_json ctx x_1 in
         Ok (SetDiscriminant (x_0, x_1))
     | `Assoc [ ("StorageDead", storage_dead) ] ->
-        let* storage_dead = var_id_of_json storage_dead in
+        let* storage_dead = var_id_of_json ctx storage_dead in
         Ok (StorageDead storage_dead)
     | `Assoc [ ("Deinit", deinit) ] ->
-        let* deinit = place_of_json deinit in
+        let* deinit = place_of_json ctx deinit in
         Ok (Deinit deinit)
     | `Assoc [ ("Drop", drop) ] ->
-        let* drop = place_of_json drop in
+        let* drop = place_of_json ctx drop in
         Ok (Drop drop)
     | `Assoc [ ("Assert", assert_) ] ->
-        let* assert_ = assertion_of_json assert_ in
+        let* assert_ = assertion_of_json ctx assert_ in
         Ok (Assert assert_)
     | `String "Nop" -> Ok Nop
     | _ -> Error "")
@@ -59,23 +61,25 @@ and statement_of_json (ctx : of_json_ctx) (js : json) :
     (match js with
     | `Assoc [ ("span", span); ("content", content) ] ->
         let* span = span_of_json ctx span in
-        let* content = raw_statement_of_json content in
+        let* content = raw_statement_of_json ctx content in
         Ok ({ span; content } : statement)
     | _ -> Error "")
 
-and switch_of_json (js : json) : (switch, string) result =
+and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("If", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = block_id_of_json x_0 in
-        let* x_1 = block_id_of_json x_1 in
+        let* x_0 = block_id_of_json ctx x_0 in
+        let* x_1 = block_id_of_json ctx x_1 in
         Ok (If (x_0, x_1))
     | `Assoc [ ("SwitchInt", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = integer_type_of_json x_0 in
+        let* x_0 = integer_type_of_json ctx x_0 in
         let* x_1 =
-          list_of_json (pair_of_json scalar_value_of_json block_id_of_json) x_1
+          list_of_json
+            (pair_of_json (scalar_value_of_json ctx) (block_id_of_json ctx) ctx)
+            ctx x_1
         in
-        let* x_2 = block_id_of_json x_2 in
+        let* x_2 = block_id_of_json ctx x_2 in
         Ok (SwitchInt (x_0, x_1, x_2))
     | _ -> Error "")
 
@@ -84,12 +88,12 @@ and raw_terminator_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Goto", `Assoc [ ("target", target) ]) ] ->
-        let* target = block_id_of_json target in
+        let* target = block_id_of_json ctx target in
         Ok (Goto target)
     | `Assoc [ ("Switch", `Assoc [ ("discr", discr); ("targets", targets) ]) ]
       ->
-        let* discr = operand_of_json discr in
-        let* targets = switch_of_json targets in
+        let* discr = operand_of_json ctx discr in
+        let* targets = switch_of_json ctx targets in
         Ok (Switch (discr, targets))
     | `Assoc [ ("Abort", abort) ] ->
         let* abort = abort_kind_of_json ctx abort in
@@ -111,7 +115,7 @@ and block_of_json (ctx : of_json_ctx) (js : json) : (block, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("statements", statements); ("terminator", terminator) ] ->
-        let* statements = list_of_json (statement_of_json ctx) statements in
+        let* statements = list_of_json (statement_of_json ctx) ctx statements in
         let* terminator = terminator_of_json ctx terminator in
         Ok ({ statements; terminator } : block)
     | _ -> Error "")

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -19,7 +19,7 @@ and block_id_of_json (ctx : of_json_ctx) (js : json) : (block_id, string) result
 and blocks_of_json (ctx : of_json_ctx) (js : json) : (blocks, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | x -> vector_of_json (block_id_of_json ctx) (block_of_json ctx) ctx x
+    | x -> vector_of_json block_id_of_json block_of_json ctx x
     | _ -> Error "")
 
 and raw_statement_of_json (ctx : of_json_ctx) (js : json) :
@@ -76,7 +76,7 @@ and switch_of_json (ctx : of_json_ctx) (js : json) : (switch, string) result =
         let* x_0 = integer_type_of_json ctx x_0 in
         let* x_1 =
           list_of_json
-            (pair_of_json (scalar_value_of_json ctx) (block_id_of_json ctx) ctx)
+            (pair_of_json scalar_value_of_json block_id_of_json)
             ctx x_1
         in
         let* x_2 = block_id_of_json ctx x_2 in
@@ -115,7 +115,7 @@ and block_of_json (ctx : of_json_ctx) (js : json) : (block, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("statements", statements); ("terminator", terminator) ] ->
-        let* statements = list_of_json (statement_of_json ctx) ctx statements in
+        let* statements = list_of_json statement_of_json ctx statements in
         let* terminator = terminator_of_json ctx terminator in
         Ok ({ statements; terminator } : block)
     | _ -> Error "")
@@ -125,7 +125,7 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Unstructured", body) ] ->
-        let* body = gexpr_body_of_json (blocks_of_json ctx) ctx body in
+        let* body = gexpr_body_of_json blocks_of_json ctx body in
         Ok body
     | _ -> Error "")
 

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -66,61 +66,8 @@ fn type_name_to_ocaml_ident(item_meta: &ItemMeta) -> String {
     make_ocaml_ident(name)
 }
 
-/// Traverse all types to figure out which ones transitively contain the given id.
-fn contains_id(crate_data: &TranslatedCrate, haystack: TypeDeclId) -> HashMap<TypeDeclId, bool> {
-    fn traverse_ty(
-        crate_data: &TranslatedCrate,
-        ty: &TypeDecl,
-        stack: &mut Vec<TypeDeclId>,
-        map: &mut HashMap<TypeDeclId, bool>,
-    ) -> Result<bool, TypeDeclId> {
-        if let Some(x) = map.get(&ty.def_id) {
-            return Ok(*x);
-        }
-        if stack.contains(&ty.def_id) {
-            return Err(ty.def_id);
-        }
-
-        stack.push(ty.def_id);
-        let exploring_def_id = ty.def_id;
-        let mut contains = false;
-        let mut requires_parent = None;
-        ty.drive(&mut Ty::visit_inside(derive_visitor::visitor_enter_fn(
-            |id: &TypeDeclId| {
-                if let Some(ty) = crate_data.type_decls.get(*id) {
-                    match traverse_ty(crate_data, ty, stack, map) {
-                        Ok(true) => contains = true,
-                        Err(loop_id) if loop_id != exploring_def_id && stack.contains(&loop_id) => {
-                            requires_parent = Some(loop_id)
-                        }
-                        _ => {}
-                    }
-                }
-            },
-        )));
-        stack.pop();
-
-        if contains {
-            map.insert(ty.def_id, true);
-            Ok(true)
-        } else if let Some(id) = requires_parent {
-            Err(id)
-        } else {
-            map.insert(ty.def_id, false);
-            Ok(false)
-        }
-    }
-    let mut map = HashMap::new();
-    map.insert(haystack, true);
-    for ty in &crate_data.type_decls {
-        let _ = traverse_ty(crate_data, ty, &mut Vec::new(), &mut map);
-    }
-    map.into_iter().map(|(id, x)| (id, x)).collect()
-}
-
 struct GenerateCtx<'a> {
     crate_data: &'a TranslatedCrate,
-    contains_raw_span: HashMap<TypeDeclId, bool>,
     name_to_type: HashMap<String, &'a TypeDecl>,
     /// For each type, list the types it contains.
     type_tree: HashMap<TypeDeclId, HashSet<TypeDeclId>>,
@@ -161,14 +108,9 @@ impl<'a> GenerateCtx<'a> {
             )));
             type_tree.insert(ty.def_id, contained);
         }
-        let contains_raw_span = {
-            let raw_span = name_to_type.get("RawSpan").unwrap();
-            contains_id(crate_data, raw_span.def_id)
-        };
 
         let mut ctx = GenerateCtx {
             crate_data: &crate_data,
-            contains_raw_span,
             name_to_type,
             type_tree,
             manual_type_impls: Default::default(),
@@ -240,10 +182,10 @@ impl<'a> GenerateCtx<'a> {
 /// functions, e.g. `list_of_json bool_of_json`.
 fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
     match ty.kind() {
-        TyKind::Literal(LiteralTy::Bool) => "bool_of_json".to_string(),
-        TyKind::Literal(LiteralTy::Char) => "char_of_json".to_string(),
-        TyKind::Literal(LiteralTy::Integer(_)) => "int_of_json".to_string(),
-        TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
+        TyKind::Literal(LiteralTy::Bool) => "bool_of_json ctx".to_string(),
+        TyKind::Literal(LiteralTy::Char) => "char_of_json ctx".to_string(),
+        TyKind::Literal(LiteralTy::Integer(_)) => "int_of_json ctx".to_string(),
+        TyKind::Literal(LiteralTy::Float(_)) => "float_of_json ctx".to_string(),
         TyKind::Adt(adt_kind, generics) => {
             let mut expr = Vec::new();
             for ty in &generics.types {
@@ -262,7 +204,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
                     }
                     expr.insert(0, first + "_of_json");
                 }
-                TypeId::Builtin(BuiltinTy::Box) => {}
+                TypeId::Builtin(BuiltinTy::Box) => expr.insert(0, "box_of_json".to_owned()),
                 TypeId::Tuple => {
                     let name = match generics.types.len() {
                         2 => "pair_of_json".to_string(),
@@ -273,11 +215,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
                 }
                 _ => unimplemented!("{ty:?}"),
             }
-            if let TypeId::Adt(id) = adt_kind {
-                if *ctx.contains_raw_span.get(&id).unwrap_or(&false) {
-                    expr.push("ctx".to_string())
-                }
-            }
+            expr.push("ctx".to_string());
             expr.into_iter().map(|f| format!("({f})")).join(" ")
         }
         TyKind::TypeVar(var_id) => format!("arg{}_of_json", var_id.index()),
@@ -374,16 +312,10 @@ fn build_branch<'a>(
     format!("| {pat} -> {convert} Ok ({construct})")
 }
 
-fn build_function(ctx: &GenerateCtx, decl: &TypeDecl, branches: &str) -> String {
+fn build_function(_ctx: &GenerateCtx, decl: &TypeDecl, branches: &str) -> String {
     let ty_name = type_name_to_ocaml_ident(&decl.item_meta);
-    let contains_raw_span = *ctx.contains_raw_span.get(&decl.def_id).unwrap();
     let signature = if decl.generics.types.is_empty() {
-        let ctx = if contains_raw_span {
-            "(ctx : of_json_ctx) "
-        } else {
-            ""
-        };
-        format!("{ty_name}_of_json {ctx}(js : json) : ({ty_name}, string) result =")
+        format!("{ty_name}_of_json (ctx : of_json_ctx) (js : json) : ({ty_name}, string) result =")
     } else {
         let types = &decl.generics.types;
         let gen_vars_space = types
@@ -403,10 +335,8 @@ fn build_function(ctx: &GenerateCtx, decl: &TypeDecl, branches: &str) -> String 
             args.push(format!("arg{i}_of_json"));
             ty_args.push(format!("(json -> ('a{i}, string) result)"));
         }
-        if contains_raw_span {
-            args.push("ctx".to_string());
-            ty_args.push("of_json_ctx".to_string());
-        }
+        args.push("ctx".to_string());
+        ty_args.push("of_json_ctx".to_string());
         args.push("js".to_string());
         ty_args.push("json".to_string());
 
@@ -452,7 +382,7 @@ fn type_decl_to_json_deserializer(ctx: &GenerateCtx, decl: &TypeDecl) -> String 
                 .unwrap()
                 .0
                 .clone();
-            format!("| x -> {short_name}.id_of_json x")
+            format!("| x -> {short_name}.id_of_json ctx x")
         }
         TypeDeclKind::Struct(fields)
             if fields.len() == 1
@@ -1107,7 +1037,7 @@ fn generate_ml(
             indoc!(
                 r#"
                 | js ->
-                    let* list = list_of_json (option_of_json arg1_of_json) js in
+                    let* list = list_of_json (option_of_json arg1_of_json ctx) ctx js in
                     Ok (List.filter_map (fun x -> x) list)
                 "#
             ),
@@ -1118,10 +1048,10 @@ fn generate_ml(
             indoc!(
                 r#"
                 | `Assoc [ ("file_id", file_id); ("beg", beg_loc); ("end", end_loc) ] ->
-                    let* file_id = file_id_of_json file_id in
+                    let* file_id = file_id_of_json ctx file_id in
                     let file = FileId.Map.find file_id ctx in
-                    let* beg_loc = loc_of_json beg_loc in
-                    let* end_loc = loc_of_json end_loc in
+                    let* beg_loc = loc_of_json ctx beg_loc in
+                    let* end_loc = loc_of_json ctx end_loc in
                     Ok { file; beg_loc; end_loc }
                 "#,
             ),
@@ -1141,7 +1071,7 @@ fn generate_ml(
                         | _ -> Error "")
                     in
                     let* value = big_int_of_json bi in
-                    let* int_ty = integer_type_of_json (`String ty) in
+                    let* int_ty = integer_type_of_json ctx (`String ty) in
                     let sv = { value; int_ty } in
                     if not (check_scalar_value_in_range sv) then
                       raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv));
@@ -1156,32 +1086,32 @@ fn generate_ml(
             indoc!(
                 r#"
                 | `Assoc [ ("Assign", `List [ place; rvalue ]) ] ->
-                    let* place = place_of_json place in
-                    let* rvalue = rvalue_of_json rvalue in
+                    let* place = place_of_json ctx place in
+                    let* rvalue = rvalue_of_json ctx rvalue in
                     Ok (Assign (place, rvalue))
                 | `Assoc [ ("FakeRead", place) ] ->
-                    let* place = place_of_json place in
+                    let* place = place_of_json ctx place in
                     Ok (FakeRead place)
                 | `Assoc [ ("SetDiscriminant", `List [ place; variant_id ]) ] ->
-                    let* place = place_of_json place in
-                    let* variant_id = VariantId.id_of_json variant_id in
+                    let* place = place_of_json ctx place in
+                    let* variant_id = VariantId.id_of_json ctx variant_id in
                     Ok (SetDiscriminant (place, variant_id))
                 | `Assoc [ ("Drop", place) ] ->
-                    let* place = place_of_json place in
+                    let* place = place_of_json ctx place in
                     Ok (Drop place)
                 | `Assoc [ ("Assert", assertion) ] ->
-                    let* assertion = assertion_of_json assertion in
+                    let* assertion = assertion_of_json ctx assertion in
                     Ok (Assert assertion)
                 | `Assoc [ ("Call", call) ] ->
-                    let* call = call_of_json call in
+                    let* call = call_of_json ctx call in
                     Ok (Call call)
                 | `Assoc [ ("Abort", _) ] -> Ok Panic
                 | `String "Return" -> Ok Return
                 | `Assoc [ ("Break", i) ] ->
-                    let* i = int_of_json i in
+                    let* i = int_of_json ctx i in
                     Ok (Break i)
                 | `Assoc [ ("Continue", i) ] ->
-                    let* i = int_of_json i in
+                    let* i = int_of_json ctx i in
                     Ok (Continue i)
                 | `String "Nop" -> Ok Nop
                 | `Assoc [ ("Switch", tgt) ] ->
@@ -1191,7 +1121,7 @@ fn generate_ml(
                     let* st = block_of_json ctx st in
                     Ok (Loop st)
                 | `Assoc [ ("Error", s) ] ->
-                    let* s = string_of_json s in
+                    let* s = string_of_json ctx s in
                     Ok (Error s)
                 "#
             ),
@@ -1204,7 +1134,7 @@ fn generate_ml(
                 | `Assoc [ ("span", span); ("statements", statements) ] -> begin
                     let* span = span_of_json ctx span in
                     let* statements =
-                      list_of_json (statement_of_json ctx) statements
+                      list_of_json (statement_of_json ctx) ctx statements
                     in
                     match List.rev statements with
                     | [] -> Ok { span; content = Nop; comments_before = [] }

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -74,7 +74,7 @@ and gfun_decl_of_json (bodies : 'body gexpr_body option list)
         let* signature = fun_sig_of_json ctx signature in
         let* kind = item_kind_of_json ctx kind in
         let* is_global_initializer =
-          option_of_json (global_decl_id_of_json ctx) ctx is_global_initializer
+          option_of_json global_decl_id_of_json ctx is_global_initializer
         in
         let* body = maybe_opaque_body_of_json bodies ctx body in
         Ok { def_id; item_meta; signature; kind; is_global_initializer; body }
@@ -92,7 +92,7 @@ and id_to_file_of_json (js : json) : (of_json_ctx, string) result =
   combine_error_msgs js __FUNCTION__
     ((* The map is stored as a list of pairs (key, value): we deserialize
       * this list then convert it to a map *)
-     let* files = list_of_json (option_of_json (file_of_json FileId.Map.empty) ()) () js in
+     let* files = list_of_json (option_of_json file_of_json) FileId.Map.empty js in
      let files_with_ids =
        List.filter_map
          (fun (i, file) ->
@@ -126,33 +126,26 @@ and gtranslated_crate_of_json
         let* name = string_of_json ctx name in
 
         let* declarations =
-          list_of_json (declaration_group_of_json ctx) ctx declarations
+          list_of_json declaration_group_of_json ctx declarations
         in
 
-        let* bodies =
-          list_of_json (option_of_json (body_of_json ctx) ctx) ctx bodies
-        in
+        let* bodies = list_of_json (option_of_json body_of_json) ctx bodies in
         let* types =
-          vector_of_json (type_id_of_json ctx) (type_decl_of_json ctx) ctx types
+          vector_of_json type_id_of_json type_decl_of_json ctx types
         in
         let* functions =
-          vector_of_json (fun_decl_id_of_json ctx)
-            (gfun_decl_of_json bodies ctx) ctx
+          vector_of_json fun_decl_id_of_json (gfun_decl_of_json bodies) ctx
             functions
         in
         let* globals =
-          vector_of_json (global_decl_id_of_json ctx)
-            (global_decl_of_json ctx) ctx
-            globals
+          vector_of_json global_decl_id_of_json global_decl_of_json ctx globals
         in
         let* trait_decls =
-          vector_of_json (trait_decl_id_of_json ctx)
-            (trait_decl_of_json ctx) ctx
+          vector_of_json trait_decl_id_of_json trait_decl_of_json ctx
             trait_decls
         in
         let* trait_impls =
-          vector_of_json (trait_impl_id_of_json ctx)
-            (trait_impl_of_json ctx) ctx
+          vector_of_json trait_impl_id_of_json trait_impl_of_json ctx
             trait_impls
         in
 

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -44,11 +44,11 @@ let region_id_of_json = RegionVarId.id_of_json
 (* __REPLACE0__ *)
 
 and maybe_opaque_body_of_json (bodies : 'body gexpr_body option list)
-    (js : json) : ('body gexpr_body option, string) result =
+    (ctx : of_json_ctx) (js : json) : ('body gexpr_body option, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Ok", body) ] ->
-        let* body_id = BodyId.id_of_json body in
+        let* body_id = BodyId.id_of_json ctx body in
         let body = List.nth bodies (BodyId.to_int body_id) in
         Ok body
     | `Assoc [ ("Err", `Null) ] -> Ok None
@@ -69,14 +69,14 @@ and gfun_decl_of_json (bodies : 'body gexpr_body option list)
           ("is_global_initializer", is_global_initializer);
           ("body", body);
         ] ->
-        let* def_id = FunDeclId.id_of_json def_id in
+        let* def_id = FunDeclId.id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* signature = fun_sig_of_json ctx signature in
-        let* kind = item_kind_of_json kind in
+        let* kind = item_kind_of_json ctx kind in
         let* is_global_initializer =
-          option_of_json global_decl_id_of_json is_global_initializer
+          option_of_json (global_decl_id_of_json ctx) ctx is_global_initializer
         in
-        let* body = maybe_opaque_body_of_json bodies body in
+        let* body = maybe_opaque_body_of_json bodies ctx body in
         Ok { def_id; item_meta; signature; kind; is_global_initializer; body }
     | _ -> Error "")
 
@@ -92,7 +92,7 @@ and id_to_file_of_json (js : json) : (of_json_ctx, string) result =
   combine_error_msgs js __FUNCTION__
     ((* The map is stored as a list of pairs (key, value): we deserialize
       * this list then convert it to a map *)
-     let* files = list_of_json (option_of_json file_of_json) js in
+     let* files = list_of_json (option_of_json (file_of_json FileId.Map.empty) ()) () js in
      let files_with_ids =
        List.filter_map
          (fun (i, file) ->
@@ -122,37 +122,37 @@ and gtranslated_crate_of_json
           ("trait_impls", trait_impls);
           ("ordered_decls", declarations);
         ] ->
-        let* name = string_of_json name in
         let* ctx = id_to_file_of_json files in
+        let* name = string_of_json ctx name in
 
         let* declarations =
-          list_of_json declaration_group_of_json declarations
+          list_of_json (declaration_group_of_json ctx) ctx declarations
         in
 
         let* bodies =
-          list_of_json (option_of_json (body_of_json ctx)) bodies
+          list_of_json (option_of_json (body_of_json ctx) ctx) ctx bodies
         in
         let* types =
-          vector_of_json type_id_of_json (type_decl_of_json ctx) types
+          vector_of_json (type_id_of_json ctx) (type_decl_of_json ctx) ctx types
         in
         let* functions =
-          vector_of_json fun_decl_id_of_json
-            (gfun_decl_of_json bodies ctx)
+          vector_of_json (fun_decl_id_of_json ctx)
+            (gfun_decl_of_json bodies ctx) ctx
             functions
         in
         let* globals =
-          vector_of_json global_decl_id_of_json
-            (global_decl_of_json ctx)
+          vector_of_json (global_decl_id_of_json ctx)
+            (global_decl_of_json ctx) ctx
             globals
         in
         let* trait_decls =
-          vector_of_json trait_decl_id_of_json
-            (trait_decl_of_json ctx)
+          vector_of_json (trait_decl_id_of_json ctx)
+            (trait_decl_of_json ctx) ctx
             trait_decls
         in
         let* trait_impls =
-          vector_of_json trait_impl_id_of_json
-            (trait_impl_of_json ctx)
+          vector_of_json (trait_impl_id_of_json ctx)
+            (trait_impl_of_json ctx) ctx
             trait_impls
         in
 
@@ -195,7 +195,7 @@ and gcrate_of_json
   match js with
   | `Assoc [ ("charon_version", charon_version); ("translated", translated) ] ->
       (* Ensure the version is the one we support. *)
-      let* charon_version = string_of_json charon_version in
+      let* charon_version = string_of_json () charon_version in
       if
         not (String.equal charon_version CharonVersion.supported_charon_version)
       then

--- a/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
@@ -10,13 +10,13 @@ open LlbcAst
 
 (* __REPLACE0__ *)
 
-let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
+let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     (expr_body, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Structured", body) ] ->
         let* body =
-          gexpr_body_of_json (block_of_json id_to_file) id_to_file body
+          gexpr_body_of_json (block_of_json ctx) ctx body
         in
         Ok body
     | _ -> Error "")

--- a/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/LlbcOfJson.ml
@@ -16,7 +16,7 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     (match js with
     | `Assoc [ ("Structured", body) ] ->
         let* body =
-          gexpr_body_of_json (block_of_json ctx) ctx body
+          gexpr_body_of_json block_of_json ctx body
         in
         Ok body
     | _ -> Error "")

--- a/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
@@ -17,7 +17,7 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     (match js with
     | `Assoc [ ("Unstructured", body) ] ->
         let* body =
-          gexpr_body_of_json (blocks_of_json ctx) ctx body
+          gexpr_body_of_json blocks_of_json ctx body
         in
         Ok body
     | _ -> Error "")

--- a/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/UllbcOfJson.ml
@@ -11,13 +11,13 @@ open UllbcAst
 
 (* __REPLACE0__ *)
 
-let expr_body_of_json (id_to_file : id_to_file_map) (js : json) :
+let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     (expr_body, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Unstructured", body) ] ->
         let* body =
-          gexpr_body_of_json (blocks_of_json id_to_file) id_to_file body
+          gexpr_body_of_json (blocks_of_json ctx) ctx body
         in
         Ok body
     | _ -> Error "")


### PR DESCRIPTION
Currently we only pass it through functions that need it, which requires finding out which types contain `RawSpan`. Much easier to pass it unconditionally everywhere.