### PR TITLE
Explicitly bind trait method generics

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.59"
+let supported_charon_version = "0.1.60"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -41,6 +41,68 @@ let locals_get_input_vars (locals : locals) : var list =
 let fun_body_get_input_vars (fbody : 'body gexpr_body) : var list =
   locals_get_input_vars fbody.locals
 
+(** Like `binder` but for the free variables bound by the generics of an item.
+    This is not present in the charon ast but returned by helpers so we don't
+    forget to substitute. Use `Substitute.apply_args_to_item_binder` to get the
+    correctly-substituted inner value. *)
+type 'a item_binder = {
+  item_binder_params : generic_params;
+  item_binder_value : 'a;
+}
+[@@deriving show, ord]
+
+(** Lookup a method in this trait decl. The two levels of binders in the output
+    reflect that there are two binding levels: the trait generics and the method
+    generics. *)
+let lookup_trait_decl_method (tdecl : trait_decl) (name : trait_item_name) :
+    fun_decl_ref binder item_binder option =
+  Option.map
+    (fun (_, bound_fn) ->
+      { item_binder_params = tdecl.generics; item_binder_value = bound_fn })
+    (List.find_opt
+       (fun (s, _) -> s = name)
+       (tdecl.required_methods @ tdecl.provided_methods))
+
+(** Lookup a method in this trait decl. The two levels of binders in the output
+    reflect that there are two binding levels: the trait generics and the method
+    generics. *)
+let lookup_trait_decl_provided_method (tdecl : trait_decl)
+    (name : trait_item_name) : fun_decl_ref binder item_binder option =
+  Option.map
+    (fun (_, bound_fn) ->
+      { item_binder_params = tdecl.generics; item_binder_value = bound_fn })
+    (List.find_opt (fun (s, _) -> s = name) tdecl.provided_methods)
+
+(** Lookup a method in this trait decl. The two levels of binders in the output
+    reflect that there are two binding levels: the trait generics and the method
+    generics. *)
+let lookup_trait_decl_required_method (tdecl : trait_decl)
+    (name : trait_item_name) : fun_decl_ref binder item_binder option =
+  Option.map
+    (fun (_, bound_fn) ->
+      { item_binder_params = tdecl.generics; item_binder_value = bound_fn })
+    (List.find_opt (fun (s, _) -> s = name) tdecl.required_methods)
+
+(** Lookup a method in this trait impl. The two levels of binders in the output
+    reflect that there are two binding levels: the impl generics and the method
+    generics. *)
+let lookup_trait_impl_provided_method (timpl : trait_impl)
+    (name : trait_item_name) : fun_decl_ref binder item_binder option =
+  Option.map
+    (fun (_, bound_fn) ->
+      { item_binder_params = timpl.generics; item_binder_value = bound_fn })
+    (List.find_opt (fun (s, _) -> s = name) timpl.provided_methods)
+
+(** Lookup a method in this trait impl. The two levels of binders in the output
+    reflect that there are two binding levels: the impl generics and the method
+    generics. *)
+let lookup_trait_impl_required_method (timpl : trait_impl)
+    (name : trait_item_name) : fun_decl_ref binder item_binder option =
+  Option.map
+    (fun (_, bound_fn) ->
+      { item_binder_params = timpl.generics; item_binder_value = bound_fn })
+    (List.find_opt (fun (s, _) -> s = name) timpl.required_methods)
+
 let g_declaration_group_to_list (g : 'a g_declaration_group) : 'a list =
   match g with
   | RecGroup ids -> ids

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -729,7 +729,7 @@ let match_fn_ptr (ctx : ctx) (c : match_config) (p : pattern) (func : E.fn_ptr)
             then
               let subst =
                 Substitute.make_subst_from_generics d.signature.generics
-                  func.generics Self
+                  func.generics
               in
               let trait_ref =
                 Substitute.trait_decl_ref_substitute subst trait_ref

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -179,13 +179,17 @@ let trait_decl_to_string (env : 'a fmt_env) (indent : string)
     let required_methods =
       List.map
         (fun (name, f) ->
-          indent1 ^ "fn " ^ name ^ " : " ^ fun_decl_id_to_string env f ^ "\n")
+          indent1 ^ "fn " ^ name ^ " : "
+          ^ fun_decl_id_to_string env f.binder_value.fun_id
+          ^ "\n")
         def.required_methods
     in
     let provided_methods =
       List.map
         (fun (name, f) ->
-          indent1 ^ "fn " ^ name ^ " : " ^ fun_decl_id_to_string env f ^ "\n")
+          indent1 ^ "fn " ^ name ^ " : "
+          ^ fun_decl_id_to_string env f.binder_value.fun_id
+          ^ "\n")
         def.provided_methods
     in
     let items =
@@ -249,7 +253,9 @@ let trait_impl_to_string (env : 'a fmt_env) (indent : string)
         def.types
     in
     let env_method (name, f) =
-      indent1 ^ "fn " ^ name ^ " : " ^ fun_decl_id_to_string env f ^ "\n"
+      indent1 ^ "fn " ^ name ^ " : "
+      ^ fun_decl_id_to_string env f.binder_value.fun_id
+      ^ "\n"
     in
     let required_methods = List.map env_method def.required_methods in
     let provided_methods = List.map env_method def.provided_methods in

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -147,20 +147,6 @@ let empty_generic_params : generic_params =
     trait_type_constraints = [];
   }
 
-let merge_generic_args (g1 : generic_args) (g2 : generic_args) : generic_args =
-  let { regions = r1; types = tys1; const_generics = cgs1; trait_refs = tr1 } =
-    g1
-  in
-  let { regions = r2; types = tys2; const_generics = cgs2; trait_refs = tr2 } =
-    g2
-  in
-  {
-    regions = r1 @ r2;
-    types = tys1 @ tys2;
-    const_generics = cgs1 @ cgs2;
-    trait_refs = tr1 @ tr2;
-  }
-
 let generic_args_of_params span (generics : generic_params) : generic_args =
   let regions =
     List.map (fun (v : region_var) -> RVar (Free v.index)) generics.regions

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -187,7 +187,9 @@ type global_decl = {
   kind : item_kind;
       (** The global kind: "regular" function, trait const declaration, etc. *)
   body : fun_decl_id;
-      (** The initializer function used to compute the initial value for this constant/static. *)
+      (** The initializer function used to compute the initial value for this constant/static. It
+        uses the same generic parameters as the global.
+     *)
 }
 [@@deriving
   show,
@@ -262,17 +264,19 @@ type trait_decl = {
       (** The associated constants declared in the trait, along with their type. *)
   types : trait_item_name list;
       (** The associated types declared in the trait. *)
-  required_methods : (trait_item_name * fun_decl_id) list;
-      (** The *required* methods.
-
-        The required methods are the methods declared by the trait but with no default
+  required_methods : (trait_item_name * fun_decl_ref binder) list;
+      (** The *required* methods: the methods declared by the trait but with no default
         implementation. The corresponding `FunDecl`s don't have a body.
-     *)
-  provided_methods : (trait_item_name * fun_decl_id) list;
-      (** The *provided* methods.
 
-        The provided methods are the methods with a default implementation. The corresponding
+        The binder contains the type parameters specific to the method. The `FunDeclRef` then
+        provides a full list of arguments to the pointed-to function.
+     *)
+  provided_methods : (trait_item_name * fun_decl_ref binder) list;
+      (** The *provided* methods: the methods with a default implementation. The corresponding
         `FunDecl`s may have a body, according to the usual rules for extracting function bodies.
+
+        The binder contains the type parameters specific to the method. The `FunDeclRef` then
+        provides a full list of arguments to the pointed-to function.
      *)
 }
 [@@deriving
@@ -319,10 +323,18 @@ type trait_impl = {
       (** The associated constants declared in the trait. *)
   types : (trait_item_name * ty) list;
       (** The associated types declared in the trait. *)
-  required_methods : (trait_item_name * fun_decl_id) list;
-      (** The implemented required methods *)
-  provided_methods : (trait_item_name * fun_decl_id) list;
-      (** The re-implemented provided methods *)
+  required_methods : (trait_item_name * fun_decl_ref binder) list;
+      (** The implemented required methods
+
+        The binder contains the type parameters specific to the method. The `FunDeclRef` then
+        provides a full list of arguments to the pointed-to function.
+     *)
+  provided_methods : (trait_item_name * fun_decl_ref binder) list;
+      (** The re-implemented provided methods
+
+        The binder contains the type parameters specific to the method. The `FunDeclRef` then
+        provides a full list of arguments to the pointed-to function.
+     *)
 }
 [@@deriving
   show,

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -408,6 +408,16 @@ and item_kind_of_json (ctx : of_json_ctx) (js : json) :
         Ok (TraitImplItem (impl_ref, trait_ref, item_name, reuses_default))
     | _ -> Error "")
 
+and fun_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
+    (fun_decl_ref, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("id", id); ("generics", generics) ] ->
+        let* fun_id = fun_decl_id_of_json ctx id in
+        let* fun_generics = generic_args_of_json ctx generics in
+        Ok ({ fun_id; fun_generics } : fun_decl_ref)
+    | _ -> Error "")
+
 and global_decl_of_json (ctx : of_json_ctx) (js : json) :
     (global_decl, string) result =
   combine_error_msgs js __FUNCTION__
@@ -480,12 +490,14 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* types = list_of_json trait_item_name_of_json ctx types in
         let* required_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            (pair_of_json trait_item_name_of_json
+               (binder_of_json fun_decl_ref_of_json))
             ctx required_methods
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            (pair_of_json trait_item_name_of_json
+               (binder_of_json fun_decl_ref_of_json))
             ctx provided_methods
         in
         Ok
@@ -539,12 +551,14 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
         in
         let* required_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            (pair_of_json trait_item_name_of_json
+               (binder_of_json fun_decl_ref_of_json))
             ctx required_methods
         in
         let* provided_methods =
           list_of_json
-            (pair_of_json trait_item_name_of_json fun_decl_id_of_json)
+            (pair_of_json trait_item_name_of_json
+               (binder_of_json fun_decl_ref_of_json))
             ctx provided_methods
         in
         Ok

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -434,8 +434,14 @@ class virtual ['self] map_ty_base_base =
         { binder_regions; binder_value }
   end
 
+(** Reference to a function declaration. *)
+type fun_decl_ref = {
+  fun_id : fun_decl_id;
+  fun_generics : generic_args;  (** Generic arguments passed to the function. *)
+}
+
 (** Reference to a global declaration. *)
-type global_decl_ref = {
+and global_decl_ref = {
   global_id : global_decl_id;
   global_generics : generic_args;
 }

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.59"
+version = "0.1.60"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.59"
+version = "0.1.60"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -142,6 +142,16 @@ pub struct FunDecl {
     pub body: Result<Body, Opaque>,
 }
 
+/// Reference to a function declaration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+pub struct FunDeclRef {
+    #[charon::rename("fun_id")]
+    pub id: FunDeclId,
+    /// Generic arguments passed to the function.
+    #[charon::rename("fun_generics")]
+    pub generics: GenericArgs,
+}
+
 /// A global variable definition (constant or static).
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct GlobalDecl {
@@ -153,7 +163,8 @@ pub struct GlobalDecl {
     pub ty: Ty,
     /// The global kind: "regular" function, trait const declaration, etc.
     pub kind: ItemKind,
-    /// The initializer function used to compute the initial value for this constant/static.
+    /// The initializer function used to compute the initial value for this constant/static. It
+    /// uses the same generic parameters as the global.
     #[charon::rename("body")]
     pub init: FunDeclId,
 }
@@ -245,6 +256,7 @@ pub struct TraitDecl {
     ///
     /// The required methods are the methods declared by the trait but with no default
     /// implementation. The corresponding `FunDecl`s don't have a body.
+    // TODO: use a properly bound `FunDeclRef`
     pub required_methods: Vec<(TraitItemName, FunDeclId)>,
     /// The *provided* methods.
     ///

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -99,6 +99,7 @@ pub enum ItemKind {
         /// The trait declaration this item belongs to.
         trait_ref: TraitDeclRef,
         /// The name of the item.
+        // TODO: also include method generics so we can recover a full `FnPtr::TraitMethod`
         #[drive(skip)]
         item_name: TraitItemName,
         /// Whether the trait declaration provides a default implementation.
@@ -112,6 +113,7 @@ pub enum ItemKind {
         /// The trait declaration that the impl block implements.
         trait_ref: TraitDeclRef,
         /// The name of the item
+        // TODO: also include method generics so we can recover a full `FnPtr::TraitMethod`
         #[drive(skip)]
         item_name: TraitItemName,
         /// True if the trait decl had a default implementation for this function/const and this
@@ -252,17 +254,18 @@ pub struct TraitDecl {
     /// TODO: Do this as we translate to avoid the need to store this vector.
     #[charon::opaque]
     pub type_clauses: Vec<(TraitItemName, Vector<TraitClauseId, TraitClause>)>,
-    /// The *required* methods.
-    ///
-    /// The required methods are the methods declared by the trait but with no default
+    /// The *required* methods: the methods declared by the trait but with no default
     /// implementation. The corresponding `FunDecl`s don't have a body.
-    // TODO: use a properly bound `FunDeclRef`
-    pub required_methods: Vec<(TraitItemName, FunDeclId)>,
-    /// The *provided* methods.
     ///
-    /// The provided methods are the methods with a default implementation. The corresponding
+    /// The binder contains the type parameters specific to the method. The `FunDeclRef` then
+    /// provides a full list of arguments to the pointed-to function.
+    pub required_methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
+    /// The *provided* methods: the methods with a default implementation. The corresponding
     /// `FunDecl`s may have a body, according to the usual rules for extracting function bodies.
-    pub provided_methods: Vec<(TraitItemName, FunDeclId)>,
+    ///
+    /// The binder contains the type parameters specific to the method. The `FunDeclRef` then
+    /// provides a full list of arguments to the pointed-to function.
+    pub provided_methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
 }
 
 /// A trait **implementation**.
@@ -296,9 +299,15 @@ pub struct TraitImpl {
     #[charon::opaque]
     pub type_clauses: Vec<(TraitItemName, Vector<TraitClauseId, TraitRef>)>,
     /// The implemented required methods
-    pub required_methods: Vec<(TraitItemName, FunDeclId)>,
+    ///
+    /// The binder contains the type parameters specific to the method. The `FunDeclRef` then
+    /// provides a full list of arguments to the pointed-to function.
+    pub required_methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
     /// The re-implemented provided methods
-    pub provided_methods: Vec<(TraitItemName, FunDeclId)>,
+    ///
+    /// The binder contains the type parameters specific to the method. The `FunDeclRef` then
+    /// provides a full list of arguments to the pointed-to function.
+    pub provided_methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
 }
 
 /// A function operand is used in function calls.

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -2,7 +2,7 @@ use crate::ast::*;
 use crate::formatter::{FmtCtx, Formatter, IntoFormatter};
 use crate::ids::Vector;
 use crate::reorder_decls::DeclarationsGroups;
-use derive_generic_visitor::{Drive, DriveMut};
+use derive_generic_visitor::{ControlFlow, Drive, DriveMut};
 use hashlink::LinkedHashSet;
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,6 @@ use serde_map_to_array::HashMapToArray;
 use std::cmp::{Ord, PartialOrd};
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{ControlFlow, Index, IndexMut};
 
 generate_index_type!(FunDeclId, "Fun");
 generate_index_type!(TypeDeclId, "Adt");
@@ -315,19 +314,21 @@ impl<'tcx, 'ctx, 'a> IntoFormatter for &'a TranslatedCrate {
 /// Delegate `Index` implementations to subfields.
 macro_rules! mk_index_impls {
     ($ty:ident.$field:ident[$idx:ty]: $output:ty) => {
-        impl Index<$idx> for $ty {
+        impl std::ops::Index<$idx> for $ty {
             type Output = $output;
             fn index(&self, index: $idx) -> &Self::Output {
                 &self.$field[index]
             }
         }
-        impl IndexMut<$idx> for $ty {
+        impl std::ops::IndexMut<$idx> for $ty {
             fn index_mut(&mut self, index: $idx) -> &mut Self::Output {
                 &mut self.$field[index]
             }
         }
     };
 }
+pub(crate) use mk_index_impls;
+
 mk_index_impls!(TranslatedCrate.type_decls[TypeDeclId]: TypeDecl);
 mk_index_impls!(TranslatedCrate.fun_decls[FunDeclId]: FunDecl);
 mk_index_impls!(TranslatedCrate.global_decls[GlobalDeclId]: GlobalDecl);

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -121,6 +121,18 @@ impl<T> Binder<T> {
             skip_binder,
         }
     }
+
+    /// Substitute the provided arguments for the variables bound in this binder and return the
+    /// substituted inner value.
+    pub fn apply(self, args: &GenericArgs) -> T
+    where
+        T: AstVisitable,
+    {
+        let mut val = self.skip_binder;
+        assert!(args.matches(&self.params));
+        val.drive_mut(&mut SubstVisitor::new(args));
+        val
+    }
 }
 
 impl GenericArgs {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -574,3 +574,12 @@ impl PartialEq for TraitClause {
 }
 
 impl Eq for TraitClause {}
+
+mk_index_impls!(GenericArgs.regions[RegionId]: Region);
+mk_index_impls!(GenericArgs.types[TypeVarId]: Ty);
+mk_index_impls!(GenericArgs.const_generics[ConstGenericVarId]: ConstGeneric);
+mk_index_impls!(GenericArgs.trait_refs[TraitClauseId]: TraitRef);
+mk_index_impls!(GenericParams.regions[RegionId]: RegionVar);
+mk_index_impls!(GenericParams.types[TypeVarId]: TypeVar);
+mk_index_impls!(GenericParams.const_generics[ConstGenericVarId]: ConstGenericVar);
+mk_index_impls!(GenericParams.trait_clauses[TraitClauseId]: TraitClause);

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -63,7 +63,8 @@ use index_vec::Idx;
     // type but can be overridden.
     override(
         DeBruijnId, Ty, Region, ConstGeneric, TraitRef,
-        GlobalDeclRef, TraitDeclRef, TraitImplRef, GenericArgs, GenericParams,
+        FunDeclRef, GlobalDeclRef, TraitDeclRef, TraitImplRef,
+        GenericArgs, GenericParams,
         for<T: AstVisitable + Idx> DeBruijnVar<T>,
         for<T: AstVisitable> RegionBinder<T>,
         for<T: AstVisitable> Binder<T>,

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -539,6 +539,18 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         Ok(())
     }
 
+    /// Translate the generics and predicates of this item without its parents.
+    pub(crate) fn translate_def_generics_without_parents(
+        &mut self,
+        span: Span,
+        def: &hax::FullDef,
+    ) -> Result<(), Error> {
+        self.binding_levels.push_front(BindingLevel::new(true));
+        self.push_generics_for_def_without_parents(span, def, true, true)?;
+        self.innermost_binder().params.check_consistency();
+        Ok(())
+    }
+
     pub(crate) fn into_generics(mut self) -> GenericParams {
         assert!(self.binding_levels.len() == 1);
         self.binding_levels.pop_back().unwrap().params

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1274,6 +1274,7 @@ fn generate_ml(
                     "TraitRefKind",
                     "TraitDeclRef",
                     "TraitImplRef",
+                    "FunDeclRef",
                     "GlobalDeclRef",
                     "GenericArgs",
                 ]),

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -531,6 +531,14 @@ where
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for FunDeclRef {
+    fn fmt_with_ctx(&self, ctx: &C) -> String {
+        let id = ctx.format_object(self.id);
+        let generics = self.generics.fmt_with_ctx(ctx);
+        format!("{id}{generics}")
+    }
+}
+
 impl<C> FmtWithCtx<C> for GlobalDecl
 where
     C: AstFormatter,
@@ -565,9 +573,9 @@ where
 
 impl<C: AstFormatter> FmtWithCtx<C> for GlobalDeclRef {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
-        let global_id = ctx.format_object(self.id);
+        let id = ctx.format_object(self.id);
         let generics = self.generics.fmt_with_ctx(ctx);
-        format!("{global_id}{generics}")
+        format!("{id}{generics}")
     }
 }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -9,7 +9,10 @@ use crate::{
     ullbc_ast::{self as ullbc, *},
 };
 use itertools::Itertools;
-use std::fmt::{self, Display, Write};
+use std::{
+    borrow::Cow,
+    fmt::{self, Display, Write},
+};
 
 /// Format the AST type as a string.
 pub trait FmtWithCtx<C> {
@@ -73,6 +76,22 @@ impl<C: AstFormatter> FmtWithCtx<C> for Assert {
             "assert({} == {})",
             self.cond.fmt_with_ctx(ctx),
             self.expected,
+        )
+    }
+}
+
+impl<T> Binder<T> {
+    /// Format the parameters and contents of this binder and returns the resulting strings. Note:
+    /// this assumes the binder fully replaces the existing generics.
+    fn fmt_split<'a, C>(&'a self, ctx: &'a C) -> (String, String)
+    where
+        C: AstFormatter,
+        T: FmtWithCtx<<C as PushBinder<'a>>::C>,
+    {
+        let ctx = &ctx.push_binder(Cow::Borrowed(&self.params));
+        (
+            self.params.fmt_with_ctx_single_line(ctx),
+            self.skip_binder.fmt_with_ctx(ctx),
         )
     }
 }
@@ -1114,44 +1133,47 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
         let (generics, clauses) = self.generics.fmt_with_ctx_with_trait_clauses(ctx, "");
 
         let items = {
-            let items =
-                self.parent_clauses
-                    .iter()
-                    .map(|c| {
-                        format!(
-                            "{TAB_INCR}parent_clause{} : {}\n",
-                            c.clause_id,
-                            c.fmt_with_ctx(ctx)
-                        )
-                    })
-                    .chain(self.type_clauses.iter().map(|(name, clauses)| {
-                        clauses
-                            .iter()
-                            .map(|c| {
-                                format!(
-                                    "{TAB_INCR}item_clause_{name}_{} : {}\n",
-                                    c.clause_id.to_string(),
-                                    c.fmt_with_ctx(ctx)
-                                )
-                            })
-                            .collect()
-                    }))
-                    .chain(self.consts.iter().map(|(name, ty)| {
-                        let ty = ty.fmt_with_ctx(ctx);
-                        format!("{TAB_INCR}const {name} : {ty}\n")
-                    }))
-                    .chain(
-                        self.types
-                            .iter()
-                            .map(|name| format!("{TAB_INCR}type {name}\n")),
+            let items = self
+                .parent_clauses
+                .iter()
+                .map(|c| {
+                    format!(
+                        "{TAB_INCR}parent_clause{} : {}\n",
+                        c.clause_id,
+                        c.fmt_with_ctx(ctx)
                     )
-                    .chain(self.required_methods.iter().map(|(name, f)| {
-                        format!("{TAB_INCR}fn {name} : {}\n", ctx.format_object(*f))
-                    }))
-                    .chain(self.provided_methods.iter().map(|(name, f)| {
-                        format!("{TAB_INCR}fn {name} : {}\n", ctx.format_object(*f))
-                    }))
-                    .collect::<Vec<String>>();
+                })
+                .chain(self.type_clauses.iter().map(|(name, clauses)| {
+                    clauses
+                        .iter()
+                        .map(|c| {
+                            format!(
+                                "{TAB_INCR}item_clause_{name}_{} : {}\n",
+                                c.clause_id.to_string(),
+                                c.fmt_with_ctx(ctx)
+                            )
+                        })
+                        .collect()
+                }))
+                .chain(self.consts.iter().map(|(name, ty)| {
+                    let ty = ty.fmt_with_ctx(ctx);
+                    format!("{TAB_INCR}const {name} : {ty}\n")
+                }))
+                .chain(
+                    self.types
+                        .iter()
+                        .map(|name| format!("{TAB_INCR}type {name}\n")),
+                )
+                .chain(
+                    self.required_methods
+                        .iter()
+                        .chain(self.provided_methods.iter())
+                        .map(|(name, bound_fn)| {
+                            let (params, fn_ref) = bound_fn.fmt_split(ctx);
+                            format!("{TAB_INCR}fn {name}{params} = {fn_ref}\n",)
+                        }),
+                )
+                .collect::<Vec<String>>();
             if items.is_empty() {
                 "".to_string()
             } else {
@@ -1214,8 +1236,9 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
                     self.required_methods
                         .iter()
                         .chain(self.provided_methods.iter())
-                        .map(|(name, f)| {
-                            format!("{TAB_INCR}fn {name} = {}\n", ctx.format_object(*f))
+                        .map(|(name, bound_fn)| {
+                            let (params, fn_ref) = bound_fn.fmt_split(ctx);
+                            format!("{TAB_INCR}fn {name}{params} = {fn_ref}\n",)
                         }),
                 )
                 .collect::<Vec<String>>();

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -95,6 +95,9 @@ impl VisitAst for CheckGenericsVisitor<'_> {
             }
         }
     }
+    fn enter_fun_decl_ref(&mut self, fun_ref: &FunDeclRef) {
+        self.generics_should_match_item(&fun_ref.generics, fun_ref.id);
+    }
     fn enter_global_decl_ref(&mut self, global_ref: &GlobalDeclRef) {
         self.generics_should_match_item(&global_ref.generics, global_ref.id);
     }

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -392,8 +392,7 @@ fn compute_declarations_graph<'tcx>(ctx: &'tcx TransformCtx) -> Deps {
                 let method_ids = required_methods
                     .iter()
                     .chain(provided_methods.iter())
-                    .map(|(_, id)| id)
-                    .copied();
+                    .map(|(_, bound_fun)| bound_fun.skip_binder.id);
                 for id in method_ids {
                     // Important: we must ignore the function id, because
                     // otherwise in the presence of associated types we may

--- a/charon/src/transform/skip_trait_refs_when_known.rs
+++ b/charon/src/transform/skip_trait_refs_when_known.rs
@@ -17,7 +17,7 @@ fn transform_call(ctx: &TransformCtx, call: &mut Call) {
         return;
     };
     // Find the function declaration corresponding to this impl.
-    let Some((_, fun_decl_id)) = trait_impl
+    let Some((_, bound_fn)) = trait_impl
         .required_methods
         .iter()
         .chain(trait_impl.provided_methods.iter())
@@ -25,12 +25,12 @@ fn transform_call(ctx: &TransformCtx, call: &mut Call) {
     else {
         return;
     };
-    let fn_generics = &fn_ptr.generics;
+    let method_generics = &fn_ptr.generics;
     // Move the trait generics to the function call.
-    // FIXME: make a better API than `concat`.
-    fn_ptr.generics = impl_generics.clone().concat(fn_generics);
+    // TODO: substitute for real
+    fn_ptr.generics = impl_generics.clone().concat(method_generics);
     // Set the call operation to use the function directly.
-    fn_ptr.func = FunIdOrTraitMethodRef::Fun(FunId::Regular(*fun_decl_id));
+    fn_ptr.func = FunIdOrTraitMethodRef::Fun(FunId::Regular(bound_fn.skip_binder.id));
 }
 
 pub struct Transform;

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -23,7 +23,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 fn take_mut::take<'_0, T, F>(@1: &'_0 mut (T), @2: F)

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -254,12 +254,12 @@ trait core::slice::index::SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
     type Output
-    fn get : core::slice::index::SliceIndex::get
-    fn get_mut : core::slice::index::SliceIndex::get_mut
-    fn get_unchecked : core::slice::index::SliceIndex::get_unchecked
-    fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
-    fn index : core::slice::index::SliceIndex::index
-    fn index_mut : core::slice::index::SliceIndex::index_mut
+    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T>
+    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>
+    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>
+    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
 }
 
 fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
@@ -300,12 +300,12 @@ where
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#1
     type Output = Slice<T>
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut
+    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0_0, T>[@TraitClause0]
+    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0_0, T>[@TraitClause0]
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0_0, T>[@TraitClause0]
+    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
@@ -405,7 +405,7 @@ fn test_crate::array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>)) -
 trait core::ops::index::Index<Self, Idx>
 {
     type Output
-    fn index : core::ops::index::Index::index
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
 }
 
 fn core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]::Output)
@@ -421,7 +421,7 @@ where
     [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     type Output = @TraitClause2::Output
-    fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
+    fn index<'_0> = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
@@ -456,7 +456,7 @@ fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2
 trait core::ops::index::IndexMut<Self, Idx>
 {
     parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
-    fn index_mut : core::ops::index::IndexMut::index_mut
+    fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx>
 }
 
 impl<T, I, const N : usize> core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I>
@@ -466,7 +466,7 @@ where
     [@TraitClause2]: core::ops::index::Index<Slice<T>, I>,
 {
     type Output = @TraitClause2::Output
-    fn index = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index
+    fn index<'_0> = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_0, T, I, const N : usize>(@1: &'_0 mut (Array<T, const N : usize>), @2: I) -> &'_0 mut (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause0]::Output)
@@ -482,7 +482,7 @@ where
     [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     parent_clause0 = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    fn index_mut = core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut
+    fn index_mut<'_0> = core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn test_crate::array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
@@ -1885,7 +1885,7 @@ where
     [@TraitClause2]: core::ops::index::IndexMut<Slice<T>, I>,
 {
     parent_clause0 = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause0]
-    fn index_mut = core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut
+    fn index_mut<'_0> = core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_0 (Self::Output)>]

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -5,8 +5,8 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -22,7 +22,7 @@ where
     parent_clause1 : [@TraitClause1]: core::clone::Clone<Self::Item>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Item>
     type Item
-    fn use_item : test_crate::Foo::use_item
+    fn use_item<'_0> = test_crate::Foo::use_item<'a, '_0_0, Self>
 }
 
 fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
@@ -30,7 +30,7 @@ fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1,
 impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T> : core::clone::Clone<&'_0 (T)>
 {
     parent_clause0 = core::marker::Sized<&'_ (T)>
-    fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_0_0, T>
 }
 
 impl<'_0, T> core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_0, T> : core::marker::Copy<&'_0 (T)>
@@ -62,8 +62,8 @@ where
     [@TraitClause1]: core::clone::Clone<T>,
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
-    fn clone = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone
-    fn clone_from = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone_from
+    fn clone<'_0> = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone<'_0_0, T>[@TraitClause0, @TraitClause1]
+    fn clone_from<'_0, '_1> = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone_from<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
 impl<'a, T> test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T)>
@@ -212,7 +212,7 @@ impl test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo
 
 trait core::borrow::Borrow<Self, Borrowed>
 {
-    fn borrow : core::borrow::Borrow::borrow
+    fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
 trait alloc::borrow::ToOwned<Self>
@@ -220,8 +220,8 @@ trait alloc::borrow::ToOwned<Self>
     parent_clause0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Owned>
     type Owned
-    fn to_owned : alloc::borrow::ToOwned::to_owned
-    fn clone_into : alloc::borrow::ToOwned::clone_into
+    fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
+    fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self>
 }
 
 enum test_crate::cow::Cow<'a, B>

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -13,7 +13,7 @@ struct test_crate::Struct<A>
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 fn core::default::Default::default<Self>() -> Self
@@ -39,7 +39,7 @@ where
     [@TraitClause1]: core::default::Default<A>,
 {
     parent_clause0 = core::marker::Sized<test_crate::Struct<A>[@TraitClause0]>
-    fn default = test_crate::{impl core::default::Default for test_crate::Struct<A>[@TraitClause0]}#1::default
+    fn default = test_crate::{impl core::default::Default for test_crate::Struct<A>[@TraitClause0]}#1::default<A>[@TraitClause0, @TraitClause1]
 }
 
 trait test_crate::Trait<Self, B>
@@ -47,20 +47,20 @@ trait test_crate::Trait<Self, B>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<B>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
     type Item
-    fn method : test_crate::Trait::method
+    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::Trait::method<Self, B, C>[@TraitClause0_0]
 }
 
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 fn test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>()
@@ -90,7 +90,7 @@ where
     parent_clause0 = @TraitClause1
     parent_clause1 = core::marker::Sized<(A, B)>
     type Item = (A, B)
-    fn method = test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method
+    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause0_0]
 }
 
 fn core::default::{impl core::default::Default for bool}#1::default() -> bool
@@ -108,7 +108,7 @@ fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (
 impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
     parent_clause0 = core::marker::Sized<u8>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0_0>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::eq<'_0, '_1>(@1: &'_0 (bool), @2: &'_1 (bool)) -> bool
@@ -117,8 +117,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::ne<'_0, '_1>
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19 : core::cmp::PartialEq<bool, bool>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19::ne<'_0_0, '_0_1>
 }
 
 fn test_crate::main()

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -22,7 +22,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -30,7 +30,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 trait core::ops::function::Fn<Self, Args>
@@ -38,7 +38,7 @@ trait core::ops::function::Fn<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call : core::ops::function::Fn::call
+    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>
 }
 
 enum core::option::Option<T>
@@ -413,8 +413,8 @@ fn test_crate::test_map_option_id2(@1: core::option::Option<u32>[core::marker::S
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
@@ -440,7 +440,7 @@ fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 
 impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
     parent_clause0 = core::marker::Sized<u32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0_0>
 }
 
 fn test_crate::test_id_clone(@1: u32) -> u32

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -141,7 +141,7 @@ struct test_crate::Foo =
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 fn core::default::{impl core::default::Default for u32}#7::default() -> u32

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -381,7 +381,7 @@ where
 
 trait test_crate::Counter<Self>
 {
-    fn incr : test_crate::Counter::incr
+    fn incr<'_0> = test_crate::Counter::incr<'_0_0, Self>
 }
 
 fn test_crate::{impl test_crate::Counter for usize}::incr<'_0>(@1: &'_0 mut (usize)) -> usize
@@ -400,7 +400,7 @@ fn test_crate::{impl test_crate::Counter for usize}::incr<'_0>(@1: &'_0 mut (usi
 
 impl test_crate::{impl test_crate::Counter for usize} : test_crate::Counter<usize>
 {
-    fn incr = test_crate::{impl test_crate::Counter for usize}::incr
+    fn incr<'_0> = test_crate::{impl test_crate::Counter for usize}::incr<'_0_0>
 }
 
 fn test_crate::Counter::incr<'_0, Self>(@1: &'_0 mut (Self)) -> usize

--- a/charon/tests/ui/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/dictionary_passing_style_woes.out
@@ -65,7 +65,7 @@ trait test_crate::X<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Assoc>
     type Assoc
-    fn method : test_crate::X::method
+    fn method<'_0> = test_crate::X::method<'_0_0, Self>
 }
 
 trait test_crate::A<Self>

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -19,7 +19,7 @@ struct core::fmt::Error = {}
 
 trait core::fmt::Display<Self>
 {
-    fn fmt : core::fmt::Display::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 struct alloc::alloc::Global = {}
@@ -80,14 +80,14 @@ fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::stri
 
 trait alloc::string::ToString<Self>
 {
-    fn to_string : alloc::string::ToString::to_string
+    fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>
 }
 
 impl<T> alloc::string::{impl alloc::string::ToString for T}#32<T> : alloc::string::ToString<T>
 where
     [@TraitClause0]: core::fmt::Display<T>,
 {
-    fn to_string = alloc::string::{impl alloc::string::ToString for T}#32::to_string
+    fn to_string<'_0> = alloc::string::{impl alloc::string::ToString for T}#32::to_string<'_0_0, T>[@TraitClause0]
 }
 
 fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -28,8 +28,8 @@ where
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -60,7 +60,7 @@ fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 
 impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
     parent_clause0 = core::marker::Sized<u32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for u32}#40 : core::marker::Copy<u32>
@@ -77,7 +77,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11 : core::clone::Clone<core::num::nonzero::private::NonZeroU32Inner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroU32Inner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner}#12 : core::marker::Copy<core::num::nonzero::private::NonZeroU32Inner>

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -5,8 +5,8 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait test_crate::Foo<Self>
@@ -14,7 +14,7 @@ trait test_crate::Foo<Self>
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self::Type>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Type>
     type Type
-    fn get_ty : test_crate::Foo::get_ty
+    fn get_ty<'_0> = test_crate::Foo::get_ty<'_0_0, Self>
 }
 
 fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 (u32)) -> u32
@@ -22,7 +22,7 @@ fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 
 impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
     parent_clause0 = core::marker::Sized<u32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0_0>
 }
 
 fn test_crate::{impl test_crate::Foo for ()}::get_ty<'_0>(@1: &'_0 (())) -> &'_0 (u32)
@@ -45,7 +45,7 @@ impl test_crate::{impl test_crate::Foo for ()} : test_crate::Foo<()>
     parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32}#8
     parent_clause1 = core::marker::Sized<u32>
     type Type = u32
-    fn get_ty = test_crate::{impl test_crate::Foo for ()}::get_ty
+    fn get_ty<'_0> = test_crate::{impl test_crate::Foo for ()}::get_ty<'_0_0>
 }
 
 fn test_crate::mk_foo()
@@ -92,7 +92,7 @@ trait test_crate::RPITIT<Self>
     parent_clause0 : [@TraitClause0]: test_crate::Foo<Self::>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::>
     type 
-    fn make_foo : test_crate::RPITIT::make_foo
+    fn make_foo = test_crate::RPITIT::make_foo<Self>
 }
 
 fn test_crate::{impl test_crate::RPITIT for ()}#1::make_foo()
@@ -173,7 +173,7 @@ fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1,
 impl<'_0, T> core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T> : core::clone::Clone<&'_0 (T)>
 {
     parent_clause0 = core::marker::Sized<&'_ (T)>
-    fn clone = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_0_0, T>
 }
 
 fn test_crate::wrap::closure<'_0, U>(@1: (), @2: &'_0 (U)) -> test_crate::WrapClone<&'_0 (U)>[core::marker::Sized<&'_0 (U)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, U>]
@@ -209,7 +209,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -207,8 +207,8 @@ fn test_crate::max() -> usize
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 fn test_crate::partial_eq<T>(@1: T)
@@ -233,7 +233,7 @@ trait core::convert::From<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
-    fn from : core::convert::From::from
+    fn from = core::convert::From::from<Self, T>
 }
 
 impl core::convert::num::{impl core::convert::From<i32> for i64}#83 : core::convert::From<i64, i32>

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -7,8 +7,8 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 fn test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0>(@1: &'_0 (test_crate::Foo)) -> test_crate::Foo
@@ -23,7 +23,7 @@ fn test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0>(@1: &'_
 impl test_crate::{impl core::clone::Clone for test_crate::Foo} : core::clone::Clone<test_crate::Foo>
 {
     parent_clause0 = core::marker::Sized<test_crate::Foo>
-    fn clone = test_crate::{impl core::clone::Clone for test_crate::Foo}::clone
+    fn clone<'_0> = test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0_0>
 }
 
 trait core::marker::Copy<Self>

--- a/charon/tests/ui/issue-159-heterogeneous-recursive-definitions.out
+++ b/charon/tests/ui/issue-159-heterogeneous-recursive-definitions.out
@@ -2,8 +2,8 @@
 
 trait test_crate::Ops<Self>
 {
-    fn ZERO : test_crate::Ops::ZERO
-    fn ntt_multiply : test_crate::Ops::ntt_multiply
+    fn ZERO = test_crate::Ops::ZERO<Self>
+    fn ntt_multiply = test_crate::Ops::ntt_multiply<Self>
 }
 
 struct test_crate::Portable = {}

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -17,8 +17,8 @@ where
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 fn alloc::vec::from_elem<T>(@1: T, @2: usize) -> alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
@@ -31,7 +31,7 @@ fn core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0>(@1: &'_0
 impl core::clone::impls::{impl core::clone::Clone for i32}#14 : core::clone::Clone<i32>
 {
     parent_clause0 = core::marker::Sized<i32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for i32}#14::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0_0>
 }
 
 fn test_crate::foo()

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -19,7 +19,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -27,7 +27,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 fn test_crate::{test_crate::S<'a, K>[@TraitClause0]}::f<'a, K, F>()

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -31,7 +31,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -39,7 +39,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 fn core::iter::sources::from_fn::from_fn<T, F>(@1: F) -> core::iter::sources::from_fn::FromFn<F>[@TraitClause1]

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -41,8 +41,8 @@ opaque type core::array::iter::IntoIter<T, const N : usize>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -73,7 +73,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -90,7 +90,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -131,7 +131,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -139,7 +139,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 opaque type core::iter::adapters::map::Map<I, F>
@@ -202,7 +202,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -221,8 +221,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -240,19 +240,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -264,21 +264,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -301,83 +301,83 @@ trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
@@ -389,7 +389,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -432,34 +432,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -471,21 +471,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 struct test_crate::S<I, F>
@@ -1028,11 +1028,63 @@ fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
-fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::default::Default::default<Self>() -> Self
 
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+
+fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
+
+fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
+
+fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
@@ -1040,11 +1092,7 @@ where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
     @TraitClause1::Item = A,
 
-fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
-
-fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
-
-fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -1059,8 +1107,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -1097,52 +1143,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
-
-fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
-
-fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
-
-fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
 
 
 

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -19,7 +19,7 @@ trait core::convert::TryFrom<Self, T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Error>
     type Error
-    fn try_from : core::convert::TryFrom::try_from
+    fn try_from = core::convert::TryFrom::try_from<Self, T>
 }
 
 fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause2::Error>[@TraitClause1, @TraitClause2::parent_clause2]
@@ -31,8 +31,8 @@ where
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -54,7 +54,7 @@ where
     parent_clause1 = core::marker::Sized<&'_ (Slice<T>)>
     parent_clause2 = core::marker::Sized<core::array::TryFromSliceError>
     type Error = core::array::TryFromSliceError
-    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from
+    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>[@TraitClause0, @TraitClause1]
 }
 
 fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
@@ -62,7 +62,7 @@ fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (
 impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
     parent_clause0 = core::marker::Sized<u8>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for u8}#38 : core::marker::Copy<u8>
@@ -78,7 +78,7 @@ struct core::fmt::Error = {}
 
 trait core::fmt::Debug<Self>
 {
-    fn fmt : core::fmt::Debug::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 fn core::result::{core::result::Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<T, E>(@1: core::result::Result<T, E>[@TraitClause0, @TraitClause1]) -> T
@@ -91,7 +91,7 @@ fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::f
 
 impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26 : core::fmt::Debug<core::array::TryFromSliceError>
 {
-    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt
+    fn fmt<'_0, '_1, '_2> = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
@@ -124,7 +124,7 @@ trait core::convert::TryInto<Self, T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Error>
     type Error
-    fn try_into : core::convert::TryInto::try_into
+    fn try_into = core::convert::TryInto::try_into<Self, T>
 }
 
 impl<T, U> core::convert::{impl core::convert::TryInto<U> for T}#6<T, U> : core::convert::TryInto<T, U>
@@ -137,7 +137,7 @@ where
     parent_clause1 = @TraitClause1
     parent_clause2 = @TraitClause2::parent_clause2
     type Error = @TraitClause2::Error
-    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into
+    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[Self::parent_clause0, Self::parent_clause2]

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -19,7 +19,7 @@ trait core::convert::TryFrom<Self, T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Error>
     type Error
-    fn try_from : core::convert::TryFrom::try_from
+    fn try_from = core::convert::TryFrom::try_from<Self, T>
 }
 
 fn core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>(@1: T) -> core::result::Result<U, @TraitClause2::Error>[@TraitClause1, @TraitClause2::parent_clause2]
@@ -31,8 +31,8 @@ where
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -54,7 +54,7 @@ where
     parent_clause1 = core::marker::Sized<&'_ (Slice<T>)>
     parent_clause2 = core::marker::Sized<core::array::TryFromSliceError>
     type Error = core::array::TryFromSliceError
-    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from
+    fn try_from = core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>[@TraitClause0, @TraitClause1]
 }
 
 fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
@@ -62,7 +62,7 @@ fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (
 impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
     parent_clause0 = core::marker::Sized<u8>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for u8}#38 : core::marker::Copy<u8>
@@ -78,7 +78,7 @@ struct core::fmt::Error = {}
 
 trait core::fmt::Debug<Self>
 {
-    fn fmt : core::fmt::Debug::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 fn core::result::{core::result::Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<T, E>(@1: core::result::Result<T, E>[@TraitClause0, @TraitClause1]) -> T
@@ -91,7 +91,7 @@ fn core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::f
 
 impl core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26 : core::fmt::Debug<core::array::TryFromSliceError>
 {
-    fn fmt = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt
+    fn fmt<'_0, '_1, '_2> = core::array::{impl core::fmt::Debug for core::array::TryFromSliceError}#26::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
@@ -124,7 +124,7 @@ trait core::convert::TryInto<Self, T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Error>
     type Error
-    fn try_into : core::convert::TryInto::try_into
+    fn try_into = core::convert::TryInto::try_into<Self, T>
 }
 
 impl<T, U> core::convert::{impl core::convert::TryInto<U> for T}#6<T, U> : core::convert::TryInto<T, U>
@@ -137,7 +137,7 @@ where
     parent_clause1 = @TraitClause1
     parent_clause2 = @TraitClause2::parent_clause2
     type Error = @TraitClause2::Error
-    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into
+    fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[Self::parent_clause0, Self::parent_clause2]

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -20,7 +20,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -28,7 +28,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 fn core::array::{Array<T, const N : usize>}#23::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
@@ -95,8 +95,8 @@ opaque type core::array::iter::IntoIter<T, const N : usize>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -127,7 +127,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -144,7 +144,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -237,7 +237,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -256,8 +256,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -275,19 +275,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -299,21 +299,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -336,83 +336,83 @@ trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
@@ -424,7 +424,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -467,34 +467,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -506,21 +506,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
@@ -533,13 +533,13 @@ trait core::iter::range::Step<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
     parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd<Self, Self>
-    fn steps_between : core::iter::range::Step::steps_between
-    fn forward_checked : core::iter::range::Step::forward_checked
-    fn backward_checked : core::iter::range::Step::backward_checked
-    fn forward : core::iter::range::Step::forward
-    fn forward_unchecked : core::iter::range::Step::forward_unchecked
-    fn backward : core::iter::range::Step::backward
-    fn backward_unchecked : core::iter::range::Step::backward_unchecked
+    fn steps_between<'_0, '_1> = core::iter::range::Step::steps_between<'_0_0, '_0_1, Self>
+    fn forward_checked = core::iter::range::Step::forward_checked<Self>
+    fn backward_checked = core::iter::range::Step::backward_checked<Self>
+    fn forward = core::iter::range::Step::forward<Self>
+    fn forward_unchecked = core::iter::range::Step::forward_unchecked<Self>
+    fn backward = core::iter::range::Step::backward<Self>
+    fn backward_unchecked = core::iter::range::Step::backward_unchecked<Self>
 }
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0])) -> core::option::Option<A>[@TraitClause0]
@@ -602,16 +602,16 @@ where
 {
     parent_clause0 = @TraitClause0
     type Item = A
-    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next
-    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::size_hint
-    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::count
-    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::last
-    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::advance_by
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::nth
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::max
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::min
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::is_sorted
-    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked
+    fn next<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn size_hint<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::size_hint<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::count<A>[@TraitClause0, @TraitClause1]
+    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::last<A>[@TraitClause0, @TraitClause1]
+    fn advance_by<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::advance_by<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn nth<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::nth<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn max<[@TraitClause0]: core::cmp::Ord<A>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::max<A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
+    fn min<[@TraitClause0]: core::cmp::Ord<A>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::min<A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::is_sorted<A>[@TraitClause0, @TraitClause1]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<core::ops::range::Range<A>[@TraitClause0]>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0_0, A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
 }
 
 fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
@@ -619,7 +619,7 @@ fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (
 impl core::clone::impls::{impl core::clone::Clone for u8}#6 : core::clone::Clone<u8>
 {
     parent_clause0 = core::marker::Sized<u8>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u8}#6::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0_0>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
@@ -628,8 +628,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::ne<'_0, '_1>(@1:
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22 : core::cmp::PartialEq<u8, u8>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::ne<'_0_0, '_0_1>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
@@ -645,11 +645,11 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge<'_0, '_1>(@1
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60 : core::cmp::PartialOrd<u8, u8>
 {
     parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::partial_cmp<'_0_0, '_0_1>
+    fn lt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::lt<'_0_0, '_0_1>
+    fn le<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::le<'_0_0, '_0_1>
+    fn gt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::gt<'_0_0, '_0_1>
+    fn ge<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60::ge<'_0_0, '_0_1>
 }
 
 fn core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -671,7 +671,7 @@ impl core::iter::range::{impl core::iter::range::Step for u8}#35 : core::iter::r
     parent_clause0 = core::marker::Sized<u8>
     parent_clause1 = core::clone::impls::{impl core::clone::Clone for u8}#6
     parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<u8> for u8}#60
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between
+    fn steps_between<'_0, '_1> = core::iter::range::{impl core::iter::range::Step for u8}#35::steps_between<'_0_0, '_0_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for u8}#35::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for u8}#35::forward
@@ -866,7 +866,7 @@ where
     parent_clause2 = @TraitClause0
     type Item = @TraitClause1::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
@@ -1448,17 +1448,31 @@ unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, 
 where
     [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
-fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
-    @TraitClause1::Item = A,
+fn core::default::Default::default<Self>() -> Self
 
 fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
 fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
 fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -1473,8 +1487,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -1511,18 +1523,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
 
 
 

--- a/charon/tests/ui/issue-70-override-provided-method.2.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2.out
@@ -2,9 +2,9 @@
 
 trait test_crate::Trait<Self>
 {
-    fn required : test_crate::Trait::required
-    fn provided1 : test_crate::Trait::provided1
-    fn provided2 : test_crate::Trait::provided2
+    fn required<'_0> = test_crate::Trait::required<'_0_0, Self>
+    fn provided1<'_0> = test_crate::Trait::provided1<'_0_0, Self>
+    fn provided2<'_0> = test_crate::Trait::provided2<'_0_0, Self>
 }
 
 struct test_crate::Foo = {}
@@ -79,7 +79,7 @@ fn test_crate::{impl test_crate::Trait for test_crate::Foo}::required<'_0>(@1: &
 
 impl test_crate::{impl test_crate::Trait for test_crate::Foo} : test_crate::Trait<test_crate::Foo>
 {
-    fn required = test_crate::{impl test_crate::Trait for test_crate::Foo}::required
+    fn required<'_0> = test_crate::{impl test_crate::Trait for test_crate::Foo}::required<'_0_0>
 }
 
 struct test_crate::Bar = {}
@@ -122,8 +122,8 @@ fn test_crate::{impl test_crate::Trait for test_crate::Bar}#1::provided1<'_0>(@1
 
 impl test_crate::{impl test_crate::Trait for test_crate::Bar}#1 : test_crate::Trait<test_crate::Bar>
 {
-    fn required = test_crate::{impl test_crate::Trait for test_crate::Bar}#1::required
-    fn provided1 = test_crate::{impl test_crate::Trait for test_crate::Bar}#1::provided1
+    fn required<'_0> = test_crate::{impl test_crate::Trait for test_crate::Bar}#1::required<'_0_0>
+    fn provided1<'_0> = test_crate::{impl test_crate::Trait for test_crate::Bar}#1::provided1<'_0_0>
 }
 
 

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -5,22 +5,22 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait test_crate::GenericTrait<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: core::clone::Clone<T>
-    fn other_method : test_crate::GenericTrait::other_method
-    fn provided : test_crate::GenericTrait::provided
+    fn other_method = test_crate::GenericTrait::other_method<Self, T>
+    fn provided<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::cmp::PartialEq<U, T>> = test_crate::GenericTrait::provided<Self, T, U>[@TraitClause0_0, @TraitClause0_1]
 }
 
 struct test_crate::Override<T>
@@ -60,8 +60,8 @@ where
     [@TraitClause1]: core::clone::Clone<T>,
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
-    fn clone = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone
-    fn clone_from = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone_from
+    fn clone<'_0> = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone<'_0_0, T>[@TraitClause0, @TraitClause1]
+    fn clone_from<'_0, '_1> = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone_from<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
 fn test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::other_method<T>()
@@ -122,8 +122,8 @@ where
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
     parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<T>[@TraitClause0, @TraitClause1::parent_clause0]
-    fn other_method = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::other_method
-    fn provided = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::provided
+    fn other_method = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::other_method<T>[@TraitClause0, @TraitClause1]
+    fn provided<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::cmp::PartialEq<U, core::option::Option<T>[@TraitClause0]>> = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::provided<T, U>[@TraitClause0, @TraitClause1, @TraitClause0_0, @TraitClause0_1]
 }
 
 struct test_crate::NoOverride<T>
@@ -155,7 +155,7 @@ where
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
     parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<T>[@TraitClause0, @TraitClause1::parent_clause0]
-    fn other_method = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::NoOverride<T>[@TraitClause0]}#1::other_method
+    fn other_method = test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::NoOverride<T>[@TraitClause0]}#1::other_method<T>[@TraitClause0, @TraitClause1]
 }
 
 fn test_crate::GenericTrait::other_method<Self, T>()

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -12,8 +12,8 @@ enum core::option::Option<T>
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 fn core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq<'_0, '_1, T>(@1: &'_0 (core::option::Option<T>[@TraitClause0]), @2: &'_1 (core::option::Option<T>[@TraitClause0])) -> bool
@@ -27,8 +27,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne<'_0, '_1>(@
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30 : core::cmp::PartialEq<i32, i32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne<'_0_0, '_0_1>
 }
 
 fn test_crate::main()
@@ -85,7 +85,7 @@ fn test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#
 
 impl test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1 : core::cmp::PartialEq<test_crate::Foo, test_crate::Foo>
 {
-    fn eq = test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1::eq
+    fn eq<'_0, '_1> = test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1::eq<'_0_0, '_0_1>
 }
 
 enum core::cmp::Ordering =
@@ -97,11 +97,11 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
@@ -131,7 +131,7 @@ fn test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}
 impl test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}#2 : core::cmp::PartialOrd<test_crate::Foo, test_crate::Foo>
 {
     parent_clause0 = test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1
-    fn partial_cmp = test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}#2::partial_cmp
+    fn partial_cmp<'_0, '_1> = test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}#2::partial_cmp<'_0_0, '_0_1>
 }
 
 fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
@@ -141,7 +141,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::cmp::PartialEq<T, T>,
 {
-    fn eq = core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq
+    fn eq<'_0, '_1> = core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
 fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
@@ -162,8 +162,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0, '_1>(@
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24 : core::cmp::PartialEq<u32, u32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0_0, '_0_1>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
@@ -177,11 +177,11 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp::PartialOrd<u32, u32>
 {
     parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp<'_0_0, '_0_1>
+    fn lt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0_0, '_0_1>
+    fn le<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le<'_0_0, '_0_1>
+    fn gt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt<'_0_0, '_0_1>
+    fn ge<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0_0, '_0_1>
 }
 
 

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -10,7 +10,7 @@ trait core::marker::Sized<Self>
 
 trait test_crate::Hash<Self>
 {
-    fn hash : test_crate::Hash::hash
+    fn hash<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: test_crate::Hasher<H>> = test_crate::Hash::hash<'_0_0, '_0_1, Self, H>[@TraitClause0_0, @TraitClause0_1]
 }
 
 fn test_crate::{impl test_crate::Hash for u32}#1::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
@@ -31,7 +31,7 @@ where
 
 impl test_crate::{impl test_crate::Hash for u32}#1 : test_crate::Hash<u32>
 {
-    fn hash = test_crate::{impl test_crate::Hash for u32}#1::hash
+    fn hash<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: test_crate::Hasher<H>> = test_crate::{impl test_crate::Hash for u32}#1::hash<'_0_0, '_0_1, H>[@TraitClause0_0, @TraitClause0_1]
 }
 
 fn test_crate::main()

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -10,8 +10,8 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -31,7 +31,7 @@ fn test_crate::{impl core::clone::Clone for test_crate::Foo}#1::clone<'_0>(@1: &
 impl test_crate::{impl core::clone::Clone for test_crate::Foo}#1 : core::clone::Clone<test_crate::Foo>
 {
     parent_clause0 = core::marker::Sized<test_crate::Foo>
-    fn clone = test_crate::{impl core::clone::Clone for test_crate::Foo}#1::clone
+    fn clone<'_0> = test_crate::{impl core::clone::Clone for test_crate::Foo}#1::clone<'_0_0>
 }
 
 impl test_crate::{impl core::marker::Copy for test_crate::Foo} : core::marker::Copy<test_crate::Foo>

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -53,13 +53,13 @@ trait test_crate::T6<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: test_crate::T7<T>
-    fn f : test_crate::T6::f
+    fn f = test_crate::T6::f<Self, T>
 }
 
 trait test_crate::T7<Self>
 {
     parent_clause0 : [@TraitClause0]: test_crate::T6<Self, Self>
-    fn g : test_crate::T7::g
+    fn g = test_crate::T7::g<Self>
 }
 
 fn test_crate::T7::g<Self>(@1: u64)

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -803,8 +803,8 @@ opaque type core::array::iter::IntoIter<T, const N : usize>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -835,7 +835,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -852,7 +852,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -893,7 +893,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -901,7 +901,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 opaque type core::iter::adapters::map::Map<I, F>
@@ -964,7 +964,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -983,8 +983,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -1002,19 +1002,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -1026,21 +1026,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -1063,83 +1063,83 @@ trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
@@ -1151,7 +1151,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -1194,34 +1194,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -1233,21 +1233,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
@@ -1260,13 +1260,13 @@ trait core::iter::range::Step<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
     parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd<Self, Self>
-    fn steps_between : core::iter::range::Step::steps_between
-    fn forward_checked : core::iter::range::Step::forward_checked
-    fn backward_checked : core::iter::range::Step::backward_checked
-    fn forward : core::iter::range::Step::forward
-    fn forward_unchecked : core::iter::range::Step::forward_unchecked
-    fn backward : core::iter::range::Step::backward
-    fn backward_unchecked : core::iter::range::Step::backward_unchecked
+    fn steps_between<'_0, '_1> = core::iter::range::Step::steps_between<'_0_0, '_0_1, Self>
+    fn forward_checked = core::iter::range::Step::forward_checked<Self>
+    fn backward_checked = core::iter::range::Step::backward_checked<Self>
+    fn forward = core::iter::range::Step::forward<Self>
+    fn forward_unchecked = core::iter::range::Step::forward_unchecked<Self>
+    fn backward = core::iter::range::Step::backward<Self>
+    fn backward_unchecked = core::iter::range::Step::backward_unchecked<Self>
 }
 
 fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0])) -> core::option::Option<A>[@TraitClause0]
@@ -1329,16 +1329,16 @@ where
 {
     parent_clause0 = @TraitClause0
     type Item = A
-    fn next = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next
-    fn size_hint = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::size_hint
-    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::count
-    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::last
-    fn advance_by = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::advance_by
-    fn nth = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::nth
-    fn max = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::max
-    fn min = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::min
-    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::is_sorted
-    fn __iterator_get_unchecked = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked
+    fn next<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn size_hint<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::size_hint<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn count = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::count<A>[@TraitClause0, @TraitClause1]
+    fn last = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::last<A>[@TraitClause0, @TraitClause1]
+    fn advance_by<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::advance_by<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn nth<'_0> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::nth<'_0_0, A>[@TraitClause0, @TraitClause1]
+    fn max<[@TraitClause0]: core::cmp::Ord<A>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::max<A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
+    fn min<[@TraitClause0]: core::cmp::Ord<A>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::min<A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
+    fn is_sorted = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::is_sorted<A>[@TraitClause0, @TraitClause1]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<core::ops::range::Range<A>[@TraitClause0]>> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0_0, A>[@TraitClause0, @TraitClause1, @TraitClause0_0]
 }
 
 fn core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0>(@1: &'_0 (i32)) -> i32
@@ -1346,7 +1346,7 @@ fn core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0>(@1: &'_0
 impl core::clone::impls::{impl core::clone::Clone for i32}#14 : core::clone::Clone<i32>
 {
     parent_clause0 = core::marker::Sized<i32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for i32}#14::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for i32}#14::clone<'_0_0>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
@@ -1355,8 +1355,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne<'_0, '_1>(@
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30 : core::cmp::PartialEq<i32, i32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::ne<'_0_0, '_0_1>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
@@ -1372,11 +1372,11 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge<'_0, '_1>(
 impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76 : core::cmp::PartialOrd<i32, i32>
 {
     parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp<'_0_0, '_0_1>
+    fn lt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::lt<'_0_0, '_0_1>
+    fn le<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::le<'_0_0, '_0_1>
+    fn gt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::gt<'_0_0, '_0_1>
+    fn ge<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::ge<'_0_0, '_0_1>
 }
 
 fn core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -1398,7 +1398,7 @@ impl core::iter::range::{impl core::iter::range::Step for i32}#40 : core::iter::
     parent_clause0 = core::marker::Sized<i32>
     parent_clause1 = core::clone::impls::{impl core::clone::Clone for i32}#14
     parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between
+    fn steps_between<'_0, '_1> = core::iter::range::{impl core::iter::range::Step for i32}#40::steps_between<'_0_0, '_0_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for i32}#40::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for i32}#40::forward
@@ -1413,8 +1413,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::ne<'_0, '_
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21 : core::cmp::PartialEq<usize, usize>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21::ne<'_0_0, '_0_1>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
@@ -1430,11 +1430,11 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge<'_0, '
 impl core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58 : core::cmp::PartialOrd<usize, usize>
 {
     parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}#21
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::partial_cmp<'_0_0, '_0_1>
+    fn lt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::lt<'_0_0, '_0_1>
+    fn le<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::le<'_0_0, '_0_1>
+    fn gt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::gt<'_0_0, '_0_1>
+    fn ge<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58::ge<'_0_0, '_0_1>
 }
 
 fn core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between<'_0, '_1>(@1: &'_0 (usize), @2: &'_1 (usize)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -1456,7 +1456,7 @@ impl core::iter::range::{impl core::iter::range::Step for usize}#43 : core::iter
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::clone::impls::{impl core::clone::Clone for usize}#5
     parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}#58
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between
+    fn steps_between<'_0, '_1> = core::iter::range::{impl core::iter::range::Step for usize}#43::steps_between<'_0_0, '_0_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}#43::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for usize}#43::forward
@@ -1626,7 +1626,7 @@ fn core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0>(@1: &'_0 
 impl core::clone::impls::{impl core::clone::Clone for u32}#8 : core::clone::Clone<u32>
 {
     parent_clause0 = core::marker::Sized<u32>
-    fn clone = core::clone::impls::{impl core::clone::Clone for u32}#8::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for u32}#8::clone<'_0_0>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
@@ -1635,8 +1635,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0, '_1>(@
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24 : core::cmp::PartialEq<u32, u32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0_0, '_0_1>
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
@@ -1652,11 +1652,11 @@ fn core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0, '_1>(
 impl core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64 : core::cmp::PartialOrd<u32, u32>
 {
     parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24
-    fn partial_cmp = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp
-    fn lt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt
-    fn le = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le
-    fn gt = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt
-    fn ge = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::partial_cmp<'_0_0, '_0_1>
+    fn lt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::lt<'_0_0, '_0_1>
+    fn le<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::le<'_0_0, '_0_1>
+    fn gt<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::gt<'_0_0, '_0_1>
+    fn ge<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64::ge<'_0_0, '_0_1>
 }
 
 fn core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -1678,7 +1678,7 @@ impl core::iter::range::{impl core::iter::range::Step for u32}#39 : core::iter::
     parent_clause0 = core::marker::Sized<u32>
     parent_clause1 = core::clone::impls::{impl core::clone::Clone for u32}#8
     parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<u32> for u32}#64
-    fn steps_between = core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between
+    fn steps_between<'_0, '_1> = core::iter::range::{impl core::iter::range::Step for u32}#39::steps_between<'_0_0, '_0_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for u32}#39::backward_checked
     fn forward = core::iter::range::{impl core::iter::range::Step for u32}#39::forward
@@ -1894,18 +1894,18 @@ trait core::slice::index::SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
     type Output
-    fn get : core::slice::index::SliceIndex::get
-    fn get_mut : core::slice::index::SliceIndex::get_mut
-    fn get_unchecked : core::slice::index::SliceIndex::get_unchecked
-    fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
-    fn index : core::slice::index::SliceIndex::index
-    fn index_mut : core::slice::index::SliceIndex::index_mut
+    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T>
+    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>
+    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>
+    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
 }
 
 trait core::ops::index::Index<Self, Idx>
 {
     type Output
-    fn index : core::ops::index::Index::index
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
 }
 
 fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]::Output)
@@ -1923,7 +1923,7 @@ where
     [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     type Output = @TraitClause3::Output
-    fn index = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index
+    fn index<'_0> = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
 }
 
 fn alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14::index_mut<'_0, T, I, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 mut (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]::Output)
@@ -1965,12 +1965,12 @@ where
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize}
     type Output = T
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index_mut
+    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get<'_0_0, T>[@TraitClause0]
+    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_mut<'_0_0, T>[@TraitClause0]
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index<'_0_0, T>[@TraitClause0]
+    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for usize}#2::index_mut<'_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::clear<'_0>(@1: &'_0 mut (alloc::vec::Vec<u32, alloc::alloc::Global>[core::marker::Sized<u32>, core::marker::Sized<alloc::alloc::Global>]))
@@ -2162,7 +2162,7 @@ where
     parent_clause2 = @TraitClause0
     type Item = @TraitClause1::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
@@ -2172,7 +2172,7 @@ fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2
 trait core::ops::index::IndexMut<Self, Idx>
 {
     parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
-    fn index_mut : core::ops::index::IndexMut::index_mut
+    fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx>
 }
 
 impl<T, I, A> alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14<T, I, A> : core::ops::index::IndexMut<alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2], I>
@@ -2183,7 +2183,7 @@ where
     [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     parent_clause0 = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
-    fn index_mut = alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14::index_mut
+    fn index_mut<'_0> = alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14::index_mut<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
 }
 
 fn core::iter::range::Step::steps_between<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -2759,21 +2759,35 @@ unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, 
 where
     [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
+fn core::default::Default::default<Self>() -> Self
+
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
-
-fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
-    @TraitClause1::Item = A,
 
 fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
 fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
 fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -2788,8 +2802,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -2826,18 +2838,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
 
 fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_0 (Self::Output)>]
 

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -5,8 +5,8 @@ trait core::marker::Sized<Self>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -17,8 +17,8 @@ trait core::marker::Copy<Self>
 trait test_crate::Trait<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn method1 : test_crate::Trait::method1
-    fn method2 : test_crate::Trait::method2
+    fn method1 = test_crate::Trait::method1<Self>
+    fn method2<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Copy<T>> = test_crate::Trait::method2<Self, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 fn test_crate::{impl test_crate::Trait for ()}::method1(@1: (), @2: &'static (u32)) -> bool
@@ -51,14 +51,14 @@ impl test_crate::{impl test_crate::Trait for ()} : test_crate::Trait<()>
 {
     parent_clause0 = core::marker::Sized<()>
     fn method1 = test_crate::{impl test_crate::Trait for ()}::method1
-    fn method2 = test_crate::{impl test_crate::Trait for ()}::method2
+    fn method2<T, [@TraitClause0]: core::marker::Sized<T>> = test_crate::{impl test_crate::Trait for ()}::method2<T>[@TraitClause0_0]
 }
 
 trait test_crate::MyCompare<Self, Other>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Other>
-    fn compare : test_crate::MyCompare::compare
+    fn compare = test_crate::MyCompare::compare<Self, Other>
 }
 
 fn test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1::compare<'a>(@1: &'a (()), @2: &'a (())) -> bool
@@ -75,7 +75,7 @@ impl<'a> test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1<'a> :
 {
     parent_clause0 = core::marker::Sized<&'_ (())>
     parent_clause1 = core::marker::Sized<&'_ (())>
-    fn compare = test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1::compare
+    fn compare = test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1::compare<'a>
 }
 
 fn test_crate::main()
@@ -130,7 +130,7 @@ fn test_crate::main()
 
 trait test_crate::Foo<Self>
 {
-    fn foo : test_crate::Foo::foo
+    fn foo<'a, 'b> = test_crate::Foo::foo<'a, 'b, Self>
 }
 
 fn test_crate::{impl test_crate::Foo for ()}#2::foo<'a, 'b>(@1: &'b (()), @2: &'a (())) -> &'b (())
@@ -145,7 +145,7 @@ fn test_crate::{impl test_crate::Foo for ()}#2::foo<'a, 'b>(@1: &'b (()), @2: &'
 
 impl test_crate::{impl test_crate::Foo for ()}#2 : test_crate::Foo<()>
 {
-    fn foo = test_crate::{impl test_crate::Foo for ()}#2::foo
+    fn foo<'a, 'b> = test_crate::{impl test_crate::Foo for ()}#2::foo<'a, 'b>
 }
 
 fn test_crate::call_foo<'e>(@1: &'e (())) -> &'e (())

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -16,7 +16,7 @@ trait core::marker::Sized<Self>
 trait test_crate::Trait<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
-    fn method : test_crate::Trait::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::Trait::method<Self, T, U>[@TraitClause0_0]
 }
 
 struct alloc::alloc::Global = {}
@@ -48,7 +48,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
-    fn method = test_crate::{impl test_crate::Trait<core::option::Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]}::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::{impl test_crate::Trait<core::option::Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]}::method<T, U>[@TraitClause0, @TraitClause0_0]
 }
 
 fn test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]> for core::option::Option<U>[@TraitClause1]}#1::method<T, U, V>()
@@ -72,7 +72,7 @@ where
     [@TraitClause1]: core::marker::Sized<U>,
 {
     parent_clause0 = core::marker::Sized<alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]>
-    fn method = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]> for core::option::Option<U>[@TraitClause1]}#1::method
+    fn method<V, [@TraitClause0]: core::marker::Sized<V>> = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]> for core::option::Option<U>[@TraitClause1]}#1::method<T, U, V>[@TraitClause0, @TraitClause1, @TraitClause0_0]
 }
 
 struct core::ops::range::RangeFrom<Idx>
@@ -93,12 +93,12 @@ trait core::slice::index::SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
     type Output
-    fn get : core::slice::index::SliceIndex::get
-    fn get_mut : core::slice::index::SliceIndex::get_mut
-    fn get_unchecked : core::slice::index::SliceIndex::get_unchecked
-    fn get_unchecked_mut : core::slice::index::SliceIndex::get_unchecked_mut
-    fn index : core::slice::index::SliceIndex::index
-    fn index_mut : core::slice::index::SliceIndex::index_mut
+    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T>
+    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>
+    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>
+    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
 }
 
 fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
@@ -139,12 +139,12 @@ where
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#3
     type Output = Slice<T>
-    fn get = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get
-    fn get_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_mut
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_unchecked
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_unchecked_mut
-    fn index = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::index
-    fn index_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::index_mut
+    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get<'_0_0, T>[@TraitClause0]
+    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_mut<'_0_0, T>[@TraitClause0]
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::index<'_0_0, T>[@TraitClause0]
+    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7::index_mut<'_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::foo()
@@ -203,7 +203,7 @@ fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &
 trait core::ops::index::Index<Self, Idx>
 {
     type Output
-    fn index : core::ops::index::Index::index
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
 }
 
 impl<T, I> core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I> : core::ops::index::Index<Slice<T>, I>
@@ -213,7 +213,7 @@ where
     [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
 {
     type Output = @TraitClause2::Output
-    fn index = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index
+    fn index<'_0> = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_0 (Self::Output)>]

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -637,7 +637,7 @@ fn test_crate::read_then_incr<'_0>(@1: &'_0 mut (u32)) -> u32
 trait core::ops::deref::Deref<Self>
 {
     type Target
-    fn deref : core::ops::deref::Deref::deref
+    fn deref<'_0> = core::ops::deref::Deref::deref<'_0_0, Self>
 }
 
 fn core::ops::deref::DerefMut::deref_mut<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self::parent_clause0::Target)
@@ -645,7 +645,7 @@ fn core::ops::deref::DerefMut::deref_mut<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0
 trait core::ops::deref::DerefMut<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::deref::Deref<Self>
-    fn deref_mut : core::ops::deref::DerefMut::deref_mut
+    fn deref_mut<'_0> = core::ops::deref::DerefMut::deref_mut<'_0_0, Self>
 }
 
 impl<T, A> alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>[@TraitClause0]}#38<T, A> : core::ops::deref::Deref<alloc::boxed::Box<T>[@TraitClause0]>
@@ -653,7 +653,7 @@ where
     [@TraitClause0]: core::marker::Sized<A>,
 {
     type Target = T
-    fn deref = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>[@TraitClause0]}#38::deref
+    fn deref<'_0> = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>[@TraitClause0]}#38::deref<'_0_0, T, A>[@TraitClause0]
 }
 
 impl<T, A> alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>[@TraitClause0]}#39<T, A> : core::ops::deref::DerefMut<alloc::boxed::Box<T>[@TraitClause0]>
@@ -661,7 +661,7 @@ where
     [@TraitClause0]: core::marker::Sized<A>,
 {
     parent_clause0 = alloc::boxed::{impl core::ops::deref::Deref for alloc::boxed::Box<T>[@TraitClause0]}#38<T, A>[@TraitClause0]
-    fn deref_mut = alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>[@TraitClause0]}#39::deref_mut
+    fn deref_mut<'_0> = alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>[@TraitClause0]}#39::deref_mut<'_0_0, T, A>[@TraitClause0]
 }
 
 fn core::ops::deref::Deref::deref<'_0, Self>(@1: &'_0 (Self)) -> &'_0 (Self::Target)

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -33,7 +33,7 @@ trait core::convert::From<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
-    fn from : core::convert::From::from
+    fn from = core::convert::From::from<Self, T>
 }
 
 fn core::convert::From::from<Self, T>(@1: T) -> Self
@@ -119,7 +119,7 @@ trait core::convert::Into<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<T>
-    fn into : core::convert::Into::into
+    fn into = core::convert::Into::into<Self, T>
 }
 
 impl<T, U> core::convert::{impl core::convert::Into<U> for T}#3<T, U> : core::convert::Into<T, U>
@@ -130,7 +130,7 @@ where
 {
     parent_clause0 = @TraitClause0
     parent_clause1 = @TraitClause1
-    fn into = core::convert::{impl core::convert::Into<U> for T}#3::into
+    fn into = core::convert::{impl core::convert::Into<U> for T}#3::into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 

--- a/charon/tests/ui/opaque_attribute.out
+++ b/charon/tests/ui/opaque_attribute.out
@@ -2,8 +2,8 @@
 
 trait test_crate::BoolTrait<Self>
 {
-    fn get_bool : test_crate::BoolTrait::get_bool
-    fn ret_true : test_crate::BoolTrait::ret_true
+    fn get_bool<'_0> = test_crate::BoolTrait::get_bool<'_0_0, Self>
+    fn ret_true<'_0> = test_crate::BoolTrait::ret_true<'_0_0, Self>
 }
 
 fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bool)) -> bool
@@ -17,7 +17,7 @@ fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bo
 
 impl test_crate::{impl test_crate::BoolTrait for bool} : test_crate::BoolTrait<bool>
 {
-    fn get_bool = test_crate::{impl test_crate::BoolTrait for bool}::get_bool
+    fn get_bool<'_0> = test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0_0>
 }
 
 trait core::marker::Sized<Self>

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -20,40 +20,40 @@ enum core::option::Option<T>
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 trait core::hash::Hasher<Self>
 {
-    fn finish : core::hash::Hasher::finish
-    fn write : core::hash::Hasher::write
-    fn write_u8 : core::hash::Hasher::write_u8
-    fn write_u16 : core::hash::Hasher::write_u16
-    fn write_u32 : core::hash::Hasher::write_u32
-    fn write_u64 : core::hash::Hasher::write_u64
-    fn write_u128 : core::hash::Hasher::write_u128
-    fn write_usize : core::hash::Hasher::write_usize
-    fn write_i8 : core::hash::Hasher::write_i8
-    fn write_i16 : core::hash::Hasher::write_i16
-    fn write_i32 : core::hash::Hasher::write_i32
-    fn write_i64 : core::hash::Hasher::write_i64
-    fn write_i128 : core::hash::Hasher::write_i128
-    fn write_isize : core::hash::Hasher::write_isize
-    fn write_length_prefix : core::hash::Hasher::write_length_prefix
-    fn write_str : core::hash::Hasher::write_str
+    fn finish<'_0> = core::hash::Hasher::finish<'_0_0, Self>
+    fn write<'_0, '_1> = core::hash::Hasher::write<'_0_0, '_0_1, Self>
+    fn write_u8<'_0> = core::hash::Hasher::write_u8<'_0_0, Self>
+    fn write_u16<'_0> = core::hash::Hasher::write_u16<'_0_0, Self>
+    fn write_u32<'_0> = core::hash::Hasher::write_u32<'_0_0, Self>
+    fn write_u64<'_0> = core::hash::Hasher::write_u64<'_0_0, Self>
+    fn write_u128<'_0> = core::hash::Hasher::write_u128<'_0_0, Self>
+    fn write_usize<'_0> = core::hash::Hasher::write_usize<'_0_0, Self>
+    fn write_i8<'_0> = core::hash::Hasher::write_i8<'_0_0, Self>
+    fn write_i16<'_0> = core::hash::Hasher::write_i16<'_0_0, Self>
+    fn write_i32<'_0> = core::hash::Hasher::write_i32<'_0_0, Self>
+    fn write_i64<'_0> = core::hash::Hasher::write_i64<'_0_0, Self>
+    fn write_i128<'_0> = core::hash::Hasher::write_i128<'_0_0, Self>
+    fn write_isize<'_0> = core::hash::Hasher::write_isize<'_0_0, Self>
+    fn write_length_prefix<'_0> = core::hash::Hasher::write_length_prefix<'_0_0, Self>
+    fn write_str<'_0, '_1> = core::hash::Hasher::write_str<'_0_0, '_0_1, Self>
 }
 
 trait core::hash::Hash<Self>
 {
-    fn hash : core::hash::Hash::hash
-    fn hash_slice : core::hash::Hash::hash_slice
+    fn hash<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: core::hash::Hasher<H>> = core::hash::Hash::hash<'_0_0, '_0_1, Self, H>[@TraitClause0_0, @TraitClause0_1]
+    fn hash_slice<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: core::hash::Hasher<H>, [@TraitClause2]: core::marker::Sized<Self>> = core::hash::Hash::hash_slice<'_0_0, '_0_1, Self, H>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::hash::BuildHasher<Self>
@@ -61,13 +61,13 @@ trait core::hash::BuildHasher<Self>
     parent_clause0 : [@TraitClause0]: core::hash::Hasher<Self::Hasher>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Hasher>
     type Hasher
-    fn build_hasher : core::hash::BuildHasher::build_hasher
-    fn hash_one : core::hash::BuildHasher::hash_one
+    fn build_hasher<'_0> = core::hash::BuildHasher::build_hasher<'_0_0, Self>
+    fn hash_one<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::hash::Hash<T>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::hash::Hasher<Self::Hasher>> = core::hash::BuildHasher::hash_one<'_0_0, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
 }
 
 trait core::borrow::Borrow<Self, Borrowed>
 {
-    fn borrow : core::borrow::Borrow::borrow
+    fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
 fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::get<'_0, '_1, K, V, S, Q>(@1: &'_0 (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: &'_1 (Q)) -> core::option::Option<&'_0 (V)>[core::marker::Sized<&'_0 (V)>]
@@ -86,7 +86,7 @@ fn core::borrow::{impl core::borrow::Borrow<T> for T}::borrow<'_0, T>(@1: &'_0 (
 
 impl<T> core::borrow::{impl core::borrow::Borrow<T> for T}<T> : core::borrow::Borrow<T, T>
 {
-    fn borrow = core::borrow::{impl core::borrow::Borrow<T> for T}::borrow
+    fn borrow<'_0> = core::borrow::{impl core::borrow::Borrow<T> for T}::borrow<'_0_0, T>
 }
 
 fn core::hash::impls::{impl core::hash::Hash for u32}#11::hash<'_0, '_1, H>(@1: &'_0 (u32), @2: &'_1 mut (H))
@@ -101,8 +101,8 @@ where
 
 impl core::hash::impls::{impl core::hash::Hash for u32}#11 : core::hash::Hash<u32>
 {
-    fn hash = core::hash::impls::{impl core::hash::Hash for u32}#11::hash
-    fn hash_slice = core::hash::impls::{impl core::hash::Hash for u32}#11::hash_slice
+    fn hash<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: core::hash::Hasher<H>> = core::hash::impls::{impl core::hash::Hash for u32}#11::hash<'_0_0, '_0_1, H>[@TraitClause0_0, @TraitClause0_1]
+    fn hash_slice<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: core::hash::Hasher<H>> = core::hash::impls::{impl core::hash::Hash for u32}#11::hash_slice<'_0_0, '_0_1, H>[@TraitClause0_0, @TraitClause0_1]
 }
 
 fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool
@@ -111,8 +111,8 @@ fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0, '_1>(@
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24 : core::cmp::PartialEq<u32, u32>
 {
-    fn eq = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq
-    fn ne = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0_0, '_0_1>
+    fn ne<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::ne<'_0_0, '_0_1>
 }
 
 impl core::cmp::impls::{impl core::cmp::Eq for u32}#43 : core::cmp::Eq<u32>
@@ -130,9 +130,9 @@ fn std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHas
 
 impl std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4 : core::hash::Hasher<std::hash::random::DefaultHasher>
 {
-    fn finish = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish
-    fn write = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write
-    fn write_str = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str
+    fn finish<'_0> = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::finish<'_0_0>
+    fn write<'_0, '_1> = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write<'_0_0, '_0_1>
+    fn write_str<'_0, '_1> = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4::write_str<'_0_0, '_0_1>
 }
 
 fn std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher<'_0>(@1: &'_0 (std::hash::random::RandomState)) -> std::hash::random::DefaultHasher
@@ -142,7 +142,7 @@ impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::Ran
     parent_clause0 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4
     parent_clause1 = core::marker::Sized<std::hash::random::DefaultHasher>
     type Hasher = std::hash::random::DefaultHasher
-    fn build_hasher = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher
+    fn build_hasher<'_0> = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher<'_0_0>
 }
 
 fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::insert<'_0, K, V, S>(@1: &'_0 mut (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: K, @3: V) -> core::option::Option<V>[@TraitClause1]
@@ -157,7 +157,7 @@ where
 trait core::ops::index::Index<Self, Idx>
 {
     type Output
-    fn index : core::ops::index::Index::index
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
 }
 
 fn std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_0, '_1, K, Q, V, S>(@1: &'_1 (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: &'_0 (Q)) -> &'_1 (std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9<'_, K, Q, V, S>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5, @TraitClause6, @TraitClause7, @TraitClause8]::Output)
@@ -246,7 +246,7 @@ where
     [@TraitClause8]: core::hash::BuildHasher<S>,
 {
     type Output = V
-    fn index = std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index
+    fn index<'_0> = std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_0, '_0_0, K, Q, V, S>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5, @TraitClause6, @TraitClause7, @TraitClause8]
 }
 
 fn core::hash::BuildHasher::hash_one<'_0, Self, T>(@1: &'_0 (Self), @2: T) -> u64

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -25,8 +25,8 @@ fn test_crate::wrap<'a>(@1: &'a (u32)) -> core::option::Option<&'a (u32)>[core::
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 fn test_crate::wrap2<'a>(@1: &'a (u32)) -> core::option::Option<&'a (u32)>[core::marker::Sized<&'_ (u32)>]

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -10,7 +10,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -18,7 +18,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 fn test_crate::foo<F>(@1: F)
@@ -87,8 +87,8 @@ opaque type core::array::iter::IntoIter<T, const N : usize>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -119,7 +119,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -136,7 +136,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -229,7 +229,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -248,8 +248,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -267,19 +267,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -291,21 +291,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -333,90 +333,90 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -459,34 +459,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -498,21 +498,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 impl<T, U> test_crate::{impl test_crate::Trait for core::result::Result<T, U>[@TraitClause0, @TraitClause1]}<T, U> : test_crate::Trait<core::result::Result<T, U>[@TraitClause0, @TraitClause1]>
@@ -1055,17 +1055,65 @@ unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, 
 where
     [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
-fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
-    @TraitClause1::Item = A,
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::default::Default::default<Self>() -> Self
 
 fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
 fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
 fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -1080,8 +1128,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -1118,52 +1164,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
-
-fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
-
-fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
-
-fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
 
 
 

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -16,7 +16,7 @@ trait test_crate::MyTryFrom<Self, T>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Error>
     type Error
-    fn from : test_crate::MyTryFrom::from
+    fn from<[@TraitClause0]: core::marker::Sized<Self>> = test_crate::MyTryFrom::from<Self, T>[@TraitClause0_0]
 }
 
 fn test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}<'_>::Error>[core::marker::Sized<bool>, core::marker::Sized<()>]
@@ -36,7 +36,7 @@ impl<'_0> test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}<'_0> : 
     parent_clause0 = core::marker::Sized<&'_ (bool)>
     parent_clause1 = core::marker::Sized<()>
     type Error = ()
-    fn from = test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}::from
+    fn from = test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}::from<'_0>
 }
 
 fn test_crate::MyTryFrom::from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[@TraitClause0, Self::parent_clause1]

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -2,8 +2,8 @@
 
 trait test_crate::BoolTrait<Self>
 {
-    fn get_bool : test_crate::BoolTrait::get_bool
-    fn ret_true : test_crate::BoolTrait::ret_true
+    fn get_bool<'_0> = test_crate::BoolTrait::get_bool<'_0_0, Self>
+    fn ret_true<'_0> = test_crate::BoolTrait::ret_true<'_0_0, Self>
 }
 
 fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bool)) -> bool
@@ -17,7 +17,7 @@ fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bo
 
 impl test_crate::{impl test_crate::BoolTrait for bool} : test_crate::BoolTrait<bool>
 {
-    fn get_bool = test_crate::{impl test_crate::BoolTrait for bool}::get_bool
+    fn get_bool<'_0> = test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0_0>
 }
 
 trait core::marker::Sized<Self>

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -43,7 +43,7 @@ struct core::fmt::Error = {}
 
 trait core::fmt::Debug<Self>
 {
-    fn fmt : core::fmt::Debug::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 fn core::result::unwrap_failed<'_0, '_1>(@1: &'_0 (Str), @2: &'_1 (dyn (exists(TODO)))) -> !
@@ -122,7 +122,7 @@ fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1: &'
 
 impl core::fmt::num::{impl core::fmt::Debug for u32}#86 : core::fmt::Debug<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 fn test_crate::unwrap(@1: core::result::Result<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]) -> u32
@@ -143,36 +143,36 @@ fn core::fmt::LowerHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (
 
 trait core::fmt::LowerHex<Self>
 {
-    fn fmt : core::fmt::LowerHex::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::LowerHex::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 impl core::fmt::num::{impl core::fmt::LowerHex for u32}#60 : core::fmt::LowerHex<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::num::{impl core::fmt::LowerHex for u32}#60::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 
 trait core::fmt::Display<Self>
 {
-    fn fmt : core::fmt::Display::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 impl core::fmt::num::imp::{impl core::fmt::Display for u32}#10 : core::fmt::Display<u32>
 {
-    fn fmt = core::fmt::num::imp::{impl core::fmt::Display for u32}#10::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::num::imp::{impl core::fmt::Display for u32}#10::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 fn core::fmt::UpperHex::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 
 trait core::fmt::UpperHex<Self>
 {
-    fn fmt : core::fmt::UpperHex::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::UpperHex::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
 impl core::fmt::num::{impl core::fmt::UpperHex for u32}#61 : core::fmt::UpperHex<u32>
 {
-    fn fmt = core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt
+    fn fmt<'_0, '_1, '_2> = core::fmt::num::{impl core::fmt::UpperHex for u32}#61::fmt<'_0_0, '_0_1, '_0_2>
 }
 
 

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -16,7 +16,7 @@ trait core::marker::Sized<Self>
 trait test_crate::Trait<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
-    fn method : test_crate::Trait::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::Trait::method<Self, T, U>[@TraitClause0_0]
 }
 
 struct alloc::alloc::Global = {}
@@ -48,7 +48,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
-    fn method = test_crate::{impl test_crate::Trait<core::option::Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]}::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::{impl test_crate::Trait<core::option::Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]}::method<T, U>[@TraitClause0, @TraitClause0_0]
 }
 
 fn test_crate::{impl test_crate::Trait<T> for Slice<T>}#1::method<T, U>()
@@ -70,7 +70,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = @TraitClause0
-    fn method = test_crate::{impl test_crate::Trait<T> for Slice<T>}#1::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::{impl test_crate::Trait<T> for Slice<T>}#1::method<T, U>[@TraitClause0, @TraitClause0_0]
 }
 
 fn test_crate::{impl test_crate::Trait<T> for &'_0 (Slice<T>)}#2::method<'_0, T, U>()
@@ -92,7 +92,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = @TraitClause0
-    fn method = test_crate::{impl test_crate::Trait<T> for &'_0 (Slice<T>)}#2::method
+    fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::{impl test_crate::Trait<T> for &'_0 (Slice<T>)}#2::method<'_0, T, U>[@TraitClause0, @TraitClause0_0]
 }
 
 fn test_crate::Trait::method<Self, T, U>()

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -2,14 +2,14 @@
 
 trait test_crate::Trait<'a, Self>
 {
-    fn method : test_crate::Trait::method
+    fn method<'b> = test_crate::Trait::method<'a, 'b, Self>
 }
 
 fn test_crate::{impl test_crate::Trait<'a> for &'a (())}::method<'a, 'b>(@1: &'b (&'a (()))) -> &'b (())
 
 impl<'a> test_crate::{impl test_crate::Trait<'a> for &'a (())}<'a> : test_crate::Trait<'a, &'a (())>
 {
-    fn method = test_crate::{impl test_crate::Trait<'a> for &'a (())}::method
+    fn method<'b> = test_crate::{impl test_crate::Trait<'a> for &'a (())}::method<'a, 'b>
 }
 
 opaque type test_crate::Foo<'a>

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -60,12 +60,12 @@ fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::stri
 
 trait alloc::string::ToString<Self>
 {
-    fn to_string : alloc::string::ToString::to_string
+    fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>
 }
 
 impl alloc::string::{impl alloc::string::ToString for Str}#102 : alloc::string::ToString<Str>
 {
-    fn to_string = alloc::string::{impl alloc::string::ToString for Str}#102::to_string
+    fn to_string<'_0> = alloc::string::{impl alloc::string::ToString for Str}#102::to_string<'_0_0>
 }
 
 

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -54,8 +54,8 @@ enum core::result::Result<T, E>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -86,7 +86,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -103,7 +103,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -144,7 +144,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -152,7 +152,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 opaque type core::iter::adapters::map::Map<I, F>
@@ -215,7 +215,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -234,8 +234,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -253,19 +253,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -277,21 +277,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -314,83 +314,83 @@ trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
@@ -402,7 +402,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -445,34 +445,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -484,21 +484,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>(@1: Array<T, const N : usize>) -> core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize>[@TraitClause0]::IntoIter
@@ -548,13 +548,13 @@ where
 {
     parent_clause0 = @TraitClause0
     type Item = T
-    fn next = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::next
-    fn size_hint = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::size_hint
-    fn count = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::count
-    fn last = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::last
-    fn advance_by = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::advance_by
-    fn fold = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::fold
-    fn __iterator_get_unchecked = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::__iterator_get_unchecked
+    fn next<'_0> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::next<'_0_0, T, const N : usize>[@TraitClause0]
+    fn size_hint<'_0> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::size_hint<'_0_0, T, const N : usize>[@TraitClause0]
+    fn count = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::count<T, const N : usize>[@TraitClause0]
+    fn last = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::last<T, const N : usize>[@TraitClause0]
+    fn advance_by<'_0> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::advance_by<'_0_0, T, const N : usize>[@TraitClause0]
+    fn fold<Acc, Fold, [@TraitClause0]: core::marker::Sized<Acc>, [@TraitClause1]: core::marker::Sized<Fold>, [@TraitClause2]: core::ops::function::FnMut<Fold, (Acc, T)>, @TraitClause1_2::parent_clause0::Output = Acc> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::fold<T, Acc, Fold, const N : usize>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn __iterator_get_unchecked<'_0> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::__iterator_get_unchecked<'_0_0, T, const N : usize>[@TraitClause0]
 }
 
 fn core::slice::{Slice<T>}::iter<'_0, T>(@1: &'_0 (Slice<T>)) -> core::slice::iter::Iter<'_0, T>[@TraitClause0]
@@ -670,22 +670,22 @@ where
 {
     parent_clause0 = core::marker::Sized<&'_ (T)>
     type Item = &'a (T)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::count
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::last
-    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::advance_by
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::nth
-    fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::for_each
-    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::fold
-    fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::all
-    fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::any
-    fn find = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find
-    fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find_map
-    fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::position
-    fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::rposition
-    fn is_sorted_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::is_sorted_by
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked
+    fn next<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next<'a, '_0_0, T>[@TraitClause0]
+    fn size_hint<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::size_hint<'a, '_0_0, T>[@TraitClause0]
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::count<'a, T>[@TraitClause0]
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::last<'a, T>[@TraitClause0]
+    fn advance_by<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::advance_by<'a, '_0_0, T>[@TraitClause0]
+    fn nth<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::nth<'a, '_0_0, T>[@TraitClause0]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = ()> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::for_each<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::ops::function::FnMut<F, (B, &'_ (T))>, @TraitClause1_2::parent_clause0::Output = B> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::all<'a, '_0_0, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::any<'a, '_0_0, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (&'_ (T)))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause3]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find_map<'a, '_0_0, T, B, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<P, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::position<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (@TraitClause1_3::parent_clause0::Item)>, [@TraitClause2]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>[@TraitClause0]>, @TraitClause1_1::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::rposition<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (&'_ (T)), &'_0_1 (&'_ (T)))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn __iterator_get_unchecked<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
 }
 
 fn core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365::add_assign<'_0, '_1>(@1: &'_1 mut (i32), @2: &'_0 (i32))
@@ -724,12 +724,12 @@ where
 {
     parent_clause0 = core::marker::Sized<&'_ (Slice<T>)>
     type Item = &'a (Slice<T>)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::count
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked
+    fn next<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::next<'a, '_0_0, T>[@TraitClause0]
+    fn size_hint<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::size_hint<'a, '_0_0, T>[@TraitClause0]
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::count<'a, T>[@TraitClause0]
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last<'a, T>[@TraitClause0]
+    fn nth<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth<'a, '_0_0, T>[@TraitClause0]
+    fn __iterator_get_unchecked<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
 }
 
 fn core::slice::{Slice<T>}::chunks_exact<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> core::slice::iter::ChunksExact<'_0, T>[@TraitClause0]
@@ -766,12 +766,12 @@ where
 {
     parent_clause0 = core::marker::Sized<&'_ (Slice<T>)>
     type Item = &'a (Slice<T>)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::count
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::last
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::nth
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::__iterator_get_unchecked
+    fn next<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::next<'a, '_0_0, T>[@TraitClause0]
+    fn size_hint<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::size_hint<'a, '_0_0, T>[@TraitClause0]
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::count<'a, T>[@TraitClause0]
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::last<'a, T>[@TraitClause0]
+    fn nth<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::nth<'a, '_0_0, T>[@TraitClause0]
+    fn __iterator_get_unchecked<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::main()
@@ -1089,7 +1089,7 @@ where
     parent_clause2 = core::marker::Sized<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>
     type Item = T
     type IntoIter = core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]
-    fn into_iter = core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter
+    fn into_iter = core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>[@TraitClause0]
 }
 
 impl<I> core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1<I> : core::iter::traits::collect::IntoIterator<I>
@@ -1102,7 +1102,7 @@ where
     parent_clause2 = @TraitClause0
     type Item = @TraitClause1::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
@@ -1112,13 +1112,13 @@ fn core::ops::arith::AddAssign::add_assign<'_0, Self, Rhs>(@1: &'_0 mut (Self), 
 trait core::ops::arith::AddAssign<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Rhs>
-    fn add_assign : core::ops::arith::AddAssign::add_assign
+    fn add_assign<'_0> = core::ops::arith::AddAssign::add_assign<'_0_0, Self, Rhs>
 }
 
 impl<'_0> core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365<'_0> : core::ops::arith::AddAssign<i32, &'_0 (i32)>
 {
     parent_clause0 = core::marker::Sized<&'_ (i32)>
-    fn add_assign = core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365::add_assign
+    fn add_assign<'_0> = core::ops::arith::{impl core::ops::arith::AddAssign<&'_0 (i32)> for i32}#365::add_assign<'_0, '_0_0>
 }
 
 fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> core::result::Result<Array<Self::Item, const N : usize>, core::array::iter::IntoIter<Self::Item, const N : usize>[Self::parent_clause0]>[core::marker::Sized<Array<Self::Item, const N : usize>>, core::marker::Sized<core::array::iter::IntoIter<Self::Item, const N : usize>[Self::parent_clause0]>]
@@ -1650,17 +1650,65 @@ unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, 
 where
     [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>,
 
-fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
-    @TraitClause1::Item = A,
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::default::Default::default<Self>() -> Self
 
 fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
 fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
 fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -1675,8 +1723,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -1713,52 +1759,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
-
-fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
-
-fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
-
-fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
 
 
 

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -2,8 +2,8 @@
 
 trait test_crate::BoolTrait<Self>
 {
-    fn get_bool : test_crate::BoolTrait::get_bool
-    fn ret_true : test_crate::BoolTrait::ret_true
+    fn get_bool<'_0> = test_crate::BoolTrait::get_bool<'_0_0, Self>
+    fn ret_true<'_0> = test_crate::BoolTrait::ret_true<'_0_0, Self>
 }
 
 fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bool)) -> bool
@@ -17,7 +17,7 @@ fn test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0>(@1: &'_0 (bo
 
 impl test_crate::{impl test_crate::BoolTrait for bool} : test_crate::BoolTrait<bool>
 {
-    fn get_bool = test_crate::{impl test_crate::BoolTrait for bool}::get_bool
+    fn get_bool<'_0> = test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0_0>
 }
 
 fn test_crate::BoolTrait::ret_true<'_0, Self>(@1: &'_0 (Self)) -> bool
@@ -87,7 +87,7 @@ impl<T> test_crate::{impl test_crate::BoolTrait for core::option::Option<T>[@Tra
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
-    fn get_bool = test_crate::{impl test_crate::BoolTrait for core::option::Option<T>[@TraitClause0]}#1::get_bool
+    fn get_bool<'_0> = test_crate::{impl test_crate::BoolTrait for core::option::Option<T>[@TraitClause0]}#1::get_bool<'_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::test_bool_trait_option<T>(@1: core::option::Option<T>[@TraitClause0]) -> bool
@@ -137,7 +137,7 @@ where
 
 trait test_crate::ToU64<Self>
 {
-    fn to_u64 : test_crate::ToU64::to_u64
+    fn to_u64 = test_crate::ToU64::to_u64<Self>
 }
 
 fn test_crate::{impl test_crate::ToU64 for u64}#2::to_u64(@1: u64) -> u64
@@ -186,7 +186,7 @@ where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: test_crate::ToU64<A>,
 {
-    fn to_u64 = test_crate::{impl test_crate::ToU64 for (A, A)}#3::to_u64
+    fn to_u64 = test_crate::{impl test_crate::ToU64 for (A, A)}#3::to_u64<A>[@TraitClause0, @TraitClause1]
 }
 
 fn test_crate::f<T>(@1: (T, T)) -> u64
@@ -262,7 +262,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: test_crate::ToU64<T>,
 {
-    fn to_u64 = test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>[@TraitClause0]}#4::to_u64
+    fn to_u64 = test_crate::{impl test_crate::ToU64 for test_crate::Wrapper<T>[@TraitClause0]}#4::to_u64<T>[@TraitClause0, @TraitClause1]
 }
 
 fn test_crate::h1(@1: test_crate::Wrapper<u64>[core::marker::Sized<u64>]) -> u64
@@ -296,7 +296,7 @@ where
 trait test_crate::ToType<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
-    fn to_type : test_crate::ToType::to_type
+    fn to_type = test_crate::ToType::to_type<Self, T>
 }
 
 fn test_crate::{impl test_crate::ToType<bool> for u64}#5::to_type(@1: u64) -> bool
@@ -319,7 +319,7 @@ impl test_crate::{impl test_crate::ToType<bool> for u64}#5 : test_crate::ToType<
 
 trait test_crate::OfType<Self>
 {
-    fn of_type : test_crate::OfType::of_type
+    fn of_type<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: test_crate::ToType<T, Self>, [@TraitClause2]: core::marker::Sized<Self>> = test_crate::OfType::of_type<Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 fn test_crate::OfType::of_type<Self, T>(@1: T) -> Self
@@ -351,7 +351,7 @@ trait test_crate::OfTypeBis<Self, T>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: test_crate::ToType<T, Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self>
-    fn of_type : test_crate::OfTypeBis::of_type
+    fn of_type<[@TraitClause0]: core::marker::Sized<Self>> = test_crate::OfTypeBis::of_type<Self, T>[@TraitClause0_0]
 }
 
 fn test_crate::OfTypeBis::of_type<Self, T>(@1: T) -> Self
@@ -474,7 +474,7 @@ where
     [@TraitClause1]: test_crate::ToType<bool, T>,
 {
     parent_clause0 = @TraitClause0
-    fn to_type = test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper}#7::to_type
+    fn to_type = test_crate::{impl test_crate::ToType<T> for test_crate::BoolWrapper}#7::to_type<T>[@TraitClause0, @TraitClause1]
 }
 
 fn test_crate::WithConstTy::LEN2<Self, const LEN : usize>() -> usize
@@ -496,7 +496,7 @@ trait test_crate::WithConstTy<Self, const LEN : usize>
     const LEN2 : usize
     type V
     type W
-    fn f : test_crate::WithConstTy::f
+    fn f<'_0, '_1> = test_crate::WithConstTy::f<'_0_0, '_0_1, Self, const LEN : usize>
 }
 
 fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1() -> usize
@@ -531,7 +531,7 @@ impl test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8 : test_cr
     const LEN2 = test_crate::WithConstTy::LEN2<bool, 32 : usize>
     type V = u8
     type W = u64
-    fn f = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f
+    fn f<'_0, '_1> = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f<'_0_0, '_0_1>
 }
 
 fn test_crate::use_with_const_ty1<H, const LEN : usize>() -> usize
@@ -614,8 +614,8 @@ trait test_crate::ParentTrait0<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::W>
     type W
-    fn get_name : test_crate::ParentTrait0::get_name
-    fn get_w : test_crate::ParentTrait0::get_w
+    fn get_name<'_0> = test_crate::ParentTrait0::get_name<'_0_0, Self>
+    fn get_w<'_0> = test_crate::ParentTrait0::get_w<'_0_0, Self>
 }
 
 trait test_crate::ParentTrait1<Self>
@@ -704,7 +704,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : test_crate::IntoIterator::into_iter
+    fn into_iter = test_crate::IntoIterator::into_iter<Self>
 }
 
 trait test_crate::FromResidual<Self, T>
@@ -735,7 +735,7 @@ trait test_crate::ParentTrait2<Self>
 trait test_crate::ChildTrait2<Self>
 {
     parent_clause0 : [@TraitClause0]: test_crate::ParentTrait2<Self>
-    fn convert : test_crate::ChildTrait2::convert
+    fn convert = test_crate::ChildTrait2::convert<Self>
 }
 
 impl test_crate::{impl test_crate::WithTarget for u32}#11 : test_crate::WithTarget<u32>
@@ -771,28 +771,28 @@ trait test_crate::CFnOnce<Self, Args>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : test_crate::CFnOnce::call_once
+    fn call_once = test_crate::CFnOnce::call_once<Self, Args>
 }
 
 trait test_crate::CFnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: test_crate::CFnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
-    fn call_mut : test_crate::CFnMut::call_mut
+    fn call_mut<'_0> = test_crate::CFnMut::call_mut<'_0_0, Self, Args>
 }
 
 trait test_crate::CFn<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: test_crate::CFnMut<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
-    fn call : test_crate::CFn::call
+    fn call<'_0> = test_crate::CFn::call<'_0_0, Self, Args>
 }
 
 trait test_crate::GetTrait<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::W>
     type W
-    fn get_w : test_crate::GetTrait::get_w
+    fn get_w<'_0> = test_crate::GetTrait::get_w<'_0_0, Self>
 }
 
 fn test_crate::GetTrait::get_w<'_0, Self>(@1: &'_0 (Self)) -> Self::W
@@ -971,7 +971,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -979,7 +979,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 trait core::ops::function::Fn<Self, Args>
@@ -987,7 +987,7 @@ trait core::ops::function::Fn<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call : core::ops::function::Fn::call
+    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>
 }
 
 fn test_crate::call<'a, F>(@1: F)
@@ -1041,12 +1041,12 @@ fn test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait::test
 
 trait test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait<Self>
 {
-    fn test : test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait::test
+    fn test<'_0> = test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait::test<'_0_0, Self>
 }
 
 impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1} : test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait<test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1>
 {
-    fn test = test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test
+    fn test<'_0> = test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test<'_0_0>
 }
 
 fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(@1: &'_0 mut (Self::W), @2: &'_1 (Array<u8, const LEN : usize>))

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -16,7 +16,7 @@ trait test_crate::From<Self, T>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Error>
     type Error
-    fn from : test_crate::From::from
+    fn from<[@TraitClause0]: core::marker::Sized<Self>> = test_crate::From::from<Self, T>[@TraitClause0_0]
 }
 
 fn test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, test_crate::{impl test_crate::From<&'_0 (bool)> for bool}<'_>::Error>[core::marker::Sized<bool>, core::marker::Sized<()>]
@@ -36,7 +36,7 @@ impl<'_0> test_crate::{impl test_crate::From<&'_0 (bool)> for bool}<'_0> : test_
     parent_clause0 = core::marker::Sized<&'_ (bool)>
     parent_clause1 = core::marker::Sized<()>
     type Error = ()
-    fn from = test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from
+    fn from = test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from<'_0>
 }
 
 fn test_crate::From::from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[@TraitClause0, Self::parent_clause1]

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -11,13 +11,13 @@ type test_crate::Generic<'a, T>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::borrow::Borrow<Self, Borrowed>
 {
-    fn borrow : core::borrow::Borrow::borrow
+    fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
 trait alloc::borrow::ToOwned<Self>
@@ -25,8 +25,8 @@ trait alloc::borrow::ToOwned<Self>
     parent_clause0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Owned>
     type Owned
-    fn to_owned : alloc::borrow::ToOwned::to_owned
-    fn clone_into : alloc::borrow::ToOwned::clone_into
+    fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
+    fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self>
 }
 
 enum alloc::borrow::Cow<'a, B>
@@ -54,7 +54,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<A>,
 {
-    fn borrow = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5::borrow
+    fn borrow<'_0> = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5::borrow<'_0_0, T, A>[@TraitClause0, @TraitClause1]
 }
 
 struct alloc::alloc::Global = {}
@@ -77,8 +77,8 @@ where
     parent_clause0 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
     parent_clause1 = core::marker::Sized<alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]>
     type Owned = alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
-    fn to_owned = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned
-    fn clone_into = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into
+    fn to_owned<'_0> = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned<'_0_0, T>[@TraitClause0, @TraitClause1]
+    fn clone_into<'_0, '_1> = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
 type test_crate::Generic2<'a, T>

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -117,8 +117,8 @@ fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_from<'_0, '_1>(@1: &'_0 mut (alloc::string::String), @2: &'_1 (alloc::string::String))
@@ -126,8 +126,8 @@ fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_f
 impl alloc::string::{impl core::clone::Clone for alloc::string::String}#6 : core::clone::Clone<alloc::string::String>
 {
     parent_clause0 = core::marker::Sized<alloc::string::String>
-    fn clone = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone
-    fn clone_from = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_from
+    fn clone<'_0> = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone<'_0_0>
+    fn clone_from<'_0, '_1> = alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone_from<'_0_0, '_0_1>
 }
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -79,8 +79,8 @@ opaque type core::array::iter::IntoIter<T, const N : usize>
 trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn clone : core::clone::Clone::clone
-    fn clone_from : core::clone::Clone::clone_from
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
+    fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
 trait core::marker::Copy<Self>
@@ -111,7 +111,7 @@ fn core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0>(@1: &'_
 impl core::clone::impls::{impl core::clone::Clone for usize}#5 : core::clone::Clone<usize>
 {
     parent_clause0 = core::marker::Sized<usize>
-    fn clone = core::clone::impls::{impl core::clone::Clone for usize}#5::clone
+    fn clone<'_0> = core::clone::impls::{impl core::clone::Clone for usize}#5::clone<'_0_0>
 }
 
 impl core::marker::{impl core::marker::Copy for usize}#37 : core::marker::Copy<usize>
@@ -128,7 +128,7 @@ fn core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero:
 impl core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26 : core::clone::Clone<core::num::nonzero::private::NonZeroUsizeInner>
 {
     parent_clause0 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
-    fn clone = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone
+    fn clone<'_0> = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26::clone<'_0_0>
 }
 
 impl core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27 : core::marker::Copy<core::num::nonzero::private::NonZeroUsizeInner>
@@ -169,7 +169,7 @@ trait core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
     type Output
-    fn call_once : core::ops::function::FnOnce::call_once
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
 trait core::ops::function::FnMut<Self, Args>
@@ -177,7 +177,7 @@ trait core::ops::function::FnMut<Self, Args>
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut : core::ops::function::FnMut::call_mut
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
 opaque type core::iter::adapters::map::Map<I, F>
@@ -240,7 +240,7 @@ opaque type core::iter::adapters::inspect::Inspect<I, F>
 trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
-    fn from_residual : core::ops::try_trait::FromResidual::from_residual
+    fn from_residual = core::ops::try_trait::FromResidual::from_residual<Self, R>
 }
 
 enum core::ops::control_flow::ControlFlow<B, C>
@@ -259,8 +259,8 @@ trait core::ops::try_trait::Try<Self>
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Residual>
     type Output
     type Residual
-    fn from_output : core::ops::try_trait::Try::from_output
-    fn branch : core::ops::try_trait::Try::branch
+    fn from_output = core::ops::try_trait::Try::from_output<Self>
+    fn branch = core::ops::try_trait::Try::branch<Self>
 }
 
 trait core::ops::try_trait::Residual<Self, O>
@@ -278,19 +278,19 @@ where
 trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    fn default : core::default::Default::default
+    fn default = core::default::Default::default<Self>
 }
 
 trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq : core::cmp::PartialEq::eq
-    fn ne : core::cmp::PartialEq::ne
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+    fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
-    fn assert_receiver_is_total_eq : core::cmp::Eq::assert_receiver_is_total_eq
+    fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
 enum core::cmp::Ordering =
@@ -302,21 +302,21 @@ enum core::cmp::Ordering =
 trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
-    fn partial_cmp : core::cmp::PartialOrd::partial_cmp
-    fn lt : core::cmp::PartialOrd::lt
-    fn le : core::cmp::PartialOrd::le
-    fn gt : core::cmp::PartialOrd::gt
-    fn ge : core::cmp::PartialOrd::ge
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+    fn lt<'_0, '_1> = core::cmp::PartialOrd::lt<'_0_0, '_0_1, Self, Rhs>
+    fn le<'_0, '_1> = core::cmp::PartialOrd::le<'_0_0, '_0_1, Self, Rhs>
+    fn gt<'_0, '_1> = core::cmp::PartialOrd::gt<'_0_0, '_0_1, Self, Rhs>
+    fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
 trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
     parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
-    fn cmp : core::cmp::Ord::cmp
-    fn max : core::cmp::Ord::max
-    fn min : core::cmp::Ord::min
-    fn clamp : core::cmp::Ord::clamp
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+    fn max<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::max<Self>[@TraitClause0_0]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::min<Self>[@TraitClause0_0]
+    fn clamp<[@TraitClause0]: core::marker::Sized<Self>> = core::cmp::Ord::clamp<Self>[@TraitClause0_0]
 }
 
 opaque type core::iter::adapters::rev::Rev<T>
@@ -339,83 +339,83 @@ trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
     type Item
-    fn next : core::iter::traits::iterator::Iterator::next
-    fn next_chunk : core::iter::traits::iterator::Iterator::next_chunk
-    fn size_hint : core::iter::traits::iterator::Iterator::size_hint
-    fn count : core::iter::traits::iterator::Iterator::count
-    fn last : core::iter::traits::iterator::Iterator::last
-    fn advance_by : core::iter::traits::iterator::Iterator::advance_by
-    fn nth : core::iter::traits::iterator::Iterator::nth
-    fn step_by : core::iter::traits::iterator::Iterator::step_by
-    fn chain : core::iter::traits::iterator::Iterator::chain
-    fn zip : core::iter::traits::iterator::Iterator::zip
-    fn intersperse : core::iter::traits::iterator::Iterator::intersperse
-    fn intersperse_with : core::iter::traits::iterator::Iterator::intersperse_with
-    fn map : core::iter::traits::iterator::Iterator::map
-    fn for_each : core::iter::traits::iterator::Iterator::for_each
-    fn filter : core::iter::traits::iterator::Iterator::filter
-    fn filter_map : core::iter::traits::iterator::Iterator::filter_map
-    fn enumerate : core::iter::traits::iterator::Iterator::enumerate
-    fn peekable : core::iter::traits::iterator::Iterator::peekable
-    fn skip_while : core::iter::traits::iterator::Iterator::skip_while
-    fn take_while : core::iter::traits::iterator::Iterator::take_while
-    fn map_while : core::iter::traits::iterator::Iterator::map_while
-    fn skip : core::iter::traits::iterator::Iterator::skip
-    fn take : core::iter::traits::iterator::Iterator::take
-    fn scan : core::iter::traits::iterator::Iterator::scan
-    fn flat_map : core::iter::traits::iterator::Iterator::flat_map
-    fn flatten : core::iter::traits::iterator::Iterator::flatten
-    fn map_windows : core::iter::traits::iterator::Iterator::map_windows
-    fn fuse : core::iter::traits::iterator::Iterator::fuse
-    fn inspect : core::iter::traits::iterator::Iterator::inspect
-    fn by_ref : core::iter::traits::iterator::Iterator::by_ref
-    fn collect : core::iter::traits::iterator::Iterator::collect
-    fn try_collect : core::iter::traits::iterator::Iterator::try_collect
-    fn collect_into : core::iter::traits::iterator::Iterator::collect_into
-    fn partition : core::iter::traits::iterator::Iterator::partition
-    fn partition_in_place : core::iter::traits::iterator::Iterator::partition_in_place
-    fn is_partitioned : core::iter::traits::iterator::Iterator::is_partitioned
-    fn try_fold : core::iter::traits::iterator::Iterator::try_fold
-    fn try_for_each : core::iter::traits::iterator::Iterator::try_for_each
-    fn fold : core::iter::traits::iterator::Iterator::fold
-    fn reduce : core::iter::traits::iterator::Iterator::reduce
-    fn try_reduce : core::iter::traits::iterator::Iterator::try_reduce
-    fn all : core::iter::traits::iterator::Iterator::all
-    fn any : core::iter::traits::iterator::Iterator::any
-    fn find : core::iter::traits::iterator::Iterator::find
-    fn find_map : core::iter::traits::iterator::Iterator::find_map
-    fn try_find : core::iter::traits::iterator::Iterator::try_find
-    fn position : core::iter::traits::iterator::Iterator::position
-    fn rposition : core::iter::traits::iterator::Iterator::rposition
-    fn max : core::iter::traits::iterator::Iterator::max
-    fn min : core::iter::traits::iterator::Iterator::min
-    fn max_by_key : core::iter::traits::iterator::Iterator::max_by_key
-    fn max_by : core::iter::traits::iterator::Iterator::max_by
-    fn min_by_key : core::iter::traits::iterator::Iterator::min_by_key
-    fn min_by : core::iter::traits::iterator::Iterator::min_by
-    fn rev : core::iter::traits::iterator::Iterator::rev
-    fn unzip : core::iter::traits::iterator::Iterator::unzip
-    fn copied : core::iter::traits::iterator::Iterator::copied
-    fn cloned : core::iter::traits::iterator::Iterator::cloned
-    fn cycle : core::iter::traits::iterator::Iterator::cycle
-    fn array_chunks : core::iter::traits::iterator::Iterator::array_chunks
-    fn sum : core::iter::traits::iterator::Iterator::sum
-    fn product : core::iter::traits::iterator::Iterator::product
-    fn cmp : core::iter::traits::iterator::Iterator::cmp
-    fn cmp_by : core::iter::traits::iterator::Iterator::cmp_by
-    fn partial_cmp : core::iter::traits::iterator::Iterator::partial_cmp
-    fn partial_cmp_by : core::iter::traits::iterator::Iterator::partial_cmp_by
-    fn eq : core::iter::traits::iterator::Iterator::eq
-    fn eq_by : core::iter::traits::iterator::Iterator::eq_by
-    fn ne : core::iter::traits::iterator::Iterator::ne
-    fn lt : core::iter::traits::iterator::Iterator::lt
-    fn le : core::iter::traits::iterator::Iterator::le
-    fn gt : core::iter::traits::iterator::Iterator::gt
-    fn ge : core::iter::traits::iterator::Iterator::ge
-    fn is_sorted : core::iter::traits::iterator::Iterator::is_sorted
-    fn is_sorted_by : core::iter::traits::iterator::Iterator::is_sorted_by
-    fn is_sorted_by_key : core::iter::traits::iterator::Iterator::is_sorted_by_key
-    fn __iterator_get_unchecked : core::iter::traits::iterator::Iterator::__iterator_get_unchecked
+    fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
+    fn next_chunk<'_0, const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_0, Self, const N : usize>[@TraitClause0_0]
+    fn size_hint<'_0> = core::iter::traits::iterator::Iterator::size_hint<'_0_0, Self>
+    fn count<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[@TraitClause0_0]
+    fn last<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[@TraitClause0_0]
+    fn advance_by<'_0> = core::iter::traits::iterator::Iterator::advance_by<'_0_0, Self>
+    fn nth<'_0> = core::iter::traits::iterator::Iterator::nth<'_0_0, Self>
+    fn step_by<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[@TraitClause0_0]
+    fn chain<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>, @TraitClause1_2::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn zip<U, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn intersperse<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn intersperse_with<G, [@TraitClause0]: core::marker::Sized<G>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<G, ()>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn filter_map<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn enumerate<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[@TraitClause0_0]
+    fn peekable<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[@TraitClause0_0]
+    fn skip_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn take_while<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn map_while<B, P, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn skip<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[@TraitClause0_0]
+    fn take<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[@TraitClause0_0]
+    fn scan<St, B, F, [@TraitClause0]: core::marker::Sized<St>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<F>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 mut (St), Self::Item)>, for<'_0> @TraitClause1_4::parent_clause0::Output = core::option::Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flat_map<U, F, [@TraitClause0]: core::marker::Sized<U>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_4::parent_clause0::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn flatten<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Array<Self::Item, const N : usize>))>, for<'_0> @TraitClause1_3::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn fuse<[@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[@TraitClause0_0]
+    fn inspect<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn by_ref<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_0, Self>[@TraitClause0_0]
+    fn collect<B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::iter::traits::collect::FromIterator<B, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_collect<'_0, B, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::try_trait::Try<Self::Item>, [@TraitClause3]: core::ops::try_trait::Residual<@TraitClause1_2::Residual, B>, [@TraitClause4]: core::iter::traits::collect::FromIterator<B, @TraitClause1_2::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_0, Self, B>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn collect_into<'_0, E, [@TraitClause0]: core::marker::Sized<E>, [@TraitClause1]: core::iter::traits::collect::Extend<E, Self::Item>, [@TraitClause2]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_0, Self, E>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn partition<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::default::Default<B>, [@TraitClause4]: core::iter::traits::collect::Extend<B, Self::Item>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_5::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn partition_in_place<'a, T, P, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<P>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (T))>, T : 'a, Self::Item = &'a mut (T), for<'_0> @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_partitioned<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_fold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn try_for_each<'_0, F, R, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::ops::try_trait::Try<R>, @TraitClause1_3::parent_clause0::Output = R, @TraitClause1_4::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_0, Self, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn reduce<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item, Self::Item)>, @TraitClause1_2::parent_clause0::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn try_reduce<'_0, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: core::ops::function::FnMut<impl FnMut(Self::Item, Self::Item) -> R, (Self::Item, Self::Item)>, @TraitClause1_3::Output = Self::Item, @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_0, Self, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_0, Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::iter::traits::iterator::Iterator::find_map<'_0_0, Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn try_find<'_0, R, impl FnMut(&Self::Item) -> R, [@TraitClause0]: core::marker::Sized<R>, [@TraitClause1]: core::marker::Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::try_trait::Try<R>, [@TraitClause4]: core::ops::try_trait::Residual<@TraitClause1_3::Residual, core::option::Option<Self::Item>[Self::parent_clause0]>, [@TraitClause5]: for<'_0> core::ops::function::FnMut<impl FnMut(&Self::Item) -> R, (&'_0_0 (Self::Item))>, @TraitClause1_3::Output = bool, for<'_0> @TraitClause1_5::parent_clause0::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_0, Self, R, impl FnMut(&Self::Item) -> R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::ops::function::FnMut<P, (Self::Item)>, @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (Self::Item)>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<Self>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn min<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn max_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn max_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn min_by_key<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::cmp::Ord<B>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: for<'_0> core::ops::function::FnMut<F, (&'_0_0 (Self::Item))>, for<'_0> @TraitClause1_4::parent_clause0::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn min_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rev<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::iter::traits::double_ended::DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn unzip<A, B, FromA, FromB, [@TraitClause0]: core::marker::Sized<A>, [@TraitClause1]: core::marker::Sized<B>, [@TraitClause2]: core::marker::Sized<FromA>, [@TraitClause3]: core::marker::Sized<FromB>, [@TraitClause4]: core::default::Default<FromA>, [@TraitClause5]: core::iter::traits::collect::Extend<FromA, A>, [@TraitClause6]: core::default::Default<FromB>, [@TraitClause7]: core::iter::traits::collect::Extend<FromB, B>, [@TraitClause8]: core::marker::Sized<Self>, [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5, @TraitClause0_6, @TraitClause0_7, @TraitClause0_8, @TraitClause0_9]
+    fn copied<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::marker::Copy<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cloned<'a, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::iterator::Iterator<Self>, [@TraitClause3]: core::clone::Clone<T>, T : 'a, Self::Item = &'a (T)> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cycle<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::clone::Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn array_chunks<const N : usize, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>[@TraitClause0_0]
+    fn sum<S, [@TraitClause0]: core::marker::Sized<S>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn product<P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: core::iter::traits::accum::Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::Ord<Self::Item>, [@TraitClause3]: core::marker::Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::cmp::Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn partial_cmp<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn partial_cmp_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn eq<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn eq_by<I, F, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause4]: core::ops::function::FnMut<F, (Self::Item, @TraitClause1_3::Item)>, @TraitClause1_4::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn ne<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn lt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn le<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn gt<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn ge<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<I>, [@TraitClause2]: core::cmp::PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3]: core::marker::Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn is_sorted<[@TraitClause0]: core::marker::Sized<Self>, [@TraitClause1]: core::cmp::PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[@TraitClause0_0, @TraitClause0_1]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn is_sorted_by_key<F, K, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<K>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>, [@TraitClause4]: core::cmp::PartialOrd<K, K>, @TraitClause1_3::parent_clause0::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
 trait core::iter::traits::collect::IntoIterator<Self>
@@ -427,7 +427,7 @@ where
     parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
     type Item
     type IntoIter
-    fn into_iter : core::iter::traits::collect::IntoIterator::into_iter
+    fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
 opaque type core::iter::adapters::intersperse::Intersperse<I>
@@ -470,34 +470,34 @@ trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn from_iter : core::iter::traits::collect::FromIterator::from_iter
+    fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::collect::Extend<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<A>
-    fn extend : core::iter::traits::collect::Extend::extend
-    fn extend_one : core::iter::traits::collect::Extend::extend_one
-    fn extend_reserve : core::iter::traits::collect::Extend::extend_reserve
-    fn extend_one_unchecked : core::iter::traits::collect::Extend::extend_one_unchecked
+    fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
+    fn extend_one<'_0> = core::iter::traits::collect::Extend::extend_one<'_0_0, Self, A>
+    fn extend_reserve<'_0> = core::iter::traits::collect::Extend::extend_reserve<'_0_0, Self, A>
+    fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
 trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn next_back : core::iter::traits::double_ended::DoubleEndedIterator::next_back
-    fn advance_back_by : core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
-    fn nth_back : core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-    fn try_rfold : core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
-    fn rfold : core::iter::traits::double_ended::DoubleEndedIterator::rfold
-    fn rfind : core::iter::traits::double_ended::DoubleEndedIterator::rfind
+    fn next_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0_0, Self>
+    fn advance_back_by<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by<'_0_0, Self>
+    fn nth_back<'_0> = core::iter::traits::double_ended::DoubleEndedIterator::nth_back<'_0_0, Self>
+    fn try_rfold<'_0, B, F, R, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<R>, [@TraitClause3]: core::marker::Sized<Self>, [@TraitClause4]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, [@TraitClause5]: core::ops::try_trait::Try<R>, @TraitClause1_4::parent_clause0::Output = R, @TraitClause1_5::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::try_rfold<'_0_0, Self, B, F, R>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
+    fn rfold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::ops::function::FnMut<F, (B, Self::parent_clause0::Item)>, @TraitClause1_3::parent_clause0::Output = B> = core::iter::traits::double_ended::DoubleEndedIterator::rfold<Self, B, F>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn rfind<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<Self>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (Self::parent_clause0::Item))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::iter::traits::double_ended::DoubleEndedIterator::rfind<'_0_0, Self, P>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
 }
 
 trait core::iter::traits::exact_size::ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
-    fn len : core::iter::traits::exact_size::ExactSizeIterator::len
-    fn is_empty : core::iter::traits::exact_size::ExactSizeIterator::is_empty
+    fn len<'_0> = core::iter::traits::exact_size::ExactSizeIterator::len<'_0_0, Self>
+    fn is_empty<'_0> = core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0_0, Self>
 }
 
 opaque type core::iter::adapters::array_chunks::ArrayChunks<I, const N : usize>
@@ -509,21 +509,21 @@ trait core::iter::traits::accum::Sum<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn sum : core::iter::traits::accum::Sum::sum
+    fn sum<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::traits::accum::Product<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<A>
-    fn product : core::iter::traits::accum::Product::product
+    fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
 trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size : core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
+    fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
 fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::size_hint<'a, '_1, T>(@1: &'_1 (core::slice::iter::Iter<'a, T>[@TraitClause0])) -> (usize, core::option::Option<usize>[core::marker::Sized<usize>])
@@ -631,22 +631,22 @@ where
 {
     parent_clause0 = core::marker::Sized<&'_ (T)>
     type Item = &'a (T)
-    fn next = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next
-    fn size_hint = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::size_hint
-    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::count
-    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::last
-    fn advance_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::advance_by
-    fn nth = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::nth
-    fn for_each = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::for_each
-    fn fold = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::fold
-    fn all = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::all
-    fn any = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::any
-    fn find = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find
-    fn find_map = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find_map
-    fn position = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::position
-    fn rposition = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::rposition
-    fn is_sorted_by = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::is_sorted_by
-    fn __iterator_get_unchecked = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked
+    fn next<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next<'a, '_0_0, T>[@TraitClause0]
+    fn size_hint<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::size_hint<'a, '_0_0, T>[@TraitClause0]
+    fn count = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::count<'a, T>[@TraitClause0]
+    fn last = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::last<'a, T>[@TraitClause0]
+    fn advance_by<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::advance_by<'a, '_0_0, T>[@TraitClause0]
+    fn nth<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::nth<'a, '_0_0, T>[@TraitClause0]
+    fn for_each<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = ()> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::for_each<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn fold<B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::ops::function::FnMut<F, (B, &'_ (T))>, @TraitClause1_2::parent_clause0::Output = B> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn all<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::all<'a, '_0_0, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn any<'_0, F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::any<'a, '_0_0, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: for<'_0> core::ops::function::FnMut<P, (&'_0_0 (&'_ (T)))>, for<'_0> @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn find_map<'_0, B, F, [@TraitClause0]: core::marker::Sized<B>, [@TraitClause1]: core::marker::Sized<F>, [@TraitClause2]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause3]: core::ops::function::FnMut<F, (&'_ (T))>, @TraitClause1_3::parent_clause0::Output = core::option::Option<B>[@TraitClause1_0]> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find_map<'a, '_0_0, T, B, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
+    fn position<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: core::ops::function::FnMut<P, (&'_ (T))>, @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::position<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn rposition<'_0, P, [@TraitClause0]: core::marker::Sized<P>, [@TraitClause1]: core::ops::function::FnMut<P, (@TraitClause1_3::parent_clause0::Item)>, [@TraitClause2]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause3]: core::iter::traits::exact_size::ExactSizeIterator<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause4]: core::iter::traits::double_ended::DoubleEndedIterator<core::slice::iter::Iter<'_, T>[@TraitClause0]>, @TraitClause1_1::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::rposition<'a, '_0_0, T, P>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
+    fn is_sorted_by<F, [@TraitClause0]: core::marker::Sized<F>, [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'_, T>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (&'_ (T)), &'_0_1 (&'_ (T)))>, for<'_0, '_1> @TraitClause1_2::parent_clause0::Output = bool> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
+    fn __iterator_get_unchecked<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
 }
 
 fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> core::result::Result<Array<Self::Item, const N : usize>, core::array::iter::IntoIter<Self::Item, const N : usize>[Self::parent_clause0]>[core::marker::Sized<Array<Self::Item, const N : usize>>, core::marker::Sized<core::array::iter::IntoIter<Self::Item, const N : usize>[Self::parent_clause0]>]
@@ -1174,11 +1174,63 @@ fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
-fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
+fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<Self>,
+
+fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
+
+fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+
+fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+fn core::default::Default::default<Self>() -> Self
 
 fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+
+fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
+
+fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
+
+fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+
+fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+
+fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
+
+fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    @TraitClause1::Item = A,
 
 fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
@@ -1186,11 +1238,7 @@ where
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
     @TraitClause1::Item = A,
 
-fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
-
-fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
-
-fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
+fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)
 where
@@ -1205,8 +1253,6 @@ fn core::iter::traits::collect::Extend::extend_reserve<'_0, Self, A>(@1: &'_0 mu
 unsafe fn core::iter::traits::collect::Extend::extend_one_unchecked<'_0, Self, A>(@1: &'_0 mut (Self), @2: A)
 where
     [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::default::Default::default<Self>() -> Self
 
 fn core::iter::traits::double_ended::DoubleEndedIterator::next_back<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::parent_clause0::Item>[Self::parent_clause0::parent_clause0]
 
@@ -1243,52 +1289,6 @@ where
 fn core::iter::traits::exact_size::ExactSizeIterator::len<'_0, Self>(@1: &'_0 (Self)) -> usize
 
 fn core::iter::traits::exact_size::ExactSizeIterator::is_empty<'_0, Self>(@1: &'_0 (Self)) -> bool
-
-fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
-
-fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Ord::clamp<Self>(@1: Self, @2: Self, @3: Self) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<Self>,
-
-fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
-
-fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
-
-fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
-
-fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::traits::accum::Product::product<Self, A, I>(@1: I) -> Self
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
-    @TraitClause1::Item = A,
-
-fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
 
 
 


### PR DESCRIPTION
The correspondance between the pair "(impl generics, method generics)" and the full list of generics that must be passed to the function item is not trivial: methods may reuse a default method (which requires changing generics), they may be more specific (e.g. have fewer trait bounds or different late-bound lifetimes) than the trait method, arguments may be out of order because charon modified the parameter list (e.g. for #127).

To support these cases, this PR adds explicit binders to methods in trait decls and trait impls. A method binder binds exactly the generics expected from the method declaration. This works as a map from method generics to a full list of generics to be passed to the bound function item. To map the other way around (from the function item generics to the correponding trait/impl generics and method generics), see in `ItemKind`.

This is progress towards #180 and #127.