### PR TITLE
Remove elaborated bounds from trait item bounds

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
+source = "git+https://github.com/cryspen/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
+source = "git+https://github.com/cryspen/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
+source = "git+https://github.com/cryspen/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "hax-adt-into"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#98ded931baf06ffb5802d1b55cd42ef39177beb6"
+source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#98ded931baf06ffb5802d1b55cd42ef39177beb6"
+source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/hacspec/hax?branch=main#98ded931baf06ffb5802d1b55cd42ef39177beb6"
+source = "git+https://github.com/hacspec/hax?branch=main#54a4159b0e7ccc8dd4fdd811a239bc271145efcb"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -78,7 +78,7 @@ tracing = { version = "0.1", features = [ "max_level_trace" ] }
 wait-timeout = { version = "0.2.0", optional = true }
 which = "7.0"
 
-hax-frontend-exporter = { git = "https://github.com/hacspec/hax", branch = "main", optional = true }
+hax-frontend-exporter = { git = "https://github.com/cryspen/hax", branch = "main", optional = true }
 # hax-frontend-exporter = { path = "../../hax/frontend/exporter", optional = true }
 macros = { path = "./macros" }
 

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -214,8 +214,8 @@ fn predicate_origins() -> anyhow::Result<()> {
                 (WhereClauseOnTrait, "Sized"),
                 (WhereClauseOnTrait, "Copy"),
                 (WhereClauseOnTrait, "Default"),
-                (TraitItem(TraitItemName("AssocType".to_owned())), "Default"),
                 (TraitItem(TraitItemName("AssocType".to_owned())), "Sized"),
+                (TraitItem(TraitItemName("AssocType".to_owned())), "Default"),
             ],
         ),
         // Interesting note: the method definition does not mention the clauses on the trait.

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -19,8 +19,8 @@ where
     Self::Item : 'a,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Copy<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self::Item>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Item>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
+    parent_clause2 : [@TraitClause2]: core::clone::Clone<Self::Item>
     type Item
     fn use_item<'_0> = test_crate::Foo::use_item<'a, '_0_0, Self>
 }
@@ -71,8 +71,8 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_, T>
-    parent_clause1 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<&'_ (T)>[core::marker::Sized<&'_ (T)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>]
-    parent_clause2 = core::marker::Sized<core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]>
+    parent_clause1 = core::marker::Sized<core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]>
+    parent_clause2 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<&'_ (T)>[core::marker::Sized<&'_ (T)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>]
     type Item = core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]
 }
 
@@ -88,7 +88,7 @@ where
     let @2: &'_ (@TraitClause1::Item); // anonymous local
 
     @2 := &x@1
-    @0 := @TraitClause1::parent_clause1::clone<'_>(move (@2))
+    @0 := @TraitClause1::parent_clause2::clone<'_>(move (@2))
     drop @2
     drop x@1
     return
@@ -142,17 +142,17 @@ impl test_crate::loopy::{impl test_crate::loopy::Bar for ()} : test_crate::loopy
 
 trait test_crate::loopy::Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::loopy::Bar<Self::FooTy>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::FooTy>
     parent_clause1 : [@TraitClause1]: test_crate::loopy::Foo<Self::FooTy>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::FooTy>
+    parent_clause2 : [@TraitClause2]: test_crate::loopy::Bar<Self::FooTy>
     type FooTy
 }
 
 impl test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1 : test_crate::loopy::Foo<()>
 {
-    parent_clause0 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
+    parent_clause0 = core::marker::Sized<()>
     parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1
-    parent_clause2 = core::marker::Sized<()>
+    parent_clause2 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
     type FooTy = ()
 }
 
@@ -195,18 +195,18 @@ where
 trait test_crate::loopy_with_generics::Foo<'b, Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
-    parent_clause1 : [@TraitClause1]: test_crate::loopy_with_generics::Bar<'_, Self::FooTy, u8, core::option::Option<T>[Self::parent_clause0]>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::FooTy>
     parent_clause2 : [@TraitClause2]: test_crate::loopy_with_generics::Foo<'_, Self::FooTy, T>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::FooTy>
+    parent_clause3 : [@TraitClause3]: test_crate::loopy_with_generics::Bar<'_, Self::FooTy, u8, core::option::Option<T>[Self::parent_clause0]>
     type FooTy
 }
 
 impl test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}#1 : test_crate::loopy_with_generics::Foo<'static, (), u16>
 {
     parent_clause0 = core::marker::Sized<u16>
-    parent_clause1 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T> for ()}<'_, core::option::Option<u16>[core::marker::Sized<u16>]>[core::marker::Sized<core::option::Option<u16>[core::marker::Sized<u16>]>]
+    parent_clause1 = core::marker::Sized<()>
     parent_clause2 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}#1
-    parent_clause3 = core::marker::Sized<()>
+    parent_clause3 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T> for ()}<'_, core::option::Option<u16>[core::marker::Sized<u16>]>[core::marker::Sized<core::option::Option<u16>[core::marker::Sized<u16>]>]
     type FooTy = ()
 }
 
@@ -217,8 +217,8 @@ trait core::borrow::Borrow<Self, Borrowed>
 
 trait alloc::borrow::ToOwned<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Owned>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Owned>
+    parent_clause1 : [@TraitClause1]: core::borrow::Borrow<Self::Owned, Self>
     type Owned
     fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
     fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self>

--- a/charon/tests/ui/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/dictionary_passing_style_woes.out
@@ -10,11 +10,11 @@ trait test_crate::Iterator<Self>
 
 trait test_crate::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: test_crate::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: test_crate::Iterator<Self::IntoIter>
     type Item
     type IntoIter
 }
@@ -25,8 +25,8 @@ where
     [@TraitClause1]: test_crate::Iterator<I>,
 {
     parent_clause0 = @TraitClause1::parent_clause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause0
+    parent_clause1 = @TraitClause0
+    parent_clause2 = @TraitClause1
     type Item = @TraitClause1::Item
     type IntoIter = I
 }

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -44,9 +44,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -90,9 +89,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20
     parent_clause0 = core::marker::Sized<u32>
     parent_clause1 = core::marker::{impl core::marker::Copy for u32}#40
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for u32}#19
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner}#12
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroU32Inner}#11
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroU32Inner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroU32Inner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroU32Inner}#12
     type NonZeroInner = core::num::nonzero::private::NonZeroU32Inner
 }
 

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -11,8 +11,8 @@ trait core::clone::Clone<Self>
 
 trait test_crate::Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::clone::Clone<Self::Type>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Type>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Type>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self::Type>
     type Type
     fn get_ty<'_0> = test_crate::Foo::get_ty<'_0_0, Self>
 }
@@ -42,8 +42,8 @@ fn test_crate::{impl test_crate::Foo for ()}::get_ty<'_0>(@1: &'_0 (())) -> &'_0
 
 impl test_crate::{impl test_crate::Foo for ()} : test_crate::Foo<()>
 {
-    parent_clause0 = core::clone::impls::{impl core::clone::Clone for u32}#8
-    parent_clause1 = core::marker::Sized<u32>
+    parent_clause0 = core::marker::Sized<u32>
+    parent_clause1 = core::clone::impls::{impl core::clone::Clone for u32}#8
     type Type = u32
     fn get_ty<'_0> = test_crate::{impl test_crate::Foo for ()}::get_ty<'_0_0>
 }
@@ -89,8 +89,8 @@ fn test_crate::use_foo()
 
 trait test_crate::RPITIT<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::Foo<Self::>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::>
+    parent_clause1 : [@TraitClause1]: test_crate::Foo<Self::>
     type 
     fn make_foo = test_crate::RPITIT::make_foo<Self>
 }
@@ -106,8 +106,8 @@ fn test_crate::{impl test_crate::RPITIT for ()}#1::make_foo()
 
 impl test_crate::{impl test_crate::RPITIT for ()}#1 : test_crate::RPITIT<()>
 {
-    parent_clause0 = test_crate::{impl test_crate::Foo for ()}
-    parent_clause1 = core::marker::Sized<()>
+    parent_clause0 = core::marker::Sized<()>
+    parent_clause1 = test_crate::{impl test_crate::Foo for ()}
     type  = ()
     fn make_foo = test_crate::{impl test_crate::RPITIT for ()}#1::make_foo
 }
@@ -133,19 +133,19 @@ where
 {
     let @0: (); // return
     let foo@1: @TraitClause1::; // local
-    let @2: @TraitClause1::parent_clause0::Type; // anonymous local
-    let @3: &'_ (@TraitClause1::parent_clause0::Type); // anonymous local
-    let @4: &'_ (@TraitClause1::parent_clause0::Type); // anonymous local
+    let @2: @TraitClause1::parent_clause1::Type; // anonymous local
+    let @3: &'_ (@TraitClause1::parent_clause1::Type); // anonymous local
+    let @4: &'_ (@TraitClause1::parent_clause1::Type); // anonymous local
     let @5: &'_ (@TraitClause1::); // anonymous local
     let @6: (); // anonymous local
 
     foo@1 := @TraitClause1::make_foo()
     @fake_read(foo@1)
     @5 := &foo@1
-    @4 := @TraitClause1::parent_clause0::get_ty<'_>(move (@5))
+    @4 := @TraitClause1::parent_clause1::get_ty<'_>(move (@5))
     @3 := &*(@4)
     drop @5
-    @2 := @TraitClause1::parent_clause0::parent_clause0::clone<'_>(move (@3))
+    @2 := @TraitClause1::parent_clause1::parent_clause1::clone<'_>(move (@3))
     drop @3
     @fake_read(@2)
     drop @2

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -81,9 +81,8 @@ where
 
 trait test_crate::Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Copy<Self::Ty>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self::Ty>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Ty>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Ty>
+    parent_clause1 : [@TraitClause1]: core::marker::Copy<Self::Ty>
     type Ty
 }
 

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -57,9 +57,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -103,9 +102,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -227,13 +225,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -382,11 +379,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -525,14 +522,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -111,9 +111,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -157,9 +156,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -262,13 +260,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -417,11 +414,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -862,8 +859,8 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause1::parent_clause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause0
+    parent_clause1 = @TraitClause0
+    parent_clause2 = @TraitClause1
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
@@ -915,14 +912,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,

--- a/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
+++ b/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
@@ -4,9 +4,8 @@ trait core::marker::Sized<Self>
 
 trait test_crate::Trait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::Trait2<Self::T>
-    parent_clause1 : [@TraitClause1]: test_crate::Trait1<Self::T>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::T>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::T>
+    parent_clause1 : [@TraitClause1]: test_crate::Trait2<Self::T>
     type T
 }
 

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -4,9 +4,8 @@ trait core::marker::Sized<Self>
 
 trait test_crate::Trait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::Trait2<Self::T>
-    parent_clause1 : [@TraitClause1]: test_crate::Trait1<Self::T>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::T>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::T>
+    parent_clause1 : [@TraitClause1]: test_crate::Trait2<Self::T>
     type T
 }
 
@@ -31,16 +30,15 @@ trait test_crate::T2<Self, T>
 
 trait test_crate::T3<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::T5<Self::T>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::T>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::T>
+    parent_clause1 : [@TraitClause1]: test_crate::T5<Self::T>
     type T
 }
 
 trait test_crate::T5<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::T4<Self::T>
-    parent_clause1 : [@TraitClause1]: test_crate::T3<Self::T>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::T>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::T>
+    parent_clause1 : [@TraitClause1]: test_crate::T4<Self::T>
     type T
 }
 

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -819,9 +819,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -865,9 +864,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -989,13 +987,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -1144,11 +1141,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -2158,8 +2155,8 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause1::parent_clause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause0
+    parent_clause1 = @TraitClause0
+    parent_clause2 = @TraitClause1
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
@@ -2226,14 +2223,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -58,8 +58,8 @@ trait core::hash::Hash<Self>
 
 trait core::hash::BuildHasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::hash::Hasher<Self::Hasher>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Hasher>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Hasher>
+    parent_clause1 : [@TraitClause1]: core::hash::Hasher<Self::Hasher>
     type Hasher
     fn build_hasher<'_0> = core::hash::BuildHasher::build_hasher<'_0_0, Self>
     fn hash_one<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::hash::Hash<T>, [@TraitClause2]: core::marker::Sized<Self>, [@TraitClause3]: core::hash::Hasher<Self::Hasher>> = core::hash::BuildHasher::hash_one<'_0_0, Self, T>[@TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
@@ -139,8 +139,8 @@ fn std::hash::random::{impl core::hash::BuildHasher for std::hash::random::Rando
 
 impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1 : core::hash::BuildHasher<std::hash::random::RandomState>
 {
-    parent_clause0 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4
-    parent_clause1 = core::marker::Sized<std::hash::random::DefaultHasher>
+    parent_clause0 = core::marker::Sized<std::hash::random::DefaultHasher>
+    parent_clause1 = std::hash::random::{impl core::hash::Hasher for std::hash::random::DefaultHasher}#4
     type Hasher = std::hash::random::DefaultHasher
     fn build_hasher<'_0> = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher<'_0_0>
 }

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -103,9 +103,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -149,9 +148,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -254,13 +252,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -326,11 +323,11 @@ opaque type core::iter::adapters::cycle::Cycle<I>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -556,14 +553,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -70,9 +70,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -116,9 +115,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -240,13 +238,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -395,11 +392,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -1085,8 +1082,8 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = @TraitClause0
-    parent_clause1 = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]
-    parent_clause2 = core::marker::Sized<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>
+    parent_clause1 = core::marker::Sized<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>
+    parent_clause2 = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]
     type Item = T
     type IntoIter = core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]
     fn into_iter = core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>[@TraitClause0]
@@ -1098,8 +1095,8 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 {
     parent_clause0 = @TraitClause1::parent_clause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause0
+    parent_clause1 = @TraitClause0
+    parent_clause2 = @TraitClause1
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
@@ -1131,14 +1128,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -490,8 +490,8 @@ global test_crate::WithConstTy::LEN2<Self, const LEN : usize>: usize = test_crat
 trait test_crate::WithConstTy<Self, const LEN : usize>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::V>
-    parent_clause1 : [@TraitClause1]: test_crate::ToU64<Self::W>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::W>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::W>
+    parent_clause2 : [@TraitClause2]: test_crate::ToU64<Self::W>
     const LEN1 : usize
     const LEN2 : usize
     type V
@@ -525,8 +525,8 @@ fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f<'_0, '_1
 impl test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8 : test_crate::WithConstTy<bool, 32 : usize>
 {
     parent_clause0 = core::marker::Sized<u8>
-    parent_clause1 = test_crate::{impl test_crate::ToU64 for u64}#2
-    parent_clause2 = core::marker::Sized<u64>
+    parent_clause1 = core::marker::Sized<u64>
+    parent_clause2 = test_crate::{impl test_crate::ToU64 for u64}#2
     const LEN1 = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1
     const LEN2 = test_crate::WithConstTy::LEN2<bool, 32 : usize>
     type V = u8
@@ -571,7 +571,7 @@ where
     let @2: @TraitClause1::W; // anonymous local
 
     @2 := move (x@1)
-    @0 := @TraitClause1::parent_clause1::to_u64(move (@2))
+    @0 := @TraitClause1::parent_clause2::to_u64(move (@2))
     drop @2
     drop x@1
     return
@@ -697,11 +697,11 @@ trait test_crate::Iterator<Self>
 
 trait test_crate::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: test_crate::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: test_crate::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = test_crate::IntoIterator::into_iter<Self>
@@ -727,8 +727,8 @@ trait test_crate::WithTarget<Self>
 
 trait test_crate::ParentTrait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::WithTarget<Self::U>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::U>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::U>
+    parent_clause1 : [@TraitClause1]: test_crate::WithTarget<Self::U>
     type U
 }
 
@@ -746,8 +746,8 @@ impl test_crate::{impl test_crate::WithTarget for u32}#11 : test_crate::WithTarg
 
 impl test_crate::{impl test_crate::ParentTrait2 for u32}#12 : test_crate::ParentTrait2<u32>
 {
-    parent_clause0 = test_crate::{impl test_crate::WithTarget for u32}#11
-    parent_clause1 = core::marker::Sized<u32>
+    parent_clause0 = core::marker::Sized<u32>
+    parent_clause1 = test_crate::{impl test_crate::WithTarget for u32}#11
     type U = u32
 }
 
@@ -943,15 +943,15 @@ where
 
 trait test_crate::RecursiveImpl<Self>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::RecursiveImpl<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
+    parent_clause1 : [@TraitClause1]: test_crate::RecursiveImpl<Self::Item>
     type Item
 }
 
 impl test_crate::{impl test_crate::RecursiveImpl for ()}#17 : test_crate::RecursiveImpl<()>
 {
-    parent_clause0 = test_crate::{impl test_crate::RecursiveImpl for ()}#17
-    parent_clause1 = core::marker::Sized<()>
+    parent_clause0 = core::marker::Sized<()>
+    parent_clause1 = test_crate::{impl test_crate::RecursiveImpl for ()}#17
     type Item = ()
 }
 
@@ -1053,7 +1053,7 @@ fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(@1: &'_0 mut (S
 
 fn test_crate::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
-fn test_crate::ChildTrait2::convert<Self>(@1: Self::parent_clause0::U) -> Self::parent_clause0::parent_clause0::Target
+fn test_crate::ChildTrait2::convert<Self>(@1: Self::parent_clause0::U) -> Self::parent_clause0::parent_clause1::Target
 
 fn test_crate::CFnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -22,8 +22,8 @@ trait core::borrow::Borrow<Self, Borrowed>
 
 trait alloc::borrow::ToOwned<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::borrow::Borrow<Self::Owned, Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Owned>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Owned>
+    parent_clause1 : [@TraitClause1]: core::borrow::Borrow<Self::Owned, Self>
     type Owned
     fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
     fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self>
@@ -44,6 +44,8 @@ opaque type alloc::vec::Vec<T, A>
       [@TraitClause0]: core::marker::Sized<T>,
       [@TraitClause1]: core::marker::Sized<A>,
 
+struct alloc::alloc::Global = {}
+
 fn alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5::borrow<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1])) -> &'_0 (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -56,8 +58,6 @@ where
 {
     fn borrow<'_0> = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5::borrow<'_0_0, T, A>[@TraitClause0, @TraitClause1]
 }
-
-struct alloc::alloc::Global = {}
 
 fn alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned<'_0, T>(@1: &'_0 (Slice<T>)) -> alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
 where
@@ -74,8 +74,8 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::clone::Clone<T>,
 {
-    parent_clause0 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
-    parent_clause1 = core::marker::Sized<alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]>
+    parent_clause0 = core::marker::Sized<alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]>
+    parent_clause1 = alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
     type Owned = alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
     fn to_owned<'_0> = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::to_owned<'_0_0, T>[@TraitClause0, @TraitClause1]
     fn clone_into<'_0, '_1> = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -95,9 +95,8 @@ trait core::num::nonzero::ZeroablePrimitive<Self>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     parent_clause1 : [@TraitClause1]: core::marker::Copy<Self>
     parent_clause2 : [@TraitClause2]: core::num::nonzero::private::Sealed<Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Copy<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: core::clone::Clone<Self::NonZeroInner>
-    parent_clause5 : [@TraitClause5]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::NonZeroInner>
+    parent_clause4 : [@TraitClause4]: core::marker::Copy<Self::NonZeroInner>
     type NonZeroInner
 }
 
@@ -141,9 +140,8 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#
     parent_clause0 = core::marker::Sized<usize>
     parent_clause1 = core::marker::{impl core::marker::Copy for usize}#37
     parent_clause2 = core::num::nonzero::{impl core::num::nonzero::private::Sealed for usize}#25
-    parent_clause3 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
-    parent_clause4 = core::num::nonzero::private::{impl core::clone::Clone for core::num::nonzero::private::NonZeroUsizeInner}#26
-    parent_clause5 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause3 = core::marker::Sized<core::num::nonzero::private::NonZeroUsizeInner>
+    parent_clause4 = core::num::nonzero::private::{impl core::marker::Copy for core::num::nonzero::private::NonZeroUsizeInner}#27
     type NonZeroInner = core::num::nonzero::private::NonZeroUsizeInner
 }
 
@@ -265,13 +263,12 @@ trait core::ops::try_trait::Try<Self>
 
 trait core::ops::try_trait::Residual<Self, O>
 where
-    Self::parent_clause1::Residual = Self,
-    Self::parent_clause1::Output = O,
+    Self::parent_clause2::Output = O,
+    Self::parent_clause2::Residual = Self,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<O>
-    parent_clause1 : [@TraitClause1]: core::ops::try_trait::Try<Self::TryType>
-    parent_clause2 : [@TraitClause2]: core::ops::try_trait::FromResidual<Self::TryType, Self>
-    parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::TryType>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::TryType>
+    parent_clause2 : [@TraitClause2]: core::ops::try_trait::Try<Self::TryType>
     type TryType
 }
 
@@ -420,11 +417,11 @@ trait core::iter::traits::iterator::Iterator<Self>
 
 trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause1::Item = Self::Item,
+    Self::parent_clause2::Item = Self::Item,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::iter::traits::iterator::Iterator<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
+    parent_clause2 : [@TraitClause2]: core::iter::traits::iterator::Iterator<Self::IntoIter>
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
@@ -671,14 +668,14 @@ fn core::iter::traits::iterator::Iterator::step_by<Self>(@1: Self, @2: usize) ->
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
-fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::chain<Self, U>(@1: Self, @2: U) -> core::iter::adapters::chain::Chain<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,
     [@TraitClause2]: core::iter::traits::collect::IntoIterator<U>,
     @TraitClause2::Item = Self::Item,
 
-fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause2]
+fn core::iter::traits::iterator::Iterator::zip<Self, U>(@1: Self, @2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause2::IntoIter>[@TraitClause1, @TraitClause2::parent_clause1]
 where
     [@TraitClause0]: core::marker::Sized<U>,
     [@TraitClause1]: core::marker::Sized<Self>,


### PR DESCRIPTION
We used to use `tcx.item_bounds` to get the predicates required on a trait associated item. On top of the explicitly-written bounds, this adds parent bounds, e.g. `type Item: Copy` would become `type Item: Copy + Clone`. These parent bounds are not necessary so we now use `explicit_item_bounds` which doesn't have them. This also gets us better spans for clauses.

Companion PR to https://github.com/cryspen/hax/pull/1222.