### PR TITLE
Allow overriding the nixpkgs used for building ocaml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,6 +53,9 @@
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-ocaml": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       }
     },


### PR DESCRIPTION
`ocamlPackages` is designed in a painful way: `ocamlPackages` itself points to a different toolchain version depending on the nixpkgs version used, and a given package only works witrh the one toolchain it was built with. This means that the practice is to choose one nixpkgs version to make sure all the dependencies use the same toolchain.

Meanwhile, we need to use a recent rust-overlay to access recent rust nightlies, but recent rust-overlay isn't compatible with old nixpkgs. Hence this PR, so we can get a recent nixpkgs for rust-overlay, and our dependents can override the nixpkgs for ocaml to ensure a common toolchain.