### PR TITLE
Overhaul the rust visitors

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
- "convert_case 0.6.0",
+ "convert_case",
  "crates_io_api",
- "derive-visitor",
+ "derive_generic_visitor",
  "env_logger",
  "flate2",
  "hashlink",
@@ -327,12 +327,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -408,6 +402,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,25 +446,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-visitor"
-version = "0.4.0"
+name = "derive_generic_visitor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47165df83b9707cbada3216607a5d66125b6a66906de0bc1216c0669767ca9e"
+checksum = "e0729a8f5d509da0c280502837a56a9d05c16866ae5b608ef34bd687e9f21af8"
 dependencies = [
- "derive-visitor-macros",
+ "derive_generic_visitor_macros",
 ]
 
 [[package]]
-name = "derive-visitor-macros"
-version = "0.4.0"
+name = "derive_generic_visitor_macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427b39a85fecafea16b1a5f3f50437151022e35eb4fe038107f08adbf7f8def6"
+checksum = "3c2b7f15bf93ca0d978ecb96792c71a43c629a1e18b2a5de7a35a5d218e6c85e"
 dependencies = [
- "convert_case 0.4.0",
- "itertools 0.10.5",
+ "convert_case",
+ "darling",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1074,6 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,15 +1188,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -48,7 +48,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
-derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
+derive_generic_visitor = "0.1.0"
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }
 hashlink = { version = "0.9", features = ["serde_impl"] }

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -67,6 +67,7 @@ pub enum ProjectionElem {
     #[charon::opaque]
     Index {
         offset: Box<Operand>,
+        #[drive(skip)]
         from_end: bool,
     },
     /// Take a subslice of a slice or array. If `from_end` is `true` this is
@@ -76,6 +77,7 @@ pub enum ProjectionElem {
     Subslice {
         from: Box<Operand>,
         to: Box<Operand>,
+        #[drive(skip)]
         from_end: bool,
     },
 }
@@ -97,6 +99,7 @@ pub enum ProjectionElem {
 pub enum FieldProjKind {
     Adt(TypeDeclId, Option<VariantId>),
     /// If we project from a tuple, the projection kind gives the arity of the tuple.
+    #[drive(skip)]
     Tuple(usize),
     /// Access to a field in a closure state.
     /// We eliminate this in a micro-pass ([crate::update_closure_signatures]).
@@ -176,6 +179,7 @@ pub enum UnOp {
 pub enum NullOp {
     SizeOf,
     AlignOf,
+    #[drive(skip)]
     OffsetOf(Vec<(usize, FieldId)>),
     UbChecks,
 }
@@ -336,6 +340,7 @@ pub enum BuiltinFunId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct BuiltinIndexOp {
     /// Whether this is a slice or array.
+    #[drive(skip)]
     pub is_array: bool,
     /// Whether we're indexing mutably or not. Determines the type ofreference of the input and
     /// output.
@@ -343,6 +348,7 @@ pub struct BuiltinIndexOp {
     /// Whether we're indexing a single element or a subrange. If `true`, the function takes
     /// two indices and the output is a slice; otherwise, the function take one index and the
     /// output is a reference to a single element.
+    #[drive(skip)]
     pub is_range: bool,
 }
 

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -1,7 +1,7 @@
 //! Implements expressions: paths, operands, rvalues, lvalues
 
 use crate::ast::*;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -16,6 +16,7 @@ pub struct Var {
     pub index: VarId,
     /// Variable name - may be `None` if the variable was introduced by Rust
     /// through desugaring.
+    #[drive(skip)]
     pub name: Option<String>,
     /// The variable type
     #[charon::rename("var_ty")]
@@ -30,6 +31,7 @@ pub struct Opaque;
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Locals {
     /// The number of local variables used for the input arguments.
+    #[drive(skip)]
     pub arg_count: usize,
     /// The local variables.
     /// We always have, in the following order:
@@ -117,8 +119,10 @@ pub enum ItemKind {
         /// The trait declaration this item belongs to.
         trait_ref: TraitDeclRef,
         /// The name of the item.
+        #[drive(skip)]
         item_name: TraitItemName,
         /// Whether the trait declaration provides a default implementation.
+        #[drive(skip)]
         has_default: bool,
     },
     /// Function/const that is part of a trait implementation.
@@ -128,9 +132,11 @@ pub enum ItemKind {
         /// The trait declaration that the impl block implements.
         trait_ref: TraitDeclRef,
         /// The name of the item
+        #[drive(skip)]
         item_name: TraitItemName,
         /// True if the trait decl had a default implementation for this function/const and this
         /// item is a copy of the default item.
+        #[drive(skip)]
         reuses_default: bool,
     },
 }
@@ -184,6 +190,7 @@ pub struct GlobalDeclRef {
 #[derive(
     Debug, Clone, Serialize, Deserialize, Drive, DriveMut, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
+#[drive(skip)]
 pub struct TraitItemName(pub String);
 
 /// A trait **declaration**.
@@ -338,5 +345,6 @@ pub enum AbortKind {
 #[charon::rename("Assertion")]
 pub struct Assert {
     pub cond: Operand,
+    #[drive(skip)]
     pub expected: bool,
 }

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -100,8 +100,10 @@ pub enum AnyTransItemMut<'ctx> {
 pub struct TranslatedCrate {
     /// The name that the user requested for the crate. This may differ from what rustc reports as
     /// the name of the crate.
+    #[drive(skip)]
     pub crate_name: String,
     /// The name of the crate according to rustc.
+    #[drive(skip)]
     pub real_crate_name: String,
 
     /// The options used when calling Charon. It is useful for the applications

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -2,7 +2,7 @@ use crate::ast::*;
 use crate::formatter::{FmtCtx, Formatter, IntoFormatter};
 use crate::ids::Vector;
 use crate::reorder_decls::DeclarationsGroups;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use hashlink::LinkedHashSet;
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use serde_map_to_array::HashMapToArray;
 use std::cmp::{Ord, PartialOrd};
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{Index, IndexMut};
+use std::ops::{ControlFlow, Index, IndexMut};
 
 generate_index_type!(FunDeclId, "Fun");
 generate_index_type!(TypeDeclId, "Adt");
@@ -76,7 +76,9 @@ wrap_unwrap_enum!(AnyTransId::TraitDecl(TraitDeclId));
 wrap_unwrap_enum!(AnyTransId::TraitImpl(TraitImplId));
 
 /// A reference to a translated item.
-#[derive(Debug, Clone, Copy, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity)]
+#[derive(
+    Debug, Clone, Copy, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut,
+)]
 pub enum AnyTransItem<'ctx> {
     Type(&'ctx TypeDecl),
     Fun(&'ctx FunDecl),
@@ -86,7 +88,7 @@ pub enum AnyTransItem<'ctx> {
 }
 
 /// A mutable reference to a translated item.
-#[derive(Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity)]
+#[derive(Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut)]
 pub enum AnyTransItemMut<'ctx> {
     Type(&'ctx mut TypeDecl),
     Fun(&'ctx mut FunDecl),
@@ -220,9 +222,9 @@ impl<'ctx> AnyTransItem<'ctx> {
         }
     }
 
-    /// We can't implement the `Drive` type because of the `'static` constraint, but it's ok
-    /// because `AnyTransItem` isn't contained in any of our types.
-    pub fn drive<V: derive_visitor::Visitor>(&self, visitor: &mut V) {
+    /// We can't implement `AstVisitable` because of the `'static` constraint, but it's ok because
+    /// `AnyTransItem` isn't contained in any of our types.
+    pub fn drive<V: VisitAst>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
         match self {
             AnyTransItem::Type(d) => d.drive(visitor),
             AnyTransItem::Fun(d) => d.drive(visitor),
@@ -245,9 +247,9 @@ impl<'ctx> AnyTransItemMut<'ctx> {
         }
     }
 
-    /// We can't implement the `DriveMut` type because of the `'static` constraint, but it's ok
-    /// because `AnyTransItemMut` isn't contained in any of our types.
-    pub fn drive_mut<V: derive_visitor::VisitorMut>(&mut self, visitor: &mut V) {
+    /// We can't implement `AstVisitable` because of the `'static` constraint, but it's ok because
+    /// `AnyTransItemMut` isn't contained in any of our types.
+    pub fn drive_mut<V: VisitAstMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         match self {
             AnyTransItemMut::Type(d) => d.drive_mut(visitor),
             AnyTransItemMut::Fun(d) => d.drive_mut(visitor),

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -177,6 +177,15 @@ impl TranslatedCrate {
             .iter()
             .flat_map(|id| Some((*id, self.get_item(*id)?)))
     }
+    pub fn all_items_mut(&mut self) -> impl Iterator<Item = AnyTransItemMut<'_>> {
+        self.type_decls
+            .iter_mut()
+            .map(AnyTransItemMut::Type)
+            .chain(self.fun_decls.iter_mut().map(AnyTransItemMut::Fun))
+            .chain(self.global_decls.iter_mut().map(AnyTransItemMut::Global))
+            .chain(self.trait_decls.iter_mut().map(AnyTransItemMut::TraitDecl))
+            .chain(self.trait_impls.iter_mut().map(AnyTransItemMut::TraitImpl))
+    }
 }
 
 impl<'ctx> AnyTransItem<'ctx> {

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -8,7 +8,7 @@
 
 pub use super::llbc_ast_utils::*;
 pub use crate::ast::*;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -36,17 +36,20 @@ pub enum RawStatement {
     /// * 0: break to first outer loop (the current loop)
     /// * 1: break to second outer loop
     /// * ...
+    #[drive(skip)]
     Break(usize),
     /// Continue to outer loops.
     /// The `usize` gives the index of the outer loop to continue to:
     /// * 0: continue to first outer loop (the current loop)
     /// * 1: continue to second outer loop
     /// * ...
+    #[drive(skip)]
     Continue(usize),
     /// No-op.
     Nop,
     Switch(Switch),
     Loop(Block),
+    #[drive(skip)]
     Error(String),
 }
 
@@ -56,6 +59,7 @@ pub struct Statement {
     pub content: RawStatement,
     /// Comments that precede this statement.
     // This is filled in a late pass after all the control-flow manipulation.
+    #[drive(skip)]
     pub comments_before: Vec<String>,
 }
 

--- a/charon/src/ast/llbc_ast_utils.rs
+++ b/charon/src/ast/llbc_ast_utils.rs
@@ -3,7 +3,7 @@
 use crate::llbc_ast::*;
 use crate::meta;
 use crate::meta::Span;
-use derive_visitor::{visitor_fn_mut, DriveMut, Event};
+use derive_visitor::{visitor_enter_fn_mut, visitor_fn_mut, DriveMut, Event};
 
 /// Combine the span information from a [Switch]
 pub fn combine_switch_targets_span(targets: &Switch) -> Span {
@@ -115,13 +115,9 @@ impl Block {
         }
     }
 
-    /// Apply a function to all the statements, in a bottom-up manner.
-    pub fn visit_statements<F: FnMut(&mut Statement)>(&mut self, f: &mut F) {
-        self.drive_mut(&mut visitor_fn_mut(|st: &mut Statement, e: Event| {
-            if matches!(e, Event::Exit) {
-                f(st)
-            }
-        }))
+    /// Apply a function to all the statements, in a top-down manner.
+    pub fn visit_statements<F: FnMut(&mut Statement)>(&mut self, f: F) {
+        self.drive_mut(&mut visitor_enter_fn_mut(f))
     }
 
     /// Apply a transformer to all the statements, in a bottom-up manner.
@@ -129,19 +125,8 @@ impl Block {
     /// The transformer should:
     /// - mutate the current statement in place
     /// - return the sequence of statements to introduce before the current statement
-    pub fn transform<F: FnMut(&mut Statement) -> Vec<Statement>>(&mut self, f: &mut F) {
-        self.drive_mut(&mut visitor_fn_mut(|blk: &mut Block, e: Event| {
-            if matches!(e, Event::Exit) {
-                for i in (0..blk.statements.len()).rev() {
-                    let prefix_to_insert = f(&mut blk.statements[i]);
-                    if !prefix_to_insert.is_empty() {
-                        // Insert the new elements at index `i`. This only modifies `vec[i..]`
-                        // so we can keep iterating `i` down as if nothing happened.
-                        blk.statements.splice(i..i, prefix_to_insert);
-                    }
-                }
-            }
-        }))
+    pub fn transform<F: FnMut(&mut Statement) -> Vec<Statement>>(&mut self, mut f: F) {
+        self.transform_sequences(|slice| f(&mut slice[0]));
     }
 
     /// Apply a transformer to all the statements, in a bottom-up manner. Compared to `transform`,
@@ -152,17 +137,28 @@ impl Block {
     /// The transformer should:
     /// - mutate the current statements in place
     /// - return the sequence of statements to introduce before the current statements
-    pub fn transform_sequences<F: FnMut(&mut [Statement]) -> Vec<Statement>>(&mut self, f: &mut F) {
+    pub fn transform_sequences<F: FnMut(&mut [Statement]) -> Vec<Statement>>(&mut self, mut f: F) {
+        self.visit_blocks_bwd(|blk: &mut Block| {
+            for i in (0..blk.statements.len()).rev() {
+                let prefix_to_insert = f(&mut blk.statements[i..]);
+                if !prefix_to_insert.is_empty() {
+                    // Insert the new elements at index `i`. This only modifies `vec[i..]`
+                    // so we can keep iterating `i` down as if nothing happened.
+                    blk.statements.splice(i..i, prefix_to_insert);
+                }
+            }
+        })
+    }
+
+    /// Visit `self` and its sub-blocks in a top-down (pre-order) traversal.
+    pub fn visit_blocks_fwd<F: FnMut(&mut Block)>(&mut self, f: F) {
+        self.drive_mut(&mut visitor_enter_fn_mut(f))
+    }
+    /// Visit `self` and its sub-blocks in a bottom-up (post-order) traversal.
+    pub fn visit_blocks_bwd<F: FnMut(&mut Block)>(&mut self, mut f: F) {
         self.drive_mut(&mut visitor_fn_mut(|blk: &mut Block, e: Event| {
             if matches!(e, Event::Exit) {
-                for i in (0..blk.statements.len()).rev() {
-                    let prefix_to_insert = f(&mut blk.statements[i..]);
-                    if !prefix_to_insert.is_empty() {
-                        // Insert the new elements at index `i`. This only modifies `vec[i..]`
-                        // so we can keep iterating `i` down as if nothing happened.
-                        blk.statements.splice(i..i, prefix_to_insert);
-                    }
-                }
+                f(blk)
             }
         }))
     }

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -56,6 +56,7 @@ pub struct RawSpan {
     Drive,
     DriveMut,
 )]
+#[drive(skip)]
 pub struct Span {
     /// The source code span.
     ///
@@ -208,10 +209,13 @@ pub struct ItemMeta {
     pub name: Name,
     pub span: Span,
     /// The source code that corresponds to this item.
+    #[drive(skip)]
     pub source_text: Option<String>,
     /// Attributes and visibility.
+    #[drive(skip)]
     pub attr_info: AttrInfo,
     /// `true` if the type decl is a local type decl, `false` if it comes from an external crate.
+    #[drive(skip)]
     pub is_local: bool,
     /// Whether this item is considered opaque. For function and globals, this means we don't
     /// translate the body (the code); for ADTs, this means we don't translate the fields/variants.
@@ -221,6 +225,7 @@ pub struct ItemMeta {
     /// This can happen either if the item was annotated with `#[charon::opaque]` or if it was
     /// declared opaque via a command-line argument.
     #[charon::opaque]
+    #[drive(skip)]
     pub opacity: ItemOpacity,
 }
 

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -2,7 +2,7 @@
 
 pub use super::meta_utils::*;
 use crate::names::Name;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -16,6 +16,7 @@ pub mod ullbc_ast;
 pub mod ullbc_ast_utils;
 pub mod values;
 pub mod values_utils;
+pub mod visitor;
 
 // Re-export everything except llbc/ullbc, for convenience.
 pub use crate::errors::Error;
@@ -29,3 +30,4 @@ pub use names::*;
 pub use types::*;
 pub use types_utils::TyVisitable;
 pub use values::*;
+pub use visitor::*;

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -12,7 +12,7 @@ generate_index_type!(Disambiguator);
 )]
 #[charon::variants_prefix("Pe")]
 pub enum PathElem {
-    Ident(String, Disambiguator),
+    Ident(#[drive(skip)] String, Disambiguator),
     Impl(ImplElem, Disambiguator),
 }
 

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -1,6 +1,6 @@
 //! Defines some utilities for the variables
 use crate::ast::*;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA};
 use serde::{Deserialize, Serialize};
 

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -133,6 +133,7 @@ pub enum TraitRefKind {
 
     /// For error reporting.
     #[charon::rename("UnknownTrait")]
+    #[drive(skip)]
     Unknown(String),
 }
 
@@ -366,14 +367,17 @@ pub enum TypeDeclKind {
     /// Used if an error happened during the extraction, and we don't panic
     /// on error.
     #[charon::rename("TError")]
+    #[drive(skip)]
     Error(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Variant {
     pub span: Span,
+    #[drive(skip)]
     pub attr_info: AttrInfo,
     #[charon::rename("variant_name")]
+    #[drive(skip)]
     pub name: String,
     pub fields: Vector<FieldId, Field>,
     /// The discriminant used at runtime. This is used in `remove_read_discriminant` to match up
@@ -384,8 +388,10 @@ pub struct Variant {
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Field {
     pub span: Span,
+    #[drive(skip)]
     pub attr_info: AttrInfo,
     #[charon::rename("field_name")]
+    #[drive(skip)]
     pub name: Option<String>,
     #[charon::rename("field_ty")]
     pub ty: Ty,
@@ -736,6 +742,7 @@ pub struct ClosureInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct FunSig {
     /// Is the function unsafe or not
+    #[drive(skip)]
     pub is_unsafe: bool,
     /// `true` if the signature is for a closure.
     ///
@@ -743,6 +750,7 @@ pub struct FunSig {
     /// - the type and const generic params actually come from the parent function
     ///   (the function in which the closure is defined)
     /// - the region variables are local to the closure
+    #[drive(skip)]
     pub is_closure: bool,
     /// Additional information if this is the signature of a closure.
     pub closure_info: Option<ClosureInfo>,

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -21,6 +21,7 @@ use crate::ast::*;
     DriveMut,
 )]
 #[serde(transparent)]
+#[drive(skip)]
 pub struct DeBruijnId {
     pub index: usize,
 }
@@ -73,6 +74,7 @@ pub struct TypeVar {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: TypeVarId,
     /// Variable name
+    #[drive(skip)]
     pub name: String,
 }
 
@@ -84,6 +86,7 @@ pub struct RegionVar {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: RegionId,
     /// Region name
+    #[drive(skip)]
     pub name: Option<String>,
 }
 
@@ -93,6 +96,7 @@ pub struct ConstGenericVar {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: ConstGenericVarId,
     /// Const generic name
+    #[drive(skip)]
     pub name: String,
     /// Type of the const generic
     pub ty: LiteralTy,
@@ -108,6 +112,7 @@ pub struct TraitClause {
     pub span: Option<Span>,
     /// Where the predicate was written, relative to the item that requires it.
     #[charon::opaque]
+    #[drive(skip)]
     pub origin: PredicateOrigin,
     /// The trait that is implemented.
     #[charon::rename("trait")]

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,10 +1,10 @@
 //! This file groups everything which is linked to implementations about [crate::types]
-use crate::ast::BoundTy;
-use crate::types::*;
-use crate::{common::visitor_event::VisitEvent, ids::Vector};
-use derive_visitor::{visitor_enter_fn_mut, Drive, DriveMut, Event, Visitor, VisitorMut};
+use crate::ast::*;
+use crate::ids::Vector;
+use derive_generic_visitor::*;
 use std::collections::HashSet;
-use std::{collections::HashMap, iter::Iterator};
+use std::convert::Infallible;
+use std::iter::Iterator;
 
 impl GenericParams {
     pub fn empty() -> Self {
@@ -320,24 +320,6 @@ impl Ty {
             _ => None,
         }
     }
-
-    /// Wrap a visitor to make it visit the contents of types it encounters.
-    pub fn visit_inside<V>(visitor: V) -> VisitInsideTy<V> {
-        VisitInsideTy {
-            visitor,
-            cache: None,
-        }
-    }
-    /// Wrap a stateless visitor to make it visit the contents of types it encounters. This will
-    /// only visit each type once and cache the results. For this to behave as expecte, the visitor
-    /// must be stateless.
-    /// The performance impact does not appear to be significant.
-    pub fn visit_inside_stateless<V>(visitor: V) -> VisitInsideTy<V> {
-        VisitInsideTy {
-            visitor,
-            cache: Some(Default::default()),
-        }
-    }
 }
 
 impl TyKind {
@@ -407,164 +389,9 @@ impl RefKind {
     }
 }
 
-// The derive macro doesn't handle generics.
-impl<T: Drive> Drive for RegionBinder<T> {
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        self.regions.drive(visitor);
-        self.skip_binder.drive(visitor);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-impl<T: DriveMut> DriveMut for RegionBinder<T> {
-    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        self.regions.drive_mut(visitor);
-        self.skip_binder.drive_mut(visitor);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-// The derive macro doesn't handle generics.
-impl<T: Drive> Drive for Binder<T> {
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        self.params.drive(visitor);
-        self.skip_binder.drive(visitor);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-impl<T: DriveMut> DriveMut for Binder<T> {
-    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        self.params.drive_mut(visitor);
-        self.skip_binder.drive_mut(visitor);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-/// See comment on `Ty`: this impl doesn't recurse into the contents of the type.
-impl Drive for Ty {
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-/// See comment on `Ty`: this impl doesn't recurse into the contents of the type.
-impl DriveMut for Ty {
-    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        visitor.visit(self, Event::Exit);
-    }
-}
-
-pub struct VisitInsideTy<V> {
-    visitor: V,
-    /// If `Some`, record the effected visits and don't do them again. Only valid if the wrapped
-    /// visitor is stateless.
-    cache: Option<HashMap<(Ty, VisitEvent), Ty>>,
-}
-
-impl<V> VisitInsideTy<V> {
-    pub fn into_inner(self) -> V {
-        self.visitor
-    }
-}
-
-impl<V: Visitor> Visitor for VisitInsideTy<V> {
-    fn visit(&mut self, item: &dyn std::any::Any, event: Event) {
-        match item.downcast_ref::<Ty>() {
-            Some(ty) => {
-                let visit_event: VisitEvent = (&event).into();
-
-                // Shortcut if we already visited this.
-                if let Some(cache) = &self.cache
-                    && cache.contains_key(&(ty.clone(), visit_event))
-                {
-                    return;
-                }
-
-                // Recursively visit the type.
-                self.visitor.visit(ty, event);
-                if matches!(visit_event, VisitEvent::Enter) {
-                    ty.drive_inner(self);
-                }
-
-                // Remember we just visited that.
-                if let Some(cache) = &mut self.cache {
-                    cache.insert((ty.clone(), visit_event), ty.clone());
-                }
-            }
-            None => {
-                self.visitor.visit(item, event);
-            }
-        }
-    }
-}
-impl<V: VisitorMut> VisitorMut for VisitInsideTy<V> {
-    fn visit(&mut self, item: &mut dyn std::any::Any, event: Event) {
-        match item.downcast_mut::<Ty>() {
-            Some(ty) => {
-                let visit_event: VisitEvent = (&event).into();
-
-                // Shortcut if we already visited this.
-                if let Some(cache) = &self.cache
-                    && let Some(new_ty) = cache.get(&(ty.clone(), visit_event))
-                {
-                    *ty = new_ty.clone();
-                    return;
-                }
-
-                // Recursively visit the type.
-                let pre_visit = ty.clone();
-                self.visitor.visit(ty, event);
-                if matches!(visit_event, VisitEvent::Enter) {
-                    ty.drive_inner_mut(self);
-                }
-
-                // Cache the visit we just did.
-                if let Some(cache) = &mut self.cache {
-                    let post_visit = ty.clone();
-                    cache.insert((pre_visit, visit_event), post_visit);
-                }
-            }
-            None => {
-                self.visitor.visit(item, event);
-            }
-        }
-    }
-}
-
-impl<V> std::ops::Deref for VisitInsideTy<V> {
-    type Target = V;
-    fn deref(&self) -> &Self::Target {
-        &self.visitor
-    }
-}
-impl<V> std::ops::DerefMut for VisitInsideTy<V> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.visitor
-    }
-}
-
 /// Visitor for the [Ty::substitute] function.
 /// This substitutes only free variables; this does not work for non-top-level binders.
-#[derive(VisitorMut)]
-#[visitor(
-    PolyTraitDeclRef(enter, exit),
-    BoundArrowSig(enter, exit),
-    BoundRegionOutlives(enter, exit),
-    BoundTypeOutlives(enter, exit),
-    BoundTraitTypeConstraint(enter, exit),
-    BoundTy(enter, exit),
-    Region(exit),
-    Ty(exit),
-    ConstGeneric(exit),
-    TraitRef(exit)
-)]
+#[derive(Visitor)]
 pub(crate) struct SubstVisitor<'a> {
     generics: &'a GenericArgs,
     // Tracks the depth of binders we're inside of.
@@ -580,11 +407,11 @@ pub(crate) struct SubstVisitor<'a> {
 }
 
 impl<'a> SubstVisitor<'a> {
-    pub(crate) fn new(generics: &'a GenericArgs) -> VisitInsideTy<Self> {
-        Ty::visit_inside(Self {
+    pub(crate) fn new(generics: &'a GenericArgs) -> Self {
+        Self {
             generics,
             binder_depth: DeBruijnId::zero(),
-        })
+        }
     }
 
     fn should_subst<Id: Copy>(&self, var: DeBruijnVar<Id>) -> Option<Id> {
@@ -593,42 +420,20 @@ impl<'a> SubstVisitor<'a> {
             DeBruijnVar::Bound(..) => None,
         }
     }
+}
 
-    fn enter_poly_trait_decl_ref(&mut self, _: &mut PolyTraitDeclRef) {
-        self.binder_depth = self.binder_depth.incr();
+impl VisitAstMut for SubstVisitor<'_> {
+    fn enter_region_binder<T: AstVisitable>(&mut self, _: &mut RegionBinder<T>) {
+        self.binder_depth = self.binder_depth.incr()
     }
-    fn exit_poly_trait_decl_ref(&mut self, _: &mut PolyTraitDeclRef) {
-        self.binder_depth = self.binder_depth.decr();
+    fn exit_region_binder<T: AstVisitable>(&mut self, _: &mut RegionBinder<T>) {
+        self.binder_depth = self.binder_depth.decr()
     }
-    fn enter_bound_arrow_sig(&mut self, _: &BoundArrowSig) {
-        self.binder_depth = self.binder_depth.incr();
+    fn enter_binder<T: AstVisitable>(&mut self, _: &mut Binder<T>) {
+        self.binder_depth = self.binder_depth.incr()
     }
-    fn exit_bound_arrow_sig(&mut self, _: &BoundArrowSig) {
-        self.binder_depth = self.binder_depth.decr();
-    }
-    fn enter_bound_ty(&mut self, _: &BoundTy) {
-        self.binder_depth = self.binder_depth.incr();
-    }
-    fn exit_bound_ty(&mut self, _: &BoundTy) {
-        self.binder_depth = self.binder_depth.decr();
-    }
-    fn enter_bound_type_outlives(&mut self, _: &BoundTypeOutlives) {
-        self.binder_depth = self.binder_depth.incr();
-    }
-    fn exit_bound_type_outlives(&mut self, _: &BoundTypeOutlives) {
-        self.binder_depth = self.binder_depth.decr();
-    }
-    fn enter_bound_region_outlives(&mut self, _: &BoundRegionOutlives) {
-        self.binder_depth = self.binder_depth.incr();
-    }
-    fn exit_bound_region_outlives(&mut self, _: &BoundRegionOutlives) {
-        self.binder_depth = self.binder_depth.decr();
-    }
-    fn enter_bound_trait_type_constraint(&mut self, _: &BoundTraitTypeConstraint) {
-        self.binder_depth = self.binder_depth.incr();
-    }
-    fn exit_bound_trait_type_constraint(&mut self, _: &BoundTraitTypeConstraint) {
-        self.binder_depth = self.binder_depth.decr();
+    fn exit_binder<T: AstVisitable>(&mut self, _: &mut Binder<T>) {
+        self.binder_depth = self.binder_depth.decr()
     }
 
     fn exit_region(&mut self, r: &mut Region) {
@@ -683,38 +488,84 @@ impl<'a> SubstVisitor<'a> {
 }
 
 /// Types that are involved at the type-level and may be substituted around.
-pub trait TyVisitable: Sized + Drive + DriveMut {
+pub trait TyVisitable: Sized + AstVisitable {
     fn substitute(&mut self, generics: &GenericArgs) {
         self.drive_mut(&mut SubstVisitor::new(generics));
     }
 
     /// Move under `depth` binders.
     fn move_under_binders(mut self, depth: DeBruijnId) -> Self {
-        self.visit_db_id(|id| *id = id.plus(depth));
+        let Continue(()) = self.visit_db_id::<Infallible>(|id| {
+            *id = id.plus(depth);
+            Continue(())
+        });
         self
     }
 
-    /// Move the region out of `depth` binders. Returns `None` if the variable is bound in one of
-    /// these `depth` binders.
+    /// Move the value out of `depth` binders. Returns `None` if it contains a variable bound in
+    /// one of these `depth` binders.
     fn move_from_under_binders(mut self, depth: DeBruijnId) -> Option<Self> {
-        let mut ok = true;
-        self.visit_db_id(|id| match id.sub(depth) {
-            Some(sub) => *id = sub,
-            None => ok = false,
-        });
-        ok.then_some(self)
+        self.visit_db_id::<()>(|id| match id.sub(depth) {
+            Some(sub) => {
+                *id = sub;
+                Continue(())
+            }
+            None => Break(()),
+        })
+        .is_continue()
+        .then_some(self)
     }
 
-    /// Helper function.
-    fn visit_db_id(&mut self, f: impl FnMut(&mut DeBruijnId)) {
-        self.drive_mut(&mut Ty::visit_inside(visitor_enter_fn_mut(f)));
+    /// Visit the de Bruijn ids contained in `self`, as seen from the outside of `self`. This means
+    /// that any variable bound inside `self` will be skipped, and all the seen indices will count
+    /// from the outside of self.
+    fn visit_db_id<B>(
+        &mut self,
+        f: impl FnMut(&mut DeBruijnId) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
+        struct Wrap<F> {
+            f: F,
+            depth: DeBruijnId,
+        }
+        impl<B, F> Visitor for Wrap<F>
+        where
+            F: FnMut(&mut DeBruijnId) -> ControlFlow<B>,
+        {
+            type Break = B;
+        }
+        impl<B, F> VisitAstMut for Wrap<F>
+        where
+            F: FnMut(&mut DeBruijnId) -> ControlFlow<B>,
+        {
+            fn enter_region_binder<T: AstVisitable>(&mut self, _: &mut RegionBinder<T>) {
+                self.depth = self.depth.incr()
+            }
+            fn exit_region_binder<T: AstVisitable>(&mut self, _: &mut RegionBinder<T>) {
+                self.depth = self.depth.decr()
+            }
+            fn enter_binder<T: AstVisitable>(&mut self, _: &mut Binder<T>) {
+                self.depth = self.depth.incr()
+            }
+            fn exit_binder<T: AstVisitable>(&mut self, _: &mut Binder<T>) {
+                self.depth = self.depth.decr()
+            }
+
+            fn visit_de_bruijn_id(&mut self, x: &mut DeBruijnId) -> ControlFlow<Self::Break> {
+                if let Some(mut shifted) = x.sub(self.depth) {
+                    (self.f)(&mut shifted)?;
+                    *x = shifted.plus(self.depth)
+                }
+                Continue(())
+            }
+        }
+        self.drive_mut(&mut Wrap {
+            f,
+            depth: DeBruijnId::zero(),
+        })
     }
 }
 
-impl TyVisitable for ConstGeneric {}
-impl TyVisitable for Region {}
-impl TyVisitable for TraitRef {}
-impl TyVisitable for Ty {}
+impl<T: AstVisitable> TyVisitable for T {}
 
 impl PartialEq for TraitClause {
     fn eq(&self, other: &Self) -> bool {

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -37,6 +37,7 @@ pub enum RawStatement {
     /// Does nothing. Useful for passes.
     Nop,
     #[charon::opaque]
+    #[drive(skip)]
     Error(String),
 }
 

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -2,7 +2,7 @@
 //! reconstruction. In effect, this is a cleaned up version of MIR.
 pub use super::ullbc_ast_utils::*;
 pub use crate::ast::*;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -2,7 +2,6 @@
 use crate::ids::Vector;
 use crate::meta::Span;
 use crate::ullbc_ast::*;
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
 use take_mut::take;
 
 impl SwitchTargets {
@@ -59,9 +58,7 @@ impl BlockData {
         // Explore the operands in the statements
         for mut st in self.statements {
             st.content
-                .drive_mut(&mut visitor_enter_fn_mut(|op: &mut Operand| {
-                    f(&st.span, &mut nst, op)
-                }));
+                .dyn_visit_in_body_mut(|op: &mut Operand| f(&st.span, &mut nst, op));
             // Add the statement to the vector of statements
             nst.push(st)
         }
@@ -69,9 +66,7 @@ impl BlockData {
         // Explore the terminator
         self.terminator
             .content
-            .drive_mut(&mut visitor_enter_fn_mut(|op: &mut Operand| {
-                f(&self.terminator.span, &mut nst, op)
-            }));
+            .dyn_visit_in_body_mut(|op: &mut Operand| f(&self.terminator.span, &mut nst, op));
 
         // Update the vector of statements
         self.statements = nst;

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -2,7 +2,7 @@
 use crate::ids::Vector;
 use crate::meta::Span;
 use crate::ullbc_ast::*;
-use derive_visitor::{visitor_enter_fn_mut, visitor_fn_mut, DriveMut, Event};
+use derive_visitor::{visitor_enter_fn_mut, DriveMut};
 use take_mut::take;
 
 impl SwitchTargets {
@@ -115,11 +115,11 @@ impl ExprBody {
 
     /// Apply a function to all the statements, in a bottom-up manner.
     pub fn visit_statements<F: FnMut(&mut Statement)>(&mut self, f: &mut F) {
-        self.drive_mut(&mut visitor_fn_mut(|st: &mut Statement, e: Event| {
-            if matches!(e, Event::Exit) {
-                f(st)
+        for block in self.body.iter_mut().rev() {
+            for st in block.statements.iter_mut().rev() {
+                f(st);
             }
-        }))
+        }
     }
 }
 

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -37,9 +37,13 @@ generate_index_type!(VarId, "");
 pub enum Literal {
     Scalar(ScalarValue),
     Float(FloatValue),
+    #[drive(skip)]
     Bool(bool),
+    #[drive(skip)]
     Char(char),
+    #[drive(skip)]
     ByteStr(Vec<u8>),
+    #[drive(skip)]
     Str(String),
 }
 
@@ -62,6 +66,7 @@ pub enum Literal {
     Drive,
     DriveMut,
 )]
+#[drive(skip)]
 pub enum ScalarValue {
     /// Using i64 to be safe
     Isize(i64),
@@ -87,6 +92,7 @@ pub enum ScalarValue {
 )]
 pub struct FloatValue {
     #[charon::rename("float_value")]
+    #[drive(skip)]
     pub value: String,
     #[charon::rename("float_ty")]
     pub ty: FloatTy,

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -2,7 +2,7 @@
 
 use crate::ast::FloatTy;
 use core::hash::Hash;
-use derive_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -1,0 +1,223 @@
+//! Defines two overrideable visitor traits that can be used to conveniently traverse the whole
+//! contents of an item. This is useful when e.g. dealing with types, which show up pretty much
+//! everywhere in the ast.
+//!
+//! The crate defines two traits:
+/// - `AstVisitable` is a trait implemented by all the types that can be visited by this;
+/// - `VisitAst[Mut]` is a (pair of) visitor trait(s) that can be implemented by visitors.
+/// To define a visitor, implement `VisitAst[Mut]` and override the methods you need. Calling
+/// `x.drive[_mut](&mut visitor)` will then traverse `x`, calling the visitor methods on all the
+/// subvalues encountered.
+///
+/// Underneath it all, this uses `derive_generic_visitor::Drive[Mut]` to do the actual visiting.
+use std::{any::Any, collections::HashMap};
+
+use crate::ast::*;
+use derive_generic_visitor::*;
+use index_vec::Idx;
+
+/// An overrideable visitor trait that can be used to conveniently traverse the whole contents of
+/// an item. This is useful when e.g. dealing with types, which show up pretty much everywhere in
+/// the ast.
+///
+/// This defines three traits:
+/// - `AstVisitable` is a trait implemented by all the types listed below; it has a
+/// `drive[_mut]` method that takes a `VisitAst[Mut]` visitor and calls its methods on all
+/// the relevant subvalues of `self` encountered.
+/// - `VisitAst[Mut]` is a (pair of) visitor trait(s) that can be implemented by visitors. To
+/// define a visitor, implement `VisitAst[Mut]` and override the methods you need.
+///
+/// This trait has a `drive[_mut]` method that knows how to drive a `VisitAst[Mut]` visitor. This
+/// trait is implemented for all the listed types. If listed as `override`, the corresponding
+/// visitor trait has an overrideable method to visit this type. If listed as `drive`, the type
+/// will only be visited by recursing into its contents.
+///
+/// Morally this represents the predicate `for<V: VisitAst[Mut]> Self:
+/// Drive[Mut]<AstVisitableWrapper<V>>`
+#[visitable_group(
+    // Defines the `Visit[Mut]` traits and the `drive[_mut]` method that drives them.
+    visitor(drive(&VisitAst)),
+    visitor(drive_mut(&mut VisitAstMut)),
+    // Types that we unconditionally explore.
+    drive(
+        AbortKind, Assert, BinOp, Body, BorrowKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy, Call,
+        CastKind, ClosureInfo, ClosureKind, ConstantExpr, ConstGenericVar, ConstGenericVarId,
+        Disambiguator, ExistentialPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
+        FnOperand, FunId, FunIdOrTraitMethodRef, FunSig, ImplElem, IntegerTy, Literal, LiteralTy,
+        llbc_ast::Block, llbc_ast::ExprBody, llbc_ast::RawStatement, llbc_ast::Statement, llbc_ast::Switch,
+        Locals, Name, NullOp, Opaque, Operand, PathElem, Place, PlaceKind, ProjectionElem, RawConstantExpr,
+        RefKind, RegionId, RegionVar, Rvalue, ScalarValue, TraitClause, TraitClauseId, TraitItemName,
+        TraitRefKind, TraitTypeConstraint, TranslatedCrate, TyKind, TypeDeclKind, TypeId, TypeVar, TypeVarId,
+        ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::RawStatement,
+        ullbc_ast::RawTerminator, ullbc_ast::Statement, ullbc_ast::SwitchTargets, ullbc_ast::Terminator,
+        UnOp, Var, Variant, VariantId, VarId,
+        for<T: AstVisitable> Box<T>,
+        for<T: AstVisitable> Option<T>,
+        for<A: AstVisitable, B: AstVisitable> (A, B),
+        for<A: AstVisitable, B: AstVisitable> Result<A, B>,
+        for<A: AstVisitable, B: AstVisitable> OutlivesPred<A, B>,
+        for<T: AstVisitable> Vec<T>,
+        for<I: Idx, T: AstVisitable> Vector<I, T>,
+    ),
+    // Types for which we call the corresponding `visit_$ty` method, which by default explores the
+    // type but can be overridden.
+    override(
+        DeBruijnId, Ty, Region, ConstGeneric, TraitRef,
+        GlobalDeclRef, TraitDeclRef, TraitImplRef, GenericArgs, GenericParams,
+        for<T: AstVisitable> DeBruijnVar<T>,
+        for<T: AstVisitable> RegionBinder<T>,
+        for<T: AstVisitable> Binder<T>,
+        AggregateKind, FnPtr, ItemKind, ItemMeta, Span,
+        BodyId, FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId,
+        FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
+    )
+)]
+pub trait AstVisitable: Any {
+    /// Visit all occurrences of that type inside `self`, in pre-order traversal.
+    fn dyn_visit<T: AstVisitable>(&self, f: impl FnMut(&T)) {
+        self.drive(&mut DynVisitor::new_shared::<T>(f));
+    }
+    /// Visit all occurrences of that type inside `self`, in pre-order traversal.
+    fn dyn_visit_mut<T: AstVisitable>(&mut self, f: impl FnMut(&mut T)) {
+        self.drive_mut(&mut DynVisitor::new_mut::<T>(f));
+    }
+}
+
+/// Manual impl that only visits the values
+impl<K: Any, T: AstVisitable> AstVisitable for HashMap<K, T> {
+    fn drive<V: VisitAst>(&self, v: &mut V) -> ControlFlow<V::Break> {
+        for x in self.values() {
+            v.visit(x)?;
+        }
+        Continue(())
+    }
+    fn drive_mut<V: VisitAstMut>(&mut self, v: &mut V) -> ControlFlow<V::Break> {
+        for x in self.values_mut() {
+            v.visit(x)?;
+        }
+        Continue(())
+    }
+}
+
+/// A smaller visitor group just for function bodies. This explores statements, places and
+/// operands, but does not recurse into types.
+///
+/// This defines three traits:
+/// - `BodyVisitable` is a trait implemented by all the types listed below; it has a
+/// `drive_body[_mut]` method that takes a `VisitBody[Mut]` visitor and calls its methods on all
+/// the relevant subvalues of `self` encountered.
+/// - `VisitBody[Mut]` is a (pair of) visitor trait(s) that can be implemented by visitors. To
+/// define a visitor, implement `VisitBody[Mut]` and override the methods you need.
+///
+/// Morally this represents the predicate `for<V: VisitBody[Mut]> Self:
+/// Drive[Mut]<BodyVisitableWrapper<V>>`
+#[visitable_group(
+    // Defines the `VisitBody[Mut]` traits and the `drive_body[_mut]` method that drives them.
+    visitor(drive_body(&VisitBody)),
+    visitor(drive_body_mut(&mut VisitBodyMut)),
+    // Types that are ignored when encountered.
+    skip(
+        AbortKind, BinOp, BorrowKind, ConstantExpr, ConstGeneric, FieldId, FieldProjKind,
+        FunDeclId, FunIdOrTraitMethodRef, GenericArgs, GlobalDeclRef, IntegerTy, Locals,
+        NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId, VarId,
+    ),
+    // Types that we unconditionally explore.
+    drive(
+        Assert, PlaceKind,
+        llbc_ast::ExprBody, llbc_ast::RawStatement, llbc_ast::Switch,
+        ullbc_ast::BlockData, ullbc_ast::ExprBody, ullbc_ast::RawStatement,
+        ullbc_ast::RawTerminator, ullbc_ast::SwitchTargets,
+        for<T: BodyVisitable> Box<T>,
+        for<T: BodyVisitable> Option<T>,
+        for<A: BodyVisitable, B: BodyVisitable> (A, B),
+        for<T: BodyVisitable> Vec<T>,
+        for<I: Idx, T: BodyVisitable> Vector<I, T>,
+    ),
+    // Types for which we call the corresponding `visit_$ty` method, which by default explores the
+    // type but can be overridden.
+    override(
+        AggregateKind, Call, FnOperand, FnPtr,
+        Operand, Place, ProjectionElem, Rvalue,
+        llbc_block: llbc_ast::Block,
+        llbc_statement: llbc_ast::Statement,
+        ullbc_statement: ullbc_ast::Statement,
+        ullbc_terminator: ullbc_ast::Terminator,
+        ullbc_block_id: ullbc_ast::BlockId,
+    )
+)]
+pub trait BodyVisitable: Any {
+    /// Visit all occurrences of that type inside `self`, in pre-order traversal.
+    fn dyn_visit_in_body<T: BodyVisitable>(&self, f: impl FnMut(&T)) {
+        self.drive_body(&mut DynVisitor::new_shared::<T>(f));
+    }
+
+    /// Visit all occurrences of that type inside `self`, in pre-order traversal.
+    fn dyn_visit_in_body_mut<T: BodyVisitable>(&mut self, f: impl FnMut(&mut T)) {
+        self.drive_body_mut(&mut DynVisitor::new_mut::<T>(f));
+    }
+}
+
+/// Ast and body visitor that uses dynamic dispatch to call the provided function on the visited
+/// values of the right type.
+#[derive(Visitor)]
+pub struct DynVisitor<F> {
+    enter: F,
+}
+impl DynVisitor<()> {
+    pub fn new_shared<T: Any>(mut f: impl FnMut(&T)) -> DynVisitor<impl FnMut(&dyn Any)> {
+        let enter = move |x: &dyn Any| {
+            if let Some(x) = x.downcast_ref::<T>() {
+                f(x);
+            }
+        };
+        DynVisitor { enter }
+    }
+    pub fn new_mut<T: Any>(mut f: impl FnMut(&mut T)) -> DynVisitor<impl FnMut(&mut dyn Any)> {
+        let enter = move |x: &mut dyn Any| {
+            if let Some(x) = x.downcast_mut::<T>() {
+                f(x);
+            }
+        };
+        DynVisitor { enter }
+    }
+}
+impl<F> VisitAst for DynVisitor<F>
+where
+    F: FnMut(&dyn Any),
+{
+    fn visit<'a, T: AstVisitable>(&'a mut self, x: &T) -> ControlFlow<Self::Break> {
+        (self.enter)(x);
+        x.drive(self)?;
+        Continue(())
+    }
+}
+impl<F> VisitAstMut for DynVisitor<F>
+where
+    F: FnMut(&mut dyn Any),
+{
+    fn visit<'a, T: AstVisitable>(&'a mut self, x: &mut T) -> ControlFlow<Self::Break> {
+        (self.enter)(x);
+        x.drive_mut(self)?;
+        Continue(())
+    }
+}
+impl<F> VisitBody for DynVisitor<F>
+where
+    F: FnMut(&dyn Any),
+{
+    fn visit<'a, T: BodyVisitable>(&'a mut self, x: &T) -> ControlFlow<Self::Break> {
+        (self.enter)(x);
+        x.drive_body(self)?;
+        Continue(())
+    }
+}
+impl<F> VisitBodyMut for DynVisitor<F>
+where
+    F: FnMut(&mut dyn Any),
+{
+    fn visit<'a, T: BodyVisitable>(&'a mut self, x: &mut T) -> ControlFlow<Self::Break> {
+        (self.enter)(x);
+        x.drive_body_mut(self)?;
+        Continue(())
+    }
+}

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -13,7 +13,6 @@ use assert_cmd::cargo::CommandCargoExt;
 use charon_lib::ast::*;
 use charon_lib::export::CrateData;
 use convert_case::{Case, Casing};
-use derive_visitor::{visitor_enter_fn, Drive};
 use indoc::indoc;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
@@ -101,11 +100,9 @@ impl<'a> GenerateCtx<'a> {
             name_to_type.insert(long_name, ty);
 
             let mut contained = HashSet::new();
-            ty.drive(&mut Ty::visit_inside(visitor_enter_fn(
-                |id: &TypeDeclId| {
-                    contained.insert(*id);
-                },
-            )));
+            ty.dyn_visit(|id: &TypeDeclId| {
+                contained.insert(*id);
+            });
             type_tree.insert(ty.def_id, contained);
         }
 

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -18,7 +18,8 @@ macro_rules! generate_index_type {
     };
     ($name:ident, $pretty_name:expr) => {
         index_vec::define_index_type! {
-            #[derive(derive_visitor::Drive, derive_visitor::DriveMut)]
+            #[derive(derive_generic_visitor::Drive, derive_generic_visitor::DriveMut)]
+            #[drive(skip)]
             pub struct $name = usize;
             // Must fit in an u32 for serialization.
             MAX_INDEX = std::u32::MAX as usize;

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -7,13 +7,14 @@
 //! Note that this data structure is implemented by using persistent vectors.
 //! This makes the clone operation almost a no-op.
 
-use derive_visitor::{Drive, DriveMut, Event, Visitor, VisitorMut};
 use index_vec::{Idx, IdxSliceIndex, IndexVec};
 use serde::{Deserialize, Serialize, Serializer};
 use std::{
     iter::{FromIterator, IntoIterator},
-    ops::{Deref, Index, IndexMut},
+    ops::{ControlFlow, Deref, Index, IndexMut},
 };
+
+use derive_generic_visitor::*;
 
 /// Indexed vector.
 /// To prevent accidental id reuse, the vector supports reserving a slot to be filled later.
@@ -324,21 +325,19 @@ impl<'de, I: Idx, T: Deserialize<'de>> Deserialize<'de> for Vector<I, T> {
     }
 }
 
-impl<I: Idx, T: Drive> Drive for Vector<I, T> {
-    fn drive<V: Visitor>(&self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
+impl<'s, I: Idx, T, V: Visit<'s, T>> Drive<'s, V> for Vector<I, T> {
+    fn drive_inner(&'s self, v: &mut V) -> ControlFlow<V::Break> {
         for x in self {
-            x.drive(visitor);
+            v.visit(x)?;
         }
-        visitor.visit(self, Event::Exit);
+        Continue(())
     }
 }
-impl<I: Idx, T: DriveMut> DriveMut for Vector<I, T> {
-    fn drive_mut<V: VisitorMut>(&mut self, visitor: &mut V) {
-        visitor.visit(self, Event::Enter);
-        for x in &mut *self {
-            x.drive_mut(visitor);
+impl<'s, I: Idx, T, V: VisitMut<'s, T>> DriveMut<'s, V> for Vector<I, T> {
+    fn drive_inner_mut(&'s mut self, v: &mut V) -> ControlFlow<V::Break> {
+        for x in self {
+            v.visit(x)?;
         }
-        visitor.visit(self, Event::Exit);
+        Continue(())
     }
 }

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -154,12 +154,12 @@ where
     }
 
     /// Iter over the nonempty slots.
-    pub fn iter(&self) -> impl Iterator<Item = &T> + Clone {
-        self.vector.iter().flat_map(|opt| opt.as_ref())
+    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator + Clone {
+        self.vector.iter().filter_map(|opt| opt.as_ref())
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
-        self.vector.iter_mut().flat_map(|opt| opt.as_mut())
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> + DoubleEndedIterator {
+        self.vector.iter_mut().filter_map(|opt| opt.as_mut())
     }
 
     pub fn iter_indexed(&self) -> impl Iterator<Item = (I, &T)> {

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -15,7 +15,6 @@
 #![recursion_limit = "256"]
 #![feature(box_patterns)]
 #![feature(deref_pure_trait)]
-#![feature(extract_if)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iterator_try_collect)]

--- a/charon/src/transform/filter_unreachable_blocks.rs
+++ b/charon/src/transform/filter_unreachable_blocks.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
 
 use super::ctx::UllbcPass;
 
@@ -34,9 +33,8 @@ impl UllbcPass for Transform {
         }
 
         // Update all block ids
-        b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|bid: &mut BlockId| {
-                *bid = *bid_map.get(bid).unwrap();
-            }));
+        b.body.dyn_visit_in_body_mut(|bid: &mut BlockId| {
+            *bid = *bid_map.get(bid).unwrap();
+        });
     }
 }

--- a/charon/src/transform/filter_unreachable_blocks.rs
+++ b/charon/src/transform/filter_unreachable_blocks.rs
@@ -1,5 +1,5 @@
 //! Some passes like [`reconstruct_assert`] lead to the apparition of "dangling" blocks,
-//! which are referenced nowhere and thus become useless. This pass filters those out.
+//! which are referenced nowhere and thus become unreachable. This pass filters those out.
 
 use std::collections::{HashMap, HashSet};
 

--- a/charon/src/transform/index_intermediate_assigns.rs
+++ b/charon/src/transform/index_intermediate_assigns.rs
@@ -66,7 +66,7 @@ pub struct Transform;
 
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body.transform(&mut |st: &mut Statement| {
+        b.body.transform(|st: &mut Statement| {
             match &mut st.content {
                 // Introduce an intermediate statement if both the rhs and the lhs contain an
                 // "index" projection element (to avoid introducing too many intermediate

--- a/charon/src/transform/index_intermediate_assigns.rs
+++ b/charon/src/transform/index_intermediate_assigns.rs
@@ -35,18 +35,17 @@
 
 use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
-use derive_visitor::{visitor_enter_fn, Drive};
 
 use super::ctx::LlbcPass;
 
-fn contains_index_proj<T: Drive>(x: &T) -> bool {
+fn contains_index_proj<T: BodyVisitable>(x: &T) -> bool {
     let mut contains_index = false;
-    x.drive(&mut visitor_enter_fn(|proj: &ProjectionElem| {
+    x.dyn_visit_in_body(|proj: &ProjectionElem| {
         use ProjectionElem::*;
         if let Index { .. } | Subslice { .. } = proj {
             contains_index = true;
         }
-    }));
+    });
     contains_index
 }
 

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -319,7 +319,7 @@ pub struct Transform;
 /// ```
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body.transform(&mut |st: &mut Statement| {
+        b.body.transform(|st: &mut Statement| {
             let mut visitor = Visitor {
                 locals: &mut b.locals,
                 statements: Vec::new(),

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -7,8 +7,6 @@
 //! ```
 //! Which defines a new function each time. This pass recognizes these functions and replaces calls
 //! to them by a `Panic` terminator.
-
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
 use std::collections::HashSet;
 
 use super::{ctx::LlbcPass, TransformCtx};
@@ -46,8 +44,8 @@ impl LlbcPass for Transform {
 
         // Replace each call to one such function with a `Panic`.
         ctx.for_each_structured_body(|_ctx, body| {
-            body.body.drive_mut(&mut visitor_enter_fn_mut(
-                |st: &mut Statement| match &mut st.content {
+            body.body
+                .visit_statements(|st: &mut Statement| match &mut st.content {
                     RawStatement::Call(Call {
                         func:
                             FnOperand::Regular(FnPtr {
@@ -59,8 +57,7 @@ impl LlbcPass for Transform {
                         st.content = panic_statement.clone();
                     }
                     _ => {}
-                },
-            ));
+                });
         });
 
         // Remove these functions from the context.

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -10,13 +10,7 @@
 use std::collections::HashSet;
 
 use super::{ctx::LlbcPass, TransformCtx};
-use crate::{
-    builtins,
-    llbc_ast::{
-        AbortKind, Call, FnOperand, FnPtr, FunId, FunIdOrTraitMethodRef, RawStatement, Statement,
-    },
-    names::Name,
-};
+use crate::{builtins, llbc_ast::*, names::Name};
 
 pub struct Transform;
 impl LlbcPass for Transform {

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -3,7 +3,6 @@
 //! of AENEAS, it means the return variable contains ⊥ upon returning.
 //! For this reason, when the function has return type unit, we insert
 //! an extra assignment just before returning.
-
 use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
 
@@ -38,7 +37,6 @@ impl LlbcPass for Transform {
         }
     }
     fn transform_body(&self, _ctx: &mut TransformCtx, body: &mut ExprBody) {
-        body.body
-            .transform(&mut |st| transform_st(&body.locals, st));
+        body.body.transform(|st| transform_st(&body.locals, st));
     }
 }

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -2,7 +2,7 @@ pub mod check_generics;
 pub mod ctx;
 pub mod duplicate_return;
 pub mod filter_invisible_trait_impls;
-pub mod filter_useless_blocks;
+pub mod filter_unreachable_blocks;
 pub mod graphs;
 pub mod hide_marker_traits;
 pub mod index_intermediate_assigns;
@@ -85,7 +85,7 @@ pub static ULLBC_PASSES: &[Pass] = &[
     UnstructuredBody(&duplicate_return::Transform),
     // # Micro-pass: filter the "dangling" blocks. Those might have been introduced by,
     // for instance, [`reconstruct_asserts`].
-    UnstructuredBody(&filter_useless_blocks::Transform),
+    UnstructuredBody(&filter_unreachable_blocks::Transform),
 ];
 
 pub static LLBC_PASSES: &[Pass] = &[

--- a/charon/src/transform/prettify_cfg.rs
+++ b/charon/src/transform/prettify_cfg.rs
@@ -40,6 +40,6 @@ impl Transform {
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
         b.body
-            .transform_sequences(&mut |seq| Transform::update_statements(&b.locals, seq))
+            .transform_sequences(|seq| Transform::update_statements(&b.locals, seq))
     }
 }

--- a/charon/src/transform/reconstruct_boxes.rs
+++ b/charon/src/transform/reconstruct_boxes.rs
@@ -1,7 +1,4 @@
 //! # Micro-pass: reconstruct piecewise box allocations using `malloc` and `ShallowInitBox`.
-use derive_visitor::visitor_enter_fn;
-use derive_visitor::Drive;
-
 use crate::register_error_or_panic;
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
@@ -113,7 +110,7 @@ impl UllbcPass for Transform {
         }
 
         // Make sure we got all the `ShallowInitBox`es.
-        b.body.drive(&mut visitor_enter_fn(|rvalue: &Rvalue| {
+        b.body.dyn_visit_in_body(|rvalue: &Rvalue| {
             if rvalue.is_shallow_init_box() {
                 register_error_or_panic!(
                     ctx,
@@ -122,6 +119,6 @@ impl UllbcPass for Transform {
                     branching during `Box` initialization is not supported."
                 );
             }
-        }));
+        });
     }
 }

--- a/charon/src/transform/recover_body_comments.rs
+++ b/charon/src/transform/recover_body_comments.rs
@@ -1,7 +1,4 @@
 //! Take all the comments found in the original body and assign them to statements.
-
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
-
 use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
 
@@ -17,13 +14,12 @@ impl LlbcPass for Transform {
 
         // This is a pretty simple heuristic which is good enough for now.
         let mut comments: Vec<(usize, Vec<String>)> = b.comments.clone();
-        b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|st: &mut Statement| {
-                let st_line = st.span.span.beg.line;
-                st.comments_before = comments
-                    .extract_if(|(i, _)| *i <= st_line)
-                    .flat_map(|(_, comments)| comments)
-                    .collect();
-            }));
+        b.body.visit_statements(|st: &mut Statement| {
+            let st_line = st.span.span.beg.line;
+            st.comments_before = comments
+                .extract_if(|(i, _)| *i <= st_line)
+                .flat_map(|(_, comments)| comments)
+                .collect();
+        });
     }
 }

--- a/charon/src/transform/remove_drop_never.rs
+++ b/charon/src/transform/remove_drop_never.rs
@@ -2,9 +2,6 @@
 //! rid of those. We proceed in two steps. First, we remove the instructions
 //! `drop(v)` where `v` has type `Never` (it can happen - this module does the
 //! filtering). Then, we filter the unused variables ([crate::remove_unused_locals]).
-
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
-
 use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
 
@@ -14,16 +11,15 @@ pub struct Transform;
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
         let locals = &b.locals;
-        b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|st: &mut Statement| {
-                // Filter the statement by replacing it with `Nop` if it is a `Drop(x)` where
-                // `x` has type `Never`. Otherwise leave it unchanged.
-                if let RawStatement::Drop(p) = &st.content
-                    && p.as_local()
-                        .is_some_and(|var_id| locals[var_id].ty.kind().is_never())
-                {
-                    st.content = RawStatement::Nop;
-                }
-            }));
+        b.body.visit_statements(|st: &mut Statement| {
+            // Filter the statement by replacing it with `Nop` if it is a `Drop(x)` where
+            // `x` has type `Never`. Otherwise leave it unchanged.
+            if let RawStatement::Drop(p) = &st.content
+                && p.as_local()
+                    .is_some_and(|var_id| locals[var_id].ty.kind().is_never())
+            {
+                st.content = RawStatement::Nop;
+            }
+        });
     }
 }

--- a/charon/src/transform/remove_nops.rs
+++ b/charon/src/transform/remove_nops.rs
@@ -8,7 +8,7 @@ use super::ctx::LlbcPass;
 pub struct Transform;
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body.visit_blocks_fwd(|blk: &mut Block| {
+        b.body.visit_blocks_bwd(|blk: &mut Block| {
             // Remove all the `Nop`s from this sequence.
             if blk.statements.iter().any(|st| st.content.is_nop()) {
                 blk.statements.retain(|st| !st.content.is_nop())

--- a/charon/src/transform/remove_nops.rs
+++ b/charon/src/transform/remove_nops.rs
@@ -1,7 +1,5 @@
 //! Remove the useless no-ops.
 
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
-
 use crate::llbc_ast::*;
 use crate::transform::TransformCtx;
 
@@ -10,12 +8,11 @@ use super::ctx::LlbcPass;
 pub struct Transform;
 impl LlbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|blk: &mut Block| {
-                // Remove all the `Nop`s from this sequence.
-                if blk.statements.iter().any(|st| st.content.is_nop()) {
-                    blk.statements.retain(|st| !st.content.is_nop())
-                }
-            }));
+        b.body.visit_blocks_fwd(|blk: &mut Block| {
+            // Remove all the `Nop`s from this sequence.
+            if blk.statements.iter().any(|st| st.content.is_nop()) {
+                blk.statements.retain(|st| !st.content.is_nop())
+            }
+        });
     }
 }

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -2,14 +2,11 @@
 //! rid of those. We proceed in two steps. First, we remove the instructions
 //! `drop(v)` where `v` has type `Never` (it can happen - this module does the
 //! filtering). Then, we filter the unused variables ([crate::remove_unused_locals]).
-
 use crate::errors::register_error_or_panic;
 use crate::formatter::IntoFormatter;
 use crate::llbc_ast::*;
 use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
-use derive_visitor::visitor_enter_fn_mut;
-use derive_visitor::DriveMut;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
@@ -159,9 +156,8 @@ impl Transform {
 
 impl LlbcPass for Transform {
     fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|block: &mut Block| {
-                Transform::update_block(ctx, block);
-            }));
+        b.body.visit_blocks_fwd(|block: &mut Block| {
+            Transform::update_block(ctx, block);
+        });
     }
 }

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -2,6 +2,7 @@
 //! rid of those. We proceed in two steps. First, we remove the instructions
 //! `drop(v)` where `v` has type `Never` (it can happen - this module does the
 //! filtering). Then, we filter the unused variables ([crate::remove_unused_locals]).
+
 use crate::errors::register_error_or_panic;
 use crate::formatter::IntoFormatter;
 use crate::llbc_ast::*;
@@ -156,7 +157,7 @@ impl Transform {
 
 impl LlbcPass for Transform {
     fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body.visit_blocks_fwd(|block: &mut Block| {
+        b.body.visit_blocks_bwd(|block: &mut Block| {
             Transform::update_block(ctx, block);
         });
     }

--- a/charon/src/transform/update_block_indices.rs
+++ b/charon/src/transform/update_block_indices.rs
@@ -2,8 +2,6 @@
 
 use std::mem;
 
-use derive_visitor::{visitor_enter_fn_mut, DriveMut};
-
 use crate::ids::*;
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
@@ -20,8 +18,6 @@ impl UllbcPass for Transform {
 
         // Update the ids.
         b.body
-            .drive_mut(&mut visitor_enter_fn_mut(|id: &mut BlockId| {
-                *id = id_map[*id]
-            }));
+            .dyn_visit_in_body_mut(|id: &mut BlockId| *id = id_map[*id]);
     }
 }


### PR DESCRIPTION
The [`derive-visitor`](https://docs.rs/derive-visitor/latest/derive_visitor/) crate has a few shortcomings:
- Doesn't support generics, which made it hard to properly account for all the cases where we may encounter `Binder<SomeType>`.
- Doesn't give control over recursion, which I worked around with the `Ty::visit_inside` hack (a regular source of confusion).
- Doesn't support exfiltrating visited references out of the visitor, which I have wanted for reconstructing comments.

The last two points could be remedied by adding features to the upstream crate, but the first one requires a completely different approach. Over the last few weeks I came up with a new design for automatically-derived visitors, which I made into a crate over the winter break.

That crate centered around the main boilerplate required for building visitors, namely the code that calls `v.visit(self.field)` for each field of a type. A derive macro provides that boilerplate, and with that boilerplate out of the way it becomes easy to define flexible visitors. The crate provides more macros for that.

This PR replaces all uses of `derive-visitor` with a custom visitor infrastructure based on my new [`derive-generic-visitor`](https://docs.rs/derive_generic_visitor/latest/derive_generic_visitor/) crate. This adds a `AstVisitable` trait implemented for all the types of the AST, as well as a pair of `VisitAst[Mut]` traits used to traverse such types. They provide a convenient overrideable interface to define visitors, of which you can see examples in this PR. Moreover we still support the extremely practical dynamic-dispatched-based API that we had with `derive-visitors`.

The second-to-last commit fixes https://github.com/AeneasVerif/charon/issues/505.