### PR TITLE
Serialize the CLI options

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.51"
+let supported_charon_version = "0.1.52"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -422,6 +422,65 @@ and declaration_group =
   | MixedGroup of any_decl_id g_declaration_group
       (** Anything that doesn't fit into these categories. *)
 
+and cli_options = {
+  ullbc : bool;
+      (** Extract the unstructured LLBC (i.e., don't reconstruct the control-flow) *)
+  lib : bool;  (** Compile the package's library *)
+  bin : string option;  (** Compile the specified binary *)
+  mir_promoted : bool;  (** Extract the promoted MIR instead of the built MIR *)
+  mir_optimized : bool;
+      (** Extract the optimized MIR instead of the built MIR *)
+  crate_name : string option;
+      (** Provide a custom name for the compiled crate (ignore the name computed
+        by Cargo)
+     *)
+  input_file : path_buf option;
+      (** The input file (the entry point of the crate to extract).
+        This is needed if you want to define a custom entry point (to only
+        extract part of a crate for instance).
+     *)
+  dest_dir : path_buf option;
+      (** The destination directory. Files will be generated as `<dest_dir>/<crate_name>.{u}llbc`,
+        unless `dest_file` is set. `dest_dir` defaults to the current directory.
+     *)
+  dest_file : path_buf option;
+      (** The destination file. By default `<dest_dir>/<crate_name>.llbc`. If this is set we ignore
+        `dest_dir`.
+     *)
+  use_polonius : bool;
+      (** If activated, use Polonius' non-lexical lifetimes (NLL) analysis.
+        Otherwise, use the standard borrow checker.
+     *)
+  no_code_duplication : bool;
+  extract_opaque_bodies : bool;
+      (** Usually we skip the bodies of foreign methods and structs with private fields. When this
+        flag is on, we don't.
+     *)
+  included : string list;
+      (** Whitelist of items to translate. These use the name-matcher syntax. *)
+  opaque : string list;
+      (** Blacklist of items to keep opaque. These use the name-matcher syntax. *)
+  exclude : string list;
+      (** Blacklist of items to not translate at all. These use the name-matcher syntax. *)
+  hide_marker_traits : bool;
+      (** Whether to hide the `Sized`, `Sync`, `Send` and `Unpin` marker traits anywhere they show
+        up.
+     *)
+  no_cargo : bool;  (** Do not run cargo; instead, run the driver directly. *)
+  rustc_args : string list;  (** Extra flags to pass to rustc. *)
+  cargo_args : string list;
+      (** Extra flags to pass to cargo. Incompatible with `--no-cargo`. *)
+  abort_on_error : bool;
+      (** Panic on the first error. This is useful for debugging. *)
+  error_on_warnings : bool;  (** Print the errors as warnings *)
+  no_serialize : bool;
+  print_original_ullbc : bool;
+  print_ullbc : bool;
+  print_built_llbc : bool;
+  print_llbc : bool;
+  no_merge_goto_chains : bool;
+}
+
 (** A (group of) top-level declaration(s), properly reordered.
     "G" stands for "generic"
  *)
@@ -461,6 +520,7 @@ type 'body gfun_decl = {
 (** A crate *)
 type 'fun_body gcrate = {
   name : string;
+  options : cli_options;
   declarations : declaration_group list;
   type_decls : type_decl TypeDeclId.Map.t;
   fun_decls : 'fun_body gfun_decl FunDeclId.Map.t;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1550,6 +1550,100 @@ and declaration_group_of_json (ctx : of_json_ctx) (js : json) :
         Ok (MixedGroup mixed)
     | _ -> Error "")
 
+and cli_options_of_json (ctx : of_json_ctx) (js : json) :
+    (cli_options, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("ullbc", ullbc);
+          ("lib", lib);
+          ("bin", bin);
+          ("mir_promoted", mir_promoted);
+          ("mir_optimized", mir_optimized);
+          ("crate_name", crate_name);
+          ("input_file", input_file);
+          ("dest_dir", dest_dir);
+          ("dest_file", dest_file);
+          ("use_polonius", use_polonius);
+          ("no_code_duplication", no_code_duplication);
+          ("extract_opaque_bodies", extract_opaque_bodies);
+          ("include", include_);
+          ("opaque", opaque);
+          ("exclude", exclude);
+          ("hide_marker_traits", hide_marker_traits);
+          ("no_cargo", no_cargo);
+          ("rustc_args", rustc_args);
+          ("cargo_args", cargo_args);
+          ("abort_on_error", abort_on_error);
+          ("error_on_warnings", error_on_warnings);
+          ("no_serialize", no_serialize);
+          ("print_original_ullbc", print_original_ullbc);
+          ("print_ullbc", print_ullbc);
+          ("print_built_llbc", print_built_llbc);
+          ("print_llbc", print_llbc);
+          ("no_merge_goto_chains", no_merge_goto_chains);
+        ] ->
+        let* ullbc = bool_of_json ctx ullbc in
+        let* lib = bool_of_json ctx lib in
+        let* bin = option_of_json string_of_json ctx bin in
+        let* mir_promoted = bool_of_json ctx mir_promoted in
+        let* mir_optimized = bool_of_json ctx mir_optimized in
+        let* crate_name = option_of_json string_of_json ctx crate_name in
+        let* input_file = option_of_json path_buf_of_json ctx input_file in
+        let* dest_dir = option_of_json path_buf_of_json ctx dest_dir in
+        let* dest_file = option_of_json path_buf_of_json ctx dest_file in
+        let* use_polonius = bool_of_json ctx use_polonius in
+        let* no_code_duplication = bool_of_json ctx no_code_duplication in
+        let* extract_opaque_bodies = bool_of_json ctx extract_opaque_bodies in
+        let* included = list_of_json string_of_json ctx include_ in
+        let* opaque = list_of_json string_of_json ctx opaque in
+        let* exclude = list_of_json string_of_json ctx exclude in
+        let* hide_marker_traits = bool_of_json ctx hide_marker_traits in
+        let* no_cargo = bool_of_json ctx no_cargo in
+        let* rustc_args = list_of_json string_of_json ctx rustc_args in
+        let* cargo_args = list_of_json string_of_json ctx cargo_args in
+        let* abort_on_error = bool_of_json ctx abort_on_error in
+        let* error_on_warnings = bool_of_json ctx error_on_warnings in
+        let* no_serialize = bool_of_json ctx no_serialize in
+        let* print_original_ullbc = bool_of_json ctx print_original_ullbc in
+        let* print_ullbc = bool_of_json ctx print_ullbc in
+        let* print_built_llbc = bool_of_json ctx print_built_llbc in
+        let* print_llbc = bool_of_json ctx print_llbc in
+        let* no_merge_goto_chains = bool_of_json ctx no_merge_goto_chains in
+        Ok
+          ({
+             ullbc;
+             lib;
+             bin;
+             mir_promoted;
+             mir_optimized;
+             crate_name;
+             input_file;
+             dest_dir;
+             dest_file;
+             use_polonius;
+             no_code_duplication;
+             extract_opaque_bodies;
+             included;
+             opaque;
+             exclude;
+             hide_marker_traits;
+             no_cargo;
+             rustc_args;
+             cargo_args;
+             abort_on_error;
+             error_on_warnings;
+             no_serialize;
+             print_original_ullbc;
+             print_ullbc;
+             print_built_llbc;
+             print_llbc;
+             no_merge_goto_chains;
+           }
+            : cli_options)
+    | _ -> Error "")
+
 and g_declaration_group_of_json :
       'a0.
       (of_json_ctx -> json -> ('a0, string) result) ->
@@ -1638,6 +1732,7 @@ and gtranslated_crate_of_json
         [
           ("crate_name", name);
           ("real_crate_name", _);
+          ("options", _);
           ("all_ids", _);
           ("item_names", _);
           ("files", files);
@@ -1651,6 +1746,7 @@ and gtranslated_crate_of_json
         ] ->
         let* ctx = id_to_file_of_json files in
         let* name = string_of_json ctx name in
+        let* options = cli_option_of_json options in
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations
@@ -1700,6 +1796,7 @@ and gtranslated_crate_of_json
         Ok
           {
             name;
+            options;
             declarations;
             type_decls;
             fun_decls;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1732,7 +1732,7 @@ and gtranslated_crate_of_json
         [
           ("crate_name", name);
           ("real_crate_name", _);
-          ("options", _);
+          ("options", options);
           ("all_ids", _);
           ("item_names", _);
           ("files", files);
@@ -1746,7 +1746,7 @@ and gtranslated_crate_of_json
         ] ->
         let* ctx = id_to_file_of_json files in
         let* name = string_of_json ctx name in
-        let* options = cli_option_of_json options in
+        let* options = cli_options_of_json ctx options in
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -254,10 +254,15 @@ class ['self] iter_crate_with_span =
       let ids = g_declaration_group_to_list g in
       List.iter (self#visit_any_decl_id decl_span_info) ids
 
+    method visit_cli_options (decl_span_info : (any_decl_id * span) option)
+        (option : cli_options) : unit =
+      ()
+
     method visit_crate (decl_span_info : (any_decl_id * span) option)
         (crate : crate) : unit =
       let {
         name;
+        options;
         declarations;
         type_decls;
         fun_decls;
@@ -268,6 +273,7 @@ class ['self] iter_crate_with_span =
         crate
       in
       self#visit_string decl_span_info name;
+      self#visit_cli_options decl_span_info options;
       List.iter (self#visit_declaration_group decl_span_info) declarations;
       TypeDeclId.Map.iter
         (fun _ -> self#visit_type_decl decl_span_info)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.51"
+version = "0.1.52"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/Charon.toml
+++ b/charon/Charon.toml
@@ -11,6 +11,7 @@ include = [
     "alloc::vec::Vec",
     "core::option::Option",
     "std::path::PathBuf",
+    "crate::options::CliOpts",
     "crate::ast",
     "crate::ast::krate",
     "crate::ast::expressions",

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -104,6 +104,12 @@ pub struct TranslatedCrate {
     /// The name of the crate according to rustc.
     pub real_crate_name: String,
 
+    /// The options used when calling Charon. It is useful for the applications
+    /// which consumed the serialized code, to check that Charon was called with
+    /// the proper options.
+    #[drive(skip)]
+    pub options: crate::options::CliOpts,
+
     /// All the item ids, in the order in which we encountered them
     #[drive(skip)]
     pub all_ids: LinkedHashSet<AnyTransId>,

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -258,6 +258,7 @@ pub fn translate<'tcx, 'ctx>(
         errors: error_ctx,
         translated: TranslatedCrate {
             crate_name: requested_crate_name,
+            options: options.clone(),
             real_crate_name,
             ..TranslatedCrate::default()
         },

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -29,6 +29,9 @@
 //! them in a specific environment variable, so that charon-driver can
 //! deserialize them later and use them to guide the extraction in the
 //! callbacks.
+#![feature(register_tool)]
+// For when we use charon on itself
+#![register_tool(charon)]
 
 // We must not link with the `charon_lib` crate because that would make `charon` need to
 // dynamically link to `librustc_driver.so` etc. The `charon` binary must be runnable _before_

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -51,6 +51,7 @@ fn make_ocaml_ident(name: &str) -> String {
             | "assert"
             | "float"
             | "end"
+            | "include"
     ) {
         name += "_";
     }

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1247,10 +1247,10 @@ fn generate_ml(
                     "TraitImpl",
                 ]),
                 (GenerationKind::TypeDecl(None), &[
+                    "CliOpts",
                     "GExprBody",
                     "GDeclarationGroup",
                     "DeclarationGroup",
-                    "CliOpts",
                 ]),
             ]),
         },

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1249,6 +1249,7 @@ fn generate_ml(
                     "GExprBody",
                     "GDeclarationGroup",
                     "DeclarationGroup",
+                    "CliOpts",
                 ]),
             ]),
         },

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -69,6 +69,7 @@ type 'body gfun_decl = {
 (** A crate *)
 type 'fun_body gcrate = {
   name : string;
+  options : cli_options;
   declarations : declaration_group list;
   type_decls : type_decl TypeDeclId.Map.t;
   fun_decls : 'fun_body gfun_decl FunDeclId.Map.t;

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -111,6 +111,7 @@ and gtranslated_crate_of_json
         [
           ("crate_name", name);
           ("real_crate_name", _);
+          ("options", _);
           ("all_ids", _);
           ("item_names", _);
           ("files", files);
@@ -124,6 +125,7 @@ and gtranslated_crate_of_json
         ] ->
         let* ctx = id_to_file_of_json files in
         let* name = string_of_json ctx name in
+        let* options = cli_option_of_json options in
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations
@@ -173,6 +175,7 @@ and gtranslated_crate_of_json
         Ok
           {
             name;
+            options;
             declarations;
             type_decls;
             fun_decls;

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -111,7 +111,7 @@ and gtranslated_crate_of_json
         [
           ("crate_name", name);
           ("real_crate_name", _);
-          ("options", _);
+          ("options", options);
           ("all_ids", _);
           ("item_names", _);
           ("files", files);
@@ -125,7 +125,7 @@ and gtranslated_crate_of_json
         ] ->
         let* ctx = id_to_file_of_json files in
         let* name = string_of_json ctx name in
-        let* options = cli_option_of_json options in
+        let* options = cli_options_of_json ctx options in
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -19,6 +19,7 @@ pub const CHARON_ARGS: &str = "CHARON_ARGS";
 // `Deserialize` options).
 #[derive(Debug, Default, Clone, Parser, Serialize, Deserialize)]
 #[clap(name = "Charon")]
+#[charon::rename("cli_options")]
 pub struct CliOpts {
     /// Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
     #[clap(long = "ullbc")]

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -140,6 +140,7 @@ pub struct CliOpts {
             items in it transparent (we will translate them if we encounter them.)
     "))]
     #[serde(default)]
+    #[charon::rename("included")]
     pub include: Vec<String>,
     /// Blacklist of items to keep opaque. These use the name-matcher syntax.
     #[clap(


### PR DESCRIPTION
This is so that projects like Aeneas can check that the proper options were used, and emit a error/warning message if it is not the case. See https://github.com/AeneasVerif/aeneas/issues/377#issuecomment-2511246069