### PR TITLE
Change the order of item exploration

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -142,7 +142,7 @@ impl TransItemSource {
     fn sort_key(&self) -> impl Ord {
         let (variant_index, _) = self.variant_index_arity();
         let def_id = self.to_def_id();
-        (variant_index, def_id.index, def_id.krate)
+        (def_id.krate, def_id.index, variant_index)
     }
 }
 

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -492,16 +492,16 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[1]
+        crate_data.fun_decls[0]
             .item_meta
             .attr_info
             .rename
             .as_deref(),
-        Some("Const_Test")
+        Some("BoolFn")
     );
 
     assert_eq!(
-        crate_data.fun_decls[2]
+        crate_data.fun_decls[1]
             .item_meta
             .attr_info
             .rename
@@ -510,12 +510,21 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[3]
+        crate_data.fun_decls[2]
             .item_meta
             .attr_info
             .rename
             .as_deref(),
         Some("retTest")
+    );
+
+    assert_eq!(
+        crate_data.fun_decls[4]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
+        Some("Const_Test")
     );
 
     assert_eq!(
@@ -525,15 +534,6 @@ fn rename_attribute() -> anyhow::Result<()> {
             .rename
             .as_deref(),
         Some("BoolImpl")
-    );
-
-    assert_eq!(
-        crate_data.fun_decls[0]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
-        Some("BoolFn")
     );
 
     assert_eq!(

--- a/charon/tests/ui/generic-associated-types.out
+++ b/charon/tests/ui/generic-associated-types.out
@@ -10,18 +10,6 @@ error: Ignoring the following item due to a previous error: test_crate::LendingI
 4 | trait LendingIterator {
   | ^^^^^^^^^^^^^^^^^^^^^
 
-error: Generic associated types are not supported
-  --> tests/ui/generic-associated-types.rs:46:9
-   |
-46 |         type Type<'b>: for<'c> Foo<&'a &'b &'c ()>;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ignoring the following item due to a previous error: test_crate::lifetimes::Bar
-  --> tests/ui/generic-associated-types.rs:45:5
-   |
-45 |     trait Bar<'a> {
-   |     ^^^^^^^^^^^^^
-
 error: Found unsupported GAT `Item` when resolving trait `core::marker::Sized<@TraitClause2::Item>`
   --> tests/ui/generic-associated-types.rs:27:28
    |
@@ -53,6 +41,18 @@ warning: unused variable: `x`
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
    = note: `#[warn(unused_variables)]` on by default
+
+error: Generic associated types are not supported
+  --> tests/ui/generic-associated-types.rs:46:9
+   |
+46 |         type Type<'b>: for<'c> Foo<&'a &'b &'c ()>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ignoring the following item due to a previous error: test_crate::lifetimes::Bar
+  --> tests/ui/generic-associated-types.rs:45:5
+   |
+45 |     trait Bar<'a> {
+   |     ^^^^^^^^^^^^^
 
 error: Found unsupported GAT `Type` when resolving trait `test_crate::lifetimes::Foo<@TraitClause1::Type, &'_ (&'_ (&'_ (())))>`
   --> tests/ui/generic-associated-types.rs:53:9

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -110,9 +110,9 @@ where
     return
 }
 
-fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
-
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 
 

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -928,20 +928,6 @@ fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
-
-fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
-
-fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>[Self::parent_clause0]
-
 fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<Self>,
@@ -1236,16 +1222,6 @@ where
     [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
     @TraitClause1::parent_clause0::Output = bool,
 
-fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::Ord<Self::Item>,
-
-fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::Ord<Self::Item>,
-
 fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>[Self::parent_clause0]
 where
     [@TraitClause0]: core::marker::Sized<B>,
@@ -1420,11 +1396,6 @@ where
     [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1::Item>,
     [@TraitClause3]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
-
 fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
 where
     [@TraitClause0]: core::marker::Sized<F>,
@@ -1440,10 +1411,6 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     [@TraitClause4]: core::cmp::PartialOrd<K, K>,
     @TraitClause3::parent_clause0::Output = K,
-
-unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
-where
-    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
@@ -1464,6 +1431,39 @@ fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
 fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
+
+fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>[Self::parent_clause0]
+
+fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
 fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -134,9 +134,9 @@ fn test_crate::main()
     return
 }
 
-fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
-
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 
 

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -2245,20 +2245,6 @@ fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
-
-fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
-
-fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>[Self::parent_clause0]
-
 fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<Self>,
@@ -2553,16 +2539,6 @@ where
     [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>,
     @TraitClause1::parent_clause0::Output = bool,
 
-fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::Ord<Self::Item>,
-
-fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::Ord<Self::Item>,
-
 fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>[Self::parent_clause0]
 where
     [@TraitClause0]: core::marker::Sized<B>,
@@ -2737,11 +2713,6 @@ where
     [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1::Item>,
     [@TraitClause3]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
-
 fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(@1: Self, @2: F) -> bool
 where
     [@TraitClause0]: core::marker::Sized<F>,
@@ -2757,24 +2728,6 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     [@TraitClause4]: core::cmp::PartialOrd<K, K>,
     @TraitClause3::parent_clause0::Output = K,
-
-unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
-where
-    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
-
-fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_1_0 (Self::Output)>]
-
-fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self::Output)>[core::marker::Sized<&'_1_0 mut (Self::Output)>]
-
-unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(@1: Self, @2: *const T) -> *const Self::Output
-
-unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(@1: Self, @2: *mut T) -> *mut Self::Output
-
-fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self::Output)
-
-fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self::Output)
-
-fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
 
 fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
@@ -2795,6 +2748,39 @@ fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
 fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
 where
     [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
+
+fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>[Self::parent_clause0]
+
+fn core::iter::traits::iterator::Iterator::max<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::min<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::Ord<Self::Item>,
+
+fn core::iter::traits::iterator::Iterator::is_sorted<Self>(@1: Self) -> bool
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+    [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
@@ -2875,6 +2861,20 @@ where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
+
+fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_1_0 (Self::Output)>]
+
+fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self::Output)>[core::marker::Sized<&'_1_0 mut (Self::Output)>]
+
+unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(@1: Self, @2: *const T) -> *const Self::Output
+
+unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(@1: Self, @2: *mut T) -> *mut Self::Output
+
+fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self::Output)
+
+fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self::Output)
+
+fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
 
 
 

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -253,37 +253,12 @@ fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map::Has
     return
 }
 
-fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
-
-fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
-
-fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::hash::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
-where
-    [@TraitClause0]: core::marker::Sized<H>,
-    [@TraitClause1]: core::hash::Hasher<H>,
-
-fn core::hash::Hash::hash_slice<'_0, '_1, Self, H>(@1: &'_0 (Slice<Self>), @2: &'_1 mut (H))
-where
-    [@TraitClause0]: core::marker::Sized<H>,
-    [@TraitClause1]: core::hash::Hasher<H>,
-    [@TraitClause2]: core::marker::Sized<Self>,
-
-fn core::hash::BuildHasher::build_hasher<'_0, Self>(@1: &'_0 (Self)) -> Self::Hasher
-
 fn core::hash::BuildHasher::hash_one<'_0, Self, T>(@1: &'_0 (Self), @2: T) -> u64
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::hash::Hash<T>,
     [@TraitClause2]: core::marker::Sized<Self>,
     [@TraitClause3]: core::hash::Hasher<Self::Hasher>,
-
-fn core::hash::Hasher::finish<'_0, Self>(@1: &'_0 (Self)) -> u64
-
-fn core::hash::Hasher::write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
 
 fn core::hash::Hasher::write_u8<'_0, Self>(@1: &'_0 mut (Self), @2: u8)
 
@@ -311,7 +286,32 @@ fn core::hash::Hasher::write_isize<'_0, Self>(@1: &'_0 mut (Self), @2: isize)
 
 fn core::hash::Hasher::write_length_prefix<'_0, Self>(@1: &'_0 mut (Self), @2: usize)
 
+fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::hash::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))
+where
+    [@TraitClause0]: core::marker::Sized<H>,
+    [@TraitClause1]: core::hash::Hasher<H>,
+
+fn core::hash::Hash::hash_slice<'_0, '_1, Self, H>(@1: &'_0 (Slice<Self>), @2: &'_1 mut (H))
+where
+    [@TraitClause0]: core::marker::Sized<H>,
+    [@TraitClause1]: core::hash::Hasher<H>,
+    [@TraitClause2]: core::marker::Sized<Self>,
+
+fn core::hash::Hasher::finish<'_0, Self>(@1: &'_0 (Self)) -> u64
+
+fn core::hash::Hasher::write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+
 fn core::hash::Hasher::write_str<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Str))
+
+fn core::hash::BuildHasher::build_hasher<'_0, Self>(@1: &'_0 (Self)) -> Self::Hasher
 
 
 

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -526,6 +526,10 @@ fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
+fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
+
+fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+
 fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
@@ -1050,10 +1054,6 @@ where
 unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
 where
     [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
-
-fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
-
-fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
 fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -1175,18 +1175,6 @@ fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
-
-fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
-
 fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
 fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) -> core::iter::adapters::step_by::StepBy<Self>[@TraitClause0]
@@ -1400,14 +1388,6 @@ where
     [@TraitClause4]: core::ops::try_trait::Try<R>,
     @TraitClause3::parent_clause0::Output = R,
     @TraitClause4::Output = (),
-
-fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
-where
-    [@TraitClause0]: core::marker::Sized<B>,
-    [@TraitClause1]: core::marker::Sized<F>,
-    [@TraitClause2]: core::marker::Sized<Self>,
-    [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>,
-    @TraitClause3::parent_clause0::Output = B,
 
 fn core::iter::traits::iterator::Iterator::reduce<Self, F>(@1: Self, @2: F) -> core::option::Option<Self::Item>[Self::parent_clause0]
 where
@@ -1688,10 +1668,6 @@ where
     [@TraitClause4]: core::cmp::PartialOrd<K, K>,
     @TraitClause3::parent_clause0::Output = K,
 
-unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
-where
-    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
-
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
@@ -1699,6 +1675,30 @@ fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Sel
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
+fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(@1: &'_0 (Self)) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
+
+fn core::iter::traits::iterator::Iterator::count<Self>(@1: Self) -> usize
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::last<Self>(@1: Self) -> core::option::Option<Self::Item>[Self::parent_clause0]
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
+
+fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(@1: Self, @2: B, @3: F) -> B
+where
+    [@TraitClause0]: core::marker::Sized<B>,
+    [@TraitClause1]: core::marker::Sized<F>,
+    [@TraitClause2]: core::marker::Sized<Self>,
+    [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>,
+    @TraitClause3::parent_clause0::Output = B,
+
+unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> Self::Item
+where
+    [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
 fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -93,15 +93,15 @@ type test_crate::GenericWithoutBound<'a, T>
   where
       [@TraitClause0]: core::marker::Sized<T>, = alloc::borrow::Cow<'a, Slice<T>>[UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
 
+fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+
+fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
+
 fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
 
 fn alloc::borrow::ToOwned::clone_into<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 mut (Self::Owned))
 
 fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
-
-fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
-
-fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
 
 


### PR DESCRIPTION
We now start with the local crate instead of sorting by item type. This means we'll generally translate all items from the current crate before attempting to translate an external item. This should make errors easier to follow.