### PR TITLE
Prepare charon for inner binding levels

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.57"
+let supported_charon_version = "0.1.58"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -481,8 +481,8 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
          - the impl is a trait impl
       *)
       match impl with
-      | ImplElemTy (_, ty) ->
-          match_expr_with_ty ctx c (mk_empty_maps ()) pty ty
+      | ImplElemTy bound_ty ->
+          match_expr_with_ty ctx c (mk_empty_maps ()) pty bound_ty.binder_value
           && g = TypesUtils.empty_generic_args
       | ImplElemTrait impl_id ->
           match_expr_with_trait_impl_id ctx c pty impl_id
@@ -496,8 +496,8 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
          - the impl is a trait impl
       *)
       match impl with
-      | ImplElemTy (_, ty) ->
-          match_expr_with_ty ctx c (mk_empty_maps ()) pty ty
+      | ImplElemTy bound_ty ->
+          match_expr_with_ty ctx c (mk_empty_maps ()) pty bound_ty.binder_value
           && match_name_with_generics ctx c p n g
       | ImplElemTrait impl_id ->
           match_expr_with_trait_impl_id ctx c pty impl_id
@@ -935,7 +935,8 @@ and path_elem_with_generic_args_to_pattern (ctx : ctx) (c : to_pat_config)
 and impl_elem_to_pattern (ctx : ctx) (c : to_pat_config) (impl : T.impl_elem) :
     pattern_elem =
   match impl with
-  | ImplElemTy (generics, ty) -> PImpl (ty_to_pattern ctx c generics ty)
+  | ImplElemTy bound_ty ->
+      PImpl (ty_to_pattern ctx c bound_ty.binder_params bound_ty.binder_value)
   | ImplElemTrait impl_id ->
       let impl = T.TraitImplId.Map.find impl_id ctx.trait_impls in
       PImpl (trait_decl_ref_to_pattern ctx c impl.generics impl.impl_trait)

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -281,10 +281,10 @@ and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
 
 and impl_elem_to_string (env : 'a fmt_env) (elem : impl_elem) : string =
   match elem with
-  | ImplElemTy (generics, ty) ->
+  | ImplElemTy bound_ty ->
       (* Locally replace the generics and the predicates *)
-      let env = fmt_env_update_generics_and_preds env generics in
-      ty_to_string env ty
+      let env = fmt_env_update_generics_and_preds env bound_ty.binder_params in
+      ty_to_string env bound_ty.binder_value
   | ImplElemTrait impl_id -> begin
       match TraitImplId.Map.find_opt impl_id env.trait_impls with
       | None -> trait_impl_id_to_string env impl_id

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -826,10 +826,9 @@ and impl_elem_of_json (ctx : of_json_ctx) (js : json) :
     (impl_elem, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("Ty", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = generic_params_of_json ctx x_0 in
-        let* x_1 = ty_of_json ctx x_1 in
-        Ok (ImplElemTy (x_0, x_1))
+    | `Assoc [ ("Ty", ty) ] ->
+        let* ty = binder_of_json ty_of_json ctx ty in
+        Ok (ImplElemTy ty)
     | `Assoc [ ("Trait", trait) ] ->
         let* trait = trait_impl_id_of_json ctx trait in
         Ok (ImplElemTrait trait)
@@ -1085,6 +1084,21 @@ and region_binder_of_json :
         in
         let* binder_value = arg0_of_json ctx skip_binder in
         Ok ({ binder_regions; binder_value } : _ region_binder)
+    | _ -> Error "")
+
+and binder_of_json :
+      'a0.
+      (of_json_ctx -> json -> ('a0, string) result) ->
+      of_json_ctx ->
+      json ->
+      ('a0 binder, string) result =
+ fun arg0_of_json ctx js ->
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("params", params); ("skip_binder", skip_binder) ] ->
+        let* binder_params = generic_params_of_json ctx params in
+        let* binder_value = arg0_of_json ctx skip_binder in
+        Ok ({ binder_params; binder_value } : _ binder)
     | _ -> Error "")
 
 and generic_params_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.57"
+version = "0.1.58"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -27,4 +27,5 @@ pub use krate::*;
 pub use meta::*;
 pub use names::*;
 pub use types::*;
+pub use types_utils::TyVisitable;
 pub use values::*;

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -29,7 +29,7 @@ pub enum PathElem {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 #[charon::variants_prefix("ImplElem")]
 pub enum ImplElem {
-    Ty(GenericParams, Ty),
+    Ty(Binder<Ty>),
     Trait(TraitImplId),
 }
 

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -29,9 +29,12 @@ pub enum PathElem {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 #[charon::variants_prefix("ImplElem")]
 pub enum ImplElem {
-    Ty(Binder<Ty>),
+    Ty(BoundTy),
     Trait(TraitImplId),
 }
+
+/// Alias used for visitors.
+pub type BoundTy = Binder<Ty>;
 
 /// An item name/path
 ///

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -234,6 +234,11 @@ pub struct RegionBinder<T> {
     pub skip_binder: T,
 }
 
+// Renames useful for visitor derives
+pub type BoundTypeOutlives = RegionBinder<TypeOutlives>;
+pub type BoundRegionOutlives = RegionBinder<RegionOutlives>;
+pub type BoundTraitTypeConstraint = RegionBinder<TraitTypeConstraint>;
+
 /// A value of type `T` bound by generic parameters. Used in any context where we're adding generic
 /// parameters that aren't on the top-level item, e.g. `for<'a>` clauses, trait methods (TODO),
 /// GATs (TODO).
@@ -262,11 +267,11 @@ pub struct GenericParams {
     // TODO: rename to match [GenericArgs]?
     pub trait_clauses: Vector<TraitClauseId, TraitClause>,
     /// The first region in the pair outlives the second region
-    pub regions_outlive: Vec<RegionBinder<RegionOutlives>>,
+    pub regions_outlive: Vec<BoundRegionOutlives>,
     /// The type outlives the region
-    pub types_outlive: Vec<RegionBinder<TypeOutlives>>,
+    pub types_outlive: Vec<BoundTypeOutlives>,
     /// Constraints over trait associated types
-    pub trait_type_constraints: Vec<RegionBinder<TraitTypeConstraint>>,
+    pub trait_type_constraints: Vec<BoundTraitTypeConstraint>,
 }
 
 /// A predicate of the form `exists<T> where T: Trait`.
@@ -657,8 +662,10 @@ pub enum TyKind {
     /// This is essentially a "constrained" function signature:
     /// arrow types can only contain generic lifetime parameters
     /// (no generic types), no predicates, etc.
-    Arrow(RegionBinder<(Vec<Ty>, Ty)>),
+    Arrow(BoundArrowSig),
 }
+
+pub type BoundArrowSig = RegionBinder<(Vec<Ty>, Ty)>;
 
 /// Builtin types identifiers.
 ///

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -68,7 +68,7 @@ generate_index_type!(ConstGenericVarId, "Const");
 generate_index_type!(TraitClauseId, "TraitClause");
 
 /// A type variable in a signature or binder.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct TypeVar {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: TypeVarId,
@@ -78,7 +78,7 @@ pub struct TypeVar {
 
 /// A region variable in a signature or binder.
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd, Ord, Drive, DriveMut,
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Drive, DriveMut,
 )]
 pub struct RegionVar {
     /// Index identifying the variable among other variables bound at the same level.
@@ -88,7 +88,7 @@ pub struct RegionVar {
 }
 
 /// A const generic variable in a signature or binder.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct ConstGenericVar {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: ConstGenericVarId,
@@ -100,7 +100,7 @@ pub struct ConstGenericVar {
 
 /// A trait predicate in a signature, of the form `Type: Trait<Args>`. This functions like a
 /// variable binder, to which variables of the form `TraitRefKind::Clause` can refer to.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct TraitClause {
     /// Index identifying the clause among other clauses bound at the same level.
     pub clause_id: TraitClauseId,

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -399,6 +399,25 @@ impl<T: DriveMut> DriveMut for RegionBinder<T> {
     }
 }
 
+// The derive macro doesn't handle generics.
+impl<T: Drive> Drive for Binder<T> {
+    fn drive<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit(self, Event::Enter);
+        self.params.drive(visitor);
+        self.skip_binder.drive(visitor);
+        visitor.visit(self, Event::Exit);
+    }
+}
+
+impl<T: DriveMut> DriveMut for Binder<T> {
+    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
+        visitor.visit(self, Event::Enter);
+        self.params.drive_mut(visitor);
+        self.skip_binder.drive_mut(visitor);
+        visitor.visit(self, Event::Exit);
+    }
+}
+
 /// See comment on `Ty`: this impl doesn't recurse into the contents of the type.
 impl Drive for Ty {
     fn drive<V: Visitor>(&self, visitor: &mut V) {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,9 +1,10 @@
 //! This file groups everything which is linked to implementations about [crate::types]
+use crate::ast::BoundTy;
 use crate::types::*;
 use crate::{common::visitor_event::VisitEvent, ids::Vector};
-use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
+use derive_visitor::{visitor_enter_fn_mut, Drive, DriveMut, Event, Visitor, VisitorMut};
+use std::collections::HashSet;
 use std::{collections::HashMap, iter::Iterator};
-use DeBruijnVar::Free;
 
 impl GenericParams {
     pub fn empty() -> Self {
@@ -19,6 +20,32 @@ impl GenericParams {
             || !self.types_outlive.is_empty()
             || !self.regions_outlive.is_empty()
             || !self.trait_type_constraints.is_empty()
+    }
+
+    /// Run some sanity checks.
+    pub fn check_consistency(&self) {
+        // Sanity check: check the clause ids are consistent.
+        assert!(self
+            .trait_clauses
+            .iter()
+            .enumerate()
+            .all(|(i, c)| c.clause_id.index() == i));
+
+        // Sanity check: region names are pairwise distinct (this caused trouble when generating
+        // names for the backward functions in Aeneas): at some point, Rustc introduced names equal
+        // to `Some("'_")` for the anonymous regions, instead of using `None` (we now check in
+        // [translate_region_name] and ignore names equal to "'_").
+        let mut s = HashSet::new();
+        for r in &self.regions {
+            if let Some(name) = &r.name {
+                assert!(
+                    !s.contains(name),
+                    "Name \"{}\" reused for two different lifetimes",
+                    name
+                );
+                s.insert(name);
+            }
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -523,25 +550,32 @@ impl<V> std::ops::DerefMut for VisitInsideTy<V> {
     }
 }
 
-type FnTys = (Vec<Ty>, Ty);
-
 /// Visitor for the [Ty::substitute] function.
+/// This substitutes only free variables; this does not work for non-top-level binders.
 #[derive(VisitorMut)]
 #[visitor(
     PolyTraitDeclRef(enter, exit),
-    FnTys(enter, exit),
+    BoundArrowSig(enter, exit),
+    BoundRegionOutlives(enter, exit),
+    BoundTypeOutlives(enter, exit),
+    BoundTraitTypeConstraint(enter, exit),
+    BoundTy(enter, exit),
     Region(exit),
     Ty(exit),
     ConstGeneric(exit),
     TraitRef(exit)
 )]
-struct SubstVisitor<'a> {
+pub(crate) struct SubstVisitor<'a> {
     generics: &'a GenericArgs,
     // Tracks the depth of binders we're inside of.
     // Important: we must update it whenever we go inside a binder. Visitors are not generic so we
     // must handle all the specific cases by hand. So far there's:
     // - `PolyTraitDeclRef`
-    // - The contents of `TyKind::Arrow`
+    // - `TyKind::Arrow`
+    // - `BoundTypeOutlives`
+    // - `BoundRegionOutlives`
+    // - `BoundTraitTypeConstraint`
+    // - `BoundTy`
     binder_depth: DeBruijnId,
 }
 
@@ -553,27 +587,55 @@ impl<'a> SubstVisitor<'a> {
         })
     }
 
+    fn should_subst<Id: Copy>(&self, var: DeBruijnVar<Id>) -> Option<Id> {
+        match var {
+            DeBruijnVar::Free(id) => Some(id),
+            DeBruijnVar::Bound(..) => None,
+        }
+    }
+
     fn enter_poly_trait_decl_ref(&mut self, _: &mut PolyTraitDeclRef) {
         self.binder_depth = self.binder_depth.incr();
     }
-
     fn exit_poly_trait_decl_ref(&mut self, _: &mut PolyTraitDeclRef) {
         self.binder_depth = self.binder_depth.decr();
     }
-
-    fn enter_fn_tys(&mut self, _: &mut FnTys) {
+    fn enter_bound_arrow_sig(&mut self, _: &BoundArrowSig) {
         self.binder_depth = self.binder_depth.incr();
     }
-
-    fn exit_fn_tys(&mut self, _: &mut FnTys) {
+    fn exit_bound_arrow_sig(&mut self, _: &BoundArrowSig) {
+        self.binder_depth = self.binder_depth.decr();
+    }
+    fn enter_bound_ty(&mut self, _: &BoundTy) {
+        self.binder_depth = self.binder_depth.incr();
+    }
+    fn exit_bound_ty(&mut self, _: &BoundTy) {
+        self.binder_depth = self.binder_depth.decr();
+    }
+    fn enter_bound_type_outlives(&mut self, _: &BoundTypeOutlives) {
+        self.binder_depth = self.binder_depth.incr();
+    }
+    fn exit_bound_type_outlives(&mut self, _: &BoundTypeOutlives) {
+        self.binder_depth = self.binder_depth.decr();
+    }
+    fn enter_bound_region_outlives(&mut self, _: &BoundRegionOutlives) {
+        self.binder_depth = self.binder_depth.incr();
+    }
+    fn exit_bound_region_outlives(&mut self, _: &BoundRegionOutlives) {
+        self.binder_depth = self.binder_depth.decr();
+    }
+    fn enter_bound_trait_type_constraint(&mut self, _: &BoundTraitTypeConstraint) {
+        self.binder_depth = self.binder_depth.incr();
+    }
+    fn exit_bound_trait_type_constraint(&mut self, _: &BoundTraitTypeConstraint) {
         self.binder_depth = self.binder_depth.decr();
     }
 
     fn exit_region(&mut self, r: &mut Region) {
         match r {
             Region::Var(var) => {
-                if let Some(varid) = var.bound_at_depth(self.binder_depth) {
-                    *r = self.generics.regions.get(varid).unwrap().clone()
+                if let Some(varid) = self.should_subst(*var) {
+                    *r = self.generics.regions[varid].move_under_binders(self.binder_depth)
                 }
             }
             _ => (),
@@ -582,9 +644,12 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_ty(&mut self, ty: &mut Ty) {
         match ty.kind() {
-            TyKind::TypeVar(Free(id)) => {
-                {}
-                *ty = self.generics.types.get(*id).unwrap().clone()
+            TyKind::TypeVar(var) => {
+                if let Some(id) = self.should_subst(*var) {
+                    *ty = self.generics.types[id]
+                        .clone()
+                        .move_under_binders(self.binder_depth)
+                }
             }
             _ => (),
         }
@@ -592,8 +657,12 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_const_generic(&mut self, cg: &mut ConstGeneric) {
         match cg {
-            ConstGeneric::Var(Free(id)) => {
-                *cg = self.generics.const_generics.get(*id).unwrap().clone()
+            ConstGeneric::Var(var) => {
+                if let Some(id) = self.should_subst(*var) {
+                    *cg = self.generics.const_generics[id]
+                        .clone()
+                        .move_under_binders(self.binder_depth)
+                }
             }
             _ => (),
         }
@@ -601,19 +670,51 @@ impl<'a> SubstVisitor<'a> {
 
     fn exit_trait_ref(&mut self, tr: &mut TraitRef) {
         match &mut tr.kind {
-            TraitRefKind::Clause(Free(id)) => {
-                *tr = self.generics.trait_refs.get(*id).unwrap().clone()
+            TraitRefKind::Clause(var) => {
+                if let Some(id) = self.should_subst(*var) {
+                    *tr = self.generics.trait_refs[id]
+                        .clone()
+                        .move_under_binders(self.binder_depth)
+                }
             }
             _ => (),
         }
     }
 }
 
-impl Ty {
-    pub fn substitute(&mut self, generics: &GenericArgs) {
-        self.drive_inner_mut(&mut SubstVisitor::new(generics));
+/// Types that are involved at the type-level and may be substituted around.
+pub trait TyVisitable: Sized + Drive + DriveMut {
+    fn substitute(&mut self, generics: &GenericArgs) {
+        self.drive_mut(&mut SubstVisitor::new(generics));
+    }
+
+    /// Move under `depth` binders.
+    fn move_under_binders(mut self, depth: DeBruijnId) -> Self {
+        self.visit_db_id(|id| *id = id.plus(depth));
+        self
+    }
+
+    /// Move the region out of `depth` binders. Returns `None` if the variable is bound in one of
+    /// these `depth` binders.
+    fn move_from_under_binders(mut self, depth: DeBruijnId) -> Option<Self> {
+        let mut ok = true;
+        self.visit_db_id(|id| match id.sub(depth) {
+            Some(sub) => *id = sub,
+            None => ok = false,
+        });
+        ok.then_some(self)
+    }
+
+    /// Helper function.
+    fn visit_db_id(&mut self, f: impl FnMut(&mut DeBruijnId)) {
+        self.drive_mut(&mut Ty::visit_inside(visitor_enter_fn_mut(f)));
     }
 }
+
+impl TyVisitable for ConstGeneric {}
+impl TyVisitable for Region {}
+impl TyVisitable for TraitRef {}
+impl TyVisitable for Ty {}
 
 impl PartialEq for TraitClause {
     fn eq(&self, other: &Self) -> bool {

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -149,19 +149,10 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 let arg = self.translate_constant_expr_to_constant_expr(span, arg)?;
                 RawConstantExpr::MutPtr(Box::new(arg))
             }
-            ConstantExprKind::ConstRef { id } => match self.lookup_const_generic_var(id) {
-                Some(var) => RawConstantExpr::Var(var),
-                None => {
-                    error_or_panic!(
-                        self,
-                        span,
-                        &format!(
-                            "Unexpected error: could not find the const generic variable {}",
-                            id.name
-                        )
-                    )
-                }
-            },
+            ConstantExprKind::ConstRef { id } => {
+                let var = self.lookup_const_generic_var(span, id)?;
+                RawConstantExpr::Var(var)
+            }
             ConstantExprKind::FnPtr {
                 def_id: fn_id,
                 generics: substs,

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -149,21 +149,19 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 let arg = self.translate_constant_expr_to_constant_expr(span, arg)?;
                 RawConstantExpr::MutPtr(Box::new(arg))
             }
-            ConstantExprKind::ConstRef { id } => {
-                let var_id = self.const_generic_vars_map.get(&id.index);
-                if let Some(var_id) = var_id {
-                    RawConstantExpr::Var(ConstGenericDbVar::free(*var_id))
-                } else {
+            ConstantExprKind::ConstRef { id } => match self.lookup_const_generic_var(id) {
+                Some(var) => RawConstantExpr::Var(var),
+                None => {
                     error_or_panic!(
                         self,
                         span,
                         &format!(
-                            "Unexpected error: could not find the const var generic of index {}",
-                            id.index
+                            "Unexpected error: could not find the const generic variable {}",
+                            id.name
                         )
                     )
                 }
-            }
+            },
             ConstantExprKind::FnPtr {
                 def_id: fn_id,
                 generics: substs,

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::fmt::Debug;
-use std::mem;
 use std::path::{Component, PathBuf};
 use std::sync::Arc;
 
@@ -194,6 +193,100 @@ pub struct TranslateCtx<'tcx> {
     pub cached_item_metas: HashMap<DefId, ItemMeta>,
 }
 
+/// A level of binding for type-level variables. Each item has a top-level binding level
+/// corresponding to the parameters and clauses to the items. We may then encounter inner binding
+/// levels in the following cases:
+/// - `for<..>` binders in predicates;
+/// - `fn<..>` function pointer types;
+/// - `dyn Trait` types, represented as `dyn<T: Trait>` (TODO);
+/// - types in a trait declaration or implementation block (TODO);
+/// - methods in a trait declaration or implementation block (TODO).
+///
+/// At each level, we store two things: a `GenericParams` that contains the parameters bound at
+/// this level, and various maps from the rustc-internal indices to our indices.
+#[derive(Default)]
+pub(crate) struct BindingLevel {
+    /// The parameters and predicates bound at this level.
+    pub params: GenericParams,
+    /// Rust makes the distinction between early and late-bound region parameters. We do not make
+    /// this distinction, and merge early and late bound regions. For details, see:
+    /// https://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
+    /// https://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
+    ///
+    /// The map from rust early regions to translated region indices.
+    pub early_region_vars: std::collections::BTreeMap<hax::EarlyParamRegion, RegionId>,
+    /// The map from rust late/bound regions to translated region indices.
+    pub bound_region_vars: Vec<RegionId>,
+    /// The map from rust type variable indices to translated type variable indices.
+    pub type_vars_map: HashMap<u32, TypeVarId>,
+    /// The map from rust const generic variables to translate const generic variable indices.
+    pub const_generic_vars_map: HashMap<u32, ConstGenericVarId>,
+    /// Cache the translation of types. This harnesses the deduplication of `TyKind` that hax does.
+    pub type_trans_cache: HashMap<HashByAddr<Arc<hax::TyKind>>, Ty>,
+}
+
+impl BindingLevel {
+    /// Important: we must push all the early-bound regions before pushing any other region.
+    pub(crate) fn push_early_region(&mut self, region: hax::EarlyParamRegion) -> RegionId {
+        let name = super::translate_types::translate_region_name(&region);
+        // Check that there are no late-bound regions
+        assert!(
+            self.bound_region_vars.is_empty(),
+            "Early regions must be tralsnated before late ones"
+        );
+        let rid = self
+            .params
+            .regions
+            .push_with(|index| RegionVar { index, name });
+        self.early_region_vars.insert(region, rid);
+        rid
+    }
+
+    /// Important: we must push all the early-bound regions before pushing any other region.
+    pub(crate) fn push_bound_region(&mut self, region: hax::BoundRegionKind) -> RegionId {
+        let name = translate_bound_region_kind_name(&region);
+        let rid = self
+            .params
+            .regions
+            .push_with(|index| RegionVar { index, name });
+        self.bound_region_vars.push(rid);
+        rid
+    }
+
+    pub(crate) fn push_type_var(&mut self, rid: u32, name: String) -> TypeVarId {
+        let var_id = self.params.types.push_with(|index| TypeVar { index, name });
+        self.type_vars_map.insert(rid, var_id);
+        var_id
+    }
+
+    pub(crate) fn push_const_generic_var(&mut self, rid: u32, ty: LiteralTy, name: String) {
+        let var_id = self
+            .params
+            .const_generics
+            .push_with(|index| ConstGenericVar { index, name, ty });
+        self.const_generic_vars_map.insert(rid, var_id);
+    }
+
+    /// Translate a binder of regions by appending the stored reguions to the given vector.
+    pub(crate) fn push_params_from_binder(&mut self, binder: hax::Binder<()>) -> Result<(), Error> {
+        use hax::BoundVariableKind::*;
+        for p in binder.bound_vars {
+            match p {
+                Region(region) => {
+                    self.push_bound_region(region);
+                }
+                Ty(_) => {
+                    panic!("Unexpected locally bound type variable");
+                }
+                Const => {
+                    panic!("Unexpected locally bound const generic variable");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 /// A translation context for type/global/function bodies.
 /// Simply augments the [TranslateCtx] with local variables.
 ///
@@ -216,50 +309,14 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx> {
     /// aliases, because rust does not enforce correct trait bounds on type aliases.
     pub error_on_impl_expr_error: bool,
 
-    /// The regions.
-    /// We use DeBruijn indices, so we have a stack of regions.
-    /// See the comments for [Region::BVar].
-    pub region_vars: VecDeque<Vector<RegionId, RegionVar>>,
-    /// The map from rust (free) regions to translated region indices.
-    /// This contains the early bound regions.
-    ///
-    /// Important:
-    /// ==========
-    /// Rust makes the distinction between the early bound regions, which
-    /// are free, and the late-bound regions, which are bound (and use
-    /// DeBruijn indices).
-    /// We do not make this distinction, and use bound regions everywhere.
-    /// This means that we consider the free regions as belonging to the first
-    /// group of bound regions.
-    ///
-    /// The [bound_region_vars] field below takes care of the regions which
-    /// are bound in the Rustc representation.
-    pub free_region_vars: std::collections::BTreeMap<hax::EarlyParamRegion, RegionId>,
-    /// The stack of late-bound parameters (can only be lifetimes for now), which
-    /// use DeBruijn indices (the other parameters use free variables).
-    /// For explanations about what early-bound and late-bound parameters are, see:
-    /// https://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
-    /// https://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
-    ///
-    /// **Important**:
-    /// ==============
-    /// We use DeBruijn indices. See the comments for [Region::Var].
-    pub bound_region_vars: VecDeque<Box<[RegionId]>>,
-    /// The generic parameters for the item. `regions` must be empty, as regions are handled
-    /// separately.
-    pub generic_params: GenericParams,
-    /// The map from rust type variable indices to translated type variable indices.
-    pub type_vars_map: HashMap<u32, TypeVarId>,
-    /// The map from rust const generic variables to translate const generic
-    /// variable indices.
-    pub const_generic_vars_map: HashMap<u32, ConstGenericVarId>,
+    /// The stack of generic parameter binders for the current context. Each binder introduces an
+    /// entry in this stack, with the entry as index `0` being the innermost binder. These
+    /// parameters are referenced using [`DeBruijnVar`]; see there for details.
+    pub binding_levels: VecDeque<BindingLevel>,
     /// (For traits only) accumulated implied trait clauses.
     pub parent_trait_clauses: Vector<TraitClauseId, TraitClause>,
     /// (For traits only) accumulated trait clauses on associated types.
     pub item_trait_clauses: HashMap<TraitItemName, Vector<TraitClauseId, TraitClause>>,
-
-    /// Cache the translation of types. This harnesses the deduplication of `TyKind` that hax does.
-    pub type_trans_cache: HashMap<HashByAddr<Arc<hax::TyKind>>, Ty>,
 
     /// The (regular) variables in the current function body.
     pub locals: Locals,
@@ -365,10 +422,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                         // substs and bounds. In order to properly do so, we introduce
                         // a body translation context.
                         let mut bt_ctx = BodyTransCtx::new(def_id, None, self);
-                        let params = bt_ctx.translate_def_generics(span, &full_def)?;
+                        bt_ctx.translate_def_generics(span, &full_def)?;
                         let ty = bt_ctx.translate_ty(span, &ty)?;
                         ImplElem::Ty(Binder {
-                            params,
+                            params: bt_ctx.into_generics(),
                             skip_binder: ty,
                         })
                     }
@@ -909,15 +966,9 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
             t_ctx,
             hax_state,
             error_on_impl_expr_error: true,
-            region_vars: [Vector::new()].into(),
-            free_region_vars: Default::default(),
-            bound_region_vars: Default::default(),
-            generic_params: Default::default(),
-            type_vars_map: Default::default(),
-            const_generic_vars_map: Default::default(),
+            binding_levels: Default::default(),
             parent_trait_clauses: Default::default(),
             item_trait_clauses: Default::default(),
-            type_trans_cache: Default::default(),
             locals: Default::default(),
             vars_map: Default::default(),
             blocks: Default::default(),
@@ -993,69 +1044,74 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         self.t_ctx.register_trait_impl_id(&src, id)
     }
 
-    /// Push a free region.
-    ///
-    /// Important: we must push *all* the free regions (which are early-bound
-    /// regions) before pushing any (late-)bound region.
-    pub(crate) fn push_free_region(&mut self, r: hax::EarlyParamRegion) -> RegionId {
-        let name = super::translate_types::translate_region_name(&r);
-        // Check that there are no late-bound regions
-        assert!(self.bound_region_vars.is_empty());
-        let rid = self.region_vars[0].push_with(|index| RegionVar { index, name });
-        self.free_region_vars.insert(r, rid);
-        rid
+    pub(crate) fn outermost_binder(&self) -> &BindingLevel {
+        self.binding_levels.back().unwrap()
     }
 
-    /// Translate a binder of regions by appending the stored reguions to the given vector.
-    pub(crate) fn register_region_binder(
-        &mut self,
-        span: Span,
-        binder: hax::Binder<()>,
-        region_vars: &mut Vector<RegionId, RegionVar>,
-    ) -> Result<Box<[RegionId]>, Error> {
-        use hax::BoundVariableKind::*;
-        binder
-            .bound_vars
-            .into_iter()
-            .map(|p| match p {
-                Region(region) => {
-                    let name = translate_bound_region_kind_name(&region);
-                    let id = region_vars.push_with(|index| RegionVar { index, name });
-                    Ok(id)
-                }
-                Ty(_) => {
-                    error_or_panic!(self, span, "Unexpected locally bound type variable");
-                }
-                Const => {
-                    error_or_panic!(
-                        self,
-                        span,
-                        "Unexpected locally bound const generic variable"
-                    );
-                }
-            })
-            .try_collect()
+    pub(crate) fn outermost_binder_mut(&mut self) -> &mut BindingLevel {
+        self.binding_levels.back_mut().unwrap()
     }
 
-    /// Set the first bound regions group
-    pub(crate) fn set_first_bound_regions_group(
-        &mut self,
-        span: Span,
-        binder: hax::Binder<()>,
-    ) -> Result<(), Error> {
-        assert!(self.bound_region_vars.is_empty());
-        assert_eq!(self.region_vars.len(), 1);
+    pub(crate) fn innermost_binder(&mut self) -> &mut BindingLevel {
+        self.binding_levels.front_mut().unwrap()
+    }
 
-        // Register the variables
-        // There may already be lifetimes in the current group.
-        let mut region_vars = mem::take(&mut self.region_vars[0]);
-        let var_ids = self.register_region_binder(span, binder, &mut region_vars)?;
-        self.region_vars[0] = region_vars;
-        self.bound_region_vars.push_front(var_ids);
-        // Translation of types depends on bound variables, we must not mix that up.
-        self.type_trans_cache = Default::default();
+    pub(crate) fn lookup_bound_region(
+        &self,
+        dbid: hax::DebruijnIndex,
+        var: hax::BoundVar,
+    ) -> Option<RegionDbVar> {
+        let rid = self.binding_levels.get(dbid)?.bound_region_vars.get(var)?;
+        Some(if dbid == self.binding_levels.len() - 1 {
+            DeBruijnVar::free(*rid)
+        } else {
+            DeBruijnVar::bound(DeBruijnId::new(dbid), *rid)
+        })
+    }
 
-        Ok(())
+    pub(crate) fn lookup_early_region(
+        &self,
+        region: &hax::EarlyParamRegion,
+    ) -> Option<RegionDbVar> {
+        // TODO: handle non-top-level full binders.
+        let id = self.outermost_binder().early_region_vars.get(region)?;
+        Some(DeBruijnVar::free(*id))
+    }
+
+    pub(crate) fn lookup_type_var(&self, param: &hax::ParamTy) -> Option<TypeDbVar> {
+        // TODO: handle non-top-level full binders.
+        let id = self.outermost_binder().type_vars_map.get(&param.index)?;
+        Some(DeBruijnVar::free(*id))
+    }
+
+    pub(crate) fn lookup_const_generic_var(
+        &self,
+        param: &hax::ParamConst,
+    ) -> Option<ConstGenericDbVar> {
+        // TODO: handle non-top-level full binders.
+        let id = self
+            .outermost_binder()
+            .const_generic_vars_map
+            .get(&param.index)?;
+        Some(DeBruijnVar::free(*id))
+    }
+
+    pub(crate) fn lookup_clause_var(&self, id: usize) -> Option<ClauseDbVar> {
+        // TODO: handle non-top-level full binders.
+        let id = TraitClauseId::from_usize(id);
+        Some(DeBruijnVar::free(id))
+    }
+
+    pub(crate) fn lookup_cached_type(
+        &self,
+        cache_key: &HashByAddr<Arc<hax::TyKind>>,
+    ) -> Option<Ty> {
+        for bl in self.binding_levels.iter().rev() {
+            if let Some(ty) = bl.type_trans_cache.get(&cache_key) {
+                return Some(ty.clone());
+            }
+        }
+        None
     }
 
     /// Push a group of bound regions and call the continuation.
@@ -1063,30 +1119,25 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
     /// it contains universally quantified regions).
     pub(crate) fn translate_region_binder<F, T, U>(
         &mut self,
-        span: Span,
+        _span: Span,
         binder: &hax::Binder<T>,
         f: F,
     ) -> Result<RegionBinder<U>, Error>
     where
         F: FnOnce(&mut Self, &T) -> Result<U, Error>,
     {
-        assert!(!self.region_vars.is_empty());
+        assert!(!self.binding_levels.is_empty());
+
         // Register the variables
-        let mut bound_vars = Vector::new();
-        let unit_binder = binder.rebind(());
-        let var_ids = self.register_region_binder(span, unit_binder, &mut bound_vars)?;
-        self.bound_region_vars.push_front(var_ids);
-        self.region_vars.push_front(bound_vars);
-        // Translation of types depends on bound variables, we must not mix that up.
-        let old_ty_cache = std::mem::take(&mut self.type_trans_cache);
+        let mut binding_level = BindingLevel::default();
+        binding_level.push_params_from_binder(binder.rebind(()))?;
+        self.binding_levels.push_front(binding_level);
 
         // Call the continuation. Important: do not short-circuit on error here.
         let res = f(self, binder.hax_skip_binder_ref());
 
         // Reset
-        self.bound_region_vars.pop_front();
-        let regions = self.region_vars.pop_front().unwrap();
-        self.type_trans_cache = old_ty_cache;
+        let regions = self.binding_levels.pop_front().unwrap().params.regions;
 
         // Return
         res.map(|skip_binder| RegionBinder {
@@ -1095,26 +1146,9 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         })
     }
 
-    pub(crate) fn push_type_var(&mut self, rid: u32, name: String) -> TypeVarId {
-        let var_id = self
-            .generic_params
-            .types
-            .push_with(|index| TypeVar { index, name });
-        self.type_vars_map.insert(rid, var_id);
-        var_id
-    }
-
     pub(crate) fn push_var(&mut self, rid: usize, ty: Ty, name: Option<String>) {
         let var_id = self.locals.vars.push_with(|index| Var { index, name, ty });
         self.vars_map.insert(rid, var_id);
-    }
-
-    pub(crate) fn push_const_generic_var(&mut self, rid: u32, ty: LiteralTy, name: String) {
-        let var_id = self
-            .generic_params
-            .const_generics
-            .push_with(|index| ConstGenericVar { index, name, ty });
-        self.const_generic_vars_map.insert(rid, var_id);
     }
 
     pub(crate) fn fresh_block_id(&mut self, rid: hax::BasicBlock) -> ast::BlockId {
@@ -1148,25 +1182,13 @@ impl<'tcx, 'ctx, 'a> IntoFormatter for &'a BodyTransCtx<'tcx, 'ctx> {
     type C = FmtCtx<'a>;
 
     fn into_fmt(self) -> Self::C {
-        // Translate our generics into a stack of generics. Only the outermost binder has
-        // non-region parameters.
-        let mut generics: VecDeque<Cow<'_, GenericParams>> = self
-            .region_vars
-            .iter()
-            .cloned()
-            .map(|regions| {
-                Cow::Owned(GenericParams {
-                    regions,
-                    ..Default::default()
-                })
-            })
-            .collect();
-        let outermost_generics = generics.back_mut().unwrap().to_mut();
-        outermost_generics.types = self.generic_params.types.clone();
-        outermost_generics.const_generics = self.generic_params.const_generics.clone();
         FmtCtx {
             translated: Some(&self.t_ctx.translated),
-            generics,
+            generics: self
+                .binding_levels
+                .iter()
+                .map(|bl| Cow::Borrowed(&bl.params))
+                .collect(),
             locals: Some(&self.locals),
         }
     }

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -366,9 +366,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                         // substs and bounds. In order to properly do so, we introduce
                         // a body translation context.
                         let mut bt_ctx = BodyTransCtx::new(def_id, None, self);
-                        let generics = bt_ctx.translate_def_generics(span, &full_def)?;
+                        let params = bt_ctx.translate_def_generics(span, &full_def)?;
                         let ty = bt_ctx.translate_ty(span, &ty)?;
-                        ImplElem::Ty(generics, ty)
+                        ImplElem::Ty(Binder {
+                            params,
+                            skip_binder: ty,
+                        })
                     }
                     // Trait implementation
                     hax::FullDefKind::TraitImpl { .. } => {

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -234,8 +234,7 @@ pub(crate) struct BodyTransCtx<'tcx, 'ctx> {
     ///
     /// The [bound_region_vars] field below takes care of the regions which
     /// are bound in the Rustc representation.
-    pub free_region_vars: std::collections::BTreeMap<hax::Region, RegionId>,
-    ///
+    pub free_region_vars: std::collections::BTreeMap<hax::EarlyParamRegion, RegionId>,
     /// The stack of late-bound parameters (can only be lifetimes for now), which
     /// use DeBruijn indices (the other parameters use free variables).
     /// For explanations about what early-bound and late-bound parameters are, see:
@@ -998,7 +997,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
     ///
     /// Important: we must push *all* the free regions (which are early-bound
     /// regions) before pushing any (late-)bound region.
-    pub(crate) fn push_free_region(&mut self, r: hax::Region) -> RegionId {
+    pub(crate) fn push_free_region(&mut self, r: hax::EarlyParamRegion) -> RegionId {
         let name = super::translate_types::translate_region_name(&r);
         // Check that there are no late-bound regions
         assert!(self.bound_region_vars.is_empty());

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1506,7 +1506,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                         ClosureKind::FnOnce => state_ty,
                         ClosureKind::Fn | ClosureKind::FnMut => {
                             let rid = self
-                                .top_level_generics_mut()
+                                .innermost_generics_mut()
                                 .regions
                                 .push_with(|index| RegionVar { index, name: None });
                             let r = Region::Var(DeBruijnVar::free(rid));
@@ -1533,7 +1533,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         };
 
         Ok(FunSig {
-            generics: self.top_level_generics().clone(),
+            generics: self.the_only_binder().params.clone(),
             is_unsafe,
             is_closure: matches!(&def.kind, hax::FullDefKind::Closure { .. }),
             closure_info,

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -1415,7 +1415,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
     ) -> Result<FunSig, Error> {
         let span = item_meta.span;
 
-        let mut generics = self.translate_def_generics(span, def)?;
+        self.translate_def_generics(span, def)?;
 
         let signature = match &def.kind {
             hax::FullDefKind::Closure { args, .. } => &args.sig,
@@ -1505,7 +1505,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                     match &kind {
                         ClosureKind::FnOnce => state_ty,
                         ClosureKind::Fn | ClosureKind::FnMut => {
-                            let rid = generics
+                            let rid = self
+                                .top_level_generics_mut()
                                 .regions
                                 .push_with(|index| RegionVar { index, name: None });
                             let r = Region::Var(DeBruijnVar::free(rid));
@@ -1532,7 +1533,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         };
 
         Ok(FunSig {
-            generics,
+            generics: self.top_level_generics().clone(),
             is_unsafe,
             is_closure: matches!(&def.kind, hax::FullDefKind::Closure { .. }),
             closure_info,
@@ -1619,7 +1620,7 @@ impl BodyTransCtx<'_, '_> {
         //   const LEN : usize = N;
         // }
         // ```
-        let generics = self.translate_def_generics(span, def)?;
+        self.translate_def_generics(span, def)?;
 
         // Retrieve the kind
         let global_kind = self.get_item_kind(span, def)?;
@@ -1638,7 +1639,7 @@ impl BodyTransCtx<'_, '_> {
         Ok(GlobalDecl {
             def_id,
             item_meta,
-            generics,
+            generics: self.into_generics(),
             ty,
             kind: global_kind,
             init: initializer,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -90,7 +90,9 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             ctx.translate_trait_predicate(span, trait_pred)
                         })?;
                         let location = match location {
-                            PredicateLocation::Base => &mut self.generic_params.trait_clauses,
+                            PredicateLocation::Base => {
+                                &mut self.top_level_generics_mut().trait_clauses
+                            }
                             PredicateLocation::Parent => &mut self.parent_trait_clauses,
                             PredicateLocation::Item(item_name) => self
                                 .item_trait_clauses
@@ -110,7 +112,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             let r1 = ctx.translate_region(span, &p.rhs)?;
                             Ok(OutlivesPred(r0, r1))
                         })?;
-                        self.generic_params.regions_outlive.push(pred);
+                        self.top_level_generics_mut().regions_outlive.push(pred);
                     }
                     ClauseKind::TypeOutlives(p) => {
                         let pred = self.translate_region_binder(span, &pred.kind, |ctx, _| {
@@ -118,7 +120,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             let r = ctx.translate_region(span, &p.rhs)?;
                             Ok(OutlivesPred(ty, r))
                         })?;
-                        self.generic_params.types_outlive.push(pred);
+                        self.top_level_generics_mut().types_outlive.push(pred);
                     }
                     ClauseKind::Projection(p) => {
                         // This is used to express constraints over associated types.
@@ -137,7 +139,9 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                                 ty,
                             })
                         })?;
-                        self.generic_params.trait_type_constraints.push(pred);
+                        self.top_level_generics_mut()
+                            .trait_type_constraints
+                            .push(pred);
                     }
                     ClauseKind::ConstArgHasType(..) => {
                         // I don't really understand that one. Why don't they put
@@ -248,7 +252,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 let mut trait_id = match &impl_source.r#impl {
                     ImplExprAtom::SelfImpl { .. } => TraitRefKind::SelfId,
                     ImplExprAtom::LocalBound { index, .. } => {
-                        TraitRefKind::Clause(DeBruijnVar::free(TraitClauseId::from_usize(*index)))
+                        let var = self.lookup_clause_var(*index).unwrap();
+                        TraitRefKind::Clause(var)
                     }
                     _ => unreachable!(),
                 };

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -103,7 +103,7 @@ impl BodyTransCtx<'_, '_> {
                         // declares them.
                         let gref = GlobalDeclRef {
                             id: self.register_global_decl_id(item_span, rust_item_id),
-                            generics: self.top_level_generics().identity_args(),
+                            generics: self.the_only_binder().params.identity_args(),
                         };
                         const_defaults.insert(item_name.clone(), gref);
                     };
@@ -251,7 +251,7 @@ impl BodyTransCtx<'_, '_> {
                     // The parameters of the constant are the same as those of the item that
                     // declares them.
                     let generics = match &impl_item.value {
-                        Provided { .. } => self.top_level_generics().identity_args(),
+                        Provided { .. } => self.the_only_binder().params.identity_args(),
                         _ => implemented_trait.generics.clone(),
                     };
                     let gref = GlobalDeclRef { id, generics };

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1299,13 +1299,14 @@ fn generate_ml(
                     "TraitTypeConstraint",
                 ]),
                 (GenerationKind::TypeDecl(None), &[
+                    "Binder",
                     "ImplElem",
                     "PathElem",
                     "Name",
                 ]),
                 (GenerationKind::TypeDecl(Some(DeriveVisitors {
                     name: "type_decl",
-                    ancestor: Some("generic_params"),
+                    ancestor: Some("type_decl_base_base"),
                     reduce: false,
                     extra_types: &["attr_info", "name"],
                 })), &[

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -170,7 +170,7 @@ impl PatElem {
                     pat_ident == ident || (pat_ident == "crate" && ident == &ctx.real_crate_name);
                 same_ident && (generics.is_empty() || PatTy::matches_generics(ctx, generics, args))
             }
-            (PatElem::Impl(_pat), PathElem::Impl(ImplElem::Ty(_, _ty), _)) => {
+            (PatElem::Impl(_pat), PathElem::Impl(ImplElem::Ty(..), _)) => {
                 // TODO
                 false
             }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -764,7 +764,7 @@ impl<T> RegionBinder<T> {
     fn fmt_split<'a, C>(&'a self, ctx: &'a C) -> (String, String)
     where
         C: AstFormatter,
-        T: FmtWithCtx<<C as PushBoundRegions<'a>>::C>,
+        T: FmtWithCtx<<C as PushBinder<'a>>::C>,
     {
         let ctx = &ctx.push_bound_regions(&self.regions);
         (
@@ -777,7 +777,7 @@ impl<T> RegionBinder<T> {
     fn fmt_as_for<'a, C>(&'a self, ctx: &'a C) -> String
     where
         C: AstFormatter,
-        T: FmtWithCtx<<C as PushBoundRegions<'a>>::C>,
+        T: FmtWithCtx<<C as PushBinder<'a>>::C>,
     {
         let (regions, value) = self.fmt_split(ctx);
         let regions = if regions.is_empty() {

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -272,23 +272,16 @@ impl<'a> Formatter<RegionDbVar> for FmtCtx<'a> {
         if self.generics.is_empty() {
             return format!("'_{var}");
         }
-        let (index, varid) = match var {
+        let (dbid, varid) = match var {
             DeBruijnVar::Bound(dbid, varid) => (dbid.index, varid),
             DeBruijnVar::Free(varid) => (self.generics.len() - 1, varid),
         };
         match self
             .generics
-            .get(index)
+            .get(dbid)
             .and_then(|generics| generics.regions.get(varid))
         {
-            None => {
-                let region = Region::Var(var).fmt_without_ctx();
-                tracing::warn!(
-                    "Found incorrect region `{region}` while pretty-printing. Look for \
-                        \"wrong_region\" in the pretty output"
-                );
-                format!("wrong_region({region})")
-            }
+            None => format!("wrong_region('_{var})"),
             Some(v) => match &v.name {
                 Some(name) => name.to_string(),
                 None => format!("'_{var}"),
@@ -308,39 +301,60 @@ impl<'a> Formatter<&RegionVar> for FmtCtx<'a> {
 
 impl<'a> Formatter<TypeDbVar> for FmtCtx<'a> {
     fn format_object(&self, var: TypeDbVar) -> String {
-        match var {
-            DeBruijnVar::Bound(..) => format!("missing_type_var({var})"),
-            DeBruijnVar::Free(id) => match &self.generics.back() {
-                None => id.to_pretty_string(),
-                Some(generics) => match generics.types.get(id) {
-                    None => id.to_pretty_string(),
-                    Some(v) => v.to_string(),
-                },
-            },
+        if self.generics.is_empty() {
+            return format!("@Type{var}");
+        }
+        let (dbid, varid) = match var {
+            DeBruijnVar::Bound(dbid, varid) => (dbid.index, varid),
+            DeBruijnVar::Free(varid) => (self.generics.len() - 1, varid),
+        };
+        match self
+            .generics
+            .get(dbid)
+            .and_then(|generics| generics.types.get(varid))
+        {
+            None => format!("missing_type_var({var})"),
+            Some(v) => v.to_string(),
         }
     }
 }
 
 impl<'a> Formatter<ConstGenericDbVar> for FmtCtx<'a> {
     fn format_object(&self, var: ConstGenericDbVar) -> String {
-        match var {
-            DeBruijnVar::Bound(..) => format!("missing_cg_var({var})"),
-            DeBruijnVar::Free(id) => match &self.generics.back() {
-                None => id.to_pretty_string(),
-                Some(generics) => match generics.const_generics.get(id) {
-                    None => id.to_pretty_string(),
-                    Some(v) => v.to_string(),
-                },
-            },
+        if self.generics.is_empty() {
+            return format!("@ConstGeneric{var}");
+        }
+        let (dbid, varid) = match var {
+            DeBruijnVar::Bound(dbid, varid) => (dbid.index, varid),
+            DeBruijnVar::Free(varid) => (self.generics.len() - 1, varid),
+        };
+        match self
+            .generics
+            .get(dbid)
+            .and_then(|generics| generics.const_generics.get(varid))
+        {
+            None => format!("missing_cg_var({var})"),
+            Some(v) => v.to_string(),
         }
     }
 }
 
 impl<'a> Formatter<ClauseDbVar> for FmtCtx<'a> {
     fn format_object(&self, var: ClauseDbVar) -> String {
-        match var {
-            DeBruijnVar::Bound(..) => format!("missing_clause_var({var})"),
-            DeBruijnVar::Free(id) => id.to_pretty_string(),
+        if self.generics.is_empty() {
+            return format!("@TraitClause{var}");
+        }
+        let (dbid, varid) = match var {
+            DeBruijnVar::Bound(dbid, varid) => (dbid.index, varid),
+            DeBruijnVar::Free(varid) => (self.generics.len() - 1, varid),
+        };
+        match self
+            .generics
+            .get(dbid)
+            .and_then(|generics| generics.trait_clauses.get(varid))
+        {
+            None => format!("missing_clause_var({var})"),
+            Some(_) => format!("@TraitClause{var}"),
         }
     }
 }

--- a/charon/tests/ui/unsupported/unbound-lifetime.out
+++ b/charon/tests/ui/unsupported/unbound-lifetime.out
@@ -6,13 +6,7 @@ error[E0261]: use of undeclared lifetime name `'a`
   |       |
   |       help: consider introducing lifetime `'a` here: `<'a>`
 
-error: Could not find region: Region { kind: ReError(ErrorGuaranteed { todo: "ErrorGuaranteed(())" }) }
-       
-       Region vars map:
-       {}
-       
-       Bound region vars:
-       [[]]
+error: Unexpected region kind: Region { kind: ReError(ErrorGuaranteed { todo: "ErrorGuaranteed(())" }) }
  --> tests/ui/unsupported/unbound-lifetime.rs:5:1
   |
 5 | fn get(_x: &'a u32) {}


### PR DESCRIPTION
This rearchitects the translation of generic parameters to prepare for non-top-level non-region binders. Part of #180 and #127.