### PR TITLE
Translate correct closure signature

### DIFF
--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -365,25 +365,12 @@ let trait_type_constraint_to_string (env : 'a fmt_env)
 
 (** Helper to format "where" clauses *)
 let clauses_to_string (indent : string) (indent_incr : string)
-    (num_inherited_clauses : int) (clauses : string list) : string =
+    (clauses : string list) : string =
   if clauses = [] then ""
   else
     let env_clause s = indent ^ indent_incr ^ s ^ "," in
     let clauses = List.map env_clause clauses in
-    let inherited, local =
-      Collections.List.split_at clauses num_inherited_clauses
-    in
-    let delim1 =
-      if inherited <> [] then [ indent ^ "  // Inherited clauses" ] else []
-    in
-    let delim2 =
-      if inherited <> [] && local <> [] then [ indent ^ "  // Local clauses" ]
-      else []
-    in
-    let clauses =
-      List.concat [ [ indent ^ "where" ]; delim1; inherited; delim2; local ]
-    in
-    "\n" ^ String.concat "\n" clauses
+    "\n" ^ indent ^ "where\n" ^ String.concat "\n" clauses
 
 (** Helper to format "where" clauses *)
 let predicates_and_trait_clauses_to_string (env : 'a fmt_env) (indent : string)
@@ -413,7 +400,7 @@ let predicates_and_trait_clauses_to_string (env : 'a fmt_env) (indent : string)
   in
   (* Split between the inherited clauses and the local clauses *)
   let clauses =
-    clauses_to_string indent indent_incr 0
+    clauses_to_string indent indent_incr
       (List.concat
          [
            trait_clauses; regions_outlive; types_outlive; trait_type_constraints;

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -36,6 +36,7 @@ let type_decl_get_fields (def : type_decl)
   match (def.kind, opt_variant_id) with
   | Enum variants, Some variant_id -> (VariantId.nth variants variant_id).fields
   | Struct fields, None -> fields
+  | Union fields, None -> fields
   | _ ->
       let opt_variant_id =
         match opt_variant_id with

--- a/charon-ml/tests/Test_Deserialize.ml
+++ b/charon-ml/tests/Test_Deserialize.ml
@@ -33,8 +33,9 @@ let run_tests (folder : string) : unit =
             exit 1
         | Ok m ->
             log#linfo (lazy ("Deserialized: " ^ file));
-            log#ldebug
-              (lazy ("\n" ^ PrintLlbcAst.Crate.crate_to_string m ^ "\n")))
+            (* Test that pretty-printing doesn't crash *)
+            let printed = PrintLlbcAst.Crate.crate_to_string m in
+            log#ldebug (lazy ("\n" ^ printed ^ "\n")))
       llbc_files
   in
 

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1415,7 +1415,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
     ) -> Result<FunSig, Error> {
         let span = item_meta.span;
 
-        let generics = self.translate_def_generics(span, def)?;
+        let mut generics = self.translate_def_generics(span, def)?;
 
         let signature = match &def.kind {
             hax::FullDefKind::Closure { args, .. } => &args.sig,
@@ -1456,7 +1456,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
 
         // Translate the signature
         trace!("signature of {def_id:?}:\n{:?}", signature.value);
-        let inputs: Vec<Ty> = signature
+        let mut inputs: Vec<Ty> = signature
             .value
             .inputs
             .iter()
@@ -1481,6 +1481,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
 
         let closure_info = match &def.kind {
             hax::FullDefKind::Closure { args, .. } => {
+                assert_eq!(inputs.len(), 1);
                 let kind = match args.kind {
                     hax::ClosureKind::Fn => ClosureKind::Fn,
                     hax::ClosureKind::FnMut => ClosureKind::FnMut,
@@ -1491,6 +1492,32 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                     .iter()
                     .map(|ty| self.translate_ty(span, &ty))
                     .try_collect()?;
+
+                // Add the state of the closure as first parameter.
+                let state_ty = {
+                    // Group the state types into a tuple
+                    let state_ty =
+                        TyKind::Adt(TypeId::Tuple, GenericArgs::new_from_types(state.clone()))
+                            .into_ty();
+                    // Depending on the kind of the closure, add a reference
+                    match &kind {
+                        ClosureKind::FnOnce => state_ty,
+                        ClosureKind::Fn | ClosureKind::FnMut => {
+                            let rid = generics
+                                .regions
+                                .push_with(|index| RegionVar { index, name: None });
+                            let r = Region::Var(DeBruijnVar::free(rid));
+                            let mutability = if kind == ClosureKind::Fn {
+                                RefKind::Shared
+                            } else {
+                                RefKind::Mut
+                            };
+                            TyKind::Ref(r, state_ty, mutability).into_ty()
+                        }
+                    }
+                };
+                inputs.insert(0, state_ty);
+
                 Some(ClosureInfo { kind, state })
             }
             _ => None,

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -54,7 +54,6 @@ fn transform_function(
         ..
     } = &mut def.signature;
     if let Some(info) = closure_info {
-        assert_eq!(inputs.len(), 2);
         // Explore the state and introduce fresh regions for the erased regions we find.
         let mut visitor = Ty::visit_inside(InsertRegions {
             regions: &mut generics.regions,

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -1,6 +1,6 @@
 # Final LLBC before serialization:
 
-fn test_cargo_dependencies::silly_incr::closure(@1: (), @2: (u32)) -> u32
+fn test_cargo_dependencies::silly_incr::closure(@1: (), @2: u32) -> u32
 {
     let @0: u32; // return
     let state@1: (); // arg #1

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -172,6 +172,48 @@ fn test_crate::test_closure_u32(@1: u32) -> u32
     return
 }
 
+fn test_crate::test_closure_u32s::closure<'_0>(@1: &'_0 (()), @2: (u32, u32)) -> u32
+{
+    let @0: u32; // return
+    let state@1: &'_0 (()); // arg #1
+    let x@2: u32; // arg #2
+    let y@3: u32; // local
+    let @4: u32; // anonymous local
+    let @5: u32; // anonymous local
+
+    @4 := copy (x@2)
+    @5 := copy (y@3)
+    @0 := move (@4) + move (@5)
+    drop @5
+    drop @4
+    return
+}
+
+fn test_crate::test_closure_u32s(@1: u32) -> u32
+{
+    let @0: u32; // return
+    let x@1: u32; // arg #1
+    let f@2: fn(u32, u32) -> u32; // local
+    let @3: fn(u32, u32) -> u32; // anonymous local
+    let @4: fn(u32, u32) -> u32; // anonymous local
+    let @5: u32; // anonymous local
+    let @6: u32; // anonymous local
+
+    @3 := {test_crate::test_closure_u32s::closure} {}
+    f@2 := cast<fn(u32, u32) -> u32, fn(u32, u32) -> u32>(move (@3))
+    drop @3
+    @fake_read(f@2)
+    @4 := copy (f@2)
+    @5 := copy (x@1)
+    @6 := copy (x@1)
+    @0 := (move @4)(move (@5), move (@6))
+    drop @6
+    drop @5
+    drop @4
+    drop f@2
+    return
+}
+
 fn test_crate::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (u32))) -> &'_0 (u32)
 {
     let @0: &'_ (u32); // return

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -140,7 +140,7 @@ fn test_crate::test_map_option1(@1: core::option::Option<u32>[core::marker::Size
     return
 }
 
-fn test_crate::test_closure_u32::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_closure_u32::closure<'_0>(@1: &'_0 (()), @2: u32) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -172,12 +172,12 @@ fn test_crate::test_closure_u32(@1: u32) -> u32
     return
 }
 
-fn test_crate::test_closure_u32s::closure<'_0>(@1: &'_0 (()), @2: (u32, u32)) -> u32
+fn test_crate::test_closure_u32s::closure<'_0>(@1: &'_0 (()), @2: u32, @3: u32) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
     let x@2: u32; // arg #2
-    let y@3: u32; // local
+    let y@3: u32; // arg #3
     let @4: u32; // anonymous local
     let @5: u32; // anonymous local
 
@@ -214,7 +214,7 @@ fn test_crate::test_closure_u32s(@1: u32) -> u32
     return
 }
 
-fn test_crate::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (u32))) -> &'_0 (u32)
+fn test_crate::test_closure_ref_u32::closure<'_0, '_1>(@1: &'_1 (()), @2: &'_0 (u32)) -> &'_0 (u32)
 {
     let @0: &'_ (u32); // return
     let state@1: &'_1 (()); // arg #1
@@ -249,7 +249,7 @@ fn test_crate::test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
     return
 }
 
-fn test_crate::test_closure_ref_param::closure<'_0, '_1, T>(@1: &'_1 (()), @2: (&'_0 (T))) -> &'_0 (T)
+fn test_crate::test_closure_ref_param::closure<'_0, '_1, T>(@1: &'_1 (()), @2: &'_0 (T)) -> &'_0 (T)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
@@ -290,7 +290,7 @@ where
 
 trait test_crate::Trait<'a, Self>
 
-fn test_crate::test_closure_ref_early_bound::closure<'a, '_1, '_2, T>(@1: &'_2 (()), @2: (&'_1 (T))) -> &'_1 (T)
+fn test_crate::test_closure_ref_early_bound::closure<'a, '_1, '_2, T>(@1: &'_2 (()), @2: &'_1 (T)) -> &'_1 (T)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: test_crate::Trait<'_, T>,
@@ -331,7 +331,7 @@ where
     return
 }
 
-fn test_crate::test_map_option2::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_map_option2::closure<'_0>(@1: &'_0 (()), @2: u32) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -496,7 +496,7 @@ fn test_crate::test_map_option_id_clone(@1: core::option::Option<u32>[core::mark
     return
 }
 
-fn test_crate::test_map_option3::closure<'_0>(@1: &'_0 (()), @2: (u32)) -> u32
+fn test_crate::test_map_option3::closure<'_0>(@1: &'_0 (()), @2: u32) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1
@@ -524,7 +524,7 @@ fn test_crate::test_map_option3(@1: core::option::Option<u32>[core::marker::Size
     return
 }
 
-fn test_crate::test_regions::closure<'_0, '_1>(@1: &'_1 (()), @2: (&'_0 (&'_ (u32)))) -> u32
+fn test_crate::test_regions::closure<'_0, '_1>(@1: &'_1 (()), @2: &'_0 (&'_ (u32))) -> u32
 {
     let @0: u32; // return
     let state@1: &'_1 (()); // arg #1
@@ -559,7 +559,7 @@ fn test_crate::test_regions<'a>(@1: &'a (u32)) -> u32
     return
 }
 
-fn test_crate::test_closure_capture::closure<'_0, '_1, '_2>(@1: &'_0 ((&'_1 (u32), &'_2 (u32))), @2: (u32)) -> u32
+fn test_crate::test_closure_capture::closure<'_0, '_1, '_2>(@1: &'_0 ((&'_1 (u32), &'_2 (u32))), @2: u32) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 ((&'_1 (u32), &'_2 (u32))); // arg #1
@@ -610,7 +610,7 @@ fn test_crate::test_closure_capture(@1: u32, @2: u32) -> u32
     return
 }
 
-fn test_crate::test_closure_clone::closure<'_0, T>(@1: &'_0 (()), @2: (T)) -> T
+fn test_crate::test_closure_clone::closure<'_0, T>(@1: &'_0 (()), @2: T) -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::clone::Clone<T>,
@@ -657,7 +657,7 @@ where
     return
 }
 
-fn test_crate::test_array_map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
+fn test_crate::test_array_map::closure<'_0>(@1: &'_0 mut (()), @2: i32) -> i32
 {
     let @0: i32; // return
     let state@1: &'_0 mut (()); // arg #1
@@ -699,14 +699,14 @@ struct test_crate::Foo<'a, T>
   &'a (T),
 }
 
-fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T))), @2: ()) -> T
+fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T)))) -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::clone::Clone<T>,
 {
     let @0: T; // return
     let state@1: &'_1 ((&'_2 (T))); // arg #1
-    let @2: &'_ (T); // arg #2
+    let @2: &'_ (T); // anonymous local
 
     @2 := &*((*(state@1)).0)
     @0 := @TraitClause1::clone<'_>(move (@2))
@@ -714,14 +714,14 @@ where
     return
 }
 
-fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T))), @2: ()) -> fn() -> T
+fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T)))) -> fn() -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::clone::Clone<T>,
 {
     let @0: fn() -> T; // return
     let state@1: &'_1 ((&'_2 (T))); // arg #1
-    let @2: &'_ (T); // arg #2
+    let @2: &'_ (T); // anonymous local
 
     @2 := &*((*(state@1)).0)
     @0 := {test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_, T>} {move (@2)}
@@ -729,14 +729,14 @@ where
     return
 }
 
-fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T))), @2: ()) -> fn() -> fn() -> T
+fn test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, '_2, T>(@1: &'_1 ((&'_2 (T)))) -> fn() -> fn() -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::clone::Clone<T>,
 {
     let @0: fn() -> fn() -> T; // return
     let state@1: &'_1 ((&'_2 (T))); // arg #1
-    let @2: &'_ (T); // arg #2
+    let @2: &'_ (T); // anonymous local
 
     @2 := &*((*(state@1)).0)
     @0 := {test_crate::{test_crate::Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_, T>} {move (@2)}
@@ -787,7 +787,7 @@ where
     return
 }
 
-fn test_crate::BLAH::closure<'_0>(@1: &'_0 (()), @2: ()) -> u32
+fn test_crate::BLAH::closure<'_0>(@1: &'_0 (())) -> u32
 {
     let @0: u32; // return
     let state@1: &'_0 (()); // arg #1

--- a/charon/tests/ui/closures.rs
+++ b/charon/tests/ui/closures.rs
@@ -38,6 +38,11 @@ pub fn test_closure_u32(x: u32) -> u32 {
     (f)(x)
 }
 
+pub fn test_closure_u32s(x: u32) -> u32 {
+    let f: fn(u32, u32) -> u32 = |x, y| x + y;
+    (f)(x, x)
+}
+
 // Local function with reference
 //
 // The lifetime 'a could be omitted, but we insert it to check that the

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -176,7 +176,7 @@ impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T
     fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone
 }
 
-fn test_crate::wrap::closure<'_0, U>(@1: (), @2: (&'_0 (U))) -> test_crate::WrapClone<&'_0 (U)>[core::marker::Sized<&'_0 (U)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, U>]
+fn test_crate::wrap::closure<'_0, U>(@1: (), @2: &'_0 (U)) -> test_crate::WrapClone<&'_0 (U)>[core::marker::Sized<&'_0 (U)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, U>]
 where
     [@TraitClause0]: core::marker::Sized<U>,
 {

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -14,11 +14,11 @@ fn test_crate::{test_crate::Rng}::next_u64<'_0>(@1: &'_0 mut (test_crate::Rng))
     return
 }
 
-fn test_crate::new::closure<'_0, '_1>(@1: &'_0 mut ((&'_1 mut (test_crate::Rng))), @2: ())
+fn test_crate::new::closure<'_0, '_1>(@1: &'_0 mut ((&'_1 mut (test_crate::Rng))))
 {
     let @0: (); // return
     let state@1: &'_0 mut ((&'_1 mut (test_crate::Rng))); // arg #1
-    let @2: (); // arg #2
+    let @2: (); // anonymous local
     let @3: &'_ mut (test_crate::Rng); // anonymous local
     let @4: (); // anonymous local
 

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -14,7 +14,7 @@ enum core::option::Option<T>
 |  Some(T)
 
 
-fn test_crate::sparse_transitions::closure<'a, '_1>(@1: &'_1 mut (()), @2: ()) -> core::option::Option<u8>[core::marker::Sized<u8>]
+fn test_crate::sparse_transitions::closure<'a, '_1>(@1: &'_1 mut (())) -> core::option::Option<u8>[core::marker::Sized<u8>]
 {
     let @0: core::option::Option<u8>[core::marker::Sized<u8>]; // return
     let state@1: &'_1 mut (()); // arg #1

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -1,6 +1,6 @@
 # Final LLBC before serialization:
 
-fn test_crate::map::closure<'_0>(@1: &'_0 mut (()), @2: (i32)) -> i32
+fn test_crate::map::closure<'_0>(@1: &'_0 mut (()), @2: i32) -> i32
 {
     let @0: i32; // return
     let state@1: &'_0 mut (()); // arg #1

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -176,7 +176,7 @@ unsafe fn test_crate::fn_casts::bar()
     return
 }
 
-fn test_crate::fn_casts::closure<'_0>(@1: &'_0 (()), @2: (u8))
+fn test_crate::fn_casts::closure<'_0>(@1: &'_0 (()), @2: u8)
 {
     let @0: (); // return
     let state@1: &'_0 (()); // arg #1


### PR DESCRIPTION
This fixes the signature we use for closures. This also fixes a crash when attempting to print crates using the charon-ml pretty-printer.