### PR TITLE
Use `DeBruijnVar` for all type-level variables

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.55"
+let supported_charon_version = "0.1.56"

--- a/charon-ml/src/Expressions.ml
+++ b/charon-ml/src/Expressions.ml
@@ -271,7 +271,8 @@ and raw_constant_expr =
           Remark: trait constants can not be used in types, they are necessarily
           values.
        *)
-  | CVar of const_generic_var_id  (** A const generic var *)
+  | CVar of (const_generic_var_id, const_generic_var_id) de_bruijn_var
+      (** A const generic var *)
   | CFnPtr of fn_ptr  (** Function pointer *)
 
 and constant_expr = { value : raw_constant_expr; ty : ty }

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -875,13 +875,6 @@ and de_bruijn_var_of_json :
         Ok (Free free)
     | _ -> Error "")
 
-and type_var_id_of_json (ctx : of_json_ctx) (js : json) :
-    (type_var_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | x -> TypeVarId.id_of_json ctx x
-    | _ -> Error "")
-
 and bound_region_id_of_json (ctx : of_json_ctx) (js : json) :
     (bound_region_id, string) result =
   combine_error_msgs js __FUNCTION__
@@ -894,6 +887,13 @@ and free_region_id_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | x -> FreeRegionId.id_of_json ctx x
+    | _ -> Error "")
+
+and type_var_id_of_json (ctx : of_json_ctx) (js : json) :
+    (type_var_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> TypeVarId.id_of_json ctx x
     | _ -> Error "")
 
 and const_generic_var_id_of_json (ctx : of_json_ctx) (js : json) :
@@ -1346,7 +1346,10 @@ and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
         let* x_1 = generic_args_of_json ctx x_1 in
         Ok (TAdt (x_0, x_1))
     | `Assoc [ ("TypeVar", type_var) ] ->
-        let* type_var = type_var_id_of_json ctx type_var in
+        let* type_var =
+          de_bruijn_var_of_json type_var_id_of_json type_var_id_of_json ctx
+            type_var
+        in
         Ok (TVar type_var)
     | `Assoc [ ("Literal", literal) ] ->
         let* literal = literal_type_of_json ctx literal in

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -256,7 +256,10 @@ and raw_constant_expr_of_json (ctx : of_json_ctx) (js : json) :
         let* x_1 = trait_item_name_of_json ctx x_1 in
         Ok (CTraitConst (x_0, x_1))
     | `Assoc [ ("Var", var) ] ->
-        let* var = const_generic_var_id_of_json ctx var in
+        let* var =
+          de_bruijn_var_of_json const_generic_var_id_of_json
+            const_generic_var_id_of_json ctx var
+        in
         Ok (CVar var)
     | `Assoc [ ("FnPtr", fn_ptr) ] ->
         let* fn_ptr = fn_ptr_of_json ctx fn_ptr in
@@ -1331,7 +1334,10 @@ and const_generic_of_json (ctx : of_json_ctx) (js : json) :
         let* global = global_decl_id_of_json ctx global in
         Ok (CgGlobal global)
     | `Assoc [ ("Var", var) ] ->
-        let* var = const_generic_var_id_of_json ctx var in
+        let* var =
+          de_bruijn_var_of_json const_generic_var_id_of_json
+            const_generic_var_id_of_json ctx var
+        in
         Ok (CgVar var)
     | `Assoc [ ("Value", value) ] ->
         let* value = literal_of_json ctx value in

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -983,7 +983,10 @@ and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
         let* x_1 = generic_args_of_json ctx x_1 in
         Ok (TraitImpl (x_0, x_1))
     | `Assoc [ ("Clause", clause) ] ->
-        let* clause = trait_clause_id_of_json ctx clause in
+        let* clause =
+          de_bruijn_var_of_json trait_clause_id_of_json trait_clause_id_of_json
+            ctx clause
+        in
         Ok (Clause clause)
     | `Assoc [ ("ParentClause", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = box_of_json trait_instance_id_of_json ctx x_0 in

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -817,12 +817,15 @@ let region_to_pattern (m : constraints) (r : T.region) : region =
          detect specific function calls) to patterns. *)
       RVar None
 
-let type_var_to_pattern (m : constraints) (v : T.TypeVarId.id) : var option =
-  match T.TypeVarId.Map.find_opt v m.tmap with
-  | Some v -> v
-  | None ->
+let type_var_to_pattern (m : constraints) (var : T.type_db_var) : var option =
+  match var with
+  | Bound _ -> failwith "bound type var"
+  | Free id -> begin
+      match T.TypeVarId.Map.find_opt id m.tmap with
+      | Some v -> v
+      | None -> None
       (* Return the empty pattern *)
-      None
+    end
 
 let const_generic_var_to_pattern (m : constraints) (v : T.ConstGenericVarId.id)
     : var option =

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -827,13 +827,16 @@ let type_var_to_pattern (m : constraints) (var : T.type_db_var) : var option =
       (* Return the empty pattern *)
     end
 
-let const_generic_var_to_pattern (m : constraints) (v : T.ConstGenericVarId.id)
-    : var option =
-  match T.ConstGenericVarId.Map.find_opt v m.cmap with
-  | Some v -> v
-  | None ->
+let const_generic_var_to_pattern (m : constraints)
+    (var : T.const_generic_db_var) : var option =
+  match var with
+  | Bound _ -> failwith "bound const generic var"
+  | Free id -> begin
+      match T.ConstGenericVarId.Map.find_opt id m.cmap with
+      | Some v -> v
+      | None -> None
       (* Return the empty pattern *)
-      None
+    end
 
 let constraints_map_compute_regions_map (regions : T.region_var list) :
     var option T.BoundRegionId.Map.t =

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -123,7 +123,7 @@ let constant_expr_to_string (env : 'a fmt_env) (cv : constant_expr) : string =
   match cv.value with
   | CLiteral lit ->
       "(" ^ literal_to_string lit ^ " : " ^ ty_to_string env cv.ty ^ ")"
-  | CVar vid -> const_generic_var_id_to_string env vid
+  | CVar var -> const_generic_db_var_to_string env var
   | CTraitConst (trait_ref, const_name) ->
       let trait_ref = trait_ref_to_string env trait_ref in
       trait_ref ^ const_name

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -62,6 +62,8 @@ let variant_id_to_pretty_string (id : variant_id) : string =
 let field_id_to_pretty_string (id : field_id) : string =
   "Field@" ^ FieldId.to_string id
 
+let trait_clause_id_to_string _ id = trait_clause_id_to_pretty_string id
+
 let region_db_var_to_string (env : 'a fmt_env) (var : region_db_var) : string =
   match var with
   | Bound (dbid, varid) -> begin
@@ -105,13 +107,16 @@ let const_generic_db_var_to_string (env : 'a fmt_env)
       | Some x -> const_generic_var_to_string x
     end
 
+let trait_db_var_to_string (env : 'a fmt_env) (var : trait_db_var) : string =
+  match var with
+  | Bound _ -> failwith "bound trait clause variable"
+  | Free id -> trait_clause_id_to_pretty_string id
+
 let region_to_string (env : 'a fmt_env) (r : region) : string =
   match r with
   | RStatic -> "'static"
   | RErased -> "'_"
   | RVar var -> region_db_var_to_string env var
-
-let trait_clause_id_to_string _ id = trait_clause_id_to_pretty_string id
 
 let region_binder_to_string (value_to_string : 'a fmt_env -> 'c -> string)
     (env : 'a fmt_env) (rb : 'c region_binder) : string =
@@ -264,7 +269,7 @@ and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
       impl ^ generics
   | BuiltinOrAuto trait ->
       region_binder_to_string trait_decl_ref_to_string env trait
-  | Clause id -> trait_clause_id_to_string env id
+  | Clause id -> trait_db_var_to_string env id
   | ParentClause (inst_id, _decl_id, clause_id) ->
       let inst_id = trait_instance_id_to_string env inst_id in
       let clause_id = trait_clause_id_to_string env clause_id in

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -90,16 +90,20 @@ let type_db_var_to_string (env : 'a fmt_env) (var : type_db_var) : string =
       | Some x -> type_var_to_string x
     end
 
-let const_generic_var_id_to_string (env : 'a fmt_env)
-    (id : const_generic_var_id) : string =
-  (* Note that the const generics are not necessarily ordered following their indices *)
-  match
-    List.find_opt
-      (fun (x : const_generic_var) -> x.index = id)
-      env.generics.const_generics
-  with
-  | None -> const_generic_var_id_to_pretty_string id
-  | Some x -> const_generic_var_to_string x
+let const_generic_db_var_to_string (env : 'a fmt_env)
+    (var : const_generic_db_var) : string =
+  match var with
+  | Bound _ -> failwith "bound const generic variable"
+  | Free id -> begin
+      (* Note that the types are not necessarily ordered following their indices *)
+      match
+        List.find_opt
+          (fun (x : const_generic_var) -> x.index = id)
+          env.generics.const_generics
+      with
+      | None -> const_generic_var_id_to_pretty_string id
+      | Some x -> const_generic_var_to_string x
+    end
 
 let region_to_string (env : 'a fmt_env) (r : region) : string =
   match r with
@@ -166,7 +170,7 @@ and trait_impl_id_to_string env id =
 and const_generic_to_string (env : 'a fmt_env) (cg : const_generic) : string =
   match cg with
   | CgGlobal id -> global_decl_id_to_string env id
-  | CgVar id -> const_generic_var_id_to_string env id
+  | CgVar var -> const_generic_db_var_to_string env var
   | CgValue lit -> literal_to_string lit
 
 and ty_to_string (env : 'a fmt_env) (ty : ty) : string =

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -78,13 +78,17 @@ let region_db_var_to_string (env : 'a fmt_env) (var : region_db_var) : string =
     end
   | Free _ -> region_db_var_to_pretty_string var
 
-let type_var_id_to_string (env : 'a fmt_env) (id : type_var_id) : string =
-  (* Note that the types are not necessarily ordered following their indices *)
-  match
-    List.find_opt (fun (x : type_var) -> x.index = id) env.generics.types
-  with
-  | None -> type_var_id_to_pretty_string id
-  | Some x -> type_var_to_string x
+let type_db_var_to_string (env : 'a fmt_env) (var : type_db_var) : string =
+  match var with
+  | Bound _ -> failwith "bound type variable"
+  | Free id -> begin
+      (* Note that the types are not necessarily ordered following their indices *)
+      match
+        List.find_opt (fun (x : type_var) -> x.index = id) env.generics.types
+      with
+      | None -> type_var_id_to_pretty_string id
+      | Some x -> type_var_to_string x
+    end
 
 let const_generic_var_id_to_string (env : 'a fmt_env)
     (id : const_generic_var_id) : string =
@@ -175,7 +179,7 @@ and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
       in
       let params = params_to_string env is_tuple generics in
       type_id_to_string env id ^ params
-  | TVar tv -> type_var_id_to_string env tv
+  | TVar tv -> type_db_var_to_string env tv
   | TNever -> "!"
   | TLiteral lit_ty -> literal_type_to_string lit_ty
   | TTraitType (trait_ref, type_name) ->

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -24,7 +24,7 @@ let empty_subst : subst =
   {
     r_subst = (fun x -> RVar x);
     ty_subst = (fun id -> TVar (Free id));
-    cg_subst = (fun id -> CgVar id);
+    cg_subst = (fun id -> CgVar (Free id));
     tr_subst = (fun id -> Clause id);
     tr_self = Self;
   }
@@ -50,7 +50,11 @@ let st_substitute_visitor =
       | Free id -> subst.ty_subst id
       | Bound _ -> failwith "bound type variable"
 
-    method! visit_CgVar (subst : subst) id = subst.cg_subst id
+    method! visit_CgVar (subst : subst) var =
+      match var with
+      | Free id -> subst.cg_subst id
+      | Bound _ -> failwith "bound const generic variable"
+
     method! visit_Clause (subst : subst) id = subst.tr_subst id
     method! visit_Self (subst : subst) = subst.tr_self
 

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -25,7 +25,7 @@ let empty_subst : subst =
     r_subst = (fun x -> RVar x);
     ty_subst = (fun id -> TVar (Free id));
     cg_subst = (fun id -> CgVar (Free id));
-    tr_subst = (fun id -> Clause id);
+    tr_subst = (fun id -> Clause (Free id));
     tr_self = Self;
   }
 
@@ -55,7 +55,11 @@ let st_substitute_visitor =
       | Free id -> subst.cg_subst id
       | Bound _ -> failwith "bound const generic variable"
 
-    method! visit_Clause (subst : subst) id = subst.tr_subst id
+    method! visit_Clause (subst : subst) var =
+      match var with
+      | Free id -> subst.tr_subst id
+      | Bound _ -> failwith "bound trait clause variable"
+
     method! visit_Self (subst : subst) = subst.tr_self
 
     method! visit_type_var_id (_ : subst) _ =

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -493,7 +493,7 @@ and region =
 and trait_instance_id =
   | TraitImpl of trait_impl_id * generic_args
       (** A specific top-level implementation item. *)
-  | Clause of trait_clause_id
+  | Clause of (trait_clause_id, trait_clause_id) de_bruijn_var
       (** One of the local clauses.
 
           Example:
@@ -984,6 +984,9 @@ type type_db_var = (type_var_id, type_var_id) de_bruijn_var [@@deriving show]
 
 type const_generic_db_var =
   (const_generic_var_id, const_generic_var_id) de_bruijn_var
+[@@deriving show]
+
+type trait_db_var = (trait_clause_id, trait_clause_id) de_bruijn_var
 [@@deriving show]
 
 type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -105,17 +105,112 @@ let option_none_id = VariantId.of_int 0
 (** The variant id for [Option::Some] *)
 let option_some_id = VariantId.of_int 1
 
+class ['self] iter_const_generic_base_base =
+  object (self : 'self)
+    inherit [_] iter_literal
+    method visit_de_bruijn_id : 'env -> de_bruijn_id -> unit = fun _ _ -> ()
+
+    method visit_de_bruijn_var
+        : 'b 'f.
+          ('env -> 'b -> unit) ->
+          ('env -> 'f -> unit) ->
+          'env ->
+          ('b, 'f) de_bruijn_var ->
+          unit =
+      fun visit_bound visit_free env x ->
+        match x with
+        | Bound (dbid, varid) ->
+            self#visit_de_bruijn_id env dbid;
+            visit_bound env varid
+        | Free varid -> visit_free env varid
+  end
+
+(** Ancestor for map visitor for {!type: Types.ty} *)
+class virtual ['self] map_const_generic_base_base =
+  object (self : 'self)
+    inherit [_] map_literal
+
+    method visit_de_bruijn_id : 'env -> de_bruijn_id -> de_bruijn_id =
+      fun _ x -> x
+
+    method visit_de_bruijn_var
+        : 'b 'f.
+          ('env -> 'b -> 'b) ->
+          ('env -> 'f -> 'f) ->
+          'env ->
+          ('b, 'f) de_bruijn_var ->
+          ('b, 'f) de_bruijn_var =
+      fun visit_bound visit_free env x ->
+        match x with
+        | Bound (dbid, varid) ->
+            let dbid = self#visit_de_bruijn_id env dbid in
+            let varid = visit_bound env varid in
+            Bound (dbid, varid)
+        | Free varid ->
+            let varid = visit_free env varid in
+            Free varid
+  end
+
+class virtual ['self] reduce_const_generic_base_base =
+  object (self : 'self)
+    inherit [_] reduce_literal
+
+    method visit_de_bruijn_id : 'env -> de_bruijn_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_de_bruijn_var
+        : 'b 'f.
+          ('env -> 'b -> 'a) ->
+          ('env -> 'f -> 'a) ->
+          'env ->
+          ('b, 'f) de_bruijn_var ->
+          'a =
+      fun visit_bound visit_free env x ->
+        match x with
+        | Bound (dbid, varid) ->
+            let acc1 = self#visit_de_bruijn_id env dbid in
+            let acc2 = visit_bound env varid in
+            self#plus acc1 acc2
+        | Free varid ->
+            let acc = visit_free env varid in
+            acc
+  end
+
+class virtual ['self] mapreduce_const_generic_base_base =
+  object (self : 'self)
+    inherit [_] mapreduce_literal
+
+    method visit_de_bruijn_id : 'env -> de_bruijn_id -> de_bruijn_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_de_bruijn_var
+        : 'b 'f.
+          ('env -> 'b -> 'b * 'a) ->
+          ('env -> 'f -> 'f * 'a) ->
+          'env ->
+          ('b, 'f) de_bruijn_var ->
+          ('b, 'f) de_bruijn_var * 'a =
+      fun visit_bound visit_free env x ->
+        match x with
+        | Bound (dbid, varid) ->
+            let dbid, acc1 = self#visit_de_bruijn_id env dbid in
+            let varid, acc2 = visit_bound env varid in
+            (Bound (dbid, varid), self#plus acc1 acc2)
+        | Free varid ->
+            let varid, acc = visit_free env varid in
+            (Free varid, acc)
+  end
+
 (* Ancestors for the const_generic visitors *)
 class ['self] iter_const_generic_base =
   object (self : 'self)
-    inherit [_] iter_literal
+    inherit [_] iter_const_generic_base_base
 
     method visit_const_generic_var_id : 'env -> const_generic_var_id -> unit =
       fun _ _ -> ()
 
     method visit_fun_decl_id : 'env -> fun_decl_id -> unit = fun _ _ -> ()
     method visit_global_decl_id : 'env -> global_decl_id -> unit = fun _ _ -> ()
-    method visit_de_bruijn_id : 'env -> de_bruijn_id -> unit = fun _ _ -> ()
     method visit_free_region_id : 'env -> free_region_id -> unit = fun _ _ -> ()
 
     method visit_bound_region_id : 'env -> bound_region_id -> unit =
@@ -132,7 +227,7 @@ class ['self] iter_const_generic_base =
 
 class ['self] map_const_generic_base =
   object (self : 'self)
-    inherit [_] map_literal
+    inherit [_] map_const_generic_base_base
 
     method visit_const_generic_var_id
         : 'env -> const_generic_var_id -> const_generic_var_id =
@@ -141,9 +236,6 @@ class ['self] map_const_generic_base =
     method visit_fun_decl_id : 'env -> fun_decl_id -> fun_decl_id = fun _ x -> x
 
     method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id =
-      fun _ x -> x
-
-    method visit_de_bruijn_id : 'env -> de_bruijn_id -> de_bruijn_id =
       fun _ x -> x
 
     method visit_free_region_id : 'env -> free_region_id -> free_region_id =
@@ -169,7 +261,7 @@ class ['self] map_const_generic_base =
 
 class virtual ['self] reduce_const_generic_base =
   object (self : 'self)
-    inherit [_] reduce_literal
+    inherit [_] reduce_const_generic_base_base
 
     method visit_const_generic_var_id : 'env -> const_generic_var_id -> 'a =
       fun _ _ -> self#zero
@@ -177,9 +269,6 @@ class virtual ['self] reduce_const_generic_base =
     method visit_fun_decl_id : 'env -> fun_decl_id -> 'a = fun _ _ -> self#zero
 
     method visit_global_decl_id : 'env -> global_decl_id -> 'a =
-      fun _ _ -> self#zero
-
-    method visit_de_bruijn_id : 'env -> de_bruijn_id -> 'a =
       fun _ _ -> self#zero
 
     method visit_free_region_id : 'env -> free_region_id -> 'a =
@@ -205,7 +294,7 @@ class virtual ['self] reduce_const_generic_base =
 
 class virtual ['self] mapreduce_const_generic_base =
   object (self : 'self)
-    inherit [_] mapreduce_literal
+    inherit [_] mapreduce_const_generic_base_base
 
     method visit_const_generic_var_id
         : 'env -> const_generic_var_id -> const_generic_var_id * 'a =
@@ -216,9 +305,6 @@ class virtual ['self] mapreduce_const_generic_base =
 
     method visit_global_decl_id : 'env -> global_decl_id -> global_decl_id * 'a
         =
-      fun _ x -> (x, self#zero)
-
-    method visit_de_bruijn_id : 'env -> de_bruijn_id -> de_bruijn_id * 'a =
       fun _ x -> (x, self#zero)
 
     method visit_free_region_id : 'env -> free_region_id -> free_region_id * 'a
@@ -249,7 +335,8 @@ class virtual ['self] mapreduce_const_generic_base =
 (** Const Generic Values. Either a primitive value, or a variable corresponding to a primitve value *)
 type const_generic =
   | CgGlobal of global_decl_id  (** A global constant *)
-  | CgVar of const_generic_var_id  (** A const generic variable *)
+  | CgVar of (const_generic_var_id, const_generic_var_id) de_bruijn_var
+      (** A const generic variable *)
   | CgValue of literal  (** A concrete value *)
 [@@deriving
   show,
@@ -320,20 +407,6 @@ class ['self] iter_ty_base_base =
         visit_left env left;
         visit_right env right
 
-    method visit_de_bruijn_var
-        : 'l 'r.
-          ('env -> 'l -> unit) ->
-          ('env -> 'r -> unit) ->
-          'env ->
-          ('l, 'r) de_bruijn_var ->
-          unit =
-      fun visit_bound visit_free env x ->
-        match x with
-        | Bound (dbid, varid) ->
-            self#visit_de_bruijn_id env dbid;
-            visit_bound env varid
-        | Free varid -> visit_free env varid
-
     method visit_region_var env (x : region_var) =
       self#visit_indexed_var self#visit_bound_region_id
         (self#visit_option self#visit_string)
@@ -377,23 +450,6 @@ class virtual ['self] map_ty_base_base =
         let left = visit_left env left in
         let right = visit_right env right in
         (left, right)
-
-    method visit_de_bruijn_var
-        : 'l 'r.
-          ('env -> 'l -> 'l) ->
-          ('env -> 'r -> 'r) ->
-          'env ->
-          ('l, 'r) de_bruijn_var ->
-          ('l, 'r) de_bruijn_var =
-      fun visit_bound visit_free env x ->
-        match x with
-        | Bound (dbid, varid) ->
-            let dbid = self#visit_de_bruijn_id env dbid in
-            let varid = visit_bound env varid in
-            Bound (dbid, varid)
-        | Free varid ->
-            let varid = visit_free env varid in
-            Free varid
 
     method visit_region_var env (x : region_var) =
       self#visit_indexed_var self#visit_bound_region_id
@@ -925,6 +981,10 @@ type region_db_var = (bound_region_id, free_region_id) de_bruijn_var
 [@@deriving show]
 
 type type_db_var = (type_var_id, type_var_id) de_bruijn_var [@@deriving show]
+
+type const_generic_db_var =
+  (const_generic_var_id, const_generic_var_id) de_bruijn_var
+[@@deriving show]
 
 type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group
 [@@deriving show]

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -571,7 +571,7 @@ and ty =
           Note: this is incorrectly named: this can refer to any valid `TypeDecl` including extern
           types.
        *)
-  | TVar of type_var_id
+  | TVar of (type_var_id, type_var_id) de_bruijn_var
   | TLiteral of literal_type
   | TNever
       (** The never type, for computations which don't return. It is sometimes
@@ -923,6 +923,8 @@ type ('rid, 'id) g_region_group = {
 
 type region_db_var = (bound_region_id, free_region_id) de_bruijn_var
 [@@deriving show]
+
+type type_db_var = (type_var_id, type_var_id) de_bruijn_var [@@deriving show]
 
 type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group
 [@@deriving show]

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -156,7 +156,9 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
       (fun (v : region_var) -> RVar (zero_db_var v.index))
       generics.regions
   in
-  let types = List.map (fun (v : type_var) -> TVar v.index) generics.types in
+  let types =
+    List.map (fun (v : type_var) -> TVar (Free v.index)) generics.types
+  in
   let const_generics =
     List.map
       (fun (v : const_generic_var) -> CgVar v.index)

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -172,7 +172,7 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
   let trait_refs =
     List.map
       (fun (c : trait_clause) ->
-        { trait_id = Clause c.clause_id; trait_decl_ref = c.trait })
+        { trait_id = Clause (Free c.clause_id); trait_decl_ref = c.trait })
       generics.trait_clauses
   in
   { regions; types; const_generics; trait_refs }

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -108,7 +108,12 @@ let trait_instance_id_as_trait_impl (id : trait_instance_id) :
   | TraitImpl (impl_id, args) -> (impl_id, args)
   | _ -> raise (Failure "Unreachable")
 
-let zero_db_var (varid : 'a) : ('a, 'b) de_bruijn_var = Bound (0, varid)
+let zero_db_var (varid : 'b) : ('b, 'f) de_bruijn_var = Bound (0, varid)
+
+let free_var_of_db_var (var : ('b, 'f) de_bruijn_var) : 'f option =
+  match var with
+  | Bound _ -> None
+  | Free id -> Some id
 
 let decr_db_var : ('a, 'b) de_bruijn_var -> ('a, 'b) de_bruijn_var = function
   | Free id -> Free id
@@ -161,7 +166,7 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
   in
   let const_generics =
     List.map
-      (fun (v : const_generic_var) -> CgVar v.index)
+      (fun (v : const_generic_var) -> CgVar (Free v.index))
       generics.const_generics
   in
   let trait_refs =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.55"
+version = "0.1.56"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.55"
+version = "0.1.56"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -459,7 +459,7 @@ pub enum RawConstantExpr {
     #[charon::opaque]
     MutPtr(Box<ConstantExpr>),
     /// A const generic var
-    Var(ConstGenericVarId),
+    Var(ConstGenericDbVar),
     /// Function pointer
     FnPtr(FnPtr),
 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -54,7 +54,7 @@ pub enum TraitRefKind {
     ///                    ^^^^^^^
     ///                    Clause(0)
     /// ```
-    Clause(TraitClauseId),
+    Clause(ClauseDbVar),
 
     /// A parent clause
     ///

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -601,7 +601,7 @@ pub enum TyKind {
     /// types.
     Adt(TypeId, GenericArgs),
     #[charon::rename("TVar")]
-    TypeVar(TypeVarId),
+    TypeVar(TypeDbVar),
     Literal(LiteralTy),
     /// The never type, for computations which don't return. It is sometimes
     /// necessary for intermediate variables. For instance, if we do (coming

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -540,7 +540,7 @@ pub enum ConstGeneric {
     /// A global constant
     Global(GlobalDeclId),
     /// A const generic variable
-    Var(ConstGenericVarId),
+    Var(ConstGenericDbVar),
     /// A concrete value
     Value(Literal),
 }

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -115,6 +115,7 @@ pub struct TraitClause {
 
 pub type RegionDbVar = DeBruijnVar<BoundRegionId, FreeRegionId>;
 pub type TypeDbVar = DeBruijnVar<TypeVarId, TypeVarId>;
+pub type ConstGenericDbVar = DeBruijnVar<ConstGenericVarId, ConstGenericVarId>;
 
 impl DeBruijnId {
     pub fn zero() -> Self {

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -60,9 +60,9 @@ pub enum DeBruijnVar<Bound, Free> {
 // to confuse them, we define an index type for every one of them (which is just a struct with a
 // unique usize field), together with some utilities like a fresh index generator, using the
 // `generate_index_type` macro.
-generate_index_type!(TypeVarId, "T");
 generate_index_type!(BoundRegionId, "BoundRegion");
 generate_index_type!(FreeRegionId, "FreeRegion");
+generate_index_type!(TypeVarId, "T");
 generate_index_type!(ConstGenericVarId, "Const");
 generate_index_type!(TraitClauseId, "TraitClause");
 
@@ -114,6 +114,7 @@ pub struct TraitClause {
 }
 
 pub type RegionDbVar = DeBruijnVar<BoundRegionId, FreeRegionId>;
+pub type TypeDbVar = DeBruijnVar<TypeVarId, TypeVarId>;
 
 impl DeBruijnId {
     pub fn zero() -> Self {
@@ -146,8 +147,16 @@ where
     Bound: Copy,
     Free: Copy,
 {
-    pub fn bound(index: DeBruijnId, var: Bound) -> Self {
-        DeBruijnVar::Bound(index, var)
+    pub fn new_at_zero(id: Bound) -> Self {
+        DeBruijnVar::Bound(DeBruijnId::new(0), id)
+    }
+
+    pub fn free(id: Free) -> Self {
+        DeBruijnVar::Free(id)
+    }
+
+    pub fn bound(index: DeBruijnId, id: Bound) -> Self {
+        DeBruijnVar::Bound(index, id)
     }
 
     pub fn decr(&self) -> Self {

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -116,6 +116,7 @@ pub struct TraitClause {
 pub type RegionDbVar = DeBruijnVar<BoundRegionId, FreeRegionId>;
 pub type TypeDbVar = DeBruijnVar<TypeVarId, TypeVarId>;
 pub type ConstGenericDbVar = DeBruijnVar<ConstGenericVarId, ConstGenericVarId>;
+pub type ClauseDbVar = DeBruijnVar<TraitClauseId, TraitClauseId>;
 
 impl DeBruijnId {
     pub fn zero() -> Self {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -64,7 +64,7 @@ impl GenericParams {
                 .trait_clauses
                 .iter_indexed()
                 .map(|(id, clause)| TraitRef {
-                    kind: TraitRefKind::Clause(id),
+                    kind: TraitRefKind::Clause(DeBruijnVar::free(id)),
                     trait_decl_ref: clause.trait_.clone(),
                 })
                 .collect(),
@@ -582,7 +582,9 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_trait_ref(&mut self, tr: &mut TraitRef) {
         match &mut tr.kind {
-            TraitRefKind::Clause(id) => *tr = self.generics.trait_refs.get(*id).unwrap().clone(),
+            TraitRefKind::Clause(Free(id)) => {
+                *tr = self.generics.trait_refs.get(*id).unwrap().clone()
+            }
             _ => (),
         }
     }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -3,6 +3,7 @@ use crate::types::*;
 use crate::{common::visitor_event::VisitEvent, ids::Vector};
 use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
 use std::{collections::HashMap, iter::Iterator};
+use DeBruijnVar::Free;
 
 impl GenericParams {
     pub fn empty() -> Self {
@@ -47,12 +48,12 @@ impl GenericParams {
             regions: self
                 .regions
                 .iter_indexed()
-                .map(|(id, _)| Region::Var(DeBruijnVar::bound(DeBruijnId::new(0), id)))
+                .map(|(id, _)| Region::Var(DeBruijnVar::new_at_zero(id)))
                 .collect(),
             types: self
                 .types
                 .iter_indexed()
-                .map(|(id, _)| TyKind::TypeVar(id).into_ty())
+                .map(|(id, _)| TyKind::TypeVar(DeBruijnVar::free(id)).into_ty())
                 .collect(),
             const_generics: self
                 .const_generics
@@ -562,7 +563,10 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_ty(&mut self, ty: &mut Ty) {
         match ty.kind() {
-            TyKind::TypeVar(id) => *ty = self.generics.types.get(*id).unwrap().clone(),
+            TyKind::TypeVar(Free(id)) => {
+                {}
+                *ty = self.generics.types.get(*id).unwrap().clone()
+            }
             _ => (),
         }
     }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -58,7 +58,7 @@ impl GenericParams {
             const_generics: self
                 .const_generics
                 .iter_indexed()
-                .map(|(id, _)| ConstGeneric::Var(id))
+                .map(|(id, _)| ConstGeneric::Var(DeBruijnVar::free(id)))
                 .collect(),
             trait_refs: self
                 .trait_clauses
@@ -573,7 +573,9 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_const_generic(&mut self, cg: &mut ConstGeneric) {
         match cg {
-            ConstGeneric::Var(id) => *cg = self.generics.const_generics.get(*id).unwrap().clone(),
+            ConstGeneric::Var(Free(id)) => {
+                *cg = self.generics.const_generics.get(*id).unwrap().clone()
+            }
             _ => (),
         }
     }

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -152,7 +152,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
             ConstantExprKind::ConstRef { id } => {
                 let var_id = self.const_generic_vars_map.get(&id.index);
                 if let Some(var_id) = var_id {
-                    RawConstantExpr::Var(*var_id)
+                    RawConstantExpr::Var(ConstGenericDbVar::free(*var_id))
                 } else {
                     error_or_panic!(
                         self,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -298,7 +298,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 let mut trait_id = match &impl_source.r#impl {
                     ImplExprAtom::SelfImpl { .. } => TraitRefKind::SelfId,
                     ImplExprAtom::LocalBound { index, .. } => {
-                        TraitRefKind::Clause(TraitClauseId::from_usize(*index))
+                        TraitRefKind::Clause(DeBruijnVar::free(TraitClauseId::from_usize(*index)))
                     }
                     _ => unreachable!(),
                 };

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -276,7 +276,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             param.name, param.index
                         )
                     ),
-                    Some(var_id) => TyKind::TypeVar(*var_id),
+                    Some(var_id) => TyKind::TypeVar(DeBruijnVar::Free(*var_id)),
                 }
             }
 

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1243,13 +1243,12 @@ fn generate_ml(
                 ]),
                 (GenerationKind::TypeDecl(Some(DeriveVisitors {
                     name: "const_generic",
-                    ancestor: Some("literal"),
+                    ancestor: Some("const_generic_base_base"),
                     reduce: true,
                     extra_types: &[
                         "const_generic_var_id",
                         "fun_decl_id",
                         "global_decl_id",
-                        "de_bruijn_id",
                         "free_region_id",
                         "bound_region_id",
                         "trait_clause_id",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -217,8 +217,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
             }
             expr.into_iter().map(|f| format!("({f})")).join(" ")
         }
-        TyKind::TypeVar(var_id) => format!("arg{}_of_json", var_id.index()),
-        // TyKind::Ref(_, _, _) => todo!(),
+        TyKind::TypeVar(DeBruijnVar::Free(id)) => format!("arg{id}_of_json"),
         _ => unimplemented!("{ty:?}"),
     }
 }
@@ -283,7 +282,7 @@ fn type_to_ocaml_name(ctx: &GenerateCtx, ty: &Ty) -> String {
                 _ => unimplemented!("{ty:?}"),
             }
         }
-        TyKind::TypeVar(var_id) => format!("'a{}", var_id.index()),
+        TyKind::TypeVar(DeBruijnVar::Free(id)) => format!("'a{id}"),
         _ => unimplemented!("{ty:?}"),
     }
 }

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -284,6 +284,7 @@ type ('rid, 'id) g_region_group = {
 type region_db_var = (bound_region_id, free_region_id) de_bruijn_var [@@deriving show]
 type type_db_var = (type_var_id, type_var_id) de_bruijn_var [@@deriving show]
 type const_generic_db_var = (const_generic_var_id, const_generic_var_id) de_bruijn_var [@@deriving show]
+type trait_db_var = (trait_clause_id, trait_clause_id) de_bruijn_var [@@deriving show]
 
 type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group
 [@@deriving show]

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -217,6 +217,7 @@ type ('rid, 'id) g_region_group = {
 [@@deriving show]
 
 type region_db_var = (bound_region_id, free_region_id) de_bruijn_var [@@deriving show]
+type type_db_var = (type_var_id, type_var_id) de_bruijn_var [@@deriving show]
 
 type region_var_group = (BoundRegionId.id, RegionGroupId.id) g_region_group
 [@@deriving show]

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1137,7 +1137,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitClause {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        let clause_id = ctx.format_object(self.clause_id);
+        let clause_id = self.clause_id.to_pretty_string();
         let trait_ = self.trait_.fmt_with_ctx(ctx);
         format!("[{clause_id}]: {trait_}")
     }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -130,8 +130,7 @@ impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
     }
 }
 
-pub trait AstFormatter = Formatter<TypeVarId>
-    + Formatter<TypeDeclId>
+pub trait AstFormatter = Formatter<TypeDeclId>
     + Formatter<ConstGenericVarId>
     + Formatter<FunDeclId>
     + Formatter<GlobalDeclId>
@@ -141,6 +140,7 @@ pub trait AstFormatter = Formatter<TypeVarId>
     + Formatter<AnyTransId>
     + Formatter<TraitClauseId>
     + Formatter<RegionDbVar>
+    + Formatter<TypeDbVar>
     + Formatter<VarId>
     + Formatter<(TypeDeclId, VariantId)>
     + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
@@ -301,13 +301,16 @@ impl<'a> Formatter<&RegionVar> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<TypeVarId> for FmtCtx<'a> {
-    fn format_object(&self, id: TypeVarId) -> String {
-        match &self.generics.back() {
-            None => id.to_pretty_string(),
-            Some(generics) => match generics.types.get(id) {
+impl<'a> Formatter<TypeDbVar> for FmtCtx<'a> {
+    fn format_object(&self, var: TypeDbVar) -> String {
+        match var {
+            DeBruijnVar::Bound(..) => format!("missing_type_var({var})"),
+            DeBruijnVar::Free(id) => match &self.generics.back() {
                 None => id.to_pretty_string(),
-                Some(v) => v.to_string(),
+                Some(generics) => match generics.types.get(id) {
+                    None => id.to_pretty_string(),
+                    Some(v) => v.to_string(),
+                },
             },
         }
     }
@@ -325,8 +328,8 @@ impl<'a> Formatter<ConstGenericVarId> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ast::TraitClauseId> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitClauseId) -> String {
+impl<'a> Formatter<TraitClauseId> for FmtCtx<'a> {
+    fn format_object(&self, id: TraitClauseId) -> String {
         id.to_pretty_string()
     }
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -131,7 +131,6 @@ impl<'a, 'b> PushBoundRegions<'a> for FmtCtx<'b> {
 }
 
 pub trait AstFormatter = Formatter<TypeDeclId>
-    + Formatter<ConstGenericVarId>
     + Formatter<FunDeclId>
     + Formatter<GlobalDeclId>
     + Formatter<BodyId>
@@ -141,6 +140,7 @@ pub trait AstFormatter = Formatter<TypeDeclId>
     + Formatter<TraitClauseId>
     + Formatter<RegionDbVar>
     + Formatter<TypeDbVar>
+    + Formatter<ConstGenericDbVar>
     + Formatter<VarId>
     + Formatter<(TypeDeclId, VariantId)>
     + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
@@ -316,13 +316,16 @@ impl<'a> Formatter<TypeDbVar> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<ConstGenericVarId> for FmtCtx<'a> {
-    fn format_object(&self, id: ConstGenericVarId) -> String {
-        match &self.generics.back() {
-            None => id.to_pretty_string(),
-            Some(generics) => match generics.const_generics.get(id) {
+impl<'a> Formatter<ConstGenericDbVar> for FmtCtx<'a> {
+    fn format_object(&self, var: ConstGenericDbVar) -> String {
+        match var {
+            DeBruijnVar::Bound(..) => format!("missing_cg_var({var})"),
+            DeBruijnVar::Free(id) => match &self.generics.back() {
                 None => id.to_pretty_string(),
-                Some(v) => v.to_string(),
+                Some(generics) => match generics.const_generics.get(id) {
+                    None => id.to_pretty_string(),
+                    Some(v) => v.to_string(),
+                },
             },
         }
     }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -137,10 +137,10 @@ pub trait AstFormatter = Formatter<TypeDeclId>
     + Formatter<TraitDeclId>
     + Formatter<TraitImplId>
     + Formatter<AnyTransId>
-    + Formatter<TraitClauseId>
     + Formatter<RegionDbVar>
     + Formatter<TypeDbVar>
     + Formatter<ConstGenericDbVar>
+    + Formatter<ClauseDbVar>
     + Formatter<VarId>
     + Formatter<(TypeDeclId, VariantId)>
     + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
@@ -331,9 +331,12 @@ impl<'a> Formatter<ConstGenericDbVar> for FmtCtx<'a> {
     }
 }
 
-impl<'a> Formatter<TraitClauseId> for FmtCtx<'a> {
-    fn format_object(&self, id: TraitClauseId) -> String {
-        id.to_pretty_string()
+impl<'a> Formatter<ClauseDbVar> for FmtCtx<'a> {
+    fn format_object(&self, var: ClauseDbVar) -> String {
+        match var {
+            DeBruijnVar::Bound(..) => format!("missing_clause_var({var})"),
+            DeBruijnVar::Free(id) => id.to_pretty_string(),
+        }
     }
 }
 


### PR DESCRIPTION
Part of #361.

Now all the type-level variables (types, const generics, and trait clauses) can be bound or free. All existing uses become `Free`, some future uses (for trait methods in particular) will introduce `Bound` variables.