### PR TITLE
Keep a full trait reference alongside methods

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.49"
+let supported_charon_version = "0.1.50"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -131,21 +131,21 @@ and 'a0 gexpr_body = {
 and item_kind =
   | RegularItem
       (** A function/const at the top level or in an inherent impl block. *)
-  | TraitDeclItem of trait_decl_id * trait_item_name * bool
+  | TraitDeclItem of trait_decl_ref * trait_item_name * bool
       (** Function/const that is part of a trait declaration. It has a body if and only if the trait
           provided a default implementation.
 
           Fields:
-          - [trait_id]:  The trait declaration this item belongs to.
+          - [trait_ref]:  The trait declaration this item belongs to.
           - [item_name]:  The name of the item.
           - [has_default]:  Whether the trait declaration provides a default implementation.
        *)
-  | TraitImplItem of trait_impl_id * trait_decl_id * trait_item_name * bool
+  | TraitImplItem of trait_impl_ref * trait_decl_ref * trait_item_name * bool
       (** Function/const that is part of a trait implementation.
 
           Fields:
-          - [impl_id]:  The trait implementation the method belongs to
-          - [trait_id]:  The trait declaration this item belongs to.
+          - [impl_ref]:  The trait implementation the method belongs to.
+          - [trait_ref]:  The trait declaration that the impl block implements.
           - [item_name]:  The name of the item
           - [reuses_default]:  True if the trait decl had a default implementation for this function/const and this
           item is a copy of the default item.

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -394,31 +394,31 @@ and item_kind_of_json (ctx : of_json_ctx) (js : json) :
           ( "TraitDecl",
             `Assoc
               [
-                ("trait_id", trait_id);
+                ("trait_ref", trait_ref);
                 ("item_name", item_name);
                 ("has_default", has_default);
               ] );
         ] ->
-        let* trait_id = trait_decl_id_of_json ctx trait_id in
+        let* trait_ref = trait_decl_ref_of_json ctx trait_ref in
         let* item_name = trait_item_name_of_json ctx item_name in
         let* has_default = bool_of_json ctx has_default in
-        Ok (TraitDeclItem (trait_id, item_name, has_default))
+        Ok (TraitDeclItem (trait_ref, item_name, has_default))
     | `Assoc
         [
           ( "TraitImpl",
             `Assoc
               [
-                ("impl_id", impl_id);
-                ("trait_id", trait_id);
+                ("impl_ref", impl_ref);
+                ("trait_ref", trait_ref);
                 ("item_name", item_name);
                 ("reuses_default", reuses_default);
               ] );
         ] ->
-        let* impl_id = trait_impl_id_of_json ctx impl_id in
-        let* trait_id = trait_decl_id_of_json ctx trait_id in
+        let* impl_ref = trait_impl_ref_of_json ctx impl_ref in
+        let* trait_ref = trait_decl_ref_of_json ctx trait_ref in
         let* item_name = trait_item_name_of_json ctx item_name in
         let* reuses_default = bool_of_json ctx reuses_default in
-        Ok (TraitImplItem (impl_id, trait_id, item_name, reuses_default))
+        Ok (TraitImplItem (impl_ref, trait_ref, item_name, reuses_default))
     | _ -> Error "")
 
 and global_decl_of_json (ctx : of_json_ctx) (js : json) :
@@ -972,6 +972,16 @@ and trait_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
         let* trait_decl_id = trait_decl_id_of_json ctx trait_id in
         let* decl_generics = generic_args_of_json ctx generics in
         Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
+    | _ -> Error "")
+
+and trait_impl_ref_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_impl_ref, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("impl_id", impl_id); ("generics", generics) ] ->
+        let* trait_impl_id = trait_impl_id_of_json ctx impl_id in
+        let* impl_generics = generic_args_of_json ctx generics in
+        Ok ({ trait_impl_id; impl_generics } : trait_impl_ref)
     | _ -> Error "")
 
 and outlives_pred_of_json :

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -399,6 +399,12 @@ and trait_decl_ref = {
   decl_generics : generic_args;
 }
 
+(** A reference to a tait impl, using the provided arguments. *)
+and trait_impl_ref = {
+  trait_impl_id : trait_impl_id;
+  impl_generics : generic_args;
+}
+
 and generic_args = {
   regions : region list;
   types : ty list;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.49"
+version = "0.1.50"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.49"
+version = "0.1.50"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -115,7 +115,7 @@ pub enum ItemKind {
     /// provided a default implementation.
     TraitDecl {
         /// The trait declaration this item belongs to.
-        trait_id: TraitDeclId,
+        trait_ref: TraitDeclRef,
         /// The name of the item.
         item_name: TraitItemName,
         /// Whether the trait declaration provides a default implementation.
@@ -123,10 +123,10 @@ pub enum ItemKind {
     },
     /// Function/const that is part of a trait implementation.
     TraitImpl {
-        /// The trait implementation the method belongs to
-        impl_id: TraitImplId,
-        /// The trait declaration this item belongs to.
-        trait_id: TraitDeclId,
+        /// The trait implementation the method belongs to.
+        impl_ref: TraitImplRef,
+        /// The trait declaration that the impl block implements.
+        trait_ref: TraitDeclRef,
         /// The name of the item
         item_name: TraitItemName,
         /// True if the trait decl had a default implementation for this function/const and this

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -250,6 +250,15 @@ pub struct TraitDeclRef {
 /// A quantified trait predicate, e.g. `for<'a> Type<'a>: Trait<'a, Args>`.
 pub type PolyTraitDeclRef = RegionBinder<TraitDeclRef>;
 
+/// A reference to a tait impl, using the provided arguments.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+pub struct TraitImplRef {
+    #[charon::rename("trait_impl_id")]
+    pub impl_id: TraitImplId,
+    #[charon::rename("impl_generics")]
+    pub generics: GenericArgs,
+}
+
 /// .0 outlives .1
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OutlivesPred<T, U>(pub T, pub U);

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1343,6 +1343,7 @@ fn generate_ml(
                     "TraitRef",
                     "TraitRefKind",
                     "TraitDeclRef",
+                    "TraitImplRef",
                     "GlobalDeclRef",
                     "GenericArgs",
                 ]),

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -15,6 +15,7 @@ use super::{ctx::TransformPass, TransformCtx};
     FnPtr(enter),
     GlobalDeclRef(enter),
     TraitDeclRef(enter),
+    TraitImplRef(enter),
     TraitRefKind(enter),
     Ty(enter)
 )]
@@ -101,6 +102,9 @@ impl CheckGenericsVisitor<'_> {
     }
     fn enter_trait_decl_ref(&mut self, tref: &TraitDeclRef) {
         self.generics_should_match_item(&tref.generics, tref.trait_id);
+    }
+    fn enter_trait_impl_ref(&mut self, impl_ref: &TraitImplRef) {
+        self.generics_should_match_item(&impl_ref.generics, impl_ref.impl_id);
     }
     fn enter_trait_ref_kind(&mut self, kind: &TraitRefKind) {
         match kind {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -224,8 +224,10 @@ impl<'tcx> Deps<'tcx> {
     fn set_impl_or_trait_id(&mut self, kind: &ItemKind) {
         match kind {
             ItemKind::Regular => {}
-            ItemKind::TraitDecl { trait_id, .. } => self.parent_trait_decl = Some(*trait_id),
-            ItemKind::TraitImpl { impl_id, .. } => self.parent_trait_impl = Some(*impl_id),
+            ItemKind::TraitDecl { trait_ref, .. } => {
+                self.parent_trait_decl = Some(trait_ref.trait_id)
+            }
+            ItemKind::TraitImpl { impl_ref, .. } => self.parent_trait_impl = Some(impl_ref.impl_id),
         }
     }
     fn set_current_id(&mut self, ctx: &TransformCtx, id: AnyTransId) {


### PR DESCRIPTION
Instead of keeping just a `TraitDeclId`/`TraitImplId` inside a method, we keep a full trait/impl reference including generic arguments.

Required for https://github.com/AeneasVerif/charon/pull/210 and https://github.com/AeneasVerif/charon/issues/127.

Requires https://github.com/hacspec/hax/pull/1122 (and currently based on https://github.com/AeneasVerif/charon/pull/465).