### PR TITLE
Clean up region variables

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.53"
+let supported_charon_version = "0.1.54"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -923,8 +923,8 @@ and const_generic_var_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ index; name; ty } : const_generic_var)
     | _ -> Error "")
 
-and region_db_id_of_json (ctx : of_json_ctx) (js : json) :
-    (region_db_id, string) result =
+and de_bruijn_id_of_json (ctx : of_json_ctx) (js : json) :
+    (de_bruijn_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | x -> int_of_json ctx x
@@ -935,7 +935,7 @@ and region_of_json (ctx : of_json_ctx) (js : json) : (region, string) result =
     (match js with
     | `String "Static" -> Ok RStatic
     | `Assoc [ ("BVar", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = region_db_id_of_json ctx x_0 in
+        let* x_0 = de_bruijn_id_of_json ctx x_0 in
         let* x_1 = bound_region_id_of_json ctx x_1 in
         Ok (RBVar (x_0, x_1))
     | `Assoc [ ("FVar", f_var) ] ->

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -930,17 +930,26 @@ and de_bruijn_id_of_json (ctx : of_json_ctx) (js : json) :
     | x -> int_of_json ctx x
     | _ -> Error "")
 
+and de_bruijn_var_of_json (ctx : of_json_ctx) (js : json) :
+    (de_bruijn_var, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Bound", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = de_bruijn_id_of_json ctx x_0 in
+        let* x_1 = bound_region_id_of_json ctx x_1 in
+        Ok (Bound (x_0, x_1))
+    | `Assoc [ ("Free", free) ] ->
+        let* free = free_region_id_of_json ctx free in
+        Ok (Free free)
+    | _ -> Error "")
+
 and region_of_json (ctx : of_json_ctx) (js : json) : (region, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
+    | `Assoc [ ("Var", var) ] ->
+        let* var = de_bruijn_var_of_json ctx var in
+        Ok (RVar var)
     | `String "Static" -> Ok RStatic
-    | `Assoc [ ("BVar", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = de_bruijn_id_of_json ctx x_0 in
-        let* x_1 = bound_region_id_of_json ctx x_1 in
-        Ok (RBVar (x_0, x_1))
-    | `Assoc [ ("FVar", f_var) ] ->
-        let* f_var = free_region_id_of_json ctx f_var in
-        Ok (RFVar f_var)
     | `String "Erased" -> Ok RErased
     | _ -> Error "")
 

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -1329,13 +1329,13 @@ and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
     | `Assoc [ ("DynTrait", dyn_trait) ] ->
         let* dyn_trait = existential_predicate_of_json ctx dyn_trait in
         Ok (TDynTrait dyn_trait)
-    | `Assoc [ ("Arrow", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 =
-          vector_of_json region_id_of_json region_var_of_json ctx x_0
+    | `Assoc [ ("Arrow", arrow) ] ->
+        let* arrow =
+          region_binder_of_json
+            (pair_of_json (list_of_json ty_of_json) ty_of_json)
+            ctx arrow
         in
-        let* x_1 = list_of_json ty_of_json ctx x_1 in
-        let* x_2 = ty_of_json ctx x_2 in
-        Ok (TArrow (x_0, x_1, x_2))
+        Ok (TArrow arrow)
     | _ -> Error "")
 
 and builtin_ty_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -29,8 +29,8 @@ let region_var_id_to_pretty_string (db_id : region_db_id) (id : region_var_id) :
     string =
   "'" ^ show_region_db_id db_id ^ "_" ^ RegionVarId.to_string id
 
-let region_id_to_pretty_string (id : region_id) : string =
-  "'" ^ RegionId.to_string id
+let free_region_id_to_pretty_string (id : free_region_id) : string =
+  "'" ^ FreeRegionId.to_string id
 
 let type_var_id_to_pretty_string (id : type_var_id) : string =
   "T@" ^ TypeVarId.to_string id
@@ -93,7 +93,7 @@ let region_to_string (env : 'a fmt_env) (r : region) : string =
   | RStatic -> "'static"
   | RErased -> "'_"
   | RBVar (db, rid) -> region_var_id_to_string env db rid
-  | RFVar rid -> region_id_to_pretty_string rid
+  | RFVar rid -> free_region_id_to_pretty_string rid
 
 let trait_clause_id_to_string _ id = trait_clause_id_to_pretty_string id
 

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -13,7 +13,7 @@ let const_generic_var_to_string (v : const_generic_var) : string = v.name
 let region_var_to_string (rv : region_var) : string =
   match rv.name with
   | Some name -> name
-  | None -> RegionVarId.to_string rv.index
+  | None -> BoundRegionId.to_string rv.index
 
 let ref_kind_to_string (rk : ref_kind) : string =
   match rk with
@@ -25,9 +25,9 @@ let builtin_ty_to_string (_ : builtin_ty) : string = "Box"
 let trait_clause_id_to_pretty_string (id : trait_clause_id) : string =
   "TraitClause@" ^ TraitClauseId.to_string id
 
-let region_var_id_to_pretty_string (db_id : region_db_id) (id : region_var_id) :
-    string =
-  "'" ^ show_region_db_id db_id ^ "_" ^ RegionVarId.to_string id
+let bound_region_id_to_pretty_string (db_id : region_db_id)
+    (id : bound_region_id) : string =
+  "'" ^ show_region_db_id db_id ^ "_" ^ BoundRegionId.to_string id
 
 let free_region_id_to_pretty_string (id : free_region_id) : string =
   "'" ^ FreeRegionId.to_string id
@@ -59,14 +59,14 @@ let variant_id_to_pretty_string (id : variant_id) : string =
 let field_id_to_pretty_string (id : field_id) : string =
   "Field@" ^ FieldId.to_string id
 
-let region_var_id_to_string (env : 'a fmt_env) (db_id : region_db_id)
-    (id : region_var_id) : string =
+let bound_region_id_to_string (env : 'a fmt_env) (db_id : region_db_id)
+    (id : bound_region_id) : string =
   match List.nth_opt env.regions db_id with
-  | None -> region_var_id_to_pretty_string db_id id
+  | None -> bound_region_id_to_pretty_string db_id id
   | Some regions -> (
       (* Note that the regions are not necessarily ordered following their indices *)
       match List.find_opt (fun (r : region_var) -> r.index = id) regions with
-      | None -> region_var_id_to_pretty_string db_id id
+      | None -> bound_region_id_to_pretty_string db_id id
       | Some r -> region_var_to_string r)
 
 let type_var_id_to_string (env : 'a fmt_env) (id : type_var_id) : string =
@@ -92,7 +92,7 @@ let region_to_string (env : 'a fmt_env) (r : region) : string =
   match r with
   | RStatic -> "'static"
   | RErased -> "'_"
-  | RBVar (db, rid) -> region_var_id_to_string env db rid
+  | RBVar (db, rid) -> bound_region_id_to_string env db rid
   | RFVar rid -> free_region_id_to_pretty_string rid
 
 let trait_clause_id_to_string _ id = trait_clause_id_to_pretty_string id

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -25,9 +25,9 @@ let builtin_ty_to_string (_ : builtin_ty) : string = "Box"
 let trait_clause_id_to_pretty_string (id : trait_clause_id) : string =
   "TraitClause@" ^ TraitClauseId.to_string id
 
-let bound_region_id_to_pretty_string (db_id : region_db_id)
+let bound_region_id_to_pretty_string (db_id : de_bruijn_id)
     (id : bound_region_id) : string =
-  "'" ^ show_region_db_id db_id ^ "_" ^ BoundRegionId.to_string id
+  "'" ^ show_de_bruijn_id db_id ^ "_" ^ BoundRegionId.to_string id
 
 let free_region_id_to_pretty_string (id : free_region_id) : string =
   "'" ^ FreeRegionId.to_string id
@@ -59,7 +59,7 @@ let variant_id_to_pretty_string (id : variant_id) : string =
 let field_id_to_pretty_string (id : field_id) : string =
   "Field@" ^ FieldId.to_string id
 
-let bound_region_id_to_string (env : 'a fmt_env) (db_id : region_db_id)
+let bound_region_id_to_string (env : 'a fmt_env) (db_id : de_bruijn_id)
     (id : bound_region_id) : string =
   match List.nth_opt env.regions db_id with
   | None -> bound_region_id_to_pretty_string db_id id

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -183,8 +183,9 @@ and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
       match ref_kind with
       | RMut -> "*mut " ^ ty_to_string env rty
       | RShared -> "*const " ^ ty_to_string env rty)
-  | TArrow (regions, inputs, output) ->
-      let env = { env with regions = regions :: env.regions } in
+  | TArrow binder ->
+      let env = { env with regions = binder.binder_regions :: env.regions } in
+      let inputs, output = binder.binder_value in
       let inputs =
         "(" ^ String.concat ", " (List.map (ty_to_string env) inputs) ^ ") -> "
       in

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -39,7 +39,7 @@ let st_substitute_visitor =
       (* Decrement the DeBruijn indices before calling the substitution *)
       let r_subst r =
         match r with
-        | RBVar (db, rid) -> subst.r_subst (RBVar (db - 1, rid))
+        | RVar var -> subst.r_subst (RVar (decr_db_var var))
         | _ -> subst.r_subst r
       in
       let subst = { subst with r_subst } in
@@ -169,10 +169,10 @@ let make_region_subst (var_ids : BoundRegionId.id list) (regions : region list)
   fun r ->
     match r with
     | RStatic | RErased -> r
-    | RFVar _ -> raise (Failure "Unexpected")
-    | RBVar (bdid, id) ->
+    | RVar (Free _) -> raise (Failure "Unexpected")
+    | RVar (Bound (dbid, varid)) ->
         (* Only substitute the bound regions with DeBruijn index equal to 0 *)
-        if bdid = 0 then BoundRegionId.Map.find id mp else r
+        if dbid = 0 then BoundRegionId.Map.find varid mp else r
 
 let make_region_subst_from_vars (vars : region_var list) (regions : region list)
     : region -> region =

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -35,20 +35,6 @@ let st_substitute_visitor =
     method! visit_region (subst : subst) r = subst.r_subst r
 
     (** We need to properly handle the DeBruijn indices *)
-    method! visit_TArrow (subst : subst) regions inputs output =
-      (* Decrement the DeBruijn indices before calling the substitution *)
-      let r_subst r =
-        match r with
-        | RBVar (db, rid) -> subst.r_subst (RBVar (db - 1, rid))
-        | _ -> subst.r_subst r
-      in
-      let subst = { subst with r_subst } in
-      (* Note that we ignore the bound regions variables *)
-      let inputs = List.map (self#visit_ty subst) inputs in
-      let output = self#visit_ty subst output in
-      TArrow (regions, inputs, output)
-
-    (** We need to properly handle the DeBruijn indices *)
     method! visit_region_binder visit_value (subst : subst) x =
       (* Decrement the DeBruijn indices before calling the substitution *)
       let r_subst r =

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -158,13 +158,13 @@ let erase_regions_substitute_types (ty_subst : TypeVarId.id -> ty)
 
 (** Create a region substitution from a list of region variable ids and a list of
     regions (with which to substitute the region variable ids *)
-let make_region_subst (var_ids : RegionVarId.id list) (regions : region list) :
-    region -> region =
+let make_region_subst (var_ids : BoundRegionId.id list) (regions : region list)
+    : region -> region =
   let ls = List.combine var_ids regions in
   let mp =
     List.fold_left
-      (fun mp (k, v) -> RegionVarId.Map.add k v mp)
-      RegionVarId.Map.empty ls
+      (fun mp (k, v) -> BoundRegionId.Map.add k v mp)
+      BoundRegionId.Map.empty ls
   in
   fun r ->
     match r with
@@ -172,7 +172,7 @@ let make_region_subst (var_ids : RegionVarId.id list) (regions : region list) :
     | RFVar _ -> raise (Failure "Unexpected")
     | RBVar (bdid, id) ->
         (* Only substitute the bound regions with DeBruijn index equal to 0 *)
-        if bdid = 0 then RegionVarId.Map.find id mp else r
+        if bdid = 0 then BoundRegionId.Map.find id mp else r
 
 let make_region_subst_from_vars (vars : region_var list) (regions : region list)
     : region -> region =

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -494,7 +494,7 @@ and ty =
 
           TODO: we don't translate this properly yet.
        *)
-  | TArrow of region_var list * ty list * ty
+  | TArrow of (ty list * ty) region_binder
       (** Arrow type, used in particular for the local function pointers.
           This is essentially a "constrained" function signature:
           arrow types can only contain generic lifetime parameters

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -548,61 +548,18 @@ and builtin_ty =
     ord,
     visitors
       {
-        name = "iter_ty_inner";
+        name = "iter_ty";
         variety = "iter";
         ancestors = [ "iter_ty_base_base" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       },
     visitors
       {
-        name = "map_ty_inner";
+        name = "map_ty";
         variety = "map";
         ancestors = [ "map_ty_base_base" ];
         nude = true (* Don't inherit VisitorsRuntime *);
       }]
-
-(** Ancestor for iter visitor for {!type: Types.ty} *)
-class ['self] iter_ty =
-  object (self : 'self)
-    inherit [_] iter_ty_inner
-
-    method! visit_RVar env (var : de_bruijn_var) =
-      match var with
-      | Free var_id -> self#visit_free_region env var_id
-      | Bound (db_id, var_id) -> self#visit_bound_region env db_id var_id
-
-    method visit_bound_region env (db_id : de_bruijn_id)
-        (var_id : bound_region_id) =
-      self#visit_de_bruijn_id env db_id;
-      self#visit_bound_region_id env var_id
-
-    method visit_free_region env (var_id : free_region_id) =
-      self#visit_free_region_id env var_id
-  end
-
-(** Ancestor for map visitor for {!type: Types.ty} *)
-class virtual ['self] map_ty =
-  object (self : 'self)
-    inherit [_] map_ty_inner
-
-    method! visit_RVar env (var : de_bruijn_var) =
-      match var with
-      | Free var_id ->
-          let var_id = self#visit_free_region env var_id in
-          RVar (Free var_id)
-      | Bound (db_id, var_id) ->
-          let db_id, var_id = self#visit_bound_region env db_id var_id in
-          RVar (Bound (db_id, var_id))
-
-    method visit_bound_region env (db_id : de_bruijn_id)
-        (var_id : bound_region_id) =
-      let db_id = self#visit_de_bruijn_id env db_id in
-      let var_id = self#visit_bound_region_id env var_id in
-      (db_id, var_id)
-
-    method visit_free_region env (var_id : free_region_id) =
-      self#visit_free_region_id env var_id
-  end
 
 (* Ancestors for the generic_params visitors *)
 class ['self] iter_generic_params_base =

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -194,22 +194,22 @@ let mk_box_ty (ty : ty) : ty =
     This function should be used on non-erased and non-bound regions.
     For sanity, we raise exceptions if this is not the case.
  *)
-let region_in_set (r : region) (rset : RegionId.Set.t) : bool =
+let region_in_set (r : region) (rset : FreeRegionId.Set.t) : bool =
   match r with
   | RStatic -> false
   | RErased ->
       raise (Failure "region_in_set shouldn't be called on erased regions")
   | RBVar _ ->
       raise (Failure "region_in_set shouldn't be called on bound regions")
-  | RFVar id -> RegionId.Set.mem id rset
+  | RFVar id -> FreeRegionId.Set.mem id rset
 
 (** Return the set of regions in an type - TODO: add static?
 
     This function should be used on non-erased and non-bound regions.
     For sanity, we raise exceptions if this is not the case.
  *)
-let ty_regions (ty : ty) : RegionId.Set.t =
-  let s = ref RegionId.Set.empty in
+let ty_regions (ty : ty) : FreeRegionId.Set.t =
+  let s = ref FreeRegionId.Set.empty in
   let add_region (r : region) =
     match r with
     | RStatic -> () (* TODO: static? *)
@@ -217,7 +217,7 @@ let ty_regions (ty : ty) : RegionId.Set.t =
         raise (Failure "ty_regions shouldn't be called on erased regions")
     | RBVar _ ->
         raise (Failure "region_in_set shouldn't be called on bound regions")
-    | RFVar rid -> s := RegionId.Set.add rid !s
+    | RFVar rid -> s := FreeRegionId.Set.add rid !s
   in
   let obj =
     object
@@ -231,9 +231,9 @@ let ty_regions (ty : ty) : RegionId.Set.t =
   !s
 
 (* TODO: merge with ty_has_regions_in_set *)
-let ty_regions_intersect (ty : ty) (regions : RegionId.Set.t) : bool =
+let ty_regions_intersect (ty : ty) (regions : FreeRegionId.Set.t) : bool =
   let ty_regions = ty_regions ty in
-  not (RegionId.Set.disjoint ty_regions regions)
+  not (FreeRegionId.Set.disjoint ty_regions regions)
 
 (** Check if a {!type:Charon.Types.ty} contains regions from a given set *)
 let ty_has_regions_in_pred (pred : region -> bool) (ty : ty) : bool =
@@ -249,5 +249,5 @@ let ty_has_regions_in_pred (pred : region -> bool) (ty : ty) : bool =
   with Found -> true
 
 (** Check if a {!type:Charon.Types.ty} contains regions from a given set *)
-let ty_has_regions_in_set (rset : RegionId.Set.t) (ty : ty) : bool =
+let ty_has_regions_in_set (rset : FreeRegionId.Set.t) (ty : ty) : bool =
   ty_has_regions_in_pred (fun r -> region_in_set r rset) ty

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.53"
+version = "0.1.54"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -66,7 +66,6 @@ pub struct ConstGenericVar {
     DriveMut,
 )]
 #[serde(transparent)]
-#[charon::rename("RegionDbId")]
 pub struct DeBruijnId {
     pub index: usize,
 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -66,6 +66,7 @@ pub struct ConstGenericVar {
     DriveMut,
 )]
 #[serde(transparent)]
+#[charon::rename("RegionDbId")]
 pub struct DeBruijnId {
     pub index: usize,
 }
@@ -113,11 +114,11 @@ pub enum Region {
     ///                                   Var id: 1
     /// ```
     BVar(DeBruijnId, BoundRegionId),
+    /// A variable not attached to specific. This is not present in translated code, and only
+    /// provided as a convenience for variable manipulation.
+    FVar(FreeRegionId),
     /// Erased region
     Erased,
-    /// For error reporting.
-    #[charon::opaque]
-    Unknown,
 }
 
 /// Identifier of a trait instance.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -755,7 +755,7 @@ pub enum TyKind {
     /// This is essentially a "constrained" function signature:
     /// arrow types can only contain generic lifetime parameters
     /// (no generic types), no predicates, etc.
-    Arrow(Vector<RegionId, RegionVar>, Vec<Ty>, Ty),
+    Arrow(RegionBinder<(Vec<Ty>, Ty)>),
 }
 
 /// Builtin types identifiers.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -14,7 +14,7 @@ pub type FieldName = String;
 generate_index_type!(TypeVarId, "T");
 generate_index_type!(VariantId, "Variant");
 generate_index_type!(FieldId, "Field");
-generate_index_type!(RegionId, "Region");
+generate_index_type!(BoundRegionId, "BoundRegion");
 generate_index_type!(FreeRegionId, "FreeRegion");
 generate_index_type!(ConstGenericVarId, "Const");
 
@@ -35,7 +35,7 @@ pub struct TypeVar {
 )]
 pub struct RegionVar {
     /// Unique index identifying the variable
-    pub index: RegionId,
+    pub index: BoundRegionId,
     /// Region name
     pub name: Option<String>,
 }
@@ -112,7 +112,7 @@ pub enum Region {
     ///                                De Bruijn: 1
     ///                                   Var id: 1
     /// ```
-    BVar(DeBruijnId, RegionId),
+    BVar(DeBruijnId, BoundRegionId),
     /// Erased region
     Erased,
     /// For error reporting.
@@ -301,7 +301,7 @@ pub struct TraitTypeConstraint {
 
 #[derive(Default, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Drive, DriveMut)]
 pub struct GenericArgs {
-    pub regions: Vector<RegionId, Region>,
+    pub regions: Vector<BoundRegionId, Region>,
     pub types: Vector<TypeVarId, Ty>,
     pub const_generics: Vector<ConstGenericVarId, ConstGeneric>,
     // TODO: rename to match [GenericParams]?
@@ -314,7 +314,7 @@ pub struct GenericArgs {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegionBinder<T> {
     #[charon::rename("binder_regions")]
-    pub regions: Vector<RegionId, RegionVar>,
+    pub regions: Vector<BoundRegionId, RegionVar>,
     /// Named this way to highlight accesses to the inner value that might be handling parameters
     /// incorrectly. Prefer using helper methods.
     #[charon::rename("binder_value")]
@@ -330,7 +330,7 @@ pub struct RegionBinder<T> {
 /// be filled with witnesses/instances.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct GenericParams {
-    pub regions: Vector<RegionId, RegionVar>,
+    pub regions: Vector<BoundRegionId, RegionVar>,
     pub types: Vector<TypeVarId, TypeVar>,
     pub const_generics: Vector<ConstGenericVarId, ConstGenericVar>,
     // TODO: rename to match [GenericArgs]?

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -15,6 +15,7 @@ generate_index_type!(TypeVarId, "T");
 generate_index_type!(VariantId, "Variant");
 generate_index_type!(FieldId, "Field");
 generate_index_type!(RegionId, "Region");
+generate_index_type!(FreeRegionId, "FreeRegion");
 generate_index_type!(ConstGenericVarId, "Const");
 
 /// Type variable.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -130,7 +130,7 @@ impl GenericArgs {
     }
 
     pub fn new(
-        regions: Vector<RegionId, Region>,
+        regions: Vector<BoundRegionId, Region>,
         types: Vector<TypeVarId, Ty>,
         const_generics: Vector<ConstGenericVarId, ConstGeneric>,
         trait_refs: Vector<TraitClauseId, TraitRef>,

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -219,7 +219,7 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx> {
     /// The regions.
     /// We use DeBruijn indices, so we have a stack of regions.
     /// See the comments for [Region::BVar].
-    pub region_vars: VecDeque<Vector<RegionId, RegionVar>>,
+    pub region_vars: VecDeque<Vector<BoundRegionId, RegionVar>>,
     /// The map from rust (free) regions to translated region indices.
     /// This contains the early bound regions.
     ///
@@ -234,7 +234,7 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx> {
     ///
     /// The [bound_region_vars] field below takes care of the regions which
     /// are bound in the Rustc representation.
-    pub free_region_vars: std::collections::BTreeMap<hax::Region, RegionId>,
+    pub free_region_vars: std::collections::BTreeMap<hax::Region, BoundRegionId>,
     ///
     /// The stack of late-bound parameters (can only be lifetimes for now), which
     /// use DeBruijn indices (the other parameters use free variables).
@@ -245,7 +245,7 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx> {
     /// **Important**:
     /// ==============
     /// We use DeBruijn indices. See the comments for [Region::Var].
-    pub bound_region_vars: VecDeque<Box<[RegionId]>>,
+    pub bound_region_vars: VecDeque<Box<[BoundRegionId]>>,
     /// The generic parameters for the item. `regions` must be empty, as regions are handled
     /// separately.
     pub generic_params: GenericParams,
@@ -995,7 +995,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
     ///
     /// Important: we must push *all* the free regions (which are early-bound
     /// regions) before pushing any (late-)bound region.
-    pub(crate) fn push_free_region(&mut self, r: hax::Region) -> RegionId {
+    pub(crate) fn push_free_region(&mut self, r: hax::Region) -> BoundRegionId {
         let name = super::translate_types::translate_region_name(&r);
         // Check that there are no late-bound regions
         assert!(self.bound_region_vars.is_empty());
@@ -1009,8 +1009,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         &mut self,
         span: Span,
         binder: hax::Binder<()>,
-        region_vars: &mut Vector<RegionId, RegionVar>,
-    ) -> Result<Box<[RegionId]>, Error> {
+        region_vars: &mut Vector<BoundRegionId, RegionVar>,
+    ) -> Result<Box<[BoundRegionId]>, Error> {
         use hax::BoundVariableKind::*;
         binder
             .bound_vars

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -72,8 +72,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                     .expect("Error: missing binder when translating lifetime")
                     .get(br.var)
                     .expect("Error: lifetime not found, binders were handled incorrectly");
-                let br_id = DeBruijnId::new(*id);
-                Ok(Region::BVar(br_id, *rid))
+                let var = DeBruijnVar::bound(DeBruijnId::new(*id), *rid);
+                Ok(Region::Var(var))
             }
             hax::RegionKind::ReVar(_) => {
                 // Shouldn't exist outside of type inference.
@@ -88,7 +88,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                         // Note that the DeBruijn index depends
                         // on the current stack of bound region groups.
                         let db_id = self.region_vars.len() - 1;
-                        Ok(Region::BVar(DeBruijnId::new(db_id), *rid))
+                        let var = DeBruijnVar::bound(DeBruijnId::new(db_id), *rid);
+                        Ok(Region::Var(var))
                     }
                     None => {
                         let err = format!(

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -323,7 +323,10 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                         .map(|x| ctx.translate_ty(span, x))
                         .try_collect()?;
                     let output = ctx.translate_ty(span, &sig.value.output)?;
-                    Ok(TyKind::Arrow(regions, inputs, output))
+                    Ok(TyKind::Arrow(RegionBinder {
+                        regions,
+                        skip_binder: (inputs, output),
+                    }))
                 })?
             }
             hax::TyKind::Error => {

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1344,6 +1344,7 @@ fn generate_ml(
                     "ExistentialPredicate",
                     "RefKind",
                     "TyKind",
+                    "DeBruijnVar",
                     "Region",
                     "TraitRef",
                     "TraitRefKind",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1352,7 +1352,7 @@ fn generate_ml(
                 // Can't merge into above because aeneas uses the above alongside their own partial
                 // copy of `ty`, which causes method type clashes.
                 (GenerationKind::TypeDecl(Some(DeriveVisitors {
-                    name: "ty",
+                    name: "ty_inner",
                     ancestor: Some("ty_base_base"),
                     reduce: false,
                     extra_types: &[],

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1008,22 +1008,6 @@ fn generate_ml(
                 "
             ),
         ),
-        // Hand-written because we add an extra variant not present on the rust side.
-        // TODO: either add this variant to the rust side or duplicate this code on the aeneas
-        // side.
-        (
-            "Region",
-            indoc!(
-                "
-                | RStatic  (** Static region *)
-                | RBVar of region_db_id * bound_region_id
-                    (** Bound region. We use those in function signatures, type definitions, etc. *)
-                | RFVar of free_region_id
-                    (** Free region. We use those during the symbolic execution. *)
-                | RErased  (** Erased region *)
-                "
-            ),
-        ),
         // Handwritten because we use `indexed_var` as a hack to be able to reuse field names.
         // TODO: remove the need for this hack.
         ("RegionVar", "(bound_region_id, string option) indexed_var"),
@@ -1154,7 +1138,6 @@ fn generate_ml(
     // Compute the sets of types to be put in each module.
     let manually_implemented: HashSet<_> = [
         "ItemOpacity",
-        "DeBruijnId",
         "PredicateOrigin",
         "Ty", // We exclude it since `TyKind` is renamed to `ty`
         "Opaque",
@@ -1315,9 +1298,11 @@ fn generate_ml(
             target: output_dir.join("Types.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(None), &[
+                    "BoundRegionId",
                     "ConstGenericVarId",
                     "Disambiguator",
                     "FieldId",
+                    "FreeRegionId",
                     "FunDeclId",
                     "GlobalDeclId",
                     "TraitClauseId",
@@ -1335,7 +1320,6 @@ fn generate_ml(
                         "const_generic_var_id",
                         "fun_decl_id",
                         "global_decl_id",
-                        "region_db_id",
                         "free_region_id",
                         "bound_region_id",
                         "trait_clause_id",
@@ -1345,6 +1329,7 @@ fn generate_ml(
                         "type_var_id",
                     ],
                 })), &[
+                    "DeBruijnId",
                     "ConstGeneric",
                 ]),
                 // Can't merge into above because aeneas uses the above alongside their own partial

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1016,7 +1016,7 @@ fn generate_ml(
             indoc!(
                 "
                 | RStatic  (** Static region *)
-                | RBVar of region_db_id * region_var_id
+                | RBVar of region_db_id * bound_region_id
                     (** Bound region. We use those in function signatures, type definitions, etc. *)
                 | RFVar of free_region_id
                     (** Free region. We use those during the symbolic execution. *)
@@ -1026,7 +1026,7 @@ fn generate_ml(
         ),
         // Handwritten because we use `indexed_var` as a hack to be able to reuse field names.
         // TODO: remove the need for this hack.
-        ("RegionVar", "(region_var_id, string option) indexed_var"),
+        ("RegionVar", "(bound_region_id, string option) indexed_var"),
         ("TypeVar", "(type_var_id, string) indexed_var"),
     ];
     let manual_json_impls = &[
@@ -1155,7 +1155,6 @@ fn generate_ml(
     let manually_implemented: HashSet<_> = [
         "ItemOpacity",
         "DeBruijnId",
-        "RegionId",
         "PredicateOrigin",
         "Ty", // We exclude it since `TyKind` is renamed to `ty`
         "Opaque",
@@ -1338,7 +1337,7 @@ fn generate_ml(
                         "global_decl_id",
                         "region_db_id",
                         "free_region_id",
-                        "region_var_id",
+                        "bound_region_id",
                         "trait_clause_id",
                         "trait_decl_id",
                         "trait_impl_id",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1018,7 +1018,7 @@ fn generate_ml(
                 | RStatic  (** Static region *)
                 | RBVar of region_db_id * region_var_id
                     (** Bound region. We use those in function signatures, type definitions, etc. *)
-                | RFVar of region_id
+                | RFVar of free_region_id
                     (** Free region. We use those during the symbolic execution. *)
                 | RErased  (** Erased region *)
                 "
@@ -1321,7 +1321,6 @@ fn generate_ml(
                     "FieldId",
                     "FunDeclId",
                     "GlobalDeclId",
-                    "RegionId",
                     "TraitClauseId",
                     "TraitDeclId",
                     "TraitImplId",
@@ -1338,7 +1337,7 @@ fn generate_ml(
                         "fun_decl_id",
                         "global_decl_id",
                         "region_db_id",
-                        "region_id",
+                        "free_region_id",
                         "region_var_id",
                         "trait_clause_id",
                         "trait_decl_id",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1298,11 +1298,9 @@ fn generate_ml(
             target: output_dir.join("Types.ml"),
             markers: ctx.markers_from_names(&[
                 (GenerationKind::TypeDecl(None), &[
-                    "BoundRegionId",
                     "ConstGenericVarId",
                     "Disambiguator",
                     "FieldId",
-                    "FreeRegionId",
                     "FunDeclId",
                     "GlobalDeclId",
                     "TraitClauseId",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1333,7 +1333,7 @@ fn generate_ml(
                 // Can't merge into above because aeneas uses the above alongside their own partial
                 // copy of `ty`, which causes method type clashes.
                 (GenerationKind::TypeDecl(Some(DeriveVisitors {
-                    name: "ty_inner",
+                    name: "ty",
                     ancestor: Some("ty_base_base"),
                     reduce: false,
                     extra_types: &[],

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -37,9 +37,7 @@ type file_id = FileId.id
 type id_to_file_map = file FileId.Map.t
 type of_json_ctx = id_to_file_map
 
-let de_bruijn_id_of_json = int_of_json
 let path_buf_of_json = string_of_json
-let region_id_of_json = BoundRegionId.id_of_json
 
 (* __REPLACE0__ *)
 

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -39,7 +39,7 @@ type of_json_ctx = id_to_file_map
 
 let de_bruijn_id_of_json = int_of_json
 let path_buf_of_json = string_of_json
-let region_id_of_json = RegionVarId.id_of_json
+let region_id_of_json = BoundRegionId.id_of_json
 
 (* __REPLACE0__ *)
 

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -162,48 +162,6 @@ class virtual ['self] map_ty_base_base =
 
 (* __REPLACE2__ *)
 
-(** Ancestor for iter visitor for {!type: Types.ty} *)
-class ['self] iter_ty =
-  object (self : 'self)
-    inherit [_] iter_ty_inner
-
-    method! visit_RVar env (var: de_bruijn_var) =
-        match var with
-        | Free var_id -> self#visit_free_region env var_id
-        | Bound (db_id, var_id) -> self#visit_bound_region env db_id var_id
-
-    method visit_bound_region env (db_id: de_bruijn_id) (var_id: bound_region_id) =
-        self#visit_de_bruijn_id env db_id;
-        self#visit_bound_region_id env var_id
-
-    method visit_free_region env (var_id: free_region_id) =
-        self#visit_free_region_id env var_id
-  end
-
-(** Ancestor for map visitor for {!type: Types.ty} *)
-class virtual ['self] map_ty =
-  object (self : 'self)
-    inherit [_] map_ty_inner
-
-    method! visit_RVar env (var: de_bruijn_var) =
-        match var with
-        | Free var_id ->
-            let var_id = self#visit_free_region env var_id in
-            RVar (Free var_id)
-        | Bound (db_id, var_id) ->
-            let (db_id, var_id) = self#visit_bound_region env db_id var_id in
-            RVar (Bound (db_id, var_id))
-
-    method visit_bound_region env (db_id: de_bruijn_id) (var_id: bound_region_id) =
-        let db_id = self#visit_de_bruijn_id env db_id in
-        let var_id = self#visit_bound_region_id env var_id in
-        (db_id, var_id)
-
-    method visit_free_region env (var_id: free_region_id) =
-        self#visit_free_region_id env var_id
-  end
-
-
 (* __REPLACE3__ *)
 
 (* __REPLACE4__ *)

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -22,7 +22,7 @@ module TraitDeclId = IdGen ()
 module TraitImplId = IdGen ()
 module TraitClauseId = IdGen ()
 module UnsolvedTraitId = IdGen ()
-module RegionVarId = IdGen ()
+module BoundRegionId = IdGen ()
 module FreeRegionId = IdGen ()
 module RegionGroupId = IdGen ()
 module Disambiguator = IdGen ()
@@ -40,7 +40,7 @@ type region_db_id = int [@@deriving show, ord]
 (** We define these types to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
-type region_var_id = RegionVarId.id [@@deriving show, ord]
+type bound_region_id = BoundRegionId.id [@@deriving show, ord]
 type free_region_id = FreeRegionId.id [@@deriving show, ord]
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
 
@@ -66,7 +66,7 @@ let option_some_id = VariantId.of_int 1
 (* __REPLACE1__ *)
 
 (** Region variable. *)
-type region_var = (region_var_id, string option) indexed_var
+type region_var = (bound_region_id, string option) indexed_var
 [@@deriving show, ord]
 
 (** A value of type `'a` bound by generic parameters. *)
@@ -103,7 +103,7 @@ class ['self] iter_ty_base_base =
         visit_right env right
 
     method visit_region_var env (x : region_var) =
-      self#visit_indexed_var self#visit_region_var_id
+      self#visit_indexed_var self#visit_bound_region_id
         (self#visit_option self#visit_string)
         env x
 
@@ -147,7 +147,7 @@ class virtual ['self] map_ty_base_base =
         (left, right)
 
     method visit_region_var env (x : region_var) =
-      self#visit_indexed_var self#visit_region_var_id
+      self#visit_indexed_var self#visit_bound_region_id
         (self#visit_option self#visit_string)
         env x
 
@@ -168,12 +168,12 @@ class ['self] iter_ty =
   object (self : 'self)
     inherit [_] iter_ty_inner
 
-    method! visit_RBVar env (db_id: region_db_id) (var_id: region_var_id) =
+    method! visit_RBVar env (db_id: region_db_id) (var_id: bound_region_id) =
         self#visit_bound_region env db_id var_id
 
-    method visit_bound_region env (db_id: region_db_id) (var_id: region_var_id) =
+    method visit_bound_region env (db_id: region_db_id) (var_id: bound_region_id) =
         self#visit_region_db_id env db_id;
-        self#visit_region_var_id env var_id
+        self#visit_bound_region_id env var_id
 
     method! visit_RFVar env (var_id: free_region_id) =
         self#visit_free_region env var_id
@@ -187,13 +187,13 @@ class virtual ['self] map_ty =
   object (self : 'self)
     inherit [_] map_ty_inner
 
-    method! visit_RBVar env (db_id: region_db_id) (var_id: region_var_id) =
+    method! visit_RBVar env (db_id: region_db_id) (var_id: bound_region_id) =
         let (db_id, var_id) = self#visit_bound_region env db_id var_id in
         RBVar (db_id, var_id)
 
-    method visit_bound_region env (db_id: region_db_id) (var_id: region_var_id) =
+    method visit_bound_region env (db_id: region_db_id) (var_id: bound_region_id) =
         let db_id = self#visit_region_db_id env db_id in
-        let var_id = self#visit_region_var_id env var_id in
+        let var_id = self#visit_bound_region_id env var_id in
         (db_id, var_id)
 
     method! visit_RFVar env (var_id: free_region_id) =
@@ -227,7 +227,7 @@ type ('rid, 'id) g_region_group = {
 }
 [@@deriving show]
 
-type region_var_group = (RegionVarId.id, RegionGroupId.id) g_region_group
+type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group
 [@@deriving show]
 
 type region_var_groups = region_var_group list [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -39,6 +39,8 @@ type literal_type = Values.literal_type [@@deriving show, ord]
 (** We define these types to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
+type bound_region_id = BoundRegionId.id [@@deriving show, ord]
+type free_region_id = FreeRegionId.id [@@deriving show, ord]
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
 
 type ('id, 'name) indexed_var = {
@@ -165,11 +167,11 @@ class ['self] iter_ty =
   object (self : 'self)
     inherit [_] iter_ty_inner
 
-    method! visit_RBVar env (db_id: region_db_id) (var_id: bound_region_id) =
+    method! visit_RBVar env (db_id: de_bruijn_id) (var_id: bound_region_id) =
         self#visit_bound_region env db_id var_id
 
-    method visit_bound_region env (db_id: region_db_id) (var_id: bound_region_id) =
-        self#visit_region_db_id env db_id;
+    method visit_bound_region env (db_id: de_bruijn_id) (var_id: bound_region_id) =
+        self#visit_de_bruijn_id env db_id;
         self#visit_bound_region_id env var_id
 
     method! visit_RFVar env (var_id: free_region_id) =
@@ -184,12 +186,12 @@ class virtual ['self] map_ty =
   object (self : 'self)
     inherit [_] map_ty_inner
 
-    method! visit_RBVar env (db_id: region_db_id) (var_id: bound_region_id) =
+    method! visit_RBVar env (db_id: de_bruijn_id) (var_id: bound_region_id) =
         let (db_id, var_id) = self#visit_bound_region env db_id var_id in
         RBVar (db_id, var_id)
 
-    method visit_bound_region env (db_id: region_db_id) (var_id: bound_region_id) =
-        let db_id = self#visit_region_db_id env db_id in
+    method visit_bound_region env (db_id: de_bruijn_id) (var_id: bound_region_id) =
+        let db_id = self#visit_de_bruijn_id env db_id in
         let var_id = self#visit_bound_region_id env var_id in
         (db_id, var_id)
 

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -23,7 +23,7 @@ module TraitImplId = IdGen ()
 module TraitClauseId = IdGen ()
 module UnsolvedTraitId = IdGen ()
 module RegionVarId = IdGen ()
-module RegionId = IdGen ()
+module FreeRegionId = IdGen ()
 module RegionGroupId = IdGen ()
 module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
@@ -41,6 +41,7 @@ type region_db_id = int [@@deriving show, ord]
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
 type region_var_id = RegionVarId.id [@@deriving show, ord]
+type free_region_id = FreeRegionId.id [@@deriving show, ord]
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
 
 type ('id, 'name) indexed_var = {
@@ -174,11 +175,11 @@ class ['self] iter_ty =
         self#visit_region_db_id env db_id;
         self#visit_region_var_id env var_id
 
-    method! visit_RFVar env (var_id: region_id) =
+    method! visit_RFVar env (var_id: free_region_id) =
         self#visit_free_region env var_id
 
-    method visit_free_region env (var_id: region_id) =
-        self#visit_region_id env var_id
+    method visit_free_region env (var_id: free_region_id) =
+        self#visit_free_region_id env var_id
   end
 
 (** Ancestor for map visitor for {!type: Types.ty} *)
@@ -195,12 +196,12 @@ class virtual ['self] map_ty =
         let var_id = self#visit_region_var_id env var_id in
         (db_id, var_id)
 
-    method! visit_RFVar env (var_id: region_id) =
+    method! visit_RFVar env (var_id: free_region_id) =
         let var_id = self#visit_free_region env var_id in
         RFVar var_id
 
-    method visit_free_region env (var_id: region_id) =
-        self#visit_region_id env var_id
+    method visit_free_region env (var_id: free_region_id) =
+        self#visit_free_region_id env var_id
   end
 
 

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -162,6 +162,48 @@ class virtual ['self] map_ty_base_base =
 
 (* __REPLACE2__ *)
 
+(** Ancestor for iter visitor for {!type: Types.ty} *)
+class ['self] iter_ty =
+  object (self : 'self)
+    inherit [_] iter_ty_inner
+
+    method! visit_RBVar env (db_id: region_db_id) (var_id: region_var_id) =
+        self#visit_bound_region env db_id var_id
+
+    method visit_bound_region env (db_id: region_db_id) (var_id: region_var_id) =
+        self#visit_region_db_id env db_id;
+        self#visit_region_var_id env var_id
+
+    method! visit_RFVar env (var_id: region_id) =
+        self#visit_free_region env var_id
+
+    method visit_free_region env (var_id: region_id) =
+        self#visit_region_id env var_id
+  end
+
+(** Ancestor for map visitor for {!type: Types.ty} *)
+class virtual ['self] map_ty =
+  object (self : 'self)
+    inherit [_] map_ty_inner
+
+    method! visit_RBVar env (db_id: region_db_id) (var_id: region_var_id) =
+        let (db_id, var_id) = self#visit_bound_region env db_id var_id in
+        RBVar (db_id, var_id)
+
+    method visit_bound_region env (db_id: region_db_id) (var_id: region_var_id) =
+        let db_id = self#visit_region_db_id env db_id in
+        let var_id = self#visit_region_var_id env var_id in
+        (db_id, var_id)
+
+    method! visit_RFVar env (var_id: region_id) =
+        let var_id = self#visit_free_region env var_id in
+        RFVar var_id
+
+    method visit_free_region env (var_id: region_id) =
+        self#visit_region_id env var_id
+  end
+
+
 (* __REPLACE3__ *)
 
 (* __REPLACE4__ *)

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -35,13 +35,10 @@ type ('id, 'x) vector = 'x list [@@deriving show, ord]
 type integer_type = Values.integer_type [@@deriving show, ord]
 type float_type = Values.float_type [@@deriving show, ord]
 type literal_type = Values.literal_type [@@deriving show, ord]
-type region_db_id = int [@@deriving show, ord]
 
 (** We define these types to control the name of the visitor functions
     (see e.g., {!class:Types.iter_ty_base} and {!Types.TVar}).
   *)
-type bound_region_id = BoundRegionId.id [@@deriving show, ord]
-type free_region_id = FreeRegionId.id [@@deriving show, ord]
 type region_group_id = RegionGroupId.id [@@deriving show, ord]
 
 type ('id, 'name) indexed_var = {

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -96,14 +96,14 @@ impl Pattern {
                 self.matches_with_generics(ctx, &name, args)
             }
             TyKind::Adt(TypeId::Tuple, _)
-            | TyKind::TypeVar(_)
-            | TyKind::Literal(_)
+            | TyKind::TypeVar(..)
+            | TyKind::Literal(..)
             | TyKind::Never
-            | TyKind::Ref(_, _, _)
-            | TyKind::RawPtr(_, _)
-            | TyKind::TraitType(_, _)
-            | TyKind::DynTrait(_)
-            | TyKind::Arrow(_, _, _) => false,
+            | TyKind::Ref(..)
+            | TyKind::RawPtr(..)
+            | TyKind::TraitType(..)
+            | TyKind::DynTrait(..)
+            | TyKind::Arrow(..) => false,
         }
     }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -810,8 +810,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for Region {
         match self {
             Region::Static => "'static".to_string(),
             Region::BVar(grid, id) => ctx.format_object((*grid, *id)),
+            Region::FVar(id) => format!("'free_{id}"),
             Region::Erased => "'_".to_string(),
-            Region::Unknown => "'_UNKNOWN_".to_string(),
         }
     }
 }
@@ -1661,8 +1661,8 @@ impl std::fmt::Display for Region {
         match self {
             Region::Static => write!(f, "'static"),
             Region::BVar(grid, id) => write!(f, "'_{}_{id}", grid.index),
+            Region::FVar(id) => write!(f, "'free_{id}"),
             Region::Erased => write!(f, "'_"),
-            Region::Unknown => write!(f, "'_UNKNOWN_"),
         }
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -809,8 +809,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Region {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match self {
             Region::Static => "'static".to_string(),
-            Region::BVar(grid, id) => ctx.format_object((*grid, *id)),
-            Region::FVar(id) => format!("'free_{id}"),
+            Region::Var(var) => ctx.format_object(*var),
             Region::Erased => "'_".to_string(),
         }
     }
@@ -1545,6 +1544,22 @@ impl std::fmt::Display for BuiltinFunId {
     }
 }
 
+impl std::fmt::Display for DeBruijnId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(f, "{}", self.index)
+    }
+}
+
+impl std::fmt::Display for DeBruijnVar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        match *self {
+            Self::Bound(dbid, varid) if dbid.is_zero() => write!(f, "{varid}"),
+            Self::Bound(dbid, varid) => write!(f, "{dbid}_{varid}"),
+            Self::Free(varid) => write!(f, "free_{varid}"),
+        }
+    }
+}
+
 impl std::fmt::Display for ConstantExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         write!(f, "{}", self.fmt_with_ctx(&FmtCtx::new()))
@@ -1660,8 +1675,7 @@ impl std::fmt::Display for Region {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             Region::Static => write!(f, "'static"),
-            Region::BVar(grid, id) => write!(f, "'_{}_{id}", grid.index),
-            Region::FVar(id) => write!(f, "'free_{id}"),
+            Region::Var(var) => write!(f, "'_{var}"),
             Region::Erased => write!(f, "'_"),
         }
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1346,22 +1346,19 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                 format!("{}::{name}", trait_ref.fmt_with_ctx(ctx),)
             }
             TyKind::DynTrait(pred) => format!("dyn ({})", pred.with_ctx(ctx)),
-            TyKind::Arrow(regions, inputs, output) => {
+            TyKind::Arrow(io) => {
                 // Update the bound regions
-                let ctx = &ctx.push_bound_regions(regions);
+                let ctx = &ctx.push_bound_regions(&io.regions);
 
-                let regions = if regions.is_empty() {
+                let regions = if io.regions.is_empty() {
                     "".to_string()
                 } else {
                     format!(
                         "<{}>",
-                        regions
-                            .iter()
-                            .map(|r| ctx.format_object(r))
-                            .collect::<Vec<String>>()
-                            .join(", ")
+                        io.regions.iter().map(|r| ctx.format_object(r)).join(", ")
                     )
                 };
+                let (inputs, output) = &io.skip_binder;
                 let inputs = inputs
                     .iter()
                     .map(|x| x.fmt_with_ctx(ctx))

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -110,13 +110,13 @@ impl<'a, 'b> SetLocals<'a> for FmtCtx<'b> {
 pub trait PushBoundRegions<'a> {
     type C: 'a + AstFormatter;
 
-    fn push_bound_regions(&'a self, regions: &'a Vector<RegionId, RegionVar>) -> Self::C;
+    fn push_bound_regions(&'a self, regions: &'a Vector<BoundRegionId, RegionVar>) -> Self::C;
 }
 
 impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
     type C = FmtCtx<'a>;
 
-    fn push_bound_regions(&'a self, regions: &'a Vector<RegionId, RegionVar>) -> Self::C {
+    fn push_bound_regions(&'a self, regions: &'a Vector<BoundRegionId, RegionVar>) -> Self::C {
         let mut generics = self.generics.clone();
         generics.push_front(Cow::Owned(GenericParams {
             regions: regions.clone(),
@@ -140,7 +140,7 @@ pub trait AstFormatter = Formatter<TypeVarId>
     + Formatter<TraitImplId>
     + Formatter<AnyTransId>
     + Formatter<TraitClauseId>
-    + Formatter<(DeBruijnId, RegionId)>
+    + Formatter<(DeBruijnId, BoundRegionId)>
     + Formatter<VarId>
     + Formatter<(TypeDeclId, VariantId)>
     + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
@@ -263,8 +263,8 @@ impl<'a> Formatter<AnyTransId> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<(DeBruijnId, RegionId)> for FmtCtx<'a> {
-    fn format_object(&self, (grid, id): (DeBruijnId, RegionId)) -> String {
+impl<'a> Formatter<(DeBruijnId, BoundRegionId)> for FmtCtx<'a> {
+    fn format_object(&self, (grid, id): (DeBruijnId, BoundRegionId)) -> String {
         match self.generics.get(grid.index) {
             None => Region::BVar(grid, id).to_string(),
             Some(generics) => match generics.regions.get(id) {

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -12,7 +12,7 @@ use super::ctx::UllbcPass;
 #[derive(VisitorMut)]
 #[visitor(Region(exit), Ty(enter, exit))]
 struct InsertRegions<'a> {
-    regions: &'a mut Vector<RegionId, RegionVar>,
+    regions: &'a mut Vector<BoundRegionId, RegionVar>,
     // The number of region groups we dived into (we don't count the regions
     // at the declaration level). We use this for the DeBruijn indices.
     depth: usize,

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -25,7 +25,7 @@ impl<'a> InsertRegions<'a> {
             let index = self
                 .regions
                 .push_with(|index| RegionVar { index, name: None });
-            *r = Region::BVar(DeBruijnId::new(self.depth), index);
+            *r = Region::Var(DeBruijnVar::bound(DeBruijnId::new(self.depth), index));
         }
     }
 


### PR DESCRIPTION
Inside Charon, all variables are bound variables that correspond to a known binder in the AST. When manipulating the AST and variables however, we substitute such variables to be bound in a current context instead; these are called "free variables". So far in Charon we have no use for these, but they are used all over the place in Aeneas, and therefore exist in the AST of charon-ml.

This PR first clarifies the distinction between these two kinds of variables by renaming the ids to `free_region_id` and `bound_region_id`, then adds free variables to the rust side (both for clarify and potential future uses). Finally this factors out a little enum that represents either of these variables, with intent to use it for the other type-level variables in a follow-up PR.