### PR TITLE
Improve the `check_generics` pass

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.60"
+let supported_charon_version = "0.1.61"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -113,14 +113,6 @@ and call = { func : fn_operand; args : operand list; dest : place }
  *)
 and assertion = { cond : operand; expected : bool }
 
-(** The id of a translated item. *)
-and any_decl_id =
-  | IdType of type_decl_id
-  | IdFun of fun_decl_id
-  | IdGlobal of global_decl_id
-  | IdTraitDecl of trait_decl_id
-  | IdTraitImpl of trait_impl_id
-
 and closure_kind = Fn | FnMut | FnOnce
 
 (** Additional information for closures.

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1057,6 +1057,20 @@ and trait_type_constraint_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ trait_ref; type_name; ty } : trait_type_constraint)
     | _ -> Error "")
 
+and generics_source_of_json (ctx : of_json_ctx) (js : json) :
+    (generics_source, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Item", item) ] ->
+        let* item = any_decl_id_of_json ctx item in
+        Ok (Item item)
+    | `Assoc [ ("Method", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = trait_decl_id_of_json ctx x_0 in
+        let* x_1 = trait_item_name_of_json ctx x_1 in
+        Ok (Method (x_0, x_1))
+    | `String "Builtin" -> Ok Builtin
+    | _ -> Error "")
+
 and generic_args_of_json (ctx : of_json_ctx) (js : json) :
     (generic_args, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1067,6 +1081,7 @@ and generic_args_of_json (ctx : of_json_ctx) (js : json) :
           ("types", types);
           ("const_generics", const_generics);
           ("trait_refs", trait_refs);
+          ("target", _);
         ] ->
         let* regions =
           vector_of_json region_id_of_json region_of_json ctx regions

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -298,8 +298,16 @@ class virtual ['self] mapreduce_const_generic_base =
       fun _ x -> (x, self#zero)
   end
 
+(** The id of a translated item. *)
+type any_decl_id =
+  | IdType of type_decl_id
+  | IdFun of fun_decl_id
+  | IdGlobal of global_decl_id
+  | IdTraitDecl of trait_decl_id
+  | IdTraitImpl of trait_impl_id
+
 (** Const Generic Values. Either a primitive value, or a variable corresponding to a primitve value *)
-type const_generic =
+and const_generic =
   | CgGlobal of global_decl_id  (** A global constant *)
   | CgVar of const_generic_var_id de_bruijn_var  (** A const generic variable *)
   | CgValue of literal  (** A concrete value *)
@@ -549,6 +557,13 @@ and trait_impl_ref = {
   impl_generics : generic_args;
 }
 
+(** Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one. *)
+and generics_source =
+  | Item of any_decl_id  (** A top-level item. *)
+  | Method of trait_decl_id * trait_item_name  (** A trait method. *)
+  | Builtin  (** A builtin item like `Box`. *)
+
+(** A set of generic arguments. *)
 and generic_args = {
   regions : region list;
   types : ty list;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.60"
+version = "0.1.61"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.60"
+version = "0.1.61"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -218,6 +218,12 @@ impl<'ctx> AnyTransItem<'ctx> {
         }
     }
 
+    /// See [`GenericParams::identity_args`].
+    pub fn identity_args(&self) -> GenericArgs {
+        self.generic_params()
+            .identity_args(GenericsSource::Item(self.id()))
+    }
+
     /// We can't implement `AstVisitable` because of the `'static` constraint, but it's ok because
     /// `AnyTransItem` isn't contained in any of our types.
     pub fn drive<V: VisitAst>(&self, visitor: &mut V) -> ControlFlow<V::Break> {

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -227,12 +227,12 @@ impl<'ctx> AnyTransItem<'ctx> {
     /// We can't implement `AstVisitable` because of the `'static` constraint, but it's ok because
     /// `AnyTransItem` isn't contained in any of our types.
     pub fn drive<V: VisitAst>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
-        match self {
-            AnyTransItem::Type(d) => d.drive(visitor),
-            AnyTransItem::Fun(d) => d.drive(visitor),
-            AnyTransItem::Global(d) => d.drive(visitor),
-            AnyTransItem::TraitDecl(d) => d.drive(visitor),
-            AnyTransItem::TraitImpl(d) => d.drive(visitor),
+        match *self {
+            AnyTransItem::Type(d) => visitor.visit(d),
+            AnyTransItem::Fun(d) => visitor.visit(d),
+            AnyTransItem::Global(d) => visitor.visit(d),
+            AnyTransItem::TraitDecl(d) => visitor.visit(d),
+            AnyTransItem::TraitImpl(d) => visitor.visit(d),
         }
     }
 }
@@ -263,11 +263,11 @@ impl<'ctx> AnyTransItemMut<'ctx> {
     /// `AnyTransItemMut` isn't contained in any of our types.
     pub fn drive_mut<V: VisitAstMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         match self {
-            AnyTransItemMut::Type(d) => d.drive_mut(visitor),
-            AnyTransItemMut::Fun(d) => d.drive_mut(visitor),
-            AnyTransItemMut::Global(d) => d.drive_mut(visitor),
-            AnyTransItemMut::TraitDecl(d) => d.drive_mut(visitor),
-            AnyTransItemMut::TraitImpl(d) => d.drive_mut(visitor),
+            AnyTransItemMut::Type(d) => visitor.visit(*d),
+            AnyTransItemMut::Fun(d) => visitor.visit(*d),
+            AnyTransItemMut::Global(d) => visitor.visit(*d),
+            AnyTransItemMut::TraitDecl(d) => visitor.visit(*d),
+            AnyTransItemMut::TraitImpl(d) => visitor.visit(*d),
         }
     }
 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -195,13 +195,29 @@ pub struct TraitTypeConstraint {
     pub ty: Ty,
 }
 
-#[derive(Default, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+/// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+pub enum GenericsSource {
+    /// A top-level item.
+    Item(AnyTransId),
+    /// A trait method.
+    Method(TraitDeclId, TraitItemName),
+    /// A builtin item like `Box`.
+    Builtin,
+}
+
+/// A set of generic arguments.
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct GenericArgs {
     pub regions: Vector<RegionId, Region>,
     pub types: Vector<TypeVarId, Ty>,
     pub const_generics: Vector<ConstGenericVarId, ConstGeneric>,
     // TODO: rename to match [GenericParams]?
     pub trait_refs: Vector<TraitClauseId, TraitRef>,
+    #[charon::opaque]
+    #[drive(skip)]
+    /// Each `GenericArgs` is meant for a corresponding `GenericParams`; this records which one.
+    pub target: GenericsSource,
 }
 
 /// A value of type `T` bound by regions. We should use `binder` instead but this causes name clash

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -75,6 +75,10 @@ use index_vec::Idx;
     )
 )]
 pub trait AstVisitable: Any {
+    /// The name of the type, used for debug logging.
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
     /// Visit all occurrences of that type inside `self`, in pre-order traversal.
     fn dyn_visit<T: AstVisitable>(&self, f: impl FnMut(&T)) {
         self.drive(&mut DynVisitor::new_shared::<T>(f));

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -1,11 +1,9 @@
 use crate::translate::translate_crate_to_ullbc;
 use charon_lib::export;
 use charon_lib::options;
-use charon_lib::reorder_decls::compute_reordered_decls;
 use charon_lib::transform::{
     FINAL_CLEANUP_PASSES, INITIAL_CLEANUP_PASSES, LLBC_PASSES, ULLBC_PASSES,
 };
-use charon_lib::ullbc_to_llbc;
 use rustc_driver::{Callbacks, Compilation};
 use rustc_interface::{interface::Compiler, Queries};
 use rustc_middle::ty::TyCtxt;
@@ -258,26 +256,11 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
     // - or they want the structured LLBC, in which case we reconstruct the
     //   control-flow and apply micro-passes
     if !options.ullbc {
-        // # Go from ULLBC to LLBC (Low-Level Borrow Calculus) by reconstructing
-        // the control flow.
-        ullbc_to_llbc::translate_functions(&mut ctx);
-
-        if options.print_built_llbc {
-            info!("# LLBC resulting from control-flow reconstruction:\n\n{ctx}\n",);
-        }
-
         // Run the micro-passes that clean up bodies.
         for pass in LLBC_PASSES.iter() {
             trace!("# Starting pass {}", pass.name());
             pass.run(&mut ctx)
         }
-        // # Reorder the graph of dependencies and compute the strictly
-        // connex components to:
-        // - compute the order in which to extract the definitions
-        // - find the recursive definitions
-        // - group the mutually recursive definitions
-        let reordered_decls = compute_reordered_decls(&ctx);
-        ctx.translated.ordered_decls = Some(reordered_decls);
 
         if options.print_llbc {
             println!("# Final LLBC before serialization:\n\n{ctx}\n");

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -112,9 +112,14 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                     generics,
                     trait_refs
                 );
-                let generics = self.translate_generic_args(span, generics, trait_refs, None)?;
-
                 let global_id = self.register_global_decl_id(span, id);
+                let generics = self.translate_generic_args(
+                    span,
+                    generics,
+                    trait_refs,
+                    None,
+                    GenericsSource::item(global_id),
+                )?;
                 RawConstantExpr::Global(GlobalDeclRef {
                     id: global_id,
                     generics,

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -301,6 +301,7 @@ pub fn translate<'tcx, 'ctx>(
         no_code_duplication: options.no_code_duplication,
         hide_marker_traits: options.hide_marker_traits,
         no_merge_goto_chains: options.no_merge_goto_chains,
+        print_built_llbc: options.print_built_llbc,
         item_opacities: ctx.options.item_opacities,
     };
 

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1118,7 +1118,6 @@ fn generate_ml(
                     extra_types: &[],
                 })), &[
                     "Var",
-                    "AnyTransId",
                     "FnOperand",
                     "Call",
                     "Assert",
@@ -1253,6 +1252,7 @@ fn generate_ml(
                         "type_var_id",
                     ],
                 })), &[
+                    "AnyTransId",
                     "ConstGeneric",
                 ]),
                 // Can't merge into above because aeneas uses the above alongside their own partial
@@ -1276,6 +1276,7 @@ fn generate_ml(
                     "TraitImplRef",
                     "FunDeclRef",
                     "GlobalDeclRef",
+                    "GenericsSource",
                     "GenericArgs",
                 ]),
                 // TODO: can't merge into above because of field name clashes (`types`, `regions` etc).

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -53,7 +53,7 @@ impl Pattern {
     }
 
     pub fn matches_item(&self, ctx: &TranslatedCrate, item: AnyTransItem<'_>) -> bool {
-        let generics = item.generic_params().identity_args();
+        let generics = item.identity_args();
         let name = &item.item_meta().name;
         self.matches_with_generics(ctx, name, Some(&generics))
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -304,6 +304,7 @@ impl GenericArgs {
             types,
             const_generics,
             trait_refs: _,
+            target: _,
         } = self;
         for x in regions {
             params.push(x.fmt_with_ctx(ctx));
@@ -327,6 +328,7 @@ impl GenericArgs {
             types,
             const_generics,
             trait_refs,
+            target: _,
         } = self;
         for x in regions {
             params.push(x.fmt_with_ctx(ctx));

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -10,143 +10,61 @@ use super::{ctx::TransformPass, TransformCtx};
 struct CheckGenericsVisitor<'a> {
     translated: &'a TranslatedCrate,
     error_ctx: &'a mut ErrorCtx,
-    // Count how many `GenericArgs` we handled. This is to make sure we don't miss one.
-    discharged_args: u32,
     // Tracks an enclosing span to make errors useful.
-    item_span: Span,
+    span: Span,
 }
 
 impl CheckGenericsVisitor<'_> {
     fn error(&mut self, message: impl Display) {
-        let span = self.item_span;
         let message = message.to_string();
-        register_error_or_panic!(self.error_ctx, self.translated, span, message);
+        register_error_or_panic!(self.error_ctx, self.translated, self.span, message);
+    }
+}
+
+impl VisitAst for CheckGenericsVisitor<'_> {
+    fn visit_aggregate_kind(&mut self, agg: &AggregateKind) -> ControlFlow<Self::Break> {
+        match agg {
+            AggregateKind::Adt(..) => self.visit_inner(agg)?,
+            AggregateKind::Closure(_id, args) => {
+                // TODO(#194): handle closure generics properly
+                // This does not visit the args themselves, only their contents, because we mess up
+                // closure generics for now.
+                self.visit_inner(args)?
+            }
+            AggregateKind::Array(..) => self.visit_inner(agg)?,
+        }
+        Continue(())
     }
 
-    /// Count that we just discharged one instance of `GenericArgs`.
-    fn discharged_one_generics(&mut self) {
-        self.discharged_args += 1;
-    }
-
-    fn generics_should_match(&mut self, args: &GenericArgs, params: &GenericParams) {
-        self.discharged_one_generics();
+    fn enter_generic_args(&mut self, args: &GenericArgs) {
+        let params = match &args.target {
+            GenericsSource::Item(item_id) => {
+                let Some(item) = self.translated.get_item(*item_id) else {
+                    return;
+                };
+                item.generic_params()
+            }
+            GenericsSource::Method(trait_id, method_name) => {
+                let Some(trait_decl) = self.translated.trait_decls.get(*trait_id) else {
+                    return;
+                };
+                let Some((_, bound_fn)) = trait_decl
+                    .required_methods
+                    .iter()
+                    .chain(trait_decl.provided_methods.iter())
+                    .find(|(n, _)| n == method_name)
+                else {
+                    return;
+                };
+                &bound_fn.params
+            }
+            GenericsSource::Builtin => return,
+        };
         if !args.matches(params) {
             self.error(format!(
                 "Mismatched generics:\nexpected: {params:?}\n     got: {args:?}"
             ))
         }
-    }
-    fn generics_should_match_item(&mut self, args: &GenericArgs, item_id: impl Into<AnyTransId>) {
-        let item_id = item_id.into();
-        assert_eq!(args.target, GenericsSource::item(item_id));
-        if let Some(item) = self.translated.get_item(item_id) {
-            let params = item.generic_params();
-            self.generics_should_match(args, params);
-        } else {
-            self.discharged_one_generics();
-        }
-    }
-    fn check_typeid_generics(&mut self, args: &GenericArgs, ty_kind: &TypeId) {
-        match ty_kind {
-            TypeId::Adt(id) => self.generics_should_match_item(args, *id),
-            TypeId::Tuple => {
-                self.discharged_one_generics();
-                if !(args.regions.is_empty()
-                    && args.const_generics.is_empty()
-                    && args.trait_refs.is_empty())
-                {
-                    self.error("Mismatched generics: generics for a tuple should be only types")
-                }
-            }
-            TypeId::Builtin(..) => {
-                // TODO: check generics for built-in types
-                self.discharged_one_generics()
-            }
-        }
-    }
-}
-
-// Visitor functions
-impl VisitAst for CheckGenericsVisitor<'_> {
-    fn enter_aggregate_kind(&mut self, agg: &AggregateKind) {
-        match agg {
-            AggregateKind::Adt(kind, _, _, args) => {
-                self.check_typeid_generics(args, kind);
-            }
-            AggregateKind::Closure(_id, _args) => {
-                // TODO(#194): handle closure generics properly
-                // self.generics_should_match_item(args, *id);
-                self.discharged_one_generics()
-            }
-            AggregateKind::Array(..) => {}
-        }
-    }
-    fn enter_fn_ptr(&mut self, fn_ptr: &FnPtr) {
-        match &fn_ptr.func {
-            FunIdOrTraitMethodRef::Fun(FunId::Regular(id)) => {
-                let args = &fn_ptr.generics;
-                self.generics_should_match_item(args, *id);
-            }
-            FunIdOrTraitMethodRef::Trait(tref, method, _) => {
-                let trait_id = tref.trait_decl_ref.skip_binder.trait_id;
-                if let Some(trait_decl) = self.translated.trait_decls.get(trait_id) {
-                    if let Some((_, bound_fn)) = trait_decl
-                        .required_methods
-                        .iter()
-                        .chain(trait_decl.provided_methods.iter())
-                        .find(|(n, _)| n == method)
-                    {
-                        // Function generics should match expected method generics.
-                        self.generics_should_match(&fn_ptr.generics, &bound_fn.params);
-                    } else {
-                        self.discharged_one_generics()
-                    }
-                } else {
-                    self.discharged_one_generics()
-                }
-            }
-            FunIdOrTraitMethodRef::Fun(FunId::Builtin(..)) => {
-                // TODO: check generics for built-in types
-                self.discharged_one_generics()
-            }
-        }
-    }
-    fn enter_fun_decl_ref(&mut self, fun_ref: &FunDeclRef) {
-        self.generics_should_match_item(&fun_ref.generics, fun_ref.id);
-    }
-    fn enter_global_decl_ref(&mut self, global_ref: &GlobalDeclRef) {
-        self.generics_should_match_item(&global_ref.generics, global_ref.id);
-    }
-    fn enter_trait_decl_ref(&mut self, tref: &TraitDeclRef) {
-        self.generics_should_match_item(&tref.generics, tref.trait_id);
-    }
-    fn enter_trait_impl_ref(&mut self, impl_ref: &TraitImplRef) {
-        self.generics_should_match_item(&impl_ref.generics, impl_ref.impl_id);
-    }
-    fn enter_trait_ref(&mut self, tref: &TraitRef) {
-        match &tref.kind {
-            TraitRefKind::TraitImpl(id, args) => self.generics_should_match_item(args, *id),
-            TraitRefKind::BuiltinOrAuto(..)
-            | TraitRefKind::Dyn(..)
-            | TraitRefKind::Clause(..)
-            | TraitRefKind::ParentClause(..)
-            | TraitRefKind::ItemClause(..)
-            | TraitRefKind::SelfId
-            | TraitRefKind::Unknown(_) => {}
-        }
-    }
-    fn enter_ty(&mut self, ty: &Ty) {
-        if let TyKind::Adt(kind, args) = ty.kind() {
-            self.check_typeid_generics(args, kind);
-        }
-    }
-
-    fn enter_generic_args(&mut self, args: &GenericArgs) {
-        if self.discharged_args == 0 {
-            // Ensure we counted all `GenericArgs`
-            panic!("Unexpected `GenericArgs` in the AST! {args:?}")
-        }
-        self.discharged_args -= 1;
     }
 
     // Special case that is not represented as a `GenericArgs`.
@@ -178,10 +96,11 @@ impl VisitAst for CheckGenericsVisitor<'_> {
     }
 
     fn visit_llbc_statement(&mut self, st: &Statement) -> ControlFlow<Self::Break> {
-        let old_span = self.item_span;
-        self.item_span = st.span;
+        // Track span for more precise error messages.
+        let old_span = self.span;
+        self.span = st.span;
         self.visit_inner(st)?;
-        self.item_span = old_span;
+        self.span = old_span;
         Continue(())
     }
 }
@@ -193,14 +112,9 @@ impl TransformPass for Check {
             let mut visitor = CheckGenericsVisitor {
                 translated: &ctx.translated,
                 error_ctx: &mut ctx.errors,
-                discharged_args: 0,
-                item_span: item.item_meta().span,
+                span: item.item_meta().span,
             };
             item.drive(&mut visitor);
-            assert_eq!(
-                visitor.discharged_args, 0,
-                "Got confused about `GenericArgs` locations"
-            );
         }
     }
 }

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -37,7 +37,9 @@ impl CheckGenericsVisitor<'_> {
         }
     }
     fn generics_should_match_item(&mut self, args: &GenericArgs, item_id: impl Into<AnyTransId>) {
-        if let Some(item) = self.translated.get_item(item_id.into()) {
+        let item_id = item_id.into();
+        assert_eq!(args.target, GenericsSource::item(item_id));
+        if let Some(item) = self.translated.get_item(item_id) {
             let params = item.generic_params();
             self.generics_should_match(args, params);
         } else {

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -18,6 +18,8 @@ pub struct TransformOptions {
     pub hide_marker_traits: bool,
     /// Do not merge the chains of gotos.
     pub no_merge_goto_chains: bool,
+    /// Print the llbc just after control-flow reconstruction.
+    pub print_built_llbc: bool,
     /// List of patterns to assign a given opacity to. Same as the corresponding `TranslateOptions`
     /// field.
     pub item_opacities: Vec<(NamePattern, ItemOpacity)>,

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -70,7 +70,7 @@ impl<'a> IndexVisitor<'a> {
         } else {
             TyKind::Adt(
                 TypeId::Builtin(BuiltinTy::Slice),
-                GenericArgs::new_from_types(vec![elem_ty].into()),
+                GenericArgs::new_for_builtin(vec![elem_ty].into()),
             )
             .into_ty()
         };

--- a/charon/src/transform/insert_assign_return_unit.rs
+++ b/charon/src/transform/insert_assign_return_unit.rs
@@ -12,7 +12,12 @@ fn transform_st(locals: &Locals, st: &mut Statement) -> Vec<Statement> {
     if let RawStatement::Return = &mut st.content {
         let ret_place = locals.return_place();
         let unit_value = Rvalue::Aggregate(
-            AggregateKind::Adt(TypeId::Tuple, None, None, GenericArgs::empty()),
+            AggregateKind::Adt(
+                TypeId::Tuple,
+                None,
+                None,
+                GenericArgs::empty(GenericsSource::Builtin),
+            ),
             Vec::new(),
         );
         let assign_st = Statement::new(st.span, RawStatement::Assign(ret_place, unit_value));

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -37,6 +37,8 @@ use Pass::*;
 pub static ULLBC_PASSES: &[Pass] = &[
     // Move clauses on associated types to be parent clauses
     NonBody(&lift_associated_item_clauses::Transform),
+    // Check that all supplied generic types match the corresponding generic parameters.
+    NonBody(&check_generics::Check("after translation")),
     // # Micro-pass: hide some overly-common traits we don't need: Sized, Sync, Allocator, etc..
     NonBody(&hide_marker_traits::Transform),
     // # Micro-pass: filter the trait impls that were marked invisible since we couldn't filter
@@ -125,7 +127,7 @@ pub static LLBC_PASSES: &[Pass] = &[
     // comments.
     StructuredBody(&recover_body_comments::Transform),
     // Check that all supplied generic types match the corresponding generic parameters.
-    NonBody(&check_generics::Check),
+    NonBody(&check_generics::Check("after transformations")),
     // Use `DeBruijnVar::Free` for the variables bound in item signatures.
     NonBody(&unbind_item_vars::Check),
 ];

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -98,6 +98,8 @@ pub static ULLBC_PASSES: &[Pass] = &[
 
 /// Body cleanup passes after control flow reconstruction.
 pub static LLBC_PASSES: &[Pass] = &[
+    // # Go from ULLBC to LLBC (Low-Level Borrow Calculus) by reconstructing the control flow.
+    NonBody(&ullbc_to_llbc::Transform),
     // # Micro-pass: `panic!()` expands to a new function definition each time. This pass cleans
     // those up.
     StructuredBody(&inline_local_panic_functions::Transform),
@@ -132,6 +134,11 @@ pub static LLBC_PASSES: &[Pass] = &[
     // statements. This must be last after all the statement-affecting passes to avoid losing
     // comments.
     StructuredBody(&recover_body_comments::Transform),
+    // # Reorder the graph of dependencies and compute the strictly connex components to:
+    // - compute the order in which to extract the definitions
+    // - find the recursive definitions
+    // - group the mutually recursive definitions
+    NonBody(&reorder_decls::Transform),
 ];
 
 /// Final passes to run at the end.

--- a/charon/src/transform/ops_to_function_calls.rs
+++ b/charon/src/transform/ops_to_function_calls.rs
@@ -23,6 +23,7 @@ fn transform_st(s: &mut Statement) {
                 vec![ty.clone()].into(),
                 vec![cg.clone()].into(),
                 vec![].into(),
+                GenericsSource::Builtin,
             );
             let func = FnOperand::Regular(FnPtr { func, generics });
             s.content = RawStatement::Call(Call {
@@ -42,6 +43,7 @@ fn transform_st(s: &mut Statement) {
                 vec![ty.clone()].into(),
                 vec![cg.clone()].into(),
                 vec![].into(),
+                GenericsSource::Builtin,
             );
             let func = FnOperand::Regular(FnPtr { func, generics });
             s.content = RawStatement::Call(Call {

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Error};
 use std::vec::Vec;
 
+use super::ctx::TransformPass;
+
 /// A (group of) top-level declaration(s), properly reordered.
 /// "G" stands for "generic"
 #[derive(
@@ -483,7 +485,7 @@ fn group_declarations_from_scc(
     reordered_decls
 }
 
-pub fn compute_reordered_decls(ctx: &TransformCtx) -> DeclarationsGroups {
+fn compute_reordered_decls(ctx: &TransformCtx) -> DeclarationsGroups {
     trace!();
 
     // Step 1: explore the declarations to build the graph
@@ -514,6 +516,14 @@ pub fn compute_reordered_decls(ctx: &TransformCtx) -> DeclarationsGroups {
 
     trace!("{:?}", reordered_decls);
     reordered_decls
+}
+
+pub struct Transform;
+impl TransformPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        let reordered_decls = compute_reordered_decls(&ctx);
+        ctx.translated.ordered_decls = Some(reordered_decls);
+    }
 }
 
 #[cfg(test)]

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -36,6 +36,8 @@ use petgraph::Direction;
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
+use super::ctx::TransformPass;
+
 /// Control-Flow Graph
 type Cfg = DiGraphMap<src::BlockId, ()>;
 
@@ -1742,28 +1744,34 @@ fn translate_body(ctx: &mut TransformCtx, no_code_duplication: bool, body: &mut 
     *body = Structured(tgt_body);
 }
 
-/// Translate the functions by reconstructing the control-flow.
-pub fn translate_functions(ctx: &mut TransformCtx) {
-    // Translate the bodies one at a time.
-    ctx.for_each_body(|ctx, body| {
-        translate_body(ctx, ctx.options.no_code_duplication, body);
-    });
+pub struct Transform;
+impl TransformPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        // Translate the bodies one at a time.
+        ctx.for_each_body(|ctx, body| {
+            translate_body(ctx, ctx.options.no_code_duplication, body);
+        });
 
-    // Print the functions
-    let fmt_ctx = ctx.into_fmt();
-    for fun in &ctx.translated.fun_decls {
-        trace!(
-            "# Signature:\n{}\n\n# Function definition:\n{}\n",
-            fmt_ctx.format_object(&fun.signature),
-            fmt_ctx.format_object(fun),
-        );
-    }
-    // Print the global variables
-    for global in &ctx.translated.global_decls {
-        trace!(
-            "# Type:\n{}\n\n# Global definition:\n{}\n",
-            fmt_ctx.format_object(&global.ty),
-            fmt_ctx.format_object(global)
-        );
+        // Print the functions
+        let fmt_ctx = ctx.into_fmt();
+        for fun in &ctx.translated.fun_decls {
+            trace!(
+                "# Signature:\n{}\n\n# Function definition:\n{}\n",
+                fmt_ctx.format_object(&fun.signature),
+                fmt_ctx.format_object(fun),
+            );
+        }
+        // Print the global variables
+        for global in &ctx.translated.global_decls {
+            trace!(
+                "# Type:\n{}\n\n# Global definition:\n{}\n",
+                fmt_ctx.format_object(&global.ty),
+                fmt_ctx.format_object(global)
+            );
+        }
+
+        if ctx.options.print_built_llbc {
+            info!("# LLBC resulting from control-flow reconstruction:\n\n{ctx}\n",);
+        }
     }
 }

--- a/charon/tests/test-rust-name-matcher.rs
+++ b/charon/tests/test-rust-name-matcher.rs
@@ -45,7 +45,7 @@ fn test_name_matcher() -> anyhow::Result<()> {
             .filter_map(|a| parse_pattern_attr(a))
             .collect_vec();
         for (pass, pat) in patterns {
-            let passes = pat.matches(&crate_data, name);
+            let passes = pat.matches_item(&crate_data, item);
             if passes != pass {
                 if passes {
                     panic!(

--- a/charon/tests/ui/rust-name-matcher-tests.rs
+++ b/charon/tests/ui/rust-name-matcher-tests.rs
@@ -16,15 +16,16 @@ mod foo {
 
 #[pattern::pass("test_crate::Trait")]
 #[pattern::fail("test_crate::Trait<_>")]
-#[pattern::fail("test_crate::Trait<_, _>")]
+#[pattern::pass("test_crate::Trait<_, _>")]
 trait Trait<T> {
     #[pattern::pass("test_crate::Trait::method")]
-    #[pattern::fail("test_crate::Trait<_>::method")]
+    #[pattern::pass("test_crate::Trait<_>::method")]
     fn method<U>();
 }
 
 #[pattern::pass("test_crate::{impl test_crate::Trait<_> for _}")]
 #[pattern::pass("test_crate::{impl test_crate::Trait<_, _>}")]
+#[pattern::fail("test_crate::{impl test_crate::Trait<_>}")]
 #[pattern::fail("test_crate::{impl test_crate::Trait<_, _> for _}")]
 #[pattern::pass(
     "test_crate::{impl test_crate::Trait<core::option::Option<_>> for alloc::boxed::Box<_>}"


### PR DESCRIPTION
This does a few things to improve the `check_generics` pass:
- We now track for each `GenericArgs` what item it applies to. This greatly simplifies the pass and will be a tremendous help for #127;
- We pretty-print the llbc before running the pass, which makes it possible to inspect the llbc output even when it faile;
- We now track which items have been visited so that errors have more context to them.