### PR TITLE
Improve the CFG reconstruction

### DIFF
--- a/charon/src/transform/duplicate_return.rs
+++ b/charon/src/transform/duplicate_return.rs
@@ -1,0 +1,79 @@
+//! The MIR uses a unique `return` node, which can be an issue when reconstructing
+//! the control-flow.
+//!
+//! For instance, it often leads to code of the following shape:
+//! ```text
+//! if b {
+//!   ...
+//!   x = 0;
+//! }
+//! else {
+//!   ...
+//!   x = 1;
+//! }
+//! return x;
+//! ```
+//!
+//! while a more natural reconstruction would be:
+//! ```text
+//! if b {
+//!   ...
+//!   return 0;
+//! }
+//! else {
+//!   ...
+//!   return 1;
+//! }
+//! ```
+
+use crate::ids::Generator;
+use crate::transform::TransformCtx;
+use crate::ullbc_ast::*;
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
+use std::collections::HashMap;
+
+use super::ctx::UllbcPass;
+
+pub struct Transform;
+impl UllbcPass for Transform {
+    fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
+        // Find the return block id (there should be one).
+        let returns: HashMap<BlockId, Span> = b
+            .body
+            .iter_indexed()
+            .filter_map(|(bid, block)| {
+                if block.statements.is_empty() && block.terminator.content.is_return() {
+                    Some((bid, block.terminator.span))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Whenever we find a goto the return block, introduce an auxiliary block
+        // for this (remark: in the end, it makes the return block dangling).
+        // We do this in two steps.
+        // First, introduce fresh ids.
+        assert!(usize::from(b.body.next_id()) == b.body.len());
+        let mut generator = Generator::new_with_init_value(b.body.len());
+        let mut new_spans = Vec::new();
+        b.body
+            .drive_mut(&mut visitor_enter_fn_mut(|bid: &mut BlockId| {
+                if let Some(span) = returns.get(bid) {
+                    *bid = generator.fresh_id();
+                    new_spans.push(*span);
+                }
+            }));
+
+        // Then introduce the new blocks
+        for span in new_spans {
+            let _ = b.body.push(BlockData {
+                statements: Vec::new(),
+                terminator: Terminator {
+                    span,
+                    content: RawTerminator::Return,
+                },
+            });
+        }
+    }
+}

--- a/charon/src/transform/filter_useless_blocks.rs
+++ b/charon/src/transform/filter_useless_blocks.rs
@@ -1,0 +1,42 @@
+//! Some passes like [`reconstruct_assert`] lead to the apparition of "dangling" blocks,
+//! which are referenced nowhere and thus become useless. This pass filters those out.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::transform::TransformCtx;
+use crate::ullbc_ast::*;
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
+
+use super::ctx::UllbcPass;
+
+pub struct Transform;
+impl UllbcPass for Transform {
+    fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
+        // Perform a depth-first search to identify all the blocks reachable
+        // from the first block.
+        let mut explored: HashSet<BlockId> = HashSet::new();
+        let mut to_explore: Vec<BlockId> = vec![BlockId::from_usize(0)];
+        while let Some(bid) = to_explore.pop() {
+            if explored.contains(&bid) {
+                continue;
+            }
+            explored.insert(bid);
+            to_explore.append(&mut b.body[bid].targets())
+        }
+
+        // Renumerotate
+        let mut bid_map: HashMap<BlockId, BlockId> = HashMap::new();
+        for (bid, block) in std::mem::take(&mut b.body).into_iter_indexed() {
+            if explored.contains(&bid) {
+                let nbid = b.body.push(block);
+                bid_map.insert(bid, nbid);
+            }
+        }
+
+        // Update all block ids
+        b.body
+            .drive_mut(&mut visitor_enter_fn_mut(|bid: &mut BlockId| {
+                *bid = *bid_map.get(bid).unwrap();
+            }));
+    }
+}

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_generics;
 pub mod ctx;
 pub mod filter_invisible_trait_impls;
+pub mod filter_useless_blocks;
 pub mod graphs;
 pub mod hide_marker_traits;
 pub mod index_intermediate_assigns;
@@ -77,11 +78,14 @@ pub static ULLBC_PASSES: &[Pass] = &[
     UnstructuredBody(&ops_to_function_calls::Transform),
     // # Micro-pass: make sure the block ids used in the ULLBC are consecutive
     UnstructuredBody(&update_block_indices::Transform),
+    // # Micro-pass: reconstruct the asserts
+    UnstructuredBody(&reconstruct_asserts::Transform),
+    // # Micro-pass: filter the "dangling" blocks. Those might have been introduced by,
+    // for instance, [`reconstruct_asserts`].
+    UnstructuredBody(&filter_useless_blocks::Transform),
 ];
 
 pub static LLBC_PASSES: &[Pass] = &[
-    // # Micro-pass: reconstruct the asserts
-    StructuredBody(&reconstruct_asserts::Transform),
     // # Micro-pass: `panic!()` expands to a new function definition each time. This pass cleans
     // those up.
     StructuredBody(&inline_local_panic_functions::Transform),

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -1,5 +1,6 @@
 pub mod check_generics;
 pub mod ctx;
+pub mod duplicate_return;
 pub mod filter_invisible_trait_impls;
 pub mod filter_useless_blocks;
 pub mod graphs;
@@ -80,6 +81,8 @@ pub static ULLBC_PASSES: &[Pass] = &[
     UnstructuredBody(&update_block_indices::Transform),
     // # Micro-pass: reconstruct the asserts
     UnstructuredBody(&reconstruct_asserts::Transform),
+    // # Micro-pass: duplicate the return blocks
+    UnstructuredBody(&duplicate_return::Transform),
     // # Micro-pass: filter the "dangling" blocks. Those might have been introduced by,
     // for instance, [`reconstruct_asserts`].
     UnstructuredBody(&filter_useless_blocks::Transform),

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -19,12 +19,13 @@ where
 
     match *(self@1) {
         1 => {
-            @0 := const (true)
         },
         0 => {
             @0 := const (false)
+            return
         },
     }
+    @0 := const (true)
     return
 }
 

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -1859,15 +1859,17 @@ fn test_crate::slice_pattern_4<'_0>(@1: &'_0 (Slice<()>))
     @3 := const (1 : usize)
     @4 := move (@2) == move (@3)
     if move (@4) {
-        @6 := &*(x@1)
-        @7 := @SliceIndexShared<'_, ()>(move (@6), const (0 : usize))
-        _named@5 := &*(@7)
-        @0 := ()
-        drop _named@5
     }
     else {
         @0 := ()
+        @0 := ()
+        return
     }
+    @6 := &*(x@1)
+    @7 := @SliceIndexShared<'_, ()>(move (@6), const (0 : usize))
+    _named@5 := &*(@7)
+    @0 := ()
+    drop _named@5
     @0 := ()
     return
 }

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -110,7 +110,6 @@ where
     @fake_read(x@1)
     match *(x@1) {
         0 => {
-            @0 := core::option::Option::None {  }
         },
         1 => {
             x@3 := &(*(x@1) as variant @1).0
@@ -123,8 +122,10 @@ where
             drop @4
             drop @4
             drop x@3
+            return
         },
     }
+    @0 := core::option::Option::None {  }
     return
 }
 

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -74,14 +74,15 @@ where
     let @3: T; // anonymous local
 
     if copy (self@1) {
-        @3 := move (t@2)
-        @0 := core::option::Option::Some { 0: move (@3) }
-        drop @3
     }
     else {
         @0 := core::option::Option::None {  }
         drop t@2
+        return
     }
+    @3 := move (t@2)
+    @0 := core::option::Option::Some { 0: move (@3) }
+    drop @3
     return
 }
 

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -14,12 +14,13 @@ fn test_crate::test1(@1: test_crate::E1) -> bool
     @fake_read(x@1)
     match x@1 {
         0 | 1 => {
-            @0 := const (true)
         },
         2 => {
             @0 := const (false)
+            return
         },
     }
+    @0 := const (true)
     return
 }
 
@@ -53,18 +54,17 @@ fn test_crate::test2(@1: test_crate::E2) -> u32
     match x@1 {
         0 => {
             n@2 := copy ((x@1 as variant @0).0)
-            @0 := copy (n@2)
-            drop n@2
         },
         1 => {
             n@2 := copy ((x@1 as variant @1).0)
-            @0 := copy (n@2)
-            drop n@2
         },
         2 => {
             @0 := const (0 : u32)
+            return
         },
     }
+    @0 := copy (n@2)
+    drop n@2
     return
 }
 

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -372,12 +372,13 @@ where
     @fake_read(l@1)
     match *(l@1) {
         0 => {
-            @0 := const (true)
         },
         1 => {
             @0 := const (false)
+            return
         },
     }
+    @0 := const (true)
     return
 }
 

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -354,16 +354,12 @@ fn test_crate::test_unreachable(@1: bool)
     let @3: (); // anonymous local
 
     @2 := copy (b@1)
-    if move (@2) {
-    }
-    else {
-        @3 := ()
-        @0 := move (@3)
-        drop @2
-        @0 := ()
-        return
-    }
-    panic(core::panicking::panic)
+    assert(move (@2) == false)
+    @3 := ()
+    @0 := move (@3)
+    drop @2
+    @0 := ()
+    return
 }
 
 fn test_crate::is_cons<'_0, T>(@1: &'_0 (test_crate::List<T>[@TraitClause0])) -> bool

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -19,12 +19,13 @@ where
 
     match *(self@1) {
         1 => {
-            @0 := const (true)
         },
         0 => {
             @0 := const (false)
+            return
         },
     }
+    @0 := const (true)
     return
 }
 

--- a/charon/tests/ui/projection-index-from-end.out
+++ b/charon/tests/ui/projection-index-from-end.out
@@ -18,17 +18,19 @@ fn test_crate::slice_pattern_end<'_0>(@1: &'_0 (Slice<()>))
     @3 := const (1 : usize)
     @4 := move (@2) >= move (@3)
     if move (@4) {
-        @6 := &*(x@1)
-        @7 := len(*(x@1))
-        @8 := copy (@7) - const (1 : usize)
-        @9 := @SliceIndexShared<'_, ()>(move (@6), copy (@8))
-        _named@5 := &*(@9)
-        @0 := ()
-        drop _named@5
     }
     else {
         @0 := ()
+        @0 := ()
+        return
     }
+    @6 := &*(x@1)
+    @7 := len(*(x@1))
+    @8 := copy (@7) - const (1 : usize)
+    @9 := @SliceIndexShared<'_, ()>(move (@6), copy (@8))
+    _named@5 := &*(@9)
+    @0 := ()
+    drop _named@5
     @0 := ()
     return
 }

--- a/charon/tests/ui/reconstruct_early_return.out
+++ b/charon/tests/ui/reconstruct_early_return.out
@@ -1,0 +1,89 @@
+# Final LLBC before serialization:
+
+fn test_crate::f() -> usize
+{
+    let @0: usize; // return
+    let i@1: i32; // local
+    let j@2: i32; // local
+    let @3: (); // anonymous local
+    let @4: (); // anonymous local
+    let @5: bool; // anonymous local
+    let @6: i32; // anonymous local
+    let @7: (); // anonymous local
+    let @8: bool; // anonymous local
+    let @9: i32; // anonymous local
+    let @10: bool; // anonymous local
+    let @11: i32; // anonymous local
+    let @12: (); // anonymous local
+    let @13: (); // anonymous local
+    let @14: (); // anonymous local
+    let @15: (); // anonymous local
+    let @16: (); // anonymous local
+
+    i@1 := const (0 : i32)
+    @fake_read(i@1)
+    j@2 := const (0 : i32)
+    @fake_read(j@2)
+    loop {
+        @6 := copy (i@1)
+        @5 := move (@6) < const (32 : i32)
+        if move (@5) {
+            drop @6
+            j@2 := copy (j@2) + const (1 : i32)
+            @9 := copy (j@2)
+            @8 := move (@9) > const (16 : i32)
+            if move (@8) {
+                drop @9
+                j@2 := copy (j@2) / const (2 : i32)
+                @14 := ()
+                @7 := move (@14)
+            }
+            else {
+                drop @9
+                @11 := copy (j@2)
+                @10 := move (@11) > const (32 : i32)
+                if move (@10) {
+                    drop @11
+                    @0 := const (1 : usize)
+                    drop @10
+                    drop @8
+                    drop @7
+                    drop @5
+                    drop @3
+                    drop j@2
+                    drop i@1
+                    return
+                }
+                else {
+                    drop @11
+                    @15 := ()
+                    @7 := move (@15)
+                    drop @10
+                }
+            }
+            drop @8
+            drop @7
+            i@1 := copy (i@1) + const (1 : i32)
+            @16 := ()
+            @4 := move (@16)
+            drop @5
+            continue 0
+        }
+        else {
+            break 0
+        }
+    }
+    drop @6
+    @13 := ()
+    @3 := move (@13)
+    drop @12
+    drop @5
+    drop @3
+    @0 := const (0 : usize)
+    drop j@2
+    drop i@1
+    return
+}
+
+
+

--- a/charon/tests/ui/reconstruct_early_return.rs
+++ b/charon/tests/ui/reconstruct_early_return.rs
@@ -1,0 +1,20 @@
+fn f() -> usize
+{
+    let mut i = 0;
+    let mut j = 0;
+    while i < 32
+    {
+        j += 1;
+        if j > 16
+        {
+            j /= 2;
+        }
+        else if j > 32
+        {
+            return 1;
+        }
+        i += 1;
+    }
+
+    0
+}

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -75,11 +75,11 @@ where
     return
 }
 
+fn core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
+
 fn core::fmt::num::imp::{impl core::fmt::Display for u32}#10::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 
 fn core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
-
-fn core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 
 fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 {
@@ -96,24 +96,25 @@ fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1: &'
     drop @4
     switch move (@3) {
         0 : u32 => {
-            drop @3
-            @6 := copy ((*(f@2)).flags)
-            @5 := move (@6) & const (32 : u32)
-            drop @6
-            switch move (@5) {
-                0 : u32 => {
-                    drop @5
-                    @0 := core::fmt::num::imp::{impl core::fmt::Display for u32}#10::fmt<'_, '_, '_>(move (self@1), move (f@2))
-                },
-                _ => {
-                    drop @5
-                    @0 := core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt<'_, '_, '_>(move (self@1), move (f@2))
-                },
-            }
         },
         _ => {
             drop @3
             @0 := core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt<'_, '_, '_>(move (self@1), move (f@2))
+            return
+        },
+    }
+    drop @3
+    @6 := copy ((*(f@2)).flags)
+    @5 := move (@6) & const (32 : u32)
+    drop @6
+    switch move (@5) {
+        0 : u32 => {
+            drop @5
+            @0 := core::fmt::num::imp::{impl core::fmt::Display for u32}#10::fmt<'_, '_, '_>(move (self@1), move (f@2))
+        },
+        _ => {
+            drop @5
+            @0 := core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt<'_, '_, '_>(move (self@1), move (f@2))
         },
     }
     return

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -73,12 +73,13 @@ where
     @fake_read(self@1)
     match *(self@1) {
         0 => {
-            @0 := const (false)
         },
         1 => {
             @0 := const (true)
+            return
         },
     }
+    @0 := const (false)
     return
 }
 


### PR DESCRIPTION
This PR improves the CFG reconstruction in two ways.

# Assert reconstruction
It first moves the assert reconstruction pass to ULLBC: it is more naturally implemented
as a pass over a CFG, which allows making it more general at the same time.
For instance, it used to miss patterns of the following shape:
```rust
if b { panic; } { nop; }
```

# Duplication of `return` node
The MIR CFG only contains one return node. Because of this, the reconstructed LLBC is
sometimes not very natural, in particular as it lacks early returns.

For instance, code of the following shape:
```rust
if b {
  return 0;
}
else {
  return 1;
}
```

used to be reconstructed the following way:
```rust
if b {
  x = 0;
}
else {
  x = 1;
}
return x;
```

In order to fix this issue, this PR introduces a pass which duplicates the `return` node:
this allows the CFG reconstruction pass to correctly reconstruct the original AST
above. The PR contains a test for this specific behavior.
