### PR TITLE
Pin a rust-overlay revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
     steps:
       - run: |
           nix build --refresh -L 'github:aeneasverif/aeneas#checks.x86_64-linux.aeneas-tests' \
-              --override-input charon github:aeneasverif/charon/${{ github.sha }} \
-              --override-input charon/rust-overlay github:oxalica/rust-overlay/master
+              --override-input charon github:aeneasverif/charon/${{ github.sha }}
 
   eurydice:
     needs: [nix]

--- a/flake.lock
+++ b/flake.lock
@@ -66,16 +66,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1729736953,
-        "narHash": "sha256-Rb6JUop7NRklg0uzcre+A+Ebrn/ZiQPkm4QdKg6/3pw=",
+        "lastModified": 1737340068,
+        "narHash": "sha256-5UciRckNV+YOZ6y6ASBIb01cySB12whDxgFUK+EqT8g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "29b1275740d9283467b8117499ec8cbb35250584",
+        "rev": "275c824ed9e90e7fd4f96d187bde3670062e721f",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "rev": "275c824ed9e90e7fd4f96d187bde3670062e721f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,9 @@
     # different ocaml version depending on the nixpkgs version.
     nixpkgs-ocaml.follows = "nixpkgs";
     rust-overlay = {
-      url = "github:oxalica/rust-overlay";
+      # We pin a specific commit because we require a relatively recent version
+      # and flake dependents don't look at flake.lock.
+      url = "github:oxalica/rust-overlay/275c824ed9e90e7fd4f96d187bde3670062e721f";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane.url = "github:ipetkov/crane";


### PR DESCRIPTION
Because we require a relatively recent version and flake dependents don't look at flake.lock. This should also avoid some unnecessary rebuilds in CI due to differing versions of `rust-overlay`.