### PR TITLE
Transform associated types into type parameters

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.63"
+let supported_charon_version = "0.1.64"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -417,6 +417,8 @@ and cli_options = {
       (** Blacklist of items to keep opaque. These use the name-matcher syntax. *)
   exclude : string list;
       (** Blacklist of items to not translate at all. These use the name-matcher syntax. *)
+  remove_associated_types : string list;
+      (** List of traits for which we transform associated types to type parameters. *)
   hide_marker_traits : bool;
       (** Whether to hide the `Sized`, `Sync`, `Send` and `Unpin` marker traits anywhere they show
         up.

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -907,6 +907,13 @@ and trait_clause_id_of_json (ctx : of_json_ctx) (js : json) :
     | x -> TraitClauseId.id_of_json ctx x
     | _ -> Error "")
 
+and trait_type_constraint_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_type_constraint_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> TraitTypeConstraintId.id_of_json ctx x
+    | _ -> Error "")
+
 and type_var_of_json (ctx : of_json_ctx) (js : json) : (type_var, string) result
     =
   combine_error_msgs js __FUNCTION__
@@ -1202,7 +1209,7 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
             ctx types_outlive
         in
         let* trait_type_constraints =
-          list_of_json
+          vector_of_json trait_type_constraint_id_of_json
             (region_binder_of_json trait_type_constraint_of_json)
             ctx trait_type_constraints
         in
@@ -1619,6 +1626,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("include", include_);
           ("opaque", opaque);
           ("exclude", exclude);
+          ("remove_associated_types", remove_associated_types);
           ("hide_marker_traits", hide_marker_traits);
           ("no_cargo", no_cargo);
           ("rustc_args", rustc_args);
@@ -1647,6 +1655,9 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* included = list_of_json string_of_json ctx include_ in
         let* opaque = list_of_json string_of_json ctx opaque in
         let* exclude = list_of_json string_of_json ctx exclude in
+        let* remove_associated_types =
+          list_of_json string_of_json ctx remove_associated_types
+        in
         let* hide_marker_traits = bool_of_json ctx hide_marker_traits in
         let* no_cargo = bool_of_json ctx no_cargo in
         let* rustc_args = list_of_json string_of_json ctx rustc_args in
@@ -1676,6 +1687,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              included;
              opaque;
              exclude;
+             remove_associated_types;
              hide_marker_traits;
              no_cargo;
              rustc_args;

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -20,6 +20,7 @@ module ConstGenericVarId = IdGen ()
 module TraitDeclId = IdGen ()
 module TraitImplId = IdGen ()
 module TraitClauseId = IdGen ()
+module TraitTypeConstraintId = IdGen ()
 module UnsolvedTraitId = IdGen ()
 module RegionId = IdGen ()
 module Disambiguator = IdGen ()
@@ -30,6 +31,11 @@ type ('id, 'x) vector = 'x list [@@deriving show, ord]
 type integer_type = Values.integer_type [@@deriving show, ord]
 type float_type = Values.float_type [@@deriving show, ord]
 type literal_type = Values.literal_type [@@deriving show, ord]
+
+(* Manually implemented because no type uses it (we use plain lists instead of
+   vectors in generic_params), which causes visitor inference problems if we
+   declare it within a visitor group. *)
+type trait_type_constraint_id = TraitTypeConstraintId.id [@@deriving show, ord]
 
 (** We define these types to control the name of the visitor functions *)
 type ('id, 'name) indexed_var = {
@@ -256,12 +262,8 @@ and trait_instance_id =
           ```
        *)
   | Self
-      (** Self, in case of trait declarations/implementations.
-
-          Putting [Self] at the end on purpose, so that when ordering the clauses
-          we start with the other clauses (in particular, the local clauses). It
-          is useful to give priority to the local clauses when solving the trait
-          obligations which are fullfilled by the trait parameters.
+      (** The implicit `Self: Trait` clause. Present inside trait declarations, including trait
+          method declarations. Not present in trait implementations as we can use `TraitImpl` intead.
        *)
   | BuiltinOrAuto of
       trait_decl_ref region_binder

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,10 +214,10 @@ dependencies = [
  "derive_generic_visitor",
  "env_logger",
  "flate2",
- "hashlink",
  "hax-frontend-exporter",
  "ignore",
  "index_vec",
+ "indexmap",
  "indoc",
  "itertools 0.13.0",
  "lazy_static",
@@ -792,28 +780,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
- "serde",
-]
 
 [[package]]
 name = "hax-adt-into"
@@ -1165,12 +1134,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2464,12 +2434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,26 +2826,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -51,7 +51,7 @@ crates_io_api = { version = "0.11.0", optional = true }
 derive_generic_visitor = "0.1.0"
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }
-hashlink = { version = "0.9", features = ["serde_impl"] }
+indexmap = { version = "2.7.1", features = ["serde"] }
 index_vec = { version = "0.1.3", features = ["serde"] }
 indoc = "2"
 itertools = "0.13"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.63"
+version = "0.1.64"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -100,16 +100,23 @@ impl ProjectionElem {
                                 if variant_id.is_some() {
                                     return Err(());
                                 };
-                                let mut ty = fields.get(*field_id).ok_or(())?.ty.clone();
-                                ty.substitute(generics);
-                                ty
+                                fields
+                                    .get(*field_id)
+                                    .ok_or(())?
+                                    .ty
+                                    .clone()
+                                    .substitute(generics)
                             }
                             Enum(variants) => {
                                 let variant_id = variant_id.ok_or(())?;
                                 let variant = variants.get(variant_id).ok_or(())?;
-                                let mut ty = variant.fields.get(*field_id).ok_or(())?.ty.clone();
-                                ty.substitute(generics);
-                                ty
+                                variant
+                                    .fields
+                                    .get(*field_id)
+                                    .ok_or(())?
+                                    .ty
+                                    .clone()
+                                    .substitute(generics)
                             }
                             Opaque | Alias(_) | Error(_) => return Err(()),
                         }

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -3,7 +3,7 @@ use crate::formatter::{FmtCtx, Formatter, IntoFormatter};
 use crate::ids::Vector;
 use crate::reorder_decls::DeclarationsGroups;
 use derive_generic_visitor::{ControlFlow, Drive, DriveMut};
-use hashlink::LinkedHashSet;
+use indexmap::IndexSet;
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
 use serde_map_to_array::HashMapToArray;
@@ -114,7 +114,7 @@ pub struct TranslatedCrate {
 
     /// All the item ids, in the order in which we encountered them
     #[drive(skip)]
-    pub all_ids: LinkedHashSet<AnyTransId>,
+    pub all_ids: IndexSet<AnyTransId>,
     /// The names of all registered items. Available so we can know the names even of items that
     /// failed to translate.
     #[serde(with = "HashMapToArray::<AnyTransId, Name>")]

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -28,6 +28,6 @@ pub use krate::*;
 pub use meta::*;
 pub use names::*;
 pub use types::*;
-pub use types_utils::TyVisitable;
+pub use types_utils::*;
 pub use values::*;
 pub use visitor::*;

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -115,12 +115,8 @@ pub enum TraitRefKind {
     #[charon::opaque]
     ItemClause(Box<TraitRefKind>, TraitDeclId, TraitItemName, TraitClauseId),
 
-    /// Self, in case of trait declarations/implementations.
-    ///
-    /// Putting [Self] at the end on purpose, so that when ordering the clauses
-    /// we start with the other clauses (in particular, the local clauses). It
-    /// is useful to give priority to the local clauses when solving the trait
-    /// obligations which are fullfilled by the trait parameters.
+    /// The implicit `Self: Trait` clause. Present inside trait declarations, including trait
+    /// method declarations. Not present in trait implementations as we can use `TraitImpl` intead.
     #[charon::rename("Self")]
     SelfId,
 
@@ -291,7 +287,7 @@ pub struct GenericParams {
     /// The type outlives the region
     pub types_outlive: Vec<RegionBinder<TypeOutlives>>,
     /// Constraints over trait associated types
-    pub trait_type_constraints: Vec<RegionBinder<TraitTypeConstraint>>,
+    pub trait_type_constraints: Vector<TraitTypeConstraintId, RegionBinder<TraitTypeConstraint>>,
 }
 
 /// A predicate of the form `exists<T> where T: Trait`.
@@ -329,7 +325,7 @@ pub enum PredicateOrigin {
     // trait Trait {}
     // ```
     TraitSelf,
-    // Note: this also includes supertrait constraings.
+    // Note: this also includes supertrait constraints.
     // ```
     // trait Trait<T: Clone> {}
     // trait Trait<T> where T: Clone {}

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -91,6 +91,7 @@ generate_index_type!(RegionId, "Region");
 generate_index_type!(TypeVarId, "T");
 generate_index_type!(ConstGenericVarId, "Const");
 generate_index_type!(TraitClauseId, "TraitClause");
+generate_index_type!(TraitTypeConstraintId, "TraitTypeConstraint");
 
 /// A type variable in a signature or binder.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -4,6 +4,7 @@ use crate::ids::Vector;
 use derive_generic_visitor::*;
 use std::collections::HashSet;
 use std::convert::Infallible;
+use std::fmt::Debug;
 use std::iter::Iterator;
 use std::mem;
 use std::ops::Index;
@@ -127,6 +128,27 @@ impl<T> RegionBinder<T> {
             regions: Default::default(),
             skip_binder: x.move_under_binder(),
         }
+    }
+
+    pub fn map_ref<U>(&self, f: impl FnOnce(&T) -> U) -> RegionBinder<U> {
+        RegionBinder {
+            regions: self.regions.clone(),
+            skip_binder: f(&self.skip_binder),
+        }
+    }
+
+    /// Substitute the bound variables with erased lifetimes.
+    pub fn erase(self) -> T
+    where
+        T: AstVisitable,
+    {
+        let mut val = self.skip_binder;
+        let args = GenericArgs {
+            regions: self.regions.map_ref_indexed(|_, _| Region::Erased),
+            ..GenericArgs::empty(GenericsSource::Builtin)
+        };
+        val.drive_mut(&mut SubstVisitor::new(&args));
+        val
     }
 }
 
@@ -265,6 +287,88 @@ impl IntegerTy {
             IntegerTy::U64 => size_of::<u64>(),
             IntegerTy::U128 => size_of::<u128>(),
         }
+    }
+}
+
+/// A value of type `T` bound by the generic parameters of item
+/// `item`. Used when dealing with multiple items at a time, to
+/// ensure we don't mix up generics.
+///
+/// To get the value, use `under_binder_of` or `subst_for`.
+#[derive(Debug, Clone, Copy)]
+pub struct ItemBinder<ItemId, T> {
+    pub item_id: ItemId,
+    val: T,
+}
+
+impl<ItemId, T> ItemBinder<ItemId, T>
+where
+    ItemId: Debug + Copy + PartialEq,
+{
+    pub fn new(item_id: ItemId, val: T) -> Self {
+        Self { item_id, val }
+    }
+
+    pub fn as_ref(&self) -> ItemBinder<ItemId, &T> {
+        ItemBinder {
+            item_id: self.item_id,
+            val: &self.val,
+        }
+    }
+
+    pub fn map_bound<U>(self, f: impl FnOnce(T) -> U) -> ItemBinder<ItemId, U> {
+        ItemBinder {
+            item_id: self.item_id,
+            val: f(self.val),
+        }
+    }
+
+    fn assert_item_id(&self, item_id: ItemId) {
+        assert_eq!(
+            self.item_id, item_id,
+            "Trying to use item bound for {:?} as if it belonged to {:?}",
+            self.item_id, item_id
+        );
+    }
+
+    /// Assert that the value is bound for item `item_id`, and returns it. This is used when we
+    /// plan to store the returned value inside that item.
+    pub fn under_binder_of(self, item_id: ItemId) -> T {
+        self.assert_item_id(item_id);
+        self.val
+    }
+
+    /// Given generic args for `item_id`, assert that the value is bound for `item_id` and
+    /// substitute it with the provided generic arguments. Because the arguments are bound in the
+    /// context of another item, so it the resulting substituted value.
+    pub fn substitute<OtherItem: Debug + Copy + PartialEq>(
+        self,
+        args: ItemBinder<OtherItem, &GenericArgs>,
+    ) -> ItemBinder<OtherItem, T>
+    where
+        ItemId: Into<AnyTransId>,
+        T: TyVisitable,
+    {
+        args.map_bound(|args| {
+            assert_eq!(
+                args.target,
+                GenericsSource::item(self.item_id),
+                "These `GenericArgs` are meant for {:?} but were used on {:?}",
+                args.target,
+                self.item_id
+            );
+            self.val.substitute(args)
+        })
+    }
+}
+
+/// Dummy item identifier that represents the current item when not ambiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CurrentItem;
+
+impl<T> ItemBinder<CurrentItem, T> {
+    pub fn under_current_binder(self) -> T {
+        self.val
     }
 }
 

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -110,12 +110,10 @@ impl<T> Binder<T> {
     /// substituted inner value.
     pub fn apply(self, args: &GenericArgs) -> T
     where
-        T: AstVisitable,
+        T: TyVisitable,
     {
-        let mut val = self.skip_binder;
         assert!(args.matches(&self.params));
-        val.drive_mut(&mut SubstVisitor::new(args));
-        val
+        self.skip_binder.substitute(args)
     }
 }
 
@@ -567,8 +565,9 @@ impl VisitAstMut for SubstVisitor<'_> {
 
 /// Types that are involved at the type-level and may be substituted around.
 pub trait TyVisitable: Sized + AstVisitable {
-    fn substitute(&mut self, generics: &GenericArgs) {
+    fn substitute(mut self, generics: &GenericArgs) -> Self {
         self.drive_mut(&mut SubstVisitor::new(generics));
+        self
     }
 
     /// Move under one binder.

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -46,8 +46,8 @@ use index_vec::Idx;
         FnOperand, FunId, FunIdOrTraitMethodRef, FunSig, ImplElem, IntegerTy, Literal, LiteralTy,
         llbc_ast::Block, llbc_ast::ExprBody, llbc_ast::RawStatement, llbc_ast::Switch,
         Locals, Name, NullOp, Opaque, Operand, PathElem, Place, PlaceKind, ProjectionElem, RawConstantExpr,
-        RefKind, RegionId, RegionVar, Rvalue, ScalarValue, TraitClause, TraitClauseId, TraitItemName,
-        TraitRefKind, TraitTypeConstraint, TranslatedCrate, TyKind, TypeDeclKind, TypeId, TypeVar, TypeVarId,
+        RefKind, RegionId, RegionVar, Rvalue, ScalarValue, TraitClauseId, TraitItemName,
+        TranslatedCrate, TypeDeclKind, TypeId, TypeVar, TypeVarId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::RawStatement,
         ullbc_ast::RawTerminator, ullbc_ast::SwitchTargets, ullbc_ast::Terminator,
         UnOp, Var, Variant, VariantId, VarId,
@@ -62,9 +62,9 @@ use index_vec::Idx;
     // Types for which we call the corresponding `visit_$ty` method, which by default explores the
     // type but can be overridden.
     override(
-        DeBruijnId, Ty, Region, ConstGeneric, TraitRef,
+        DeBruijnId, Ty, TyKind, Region, ConstGeneric, TraitRef, TraitRefKind,
         FunDeclRef, GlobalDeclRef, TraitDeclRef, TraitImplRef,
-        GenericArgs, GenericParams,
+        GenericArgs, GenericParams, TraitClause, TraitTypeConstraint,
         for<T: AstVisitable + Idx> DeBruijnVar<T>,
         for<T: AstVisitable> RegionBinder<T>,
         for<T: AstVisitable> Binder<T>,

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -252,7 +252,10 @@ pub fn translate(tcx: TyCtxt, internal: &mut CharonCallbacks) -> export::CrateDa
     // run several passes that simplify the items and cleanup the bodies.
     for pass in transformation_passes(options) {
         trace!("# Starting pass {}", pass.name());
-        pass.run(&mut transform_ctx)
+        pass.run(&mut transform_ctx);
+        if transform_ctx.errors.borrow().has_errors() {
+            break;
+        }
     }
 
     // Update the error count

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -1,7 +1,6 @@
 use super::translate_ctx::*;
 use charon_lib::ast::*;
 use charon_lib::options::CliOpts;
-use charon_lib::transform::ctx::TransformOptions;
 use charon_lib::transform::TransformCtx;
 use hax_frontend_exporter as hax;
 use rustc_hir::def_id::DefId;
@@ -297,13 +296,9 @@ pub fn translate<'tcx, 'ctx>(
     }
 
     // Return the context, dropping the hax state and rustc `tcx`.
-    let transform_options = TransformOptions {
-        no_code_duplication: options.no_code_duplication,
-        hide_marker_traits: options.hide_marker_traits,
-        no_merge_goto_chains: options.no_merge_goto_chains,
-        print_built_llbc: options.print_built_llbc,
-        item_opacities: ctx.options.item_opacities,
-    };
+    let transform_options = ctx
+        .options
+        .into_transform_options(&mut *ctx.errors.borrow_mut(), options);
 
     TransformCtx {
         options: transform_options,

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -548,7 +548,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         def: &hax::FullDef,
     ) -> Result<(), Error> {
         assert!(self.binding_levels.len() == 0);
-        self.binding_levels.push_front(BindingLevel::new(true));
+        self.binding_levels.push(BindingLevel::new(true));
         self.push_generics_for_def(span, def, false)?;
         self.innermost_binder_mut().params.check_consistency();
         Ok(())
@@ -560,7 +560,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         span: Span,
         def: &hax::FullDef,
     ) -> Result<(), Error> {
-        self.binding_levels.push_front(BindingLevel::new(true));
+        self.binding_levels.push(BindingLevel::new(true));
         self.push_generics_for_def_without_parents(span, def, true, true)?;
         self.innermost_binder().params.check_consistency();
         Ok(())
@@ -568,7 +568,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
 
     pub(crate) fn into_generics(mut self) -> GenericParams {
         assert!(self.binding_levels.len() == 1);
-        self.binding_levels.pop_back().unwrap().params
+        self.binding_levels.pop().unwrap().params
     }
 
     /// Add the generics and predicates of this item and its parents to the current context.

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1078,7 +1078,13 @@ fn generate_ml(
         ),
     ];
     // Types for which we don't want to generate a type at all.
-    let dont_generate_ty = &["ItemOpacity", "PredicateOrigin", "Ty", "Vector"];
+    let dont_generate_ty = &[
+        "ItemOpacity",
+        "PredicateOrigin",
+        "TraitTypeConstraintId",
+        "Ty",
+        "Vector",
+    ];
     // Types that we don't want visitors to go into.
     let opaque_for_visitor = &["Name"];
     let ctx = GenerateCtx::new(

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -22,6 +22,7 @@ module ConstGenericVarId = IdGen ()
 module TraitDeclId = IdGen ()
 module TraitImplId = IdGen ()
 module TraitClauseId = IdGen ()
+module TraitTypeConstraintId = IdGen ()
 module UnsolvedTraitId = IdGen ()
 module RegionId = IdGen ()
 module Disambiguator = IdGen ()
@@ -33,6 +34,11 @@ type ('id, 'x) vector = 'x list [@@deriving show, ord]
 type integer_type = Values.integer_type [@@deriving show, ord]
 type float_type = Values.float_type [@@deriving show, ord]
 type literal_type = Values.literal_type [@@deriving show, ord]
+
+(* Manually implemented because no type uses it (we use plain lists instead of
+   vectors in generic_params), which causes visitor inference problems if we
+   declare it within a visitor group. *)
+type trait_type_constraint_id = TraitTypeConstraintId.id [@@deriving show, ord]
 
 (** We define these types to control the name of the visitor functions *)
 type ('id, 'name) indexed_var = {

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -210,7 +210,7 @@ impl ErrorCtx {
     pub fn continue_on_failure(&self) -> bool {
         self.continue_on_failure
     }
-    pub(crate) fn has_errors(&self) -> bool {
+    pub fn has_errors(&self) -> bool {
         self.error_count > 0
     }
 

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -156,6 +156,14 @@ pub struct CliOpts {
     )]
     #[serde(default)]
     pub exclude: Vec<String>,
+    /// List of traits for which we transform associated types to type parameters.
+    #[clap(
+        long = "remove-associated-types",
+        help = "List of traits for which we transform associated types to type parameters. \
+        The syntax is like `--include`, see the doc there."
+    )]
+    #[serde(default)]
+    pub remove_associated_types: Vec<String>,
     /// Whether to hide the `Sized`, `Sync`, `Send` and `Unpin` marker traits anywhere they show
     /// up.
     #[clap(long = "hide-marker-traits")]

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -1,0 +1,1295 @@
+//! Change trait associated types to be type parameters instead. E.g.
+//! ```rust,ignore
+//! trait Iterator {
+//!     type Item;
+//! }
+//! fn merge<I, J>(...) -> ...
+//! where
+//!     I: Iterator,
+//!     J: Iterator<Item = I::Item>,
+//! {}
+//! // becomes
+//! trait Iterator<Item> {
+//! }
+//! fn merge<I, J, Item>(...) -> ...
+//! where
+//!     I: Iterator<Item>,
+//!     J: Iterator<Item>,
+//! {}
+//! ```
+//!
+//! This pass only transforms traits that are selected with the `--remove-associated-types` option.
+//! The pass also normalizes associated types everywhere.
+//!
+//! The pass works as follows:
+//! 1. We compute for each item the list of associated types that need to be provided a value,
+//!    represented with `AssocTypePath`. E.g. the above example gives us one extra param for
+//!    `Iterator`, corresponding to `Self::Item`.
+//!    If the associated type was constrained by a `Trait::Type = T` clause, we remember that.
+//! 2. For each item, for each such associated type for which we don't have a value, we add a type
+//!    parameter to the item. We then update each `GenericArgs`,`TraitRef` and `TyKind::TraitType`
+//!    pointing to a modified item. This includes going into function and type bodies to replace
+//!    all trait type references with our new parameters.
+//!
+//! Note that the first step is recursive: if a trait has parent clauses, types needed by these
+//! parent clauses will be needed by the trait itself too.
+//! ```rust,ignore
+//! trait Foo {
+//!     type Item: Bar;
+//! }
+//! trait Bar {
+//!     type Output;
+//! }
+//! // becomes:
+//! trait Foo<Item, Bar_Output>
+//! where Item: Bar<Bar_Output> {}
+//! trait Bar<Output> {}
+//! ```
+//!
+//! In this process we detect recursive cases that we can't handle and skip them. For example:
+//! ```rust,ignore
+//! trait Bar {
+//!     type BarTy;
+//! }
+//! trait Foo {
+//!     type FooTy: Foo + Bar;
+//! }
+//! // becomes:
+//! trait Bar<BarTy> {}
+//! trait Foo {
+//!     type FooTy: Foo + Bar<Self::FooTy_BarTy>;
+//!     // We need to supply an argument to `Bar` but we can't add a type parameter, so we add a
+//!     // new associated type.
+//!     type FooTy_BarTy;
+//! }
+//! ```
+//!
+//! Limitations:
+//! - we're missing assoc type info in `dyn Trait`, so we can't fixup the generics there.
+//! - we don't track bound lifetimes in quantified clauses properly (https://github.com/AeneasVerif/charon/issues/534).
+//! - type aliases don't have the correct clauses in scope (https://github.com/AeneasVerif/charon/issues/531).
+//! - we don't take into account unicity of trait implementations. This means we won't detect type
+//! equalities due to the same trait predicate appearing twice, or a trait predicate coinciding
+//! with an existing trait impl. See the `dictionary_passing_style_woes.rs` test file.
+use derive_generic_visitor::*;
+use itertools::Itertools;
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+};
+
+use macros::EnumAsGetters;
+
+use crate::{ast::*, formatter::FmtCtx, ids::Vector, pretty::FmtWithCtx, register_error};
+
+use super::{ctx::TransformPass, TransformCtx};
+
+/// Represent some `TraitRef`s as paths for easier manipulation.
+use trait_ref_path::*;
+mod trait_ref_path {
+    use macros::{EnumIsA, EnumToGetters};
+
+    use crate::ast::*;
+
+    /// A base clause: the special `Self: Trait` clause present in trait declarations, or a local
+    /// clause.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, EnumIsA, EnumToGetters)]
+    pub enum BaseClause {
+        SelfClause,
+        Local(DeBruijnVar<TraitClauseId>),
+    }
+
+    /// A `TraitRef` represented as a path.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct TraitRefPath {
+        /// The base clause we start from.
+        pub base: BaseClause,
+        /// Starting from `base`, recursively take the ith parent clause of the current clause. Each id
+        /// corresponds to a parent of the previous one, e.g.
+        /// ```rust,ignore
+        /// trait Foo {
+        ///     type FooTy;
+        /// }
+        /// trait Bar: Foo {} // `Self: Foo` is parent clause 0
+        /// trait Baz: Copy // `Self: Copy` is parent clause 0
+        /// {
+        ///     // `Self::BazTy: Bar` is parent clause 1
+        ///     // `<Self::BazTy as Foo>::FooTy = bool` is type constraint 0
+        ///     // The `TraitRefPath` for `<Self::BazTy as Foo>` has base `Self` and `parent_path == [1, 0]`.
+        ///     type BazTy: Bar<FooTy = bool>;
+        /// }
+        /// ```
+        pub parent_path: Vec<TraitClauseId>,
+    }
+
+    impl TraitRefPath {
+        /// Make a trait ref that refers to the special `Self` clause.
+        pub fn self_ref() -> Self {
+            Self {
+                base: BaseClause::SelfClause,
+                parent_path: vec![],
+            }
+        }
+        /// Make a trait ref that refers to the given clause at depth 0.
+        pub fn local_clause(clause_id: TraitClauseId) -> Self {
+            Self {
+                base: BaseClause::Local(DeBruijnVar::new_at_zero(clause_id)),
+                parent_path: vec![],
+            }
+        }
+        /// Make a trait ref that refers to the given parent clause on `Self`.
+        /// Given a ref on a local clause, move it to refer to `Self`. This is used when we generate
+        /// paths for the `GenericParams` of a trait: within the `GenericParams` we don't know whether
+        /// we're talking about local clauses of trait implied clauses; we fix this here.
+        pub fn parent_clause(id: TraitClauseId) -> Self {
+            Self {
+                base: BaseClause::SelfClause,
+                parent_path: vec![id],
+            }
+        }
+
+        pub fn with_assoc_type(self, type_name: TraitItemName) -> AssocTypePath {
+            AssocTypePath {
+                tref: self,
+                type_name,
+            }
+        }
+
+        /// Given a ref on `Self`, make it into a ref on the given clause.
+        pub fn on_local_clause(&self, id: TraitClauseId) -> Self {
+            assert!(matches!(self.base, BaseClause::SelfClause));
+            let mut new_ref = self.clone();
+            new_ref.base = BaseClause::Local(DeBruijnVar::new_at_zero(id));
+            new_ref
+        }
+
+        /// Given a ref on `Self`, apply it on top of given ref.
+        pub fn on_tref(&self, tref: &TraitRefPath) -> TraitRefPath {
+            assert!(matches!(self.base, BaseClause::SelfClause));
+            let mut new_ref = tref.clone();
+            new_ref.parent_path.extend(self.parent_path.iter().copied());
+            new_ref
+        }
+
+        /// References the same clause one level up.
+        pub fn pop_base(&self) -> Self {
+            let mut new_ref = self.clone();
+            match self.base {
+                BaseClause::Local(_) => {
+                    new_ref.base = BaseClause::SelfClause;
+                }
+                BaseClause::SelfClause => panic!(),
+            }
+            new_ref
+        }
+
+        /// For a ref based on `Self` parent clauses, this returns the first parent id and the rest of
+        /// the ref (that applies to the parent trait).
+        pub fn pop_first_parent(&self) -> Option<(TraitClauseId, Self)> {
+            assert!(self.base.is_self_clause());
+            if self.parent_path.is_empty() {
+                None
+            } else {
+                let mut this = self.clone();
+                let clause_id = this.parent_path.remove(0);
+                Some((clause_id, this))
+            }
+        }
+
+        fn move_from_under_binders(mut self, depth: DeBruijnId) -> Option<Self> {
+            match &mut self.base {
+                BaseClause::SelfClause => {}
+                BaseClause::Local(var) => *var = var.move_from_under_binders(depth)?,
+            }
+            Some(self)
+        }
+    }
+
+    impl TraitRefKind {
+        pub fn to_path(&self) -> Option<TraitRefPath> {
+            match self {
+                TraitRefKind::SelfId => Some(TraitRefPath {
+                    base: BaseClause::SelfClause,
+                    parent_path: vec![],
+                }),
+                TraitRefKind::Clause(id) => Some(TraitRefPath {
+                    base: BaseClause::Local(*id),
+                    parent_path: vec![],
+                }),
+                TraitRefKind::ParentClause(tref, _, id) => {
+                    let mut path = tref.to_path()?;
+                    path.parent_path.push(*id);
+                    Some(path)
+                }
+                TraitRefKind::ItemClause(_, _, _, _) => unreachable!(),
+                TraitRefKind::TraitImpl(_, _)
+                | TraitRefKind::BuiltinOrAuto { .. }
+                | TraitRefKind::Dyn(_)
+                | TraitRefKind::Unknown(_) => None,
+            }
+        }
+    }
+
+    impl TraitRef {
+        pub fn to_path(&self) -> Option<TraitRefPath> {
+            self.kind.to_path()
+        }
+    }
+
+    /// The path to an associated type that depends on a local clause.
+    #[derive(Debug, Clone)]
+    pub struct AssocTypePath {
+        /// The trait clause that has the associated type.
+        pub tref: TraitRefPath,
+        /// The name of the associated type.
+        pub type_name: TraitItemName,
+    }
+
+    impl AssocTypePath {
+        /// See [`TraitRefPath::on_local_clause`].
+        pub fn on_local_clause(&self, id: TraitClauseId) -> AssocTypePath {
+            Self {
+                tref: self.tref.on_local_clause(id),
+                type_name: self.type_name.clone(),
+            }
+        }
+
+        /// See [`TraitRefPath::on_local_tref`].
+        pub fn on_tref(&self, tref: &TraitRefPath) -> AssocTypePath {
+            Self {
+                tref: self.tref.on_tref(&tref),
+                type_name: self.type_name.clone(),
+            }
+        }
+
+        /// See [`TraitRefPath::pop_base`].
+        pub fn pop_base(&self) -> Self {
+            Self {
+                tref: self.tref.pop_base(),
+                type_name: self.type_name.clone(),
+            }
+        }
+
+        /// For a ref based on `Self` parent clauses, this returns the first parent id and the rest of
+        /// the ref (that applies to the parent trait).
+        pub fn pop_first_parent(&self) -> Option<(TraitClauseId, Self)> {
+            let (clause_id, sub_tref) = self.tref.pop_first_parent()?;
+            let sub_path = Self {
+                tref: sub_tref,
+                type_name: self.type_name.clone(),
+            };
+            Some((clause_id, sub_path))
+        }
+
+        /// Transform a trait type constraint into a (path, ty) pair. If the constraint does not refer
+        /// to a local clause, we return it unchanged.
+        pub fn from_constraint(cstr: &RegionBinder<TraitTypeConstraint>) -> Option<Self> {
+            // `unwrap()` is ok because a path only contains clause variables, which can't be bound
+            // in a predicate binder.
+            let tref = cstr
+                .skip_binder
+                .trait_ref
+                .to_path()?
+                .move_from_under_binders(DeBruijnId::one())
+                .unwrap();
+            Some(AssocTypePath {
+                tref,
+                type_name: cstr.skip_binder.type_name.clone(),
+            })
+        }
+
+        /// Construct a name that can be used to name a new type parameter/associated type
+        /// corresponding to this path.
+        pub fn to_name(&self) -> String {
+            use std::fmt::Write;
+            let mut buf = match &self.tref.base {
+                BaseClause::SelfClause => "Self".to_string(),
+                BaseClause::Local(var) => {
+                    format!("Clause{}", var.bound_at_depth(DeBruijnId::zero()).unwrap())
+                }
+            };
+            for id in &self.tref.parent_path {
+                let _ = write!(&mut buf, "_Clause{id}");
+            }
+            let _ = write!(&mut buf, "_{}", self.type_name);
+            buf
+        }
+    }
+
+    impl std::fmt::Display for AssocTypePath {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match &self.tref.base {
+                BaseClause::SelfClause => write!(f, "Self")?,
+                BaseClause::Local(var) => write!(f, "Clause{var}")?,
+            };
+            for id in &self.tref.parent_path {
+                write!(f, "::Clause{id}")?;
+            }
+            write!(f, "::{}", self.type_name)?;
+            Ok(())
+        }
+    }
+}
+
+/// Efficient representation of a set of `<Type as Trait>::Type = T` constraints.
+use type_constraint_set::*;
+mod type_constraint_set {
+    use std::collections::HashMap;
+
+    use super::trait_ref_path::*;
+    use crate::ast::*;
+
+    /// A set of local `TraitTypeConstraint`s, represented as a trie.
+    #[derive(Default, Clone)]
+    pub struct TypeConstraintSet {
+        /// For each base clause, a sub-trie of type constraints.
+        clauses: HashMap<BaseClause, TypeConstraintSetInner>,
+    }
+
+    /// A set of `TraitTypeConstraint`s that apply to a trait.
+    #[derive(Debug, Default, Clone)]
+    struct TypeConstraintSetInner {
+        /// The types that correspond to `Self::<Name>` for each `Name`. We also remember the id of the
+        /// original constraint if applicable.
+        assoc_tys: HashMap<TraitItemName, (Option<TraitTypeConstraintId>, Ty)>,
+        /// The types constraints that depend on the ith parent clause.
+        parent_clauses: Vector<TraitClauseId, Self>,
+    }
+
+    impl TypeConstraintSet {
+        pub fn from_constraints(
+            constraints: &Vector<TraitTypeConstraintId, RegionBinder<TraitTypeConstraint>>,
+        ) -> Self {
+            let mut this = TypeConstraintSet::default();
+            for (i, c) in constraints.iter_indexed() {
+                this.insert_type_constraint(i, c);
+            }
+            this
+        }
+
+        /// Add a type constraint to the set.
+        fn insert_inner(
+            &mut self,
+            path: &AssocTypePath,
+            cid: Option<TraitTypeConstraintId>,
+            ty: Ty,
+        ) {
+            let mut trie = self.clauses.entry(path.tref.base).or_default();
+            for id in &path.tref.parent_path {
+                trie = trie
+                    .parent_clauses
+                    .get_or_extend_and_insert(*id, Default::default);
+            }
+            trie.assoc_tys.insert(path.type_name.clone(), (cid, ty));
+        }
+
+        /// Add a type constraint to the set that doesn't come from a `TraitTypeConstraint`.
+        pub fn insert_path(&mut self, path: &AssocTypePath, ty: Ty) {
+            self.insert_inner(path, None, ty);
+        }
+
+        /// Add a type constraint to the set.
+        fn insert_type_constraint(
+            &mut self,
+            cid: TraitTypeConstraintId,
+            cstr: &RegionBinder<TraitTypeConstraint>,
+        ) {
+            let Some(path) = AssocTypePath::from_constraint(cstr) else {
+                // We ignore non-local constraints.
+                return;
+            };
+            // Erase bound lifetimes; handling them correctly would require tracking a lot more
+            // info.
+            let ty = cstr.map_ref(|cstr| cstr.ty.clone()).erase();
+            self.insert_inner(&path, Some(cid), ty);
+        }
+
+        /// Find the entry at that path from the trie, if it exists.
+        pub fn find(&self, path: &AssocTypePath) -> Option<(Option<TraitTypeConstraintId>, &Ty)> {
+            if let BaseClause::Local(var) = path.tref.base {
+                // Only lookup at level zero because replacements are always at level zero relative to
+                // the item.
+                assert!(var.bound_at_depth(DeBruijnId::zero()).is_some());
+            }
+            let mut trie = self.clauses.get(&path.tref.base)?;
+            for id in &path.tref.parent_path {
+                trie = trie.parent_clauses.get(*id)?;
+            }
+            trie.assoc_tys
+                .get(&path.type_name)
+                .map(|(id, ty)| (*id, ty))
+        }
+
+        pub fn iter(&self) -> impl Iterator<Item = (AssocTypePath, Ty)> {
+            let mut vec = vec![];
+            for (base, inner) in &self.clauses {
+                inner.to_vec_inner(
+                    &mut vec,
+                    &TraitRefPath {
+                        base: *base,
+                        parent_path: vec![],
+                    },
+                )
+            }
+            vec.into_iter()
+        }
+    }
+
+    impl TypeConstraintSetInner {
+        fn debug_fmt(
+            &self,
+            f: &mut std::fmt::Formatter<'_>,
+            base: BaseClause,
+            parents: &[TraitClauseId],
+        ) -> std::fmt::Result {
+            for (name, (_, ty)) in &self.assoc_tys {
+                match base {
+                    BaseClause::SelfClause => write!(f, "Self")?,
+                    BaseClause::Local(id) => write!(f, "Clause{id}")?,
+                }
+                for id in parents {
+                    write!(f, "::Clause{id}")?;
+                }
+                write!(f, "::{name} = {ty:?}, ")?;
+            }
+            for (parent_id, parent_trie) in self.parent_clauses.iter_indexed() {
+                let mut new_parents = parents.to_vec();
+                new_parents.push(parent_id);
+                parent_trie.debug_fmt(f, base, &new_parents)?;
+            }
+            Ok(())
+        }
+
+        fn to_vec_inner(&self, vec: &mut Vec<(AssocTypePath, Ty)>, base_path: &TraitRefPath) {
+            for (name, (_, ty)) in &self.assoc_tys {
+                vec.push((base_path.clone().with_assoc_type(name.clone()), ty.clone()));
+            }
+            for (clause_id, inner) in self.parent_clauses.iter_indexed() {
+                let mut base_path = base_path.clone();
+                base_path.parent_path.push(clause_id);
+                inner.to_vec_inner(vec, &base_path);
+            }
+        }
+    }
+
+    impl std::fmt::Debug for TypeConstraintSet {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("{ ")?;
+            for (base, inner) in self.clauses.iter() {
+                inner.debug_fmt(f, *base, &[])?;
+            }
+            f.write_str("}")?;
+            Ok(())
+        }
+    }
+}
+
+/// Records the modifications we are operating on the given item.
+#[derive(Debug, Clone)]
+struct ItemModifications {
+    /// The constraints on associated types for this item.
+    type_constraints: TypeConstraintSet,
+    /// Associated item paths for which we don't know a type they correspond to, so we will have to
+    /// add a new type parameter to the signature of the item.
+    required_extra_paths: Vec<AssocTypePath>,
+    /// These constraints refer to now-removed associated types. We have taken them into account,
+    /// they should be removed.
+    remove_constraints: HashSet<TraitTypeConstraintId>,
+    /// For trait declarations only: if `true`, we turn its associated types into parameters and
+    /// turn any extra required params into new params. If `false`, we keep its associated types
+    /// and turn extra require params into new associated types.
+    /// For non-traits, this is always `true`.
+    add_type_params: bool,
+}
+
+impl ItemModifications {
+    fn new(
+        type_constraints: &Vector<TraitTypeConstraintId, RegionBinder<TraitTypeConstraint>>,
+        add_type_params: bool,
+    ) -> Self {
+        Self::from_constraint_set(
+            TypeConstraintSet::from_constraints(type_constraints),
+            add_type_params,
+        )
+    }
+
+    fn from_constraint_set(type_constraints: TypeConstraintSet, add_type_params: bool) -> Self {
+        Self {
+            type_constraints,
+            required_extra_paths: Default::default(),
+            remove_constraints: Default::default(),
+            add_type_params,
+        }
+    }
+
+    /// Record that we must replace this path. If there is a relevant type constraint we can use
+    /// it, otherwise we will need to add a new type parameter to supply a value for this path.
+    fn replace_path(&mut self, path: AssocTypePath) {
+        if let Some((cstr_id, _)) = self.type_constraints.find(&path) {
+            // The local constraints already give us a value for this associated type; we
+            // use that.
+            if let Some(cstr_id) = cstr_id {
+                self.remove_constraints.insert(cstr_id);
+            }
+            // The path is already in the set, no need to replace it.
+        } else {
+            // We don't have a value for this associated type; we add a new type parameter
+            // to supply it.
+            self.required_extra_paths.push(path);
+        }
+    }
+
+    /// Iterate over the paths that need to be filled.
+    fn required_extra_paths(&self) -> impl Iterator<Item = &AssocTypePath> {
+        self.required_extra_paths.iter()
+    }
+
+    /// Iterate over the paths that require adding new type parameters.
+    fn required_extra_params(&self) -> impl Iterator<Item = &AssocTypePath> {
+        if self.add_type_params {
+            Some(self.required_extra_paths())
+        } else {
+            None
+        }
+        .into_iter()
+        .flatten()
+    }
+
+    /// Iterate over the paths that require adding new associated types.
+    fn required_extra_assoc_types(&self) -> impl Iterator<Item = &AssocTypePath> {
+        if self.add_type_params {
+            None
+        } else {
+            Some(self.required_extra_paths())
+        }
+        .into_iter()
+        .flatten()
+    }
+
+    /// Compute the type replacements needed to update the body of this item. We use the provided
+    /// function to make new types for each missing type. That function will typically add new type
+    /// parameters to the item signature.
+    fn compute_replacements(&self, mut f: impl FnMut(&AssocTypePath) -> Ty) -> TypeConstraintSet {
+        let mut set = self.type_constraints.clone();
+        for path in &self.required_extra_paths {
+            let ty = f(path);
+            set.insert_path(path, ty);
+        }
+        set
+    }
+}
+
+/// An enum to manage potentially-cyclic computations.
+#[derive(Debug, EnumAsGetters)]
+enum Processing<T> {
+    /// We haven't analyzed this yet.
+    Unprocessed,
+    /// Sentinel value that we set when starting the computation on an item. If we ever encounter
+    /// this, we know we encountered a loop that we can't handle.
+    Processing,
+    /// Sentinel value we put when encountering a cycle, so we can know that happened.
+    Cyclic,
+    /// The final result of the computation.
+    Processed(T),
+}
+
+struct ComputeItemModifications<'a> {
+    ctx: &'a TransformCtx,
+    /// Records the modifications for each trait.
+    trait_modifications: Vector<TraitDeclId, Processing<ItemModifications>>,
+    /// Records the set of known associated types for this trait impl, including parent impls and
+    /// associated type constraints.
+    impl_assoc_tys: Vector<TraitImplId, Processing<TypeConstraintSet>>,
+}
+
+impl<'a> ComputeItemModifications<'a> {
+    fn new(ctx: &'a TransformCtx) -> Self {
+        ComputeItemModifications {
+            ctx,
+            trait_modifications: ctx
+                .translated
+                .trait_decls
+                .map_ref_opt(|_| Some(Processing::Unprocessed)),
+            impl_assoc_tys: ctx
+                .translated
+                .trait_impls
+                .map_ref_opt(|_| Some(Processing::Unprocessed)),
+        }
+    }
+
+    fn compute_item_modifications(&mut self, item: AnyTransItem<'_>) -> ItemModifications {
+        if let AnyTransItem::TraitDecl(tdecl) = item {
+            // The complex case is traits: we call `compute_extra_params_for_trait` to
+            // compute the right thing.
+            let id = tdecl.def_id;
+            let _ = self.compute_extra_params_for_trait(id);
+            self.trait_modifications[id].as_processed().unwrap().clone()
+        } else if let AnyTransItem::TraitImpl(timpl) = item {
+            let _ = self.compute_assoc_tys_for_impl(timpl.def_id);
+            let type_constraints = self.impl_assoc_tys[timpl.def_id]
+                .as_processed()
+                .unwrap()
+                .clone();
+            let mut modifications = ItemModifications::from_constraint_set(type_constraints, true);
+            for clause in &timpl.generics.trait_clauses {
+                for path in self.compute_extra_params_for_clause(clause, TraitRefPath::local_clause)
+                {
+                    modifications.replace_path(path);
+                }
+            }
+            modifications
+        } else {
+            let mut modifications = self.compute_non_trait_modifications(item.generic_params());
+            // Trait method declarations have an implicit `Self` clause. We process it like a real
+            // clause.
+            if let AnyTransItem::Fun(FunDecl {
+                kind: ItemKind::TraitDecl { trait_ref, .. },
+                ..
+            })
+            | AnyTransItem::Global(GlobalDecl {
+                kind: ItemKind::TraitDecl { trait_ref, .. },
+                ..
+            }) = item
+            {
+                let trait_id = trait_ref.trait_id;
+                if self.ctx.translated.trait_decls.get(trait_id).is_some() {
+                    for path in self.compute_extra_params_for_trait(trait_id) {
+                        modifications.replace_path(path.clone());
+                    }
+                }
+            }
+            modifications
+        }
+    }
+
+    fn compute_non_trait_modifications(&mut self, params: &GenericParams) -> ItemModifications {
+        // For non-traits, we simply iterate through the clauses of the item and
+        // collect new paths to replace.
+        let mut modifications = ItemModifications::new(&params.trait_type_constraints, true);
+        // For each clause, we need to supply types for the new parameters. `replace_path` either
+        // finds the right type in the type constraints, or records that we need to add new
+        // parameters to this trait's signature.
+        for clause in &params.trait_clauses {
+            for path in self.compute_extra_params_for_clause(clause, TraitRefPath::local_clause) {
+                modifications.replace_path(path);
+            }
+        }
+        modifications
+    }
+
+    /// Returns the extra parameters that we add to the given trait. If we hadn't processed this
+    /// trait before, we modify it to add the parameters in question and remove its associated
+    /// types.
+    fn compute_extra_params_for_trait(
+        &mut self,
+        id: TraitDeclId,
+    ) -> impl Iterator<Item = &AssocTypePath> {
+        if let Processing::Unprocessed = self.trait_modifications[id] {
+            if let Some(tr) = self.ctx.translated.trait_decls.get(id) {
+                // Put the sentinel value to detect loops.
+                self.trait_modifications[id] = Processing::Processing;
+
+                // The heart of the recursion: we process the trait clauses, which recursively computes
+                // the extra parameters needed for each corresponding trait. Each of the referenced
+                // traits may need to be supplied extra type parameters. `replace_path` either finds
+                // the right type in the type constraints, or records that we need to add new
+                // parameters to this trait's signature.
+                let mut replace = vec![];
+                for clause in &tr.generics.trait_clauses {
+                    for path in
+                        self.compute_extra_params_for_clause(clause, TraitRefPath::local_clause)
+                    {
+                        replace.push(path);
+                    }
+                }
+                for clause in &tr.parent_clauses {
+                    for path in
+                        self.compute_extra_params_for_clause(clause, TraitRefPath::parent_clause)
+                    {
+                        replace.push(path);
+                    }
+                }
+
+                let is_self_referential = match &self.trait_modifications[id] {
+                    Processing::Unprocessed | Processing::Processed(_) => unreachable!(),
+                    Processing::Processing => false,
+                    Processing::Cyclic => true,
+                };
+                let remove_assoc_type = self
+                    .ctx
+                    .options
+                    .remove_associated_types
+                    .iter()
+                    .any(|pat| pat.matches(&self.ctx.translated, &tr.item_meta.name));
+                let remove_assoc_types = !is_self_referential && remove_assoc_type;
+                let mut modifications =
+                    ItemModifications::new(&tr.generics.trait_type_constraints, remove_assoc_types);
+                if modifications.add_type_params {
+                    // Remove all associated types and turn them into new parameters. We add these
+                    // before the paths in `replace` because it's more logical to do the local
+                    // types first.
+                    for type_name in &tr.types {
+                        let path = TraitRefPath::self_ref().with_assoc_type(type_name.clone());
+                        modifications.replace_path(path);
+                    }
+                }
+                for path in replace {
+                    modifications.replace_path(path);
+                }
+
+                self.trait_modifications[id] = Processing::Processed(modifications);
+            }
+        } else if let Processing::Processing = self.trait_modifications[id] {
+            // This is already being processed: we encountered a cycle.
+            self.trait_modifications[id] = Processing::Cyclic;
+        }
+
+        match &self.trait_modifications[id] {
+            Processing::Unprocessed => None,
+            Processing::Processing | Processing::Cyclic => {
+                // We're recursively processing ourselves. We already know we won't add new type
+                // parameters, so we correctly return an empty iterator.
+                None
+            }
+            Processing::Processed(modifs) => Some(modifs.required_extra_params()),
+        }
+        .into_iter()
+        .flatten()
+    }
+
+    fn compute_extra_params_for_clause<'b, F>(
+        &'b mut self,
+        clause: &TraitClause,
+        clause_to_path: F,
+    ) -> impl Iterator<Item = AssocTypePath> + use<'b, F>
+    where
+        F: Fn(TraitClauseId) -> TraitRefPath,
+    {
+        let trait_id = clause.trait_.skip_binder.trait_id;
+        let clause_path = clause_to_path(clause.clause_id);
+        self.compute_extra_params_for_trait(trait_id)
+            .map(move |path| path.on_tref(&clause_path))
+    }
+
+    /// Returns the associated types values known for the given impl. If the impl is cyclic, the
+    /// set will not be exhaustive.
+    fn compute_assoc_tys_for_impl(&mut self, id: TraitImplId) -> Option<&TypeConstraintSet> {
+        if let Processing::Unprocessed = self.impl_assoc_tys[id] {
+            if let Some(timpl) = self.ctx.translated.trait_impls.get(id) {
+                // Put the sentinel value to detect loops.
+                self.impl_assoc_tys[id] = Processing::Processing;
+
+                let mut set =
+                    TypeConstraintSet::from_constraints(&timpl.generics.trait_type_constraints);
+                for (name, ty) in &timpl.types {
+                    let path = TraitRefPath::self_ref().with_assoc_type(name.clone());
+                    set.insert_path(&path, ty.clone());
+                }
+                for (clause_id, tref) in timpl.parent_trait_refs.iter_indexed() {
+                    let clause_path = TraitRefPath::parent_clause(clause_id);
+                    for (path, ty) in
+                        self.compute_assoc_tys_for_tref(timpl.item_meta.span, &tref.kind)
+                    {
+                        let path = path.on_tref(&clause_path);
+                        set.insert_path(&path, ty);
+                    }
+                }
+
+                self.impl_assoc_tys[id] = Processing::Processed(set);
+            }
+        }
+        self.impl_assoc_tys[id].as_processed()
+    }
+
+    /// Returns the associated types values known for the given trait ref.
+    // TODO: also extract refs from `dyn Trait` refs.
+    fn compute_assoc_tys_for_tref(
+        &mut self,
+        span: Span,
+        tref: &TraitRefKind,
+    ) -> Vec<(AssocTypePath, Ty)> {
+        let mut out = vec![];
+        match tref {
+            TraitRefKind::Clause(..)
+            | TraitRefKind::ParentClause(..)
+            | TraitRefKind::ItemClause(..)
+            | TraitRefKind::SelfId
+            | TraitRefKind::Unknown(_) => {}
+            TraitRefKind::TraitImpl(clause_impl_id, generics) => {
+                let generics = ItemBinder::new(CurrentItem, generics);
+                if let Some(set_for_clause) = self.compute_assoc_tys_for_impl(*clause_impl_id) {
+                    for (path, ty) in set_for_clause.iter() {
+                        let ty = ItemBinder::new(*clause_impl_id, ty)
+                            .substitute(generics)
+                            .under_current_binder();
+                        out.push((path, ty));
+                    }
+                }
+            }
+            TraitRefKind::BuiltinOrAuto {
+                parent_trait_refs,
+                types,
+                ..
+            } => {
+                for (name, ty) in types.iter().cloned() {
+                    let path = TraitRefPath::self_ref().with_assoc_type(name);
+                    out.push((path, ty));
+                }
+                for (parent_clause_id, parent_ref) in parent_trait_refs.iter_indexed() {
+                    let clause_path = TraitRefPath::parent_clause(parent_clause_id);
+                    out.extend(
+                        self.compute_assoc_tys_for_tref(span, &parent_ref.kind)
+                            .into_iter()
+                            .map(|(path, ty)| {
+                                let path = path.on_tref(&clause_path);
+                                (path, ty)
+                            }),
+                    )
+                }
+            }
+            TraitRefKind::Dyn(..) => {
+                register_error!(
+                    self.ctx,
+                    span,
+                    "Can't process associated types for `dyn Trait`"
+                );
+            }
+        }
+        out
+    }
+}
+
+/// Visitor that will traverse item bodies and update `GenericArgs` to match the new item
+/// signatures. This also replaces `TyKind::TraitType`s for which we have a replacement.
+///
+/// The tricky part is that to update `GenericArgs` that apply to traits, we need to know the
+/// `TraitRef` they apply to in order to get the values of the appropriate types. To do this,
+/// `visit_generic_args` will skip `GenericArgs` meant for traits, and we must manually catch
+#[derive(Visitor)]
+struct UpdateItemBody<'a> {
+    ctx: &'a TransformCtx,
+    span: Span,
+    item_modifications: &'a HashMap<GenericsSource, ItemModifications>,
+    // It's a reversed stack, for when we go under binders.
+    type_replacements: BindingStack<TypeConstraintSet>,
+}
+
+impl UpdateItemBody<'_> {
+    fn under_binder<R>(&mut self, repls: TypeConstraintSet, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.type_replacements.push(repls);
+        let ret = f(self);
+        self.type_replacements.pop();
+        ret
+    }
+
+    fn lookup_type_replacement(&self, path: &AssocTypePath) -> Option<Ty> {
+        let mut path = path.clone();
+        let dbid = match &mut path.tref.base {
+            BaseClause::Local(DeBruijnVar::Bound(dbid, _)) => {
+                // Make the variable relative to the target item. Where clauses are always at
+                // binder level zero.
+                mem::replace(dbid, DeBruijnId::zero())
+            }
+            _ => self.type_replacements.depth(),
+        };
+        let ty = self.type_replacements[dbid].find(&path)?.1;
+        Some(ty.clone().move_under_binders(dbid))
+    }
+
+    fn lookup_path_on_trait_ref(&self, path: &AssocTypePath, tref: &TraitRefKind) -> Option<Ty> {
+        assert!(path.tref.base.is_self_clause());
+        match tref {
+            TraitRefKind::TraitImpl(impl_id, generics) => {
+                // The type constraints of trait impls already contain all relevant type
+                // equalities.
+                let (_, ty) = self
+                    .item_modifications
+                    .get(&GenericsSource::item(*impl_id))?
+                    .type_constraints
+                    .find(path)?;
+                Some(
+                    ItemBinder::new(*impl_id, ty.clone())
+                        .substitute(ItemBinder::new(CurrentItem, generics))
+                        .under_current_binder(),
+                )
+            }
+            TraitRefKind::Clause(..)
+            | TraitRefKind::ParentClause(..)
+            | TraitRefKind::ItemClause(..)
+            | TraitRefKind::SelfId => {
+                let path = path.on_tref(&tref.to_path().unwrap());
+                self.lookup_type_replacement(&path)
+            }
+            TraitRefKind::BuiltinOrAuto {
+                parent_trait_refs,
+                types,
+                ..
+            } => match path.pop_first_parent() {
+                None => types
+                    .iter()
+                    .find(|(name, _)| name == &path.type_name)
+                    .map(|(_, ty)| ty.clone()),
+                Some((parent_clause_id, sub_path)) => {
+                    let parent_ref = &parent_trait_refs[parent_clause_id];
+                    self.lookup_path_on_trait_ref(&sub_path, &parent_ref.kind)
+                }
+            },
+            // TODO: add enough info to recover assoc types.
+            TraitRefKind::Dyn(..) => None,
+            TraitRefKind::Unknown(..) => None,
+        }
+    }
+
+    fn update_generics(&mut self, args: &mut GenericArgs, self_path: Option<TraitRefKind>) {
+        let Some(modifications) = self.item_modifications.get(&args.target) else {
+            return;
+        };
+        for path in modifications.required_extra_params() {
+            let mut path = path.clone();
+            let base_tref = match path.tref.base {
+                BaseClause::SelfClause => {
+                    match &self_path {
+                        Some(self_path) => self_path,
+                        None => {
+                            // For traits we provide a `self_path`. The only other items that can
+                            // have `Self` modifications are method/assoc global declarations.
+                            // These are only referred to from a `TraitDecl`, so we know that their
+                            // `Self` actually refers to the current `Self`.
+                            match &args.target {
+                                GenericsSource::Item(AnyTransId::Fun(_))
+                                | GenericsSource::Item(AnyTransId::Global(_)) => {
+                                    &TraitRefKind::SelfId
+                                }
+                                target => unreachable!(
+                                    "Found unexpected target with a `Self` \
+                                    clause modification: {target:?}"
+                                ),
+                            }
+                        }
+                    }
+                }
+                BaseClause::Local(var) => {
+                    let clause_id = var
+                        .bound_at_depth(DeBruijnId::zero())
+                        .expect("found replacement not at binder level 0?");
+                    path = path.pop_base();
+                    &args.trait_refs[clause_id].kind
+                }
+            };
+            if let Some(ty) = self.lookup_path_on_trait_ref(&path, &base_tref) {
+                args.types.push(ty.clone());
+            } else {
+                let mut path = path;
+                if let Some(tref) = base_tref.to_path() {
+                    path = path.on_tref(&tref);
+                }
+                register_error!(
+                    self.ctx,
+                    self.span,
+                    "Could not compute the value of {path} needed to update \
+                    generics {args:?} for item {:?}.\
+                    \nConstraints in scope:\n{}",
+                    args.target,
+                    self.type_replacements
+                        .iter()
+                        .flat_map(|x| x.iter())
+                        .map(|(path, ty)| format!(
+                            "  - {path} = {}",
+                            ty.fmt_with_ctx(&FmtCtx::new())
+                        ))
+                        .join("\n"),
+                );
+            }
+        }
+    }
+
+    /// A `TraitDeclRef` must always be paired with a path in order to get access to the
+    /// appropriate associated types. We therefore ignore the trait args in `enter_generic_args`,
+    /// and must carefully call `process_trait_decl_ref` on all the right places of the AST to
+    /// catch the `GenericArgs` we skipped.
+    /// `TraitDeclRef`s exist in three places: in `TraitClause`, `TraitRef`, and directly in
+    /// `TraitImpl`.
+    fn process_trait_decl_ref(&mut self, tref: &mut TraitDeclRef, self_path: TraitRefKind) {
+        trace!("{tref:?}");
+        self.update_generics(&mut tref.generics, Some(self_path));
+    }
+
+    /// See `process_trait_decl_ref`.
+    fn process_poly_trait_decl_ref(
+        &mut self,
+        tref: &mut PolyTraitDeclRef,
+        self_path: TraitRefKind,
+    ) {
+        trace!("{tref:?}");
+        self.under_binder(Default::default(), |this| {
+            let self_path = self_path.move_under_binder();
+            this.process_trait_decl_ref(&mut tref.skip_binder, self_path)
+        });
+    }
+}
+
+impl VisitAstMut for UpdateItemBody<'_> {
+    fn visit_binder<T: AstVisitable>(
+        &mut self,
+        binder: &mut Binder<T>,
+    ) -> ControlFlow<Self::Break> {
+        let generics = &mut binder.params;
+        let mut modifications;
+        let modifications = match &binder.kind {
+            BinderKind::TraitMethod(trait_id, method_name) => self
+                .item_modifications
+                .get(&GenericsSource::Method(*trait_id, method_name.clone())),
+            BinderKind::InherentImplBlock => {
+                // An inner binder. Because it's not a globally-addressable item, we haven't computed
+                // appropriate modifications yet, so we compute them.
+                modifications = ItemModifications::new(&generics.trait_type_constraints, true);
+                for clause in &generics.trait_clauses {
+                    let trait_id = clause.trait_.skip_binder.trait_id;
+                    if let Some(tmods) =
+                        self.item_modifications.get(&GenericsSource::item(trait_id))
+                    {
+                        for path in tmods.required_extra_params() {
+                            let path = path.on_local_clause(clause.clause_id);
+                            modifications.replace_path(path);
+                        }
+                    }
+                }
+                Some(&modifications)
+            }
+            BinderKind::Other => unreachable!("no `BinderKind::Other` in the AST"),
+        };
+        let replacements = modifications
+            .map(|mods| {
+                mods.compute_replacements(|path| {
+                    let var_id = generics
+                        .types
+                        .push_with(|id| TypeVar::new(id, path.to_name()));
+                    TyKind::TypeVar(DeBruijnVar::new_at_zero(var_id)).into_ty()
+                })
+            })
+            .unwrap_or_default();
+        self.under_binder(replacements, |this| {
+            this.visit_inner(binder);
+        });
+        Continue(())
+    }
+
+    fn visit_region_binder<T: AstVisitable>(
+        &mut self,
+        binder: &mut RegionBinder<T>,
+    ) -> ControlFlow<Self::Break> {
+        self.under_binder(Default::default(), |this| {
+            this.visit_inner(binder);
+        });
+        Continue(())
+    }
+
+    fn enter_trait_impl(&mut self, timpl: &mut TraitImpl) {
+        self.process_trait_decl_ref(&mut timpl.impl_trait, TraitRefKind::SelfId);
+    }
+
+    fn enter_trait_decl(&mut self, tdecl: &mut TraitDecl) {
+        for (clause_id, clause) in tdecl.parent_clauses.iter_mut_indexed() {
+            let self_path =
+                TraitRefKind::ParentClause(Box::new(TraitRefKind::SelfId), tdecl.def_id, clause_id);
+            self.process_poly_trait_decl_ref(&mut clause.trait_, self_path);
+        }
+    }
+
+    fn enter_generic_params(&mut self, params: &mut GenericParams) {
+        for (clause_id, clause) in params.trait_clauses.iter_mut_indexed() {
+            let self_path = TraitRefKind::Clause(DeBruijnVar::new_at_zero(clause_id));
+            self.process_poly_trait_decl_ref(&mut clause.trait_, self_path);
+        }
+    }
+
+    fn enter_generic_args(&mut self, args: &mut GenericArgs) {
+        if !matches!(args.target, GenericsSource::Item(AnyTransId::TraitDecl(..))) {
+            // To update `GenericArgs` that apply to traits we need to know the `TraitRef` they
+            // apply to. Hence we skip them here and we have to manually catch all these cases with
+            // `process_trait_decl_ref`.
+            self.update_generics(args, None);
+        }
+    }
+
+    fn enter_trait_ref(&mut self, tref: &mut TraitRef) {
+        self.process_poly_trait_decl_ref(&mut tref.trait_decl_ref, tref.kind.clone());
+    }
+
+    fn enter_trait_ref_kind(&mut self, kind: &mut TraitRefKind) {
+        // There are some stray `TraitDeclRef`s that we have to update.
+        // TODO: we should make `TraitRefKind` recursively contain full `TraitRef`s so we have the
+        // implemented trait info at each level. This would require hax to give us more info.
+        let kind_clone = kind.clone();
+        match kind {
+            TraitRefKind::BuiltinOrAuto {
+                trait_decl_ref: tref,
+                ..
+            }
+            | TraitRefKind::Dyn(tref) => {
+                self.process_poly_trait_decl_ref(tref, kind_clone);
+            }
+            _ => {}
+        }
+    }
+
+    fn enter_item_kind(&mut self, kind: &mut ItemKind) {
+        match kind {
+            ItemKind::Regular => {}
+            // Inside method declarations, we have access to the implicit `Self` clause.
+            ItemKind::TraitDecl { trait_ref, .. } => {
+                self.process_trait_decl_ref(trait_ref, TraitRefKind::SelfId)
+            }
+            ItemKind::TraitImpl {
+                impl_ref,
+                trait_ref,
+                ..
+            } => self.process_trait_decl_ref(
+                trait_ref,
+                TraitRefKind::TraitImpl(impl_ref.impl_id, impl_ref.generics.clone()),
+            ),
+        }
+    }
+
+    fn enter_ty_kind(&mut self, kind: &mut TyKind) {
+        if let TyKind::TraitType(tref, name) = kind {
+            let path = TraitRefPath::self_ref().with_assoc_type(name.clone());
+            if let Some(new_ty) = self.lookup_path_on_trait_ref(&path, &tref.kind) {
+                *kind = new_ty.kind().clone();
+                // Fix the newly-substituted type.
+                self.visit(kind);
+            }
+        }
+    }
+
+    fn visit_ullbc_statement(&mut self, st: &mut ullbc_ast::Statement) -> ControlFlow<Self::Break> {
+        // Track span for more precise error messages.
+        let old_span = self.span;
+        self.span = st.span;
+        self.visit_inner(st)?;
+        self.span = old_span;
+        Continue(())
+    }
+
+    fn visit_llbc_statement(&mut self, st: &mut llbc_ast::Statement) -> ControlFlow<Self::Break> {
+        // Track span for more precise error messages.
+        let old_span = self.span;
+        self.span = st.span;
+        self.visit_inner(st)?;
+        self.span = old_span;
+        Continue(())
+    }
+}
+
+pub struct Transform;
+impl TransformPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        // Compute all the necessary type info to be able to replace and normalize associated
+        // types.
+        let item_modifications: HashMap<GenericsSource, ItemModifications> = {
+            let mut computer = ComputeItemModifications::new(ctx);
+            let mut item_modifications = HashMap::new();
+            for (id, item) in ctx.translated.all_items_with_ids() {
+                let modifications = computer.compute_item_modifications(item);
+                item_modifications.insert(GenericsSource::Item(id), modifications);
+                if let AnyTransItem::TraitDecl(tdecl) = item {
+                    for (name, bound_fn) in
+                        tdecl.required_methods.iter().chain(&tdecl.provided_methods)
+                    {
+                        let modifications =
+                            computer.compute_non_trait_modifications(&bound_fn.params);
+                        item_modifications.insert(
+                            GenericsSource::Method(tdecl.def_id, name.clone()),
+                            modifications,
+                        );
+                    }
+                }
+            }
+            item_modifications
+        };
+
+        // Apply the computed modifications to each item.
+        ctx.for_each_item_mut(|ctx, mut item| {
+            let id = item.as_ref().id();
+            let span = item.as_ref().item_meta().span;
+            let modifications = item_modifications.get(&GenericsSource::Item(id)).unwrap();
+
+            // Add new parameters or associated types in order to have types to fill in all the
+            // replaced paths. We then collect the replaced paths and their associated value.
+            let type_replacements: TypeConstraintSet = if let AnyTransItemMut::TraitDecl(tr) =
+                &mut item
+                && !modifications.add_type_params
+            {
+                // If we're self-referential, instead of adding new type parameters to pass to our
+                // parent clauses, we add new associated types. That way the parameter list of the
+                // trait stays unchanged.
+                let self_tref = TraitRef {
+                    kind: TraitRefKind::SelfId,
+                    trait_decl_ref: RegionBinder::empty(TraitDeclRef {
+                        trait_id: tr.def_id,
+                        generics: tr.generics.identity_args(GenericsSource::item(tr.def_id)),
+                    }),
+                };
+                modifications.compute_replacements(|path| {
+                    let new_type_name = TraitItemName(path.to_name());
+                    tr.types.push(new_type_name.clone());
+                    TyKind::TraitType(self_tref.clone(), new_type_name).into_ty()
+                })
+            } else {
+                modifications.compute_replacements(|path| {
+                    let var_id = item
+                        .generic_params()
+                        .types
+                        .push_with(|id| TypeVar::new(id, path.to_name()));
+                    TyKind::TypeVar(DeBruijnVar::new_at_zero(var_id)).into_ty()
+                })
+            };
+
+            // Remove used constraints.
+            for cid in &modifications.remove_constraints {
+                item.generic_params().trait_type_constraints.remove(*cid);
+            }
+
+            // Remove trait associated types.
+            if let AnyTransItemMut::TraitDecl(tr) = &mut item
+                && modifications.add_type_params
+            {
+                tr.types.clear();
+            }
+
+            // Adjust impl associated types.
+            if let AnyTransItemMut::TraitImpl(timpl) = &mut item {
+                let trait_id = timpl.impl_trait.trait_id;
+                if let Some(decl_modifs) = item_modifications.get(&GenericsSource::item(trait_id)) {
+                    if decl_modifs.add_type_params {
+                        timpl.types.clear();
+                    }
+                    for path in decl_modifs.required_extra_assoc_types() {
+                        let new_type_name = TraitItemName(path.to_name());
+                        if let Some((_, ty)) = type_replacements.find(&path) {
+                            trace!("Adding associated type {new_type_name} = {ty:?}");
+                            timpl.types.push((new_type_name, ty.clone()));
+                        } else {
+                            register_error!(
+                                ctx,
+                                span,
+                                "Could not figure out type for new associated type {new_type_name}.\
+                                \nAvailable: {:?}",
+                                type_replacements
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Update the rest of the items: all the `GenericArgs` and the non-top-level binders
+            // (trait methods and inherent impls in `Name`s).
+            item.drive_mut(&mut UpdateItemBody {
+                ctx,
+                span,
+                item_modifications: &item_modifications,
+                type_replacements: BindingStack::new(type_replacements),
+            });
+        });
+    }
+}

--- a/charon/src/transform/graphs.rs
+++ b/charon/src/transform/graphs.rs
@@ -1,4 +1,4 @@
-use hashlink::LinkedHashSet;
+use indexmap::IndexSet;
 use std::collections::BTreeSet as OrdSet;
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -23,7 +23,7 @@ pub struct SCCs<Id> {
 /// We also compute the SCC dependencies while performing this exploration.
 fn insert_scc_with_deps<Id: Copy + std::hash::Hash + Eq>(
     get_id_dependencies: &dyn Fn(Id) -> Vec<Id>,
-    reordered_sccs: &mut LinkedHashSet<usize>,
+    reordered_sccs: &mut IndexSet<usize>,
     scc_deps: &mut Vec<OrdSet<usize>>,
     sccs: &Vec<Vec<Id>>,
     id_to_scc: &HashMap<Id, usize>,
@@ -131,7 +131,7 @@ pub fn reorder_sccs<Id: std::fmt::Debug + Copy + std::hash::Hash + Eq>(
 
     // Reorder the SCCs themselves - just do a depth first search. Iterate over
     // the def ids, and add the corresponding SCCs (with their dependencies).
-    let mut reordered_sccs_ids = LinkedHashSet::<usize>::new();
+    let mut reordered_sccs_ids = IndexSet::<usize>::new();
     let mut scc_deps: Vec<OrdSet<usize>> = reordered_sccs.iter().map(|_| OrdSet::new()).collect();
     for id in ids {
         let scc_id = id_to_scc.get(id).unwrap();

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_generics;
 pub mod ctx;
 pub mod duplicate_return;
+pub mod expand_associated_types;
 pub mod filter_invisible_trait_impls;
 pub mod filter_unreachable_blocks;
 pub mod graphs;
@@ -39,6 +40,7 @@ pub static INITIAL_CLEANUP_PASSES: &[Pass] = &[
     // Move clauses on associated types to be parent clauses
     NonBody(&lift_associated_item_clauses::Transform),
     // Check that all supplied generic types match the corresponding generic parameters.
+    // Needs `lift_associated_item_clauses`.
     NonBody(&check_generics::Check("after translation")),
     // # Micro-pass: hide some overly-common traits we don't need: Sized, Sync, Allocator, etc..
     NonBody(&hide_marker_traits::Transform),
@@ -49,6 +51,8 @@ pub static INITIAL_CLEANUP_PASSES: &[Pass] = &[
     // directly instead of going via a `TraitRef`. This is done before `reorder_decls` to remove
     // some sources of mutual recursion.
     UnstructuredBody(&skip_trait_refs_when_known::Transform),
+    // Change trait associated types to be type parameters instead. See the module for details.
+    NonBody(&expand_associated_types::Transform),
 ];
 
 /// Body cleanup passes on the ullbc.

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -4,7 +4,7 @@ use crate::graphs::*;
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
 use derive_generic_visitor::*;
-use hashlink::{LinkedHashMap, LinkedHashSet};
+use indexmap::{IndexMap, IndexSet};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
@@ -153,7 +153,7 @@ impl Display for DeclarationGroup {
 pub struct Deps {
     dgraph: DiGraphMap<AnyTransId, ()>,
     // Want to make sure we remember the order of insertion
-    graph: LinkedHashMap<AnyTransId, LinkedHashSet<AnyTransId>>,
+    graph: IndexMap<AnyTransId, IndexSet<AnyTransId>>,
     // We use this when computing the graph
     current_id: Option<AnyTransId>,
     // We use this to track the trait impl block the current item belongs to
@@ -205,7 +205,7 @@ impl Deps {
     fn new() -> Self {
         Deps {
             dgraph: DiGraphMap::new(),
-            graph: LinkedHashMap::new(),
+            graph: IndexMap::new(),
             current_id: None,
             parent_trait_impl: None,
             parent_trait_decl: None,
@@ -253,7 +253,7 @@ impl Deps {
         if !self.dgraph.contains_node(id) {
             self.dgraph.add_node(id);
             assert!(!self.graph.contains_key(&id));
-            self.graph.insert(id, LinkedHashSet::new());
+            self.graph.insert(id, IndexSet::new());
         }
     }
 

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -28,7 +28,7 @@ use crate::llbc_ast as tgt;
 use crate::meta::{combine_span, Span};
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::{self as src};
-use hashlink::linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use num_rational::BigRational;
@@ -365,7 +365,7 @@ fn list_reachable(cfg: &Cfg, start: src::BlockId) -> HashMap<src::BlockId, usize
 /// parent loops.
 fn register_children_as_loop_exit_candidates(
     cfg: &CfgInfo,
-    loop_exits: &mut HashMap<src::BlockId, LinkedHashMap<src::BlockId, LoopExitCandidateInfo>>,
+    loop_exits: &mut HashMap<src::BlockId, IndexMap<src::BlockId, LoopExitCandidateInfo>>,
     removed_parent_loops: &Vec<(src::BlockId, usize)>,
     block_id: src::BlockId,
 ) {
@@ -412,7 +412,7 @@ fn compute_loop_exit_candidates(
     cfg: &CfgInfo,
     explored: &mut HashSet<src::BlockId>,
     ordered_loops: &mut Vec<src::BlockId>,
-    loop_exits: &mut HashMap<src::BlockId, LinkedHashMap<src::BlockId, LoopExitCandidateInfo>>,
+    loop_exits: &mut HashMap<src::BlockId, IndexMap<src::BlockId, LoopExitCandidateInfo>>,
     // List of parent loops, with the distance to the entry of the loop (the distance
     // is the distance between the current node and the loop entry for the last parent,
     // and the distance between the parents for the others).
@@ -638,7 +638,7 @@ fn compute_loop_exits(
 
     // Initialize the loop exits candidates
     for loop_id in &cfg.loop_entries {
-        loop_exits.insert(*loop_id, LinkedHashMap::new());
+        loop_exits.insert(*loop_id, IndexMap::new());
     }
 
     // Compute the candidates
@@ -1543,8 +1543,8 @@ fn translate_terminator(
                     // We link block ids to:
                     // - vector of matched integer values
                     // - translated blocks
-                    let mut branches: LinkedHashMap<src::BlockId, (Vec<ScalarValue>, tgt::Block)> =
-                        LinkedHashMap::new();
+                    let mut branches: IndexMap<src::BlockId, (Vec<ScalarValue>, tgt::Block)> =
+                        IndexMap::new();
 
                     // Translate the children expressions
                     for (v, bid) in targets.iter() {

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -250,62 +250,60 @@ enum core::option::Option<T>
 |  Some(T)
 
 
-trait core::slice::index::SliceIndex<Self, T>
+trait core::slice::index::SliceIndex<Self, T, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
-    type Output
-    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T>
-    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T>
-    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T>
-    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>
-    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>
-    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
+    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T, Self_Output>
+    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T, Self_Output>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T, Self_Output>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T, Self_Output>
+    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T, Self_Output>
+    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T, Self_Output>
 }
 
-fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
+fn core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}::index<'_0, T, I, Clause2_Output>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (Clause2_Output)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>, Clause2_Output>,
 
 impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#1 : core::slice::index::private_slice_index::Sealed<core::ops::range::Range<usize>[core::marker::Sized<usize>]>
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>[core::marker::Sized<&'_0 (Slice<T>)>]
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>[core::marker::Sized<&'_0 (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>[core::marker::Sized<&'_0 mut (Slice<T>)>]
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>[core::marker::Sized<&'_0 mut (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *const Slice<T>) -> *const Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *const Slice<T>) -> *const Slice<T>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *mut Slice<T>) -> *mut Slice<T>
+unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *mut Slice<T>) -> *mut Slice<T>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<T>>
+impl<T> core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<T>, Slice<T>>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#1
-    type Output = Slice<T>
-    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0_0, T>[@TraitClause0]
-    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0_0, T>[@TraitClause0]
-    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0_0, T>[@TraitClause0]
-    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0_0, T>[@TraitClause0]
+    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0_0, T>[@TraitClause0]
+    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0_0, T>[@TraitClause0]
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0_0, T>[@TraitClause0]
+    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0_0, T>[@TraitClause0]
 }
 
 fn test_crate::slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
@@ -327,7 +325,7 @@ fn test_crate::slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3:
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]](move (@6), move (@7))
+    @5 := core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]](move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)
@@ -337,11 +335,11 @@ fn test_crate::slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3:
     return
 }
 
-fn core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut<'_0, T, I>(@1: &'_0 mut (Slice<T>), @2: I) -> &'_0 mut (@TraitClause2::Output)
+fn core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1::index_mut<'_0, T, I, Clause2_Output>(@1: &'_0 mut (Slice<T>), @2: I) -> &'_0 mut (Clause2_Output)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>, Clause2_Output>,
 
 fn test_crate::slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
 {
@@ -363,7 +361,7 @@ fn test_crate::slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3
     @8 := core::ops::range::Range { start: move (@9), end: move (@10) }
     drop @10
     drop @9
-    @6 := core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]](move (@7), move (@8))
+    @6 := core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]](move (@7), move (@8))
     drop @8
     drop @7
     @5 := &mut *(@6)
@@ -402,26 +400,24 @@ fn test_crate::array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>)) -
     return
 }
 
-trait core::ops::index::Index<Self, Idx>
+trait core::ops::index::Index<Self, Idx, Self_Output>
 {
-    type Output
-    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx, Self_Output>
 }
 
-fn core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]::Output)
+fn core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15::index<'_0, T, I, Clause2_Output, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (Clause2_Output)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::ops::index::Index<Slice<T>, I>,
+    [@TraitClause2]: core::ops::index::Index<Slice<T>, I, Clause2_Output>,
 
-impl<T, I> core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I> : core::ops::index::Index<Slice<T>, I>
+impl<T, I, Clause2_Output> core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}<T, I, Clause2_Output> : core::ops::index::Index<Slice<T>, I, Clause2_Output>
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>, Clause2_Output>,
 {
-    type Output = @TraitClause2::Output
-    fn index<'_0> = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0> = core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}::index<'_0_0, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
@@ -443,7 +439,7 @@ fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>, 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)
@@ -453,36 +449,26 @@ fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2
     return
 }
 
-trait core::ops::index::IndexMut<Self, Idx>
+trait core::ops::index::IndexMut<Self, Idx, Self_Clause0_Output>
 {
-    parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
-    fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx>
+    parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx, Self_Clause0_Output>
+    fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx, Self_Clause0_Output>
 }
 
-impl<T, I, const N : usize> core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I>
+fn core::array::{impl core::ops::index::IndexMut<I, Clause2_Clause0_Output> for Array<T, const N : usize>}#16::index_mut<'_0, T, I, Clause2_Clause0_Output, const N : usize>(@1: &'_0 mut (Array<T, const N : usize>), @2: I) -> &'_0 mut (Clause2_Clause0_Output)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::ops::index::Index<Slice<T>, I>,
-{
-    type Output = @TraitClause2::Output
-    fn index<'_0> = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
-}
+    [@TraitClause2]: core::ops::index::IndexMut<Slice<T>, I, Clause2_Clause0_Output>,
 
-fn core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_0, T, I, const N : usize>(@1: &'_0 mut (Array<T, const N : usize>), @2: I) -> &'_0 mut (core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause0]::Output)
+impl<T, I, Clause2_Output> core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1<T, I, Clause2_Output> : core::ops::index::IndexMut<Slice<T>, I, Clause2_Output>
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::ops::index::IndexMut<Slice<T>, I>,
-
-impl<T, I> core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<T, I> : core::ops::index::IndexMut<Slice<T>, I>
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>, Clause2_Output>,
 {
-    parent_clause0 = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    fn index_mut<'_0> = core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1::index_mut<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    parent_clause0 = core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}<T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index_mut<'_0> = core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1::index_mut<'_0_0, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 fn test_crate::array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
@@ -505,7 +491,7 @@ fn test_crate::array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @
     @8 := core::ops::range::Range { start: move (@9), end: move (@10) }
     drop @10
     drop @9
-    @6 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@7), move (@8))
+    @6 := core::array::{impl core::ops::index::IndexMut<I, Clause2_Clause0_Output> for Array<T, const N : usize>}#16::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>, 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@7), move (@8))
     drop @8
     drop @7
     @5 := &mut *(@6)
@@ -1104,7 +1090,7 @@ fn test_crate::range_all()
     // CONFIRM: there is no way to shrink [T;N] into [T;M] with M<N?
     @6 := &mut x@1
     @7 := core::ops::range::Range { start: const (1 : usize), end: const (3 : usize) }
-    @5 := core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], 4 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::IndexMut<I> for Slice<T>}#1<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::IndexMut<I, Clause2_Clause0_Output> for Array<T, const N : usize>}#16::index_mut<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>, 4 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::IndexMut<I, Clause2_Output> for Slice<T>}#1<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
     drop @7
     drop @6
     @4 := &mut *(@5)
@@ -1457,7 +1443,7 @@ fn test_crate::f4<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) 
     @7 := core::ops::range::Range { start: move (@8), end: move (@9) }
     drop @9
     drop @8
-    @5 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
+    @5 := core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15::index<'_, u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>, 32 : usize>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::Index<I, Clause2_Output> for Slice<T>}<u32, core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<u32>>[core::marker::Sized<u32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>, Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<u32>[core::marker::Sized<u32>]]](move (@6), move (@7))
     drop @7
     drop @6
     @4 := &*(@5)
@@ -1874,31 +1860,40 @@ fn test_crate::slice_pattern_4<'_0>(@1: &'_0 (Slice<()>))
     return
 }
 
-fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
+fn core::ops::index::Index::index<'_0, Self, Idx, Self_Output>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self_Output)
 
-fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut (Self::parent_clause0::Output)
+fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx, Self_Clause0_Output>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut (Self_Clause0_Output)
 
-impl<T, I, const N : usize> core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16<T, I, const N : usize> : core::ops::index::IndexMut<Array<T, const N : usize>, I>
+impl<T, I, Clause2_Output, const N : usize> core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15<T, I, Clause2_Output, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I, Clause2_Output>
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::ops::index::IndexMut<Slice<T>, I>,
+    [@TraitClause2]: core::ops::index::Index<Slice<T>, I, Clause2_Output>,
 {
-    parent_clause0 = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause0]
-    fn index_mut<'_0> = core::array::{impl core::ops::index::IndexMut<I> for Array<T, const N : usize>}#16::index_mut<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0> = core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15::index<'_0_0, T, I, Clause2_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
-fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_0 (Self::Output)>]
+impl<T, I, Clause2_Clause0_Output, const N : usize> core::array::{impl core::ops::index::IndexMut<I, Clause2_Clause0_Output> for Array<T, const N : usize>}#16<T, I, Clause2_Clause0_Output, const N : usize> : core::ops::index::IndexMut<Array<T, const N : usize>, I, Clause2_Clause0_Output>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::ops::index::IndexMut<Slice<T>, I, Clause2_Clause0_Output>,
+{
+    parent_clause0 = core::array::{impl core::ops::index::Index<I, Clause2_Output> for Array<T, const N : usize>}#15<T, I, Clause2_Clause0_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause0]
+    fn index_mut<'_0> = core::array::{impl core::ops::index::IndexMut<I, Clause2_Clause0_Output> for Array<T, const N : usize>}#16::index_mut<'_0_0, T, I, Clause2_Clause0_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
+}
 
-fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self::Output)>[core::marker::Sized<&'_0 mut (Self::Output)>]
+fn core::slice::index::SliceIndex::get<'_0, Self, T, Self_Output>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self_Output)>[core::marker::Sized<&'_0 (Self_Output)>]
 
-unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(@1: Self, @2: *const T) -> *const Self::Output
+fn core::slice::index::SliceIndex::get_mut<'_0, Self, T, Self_Output>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self_Output)>[core::marker::Sized<&'_0 mut (Self_Output)>]
 
-unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(@1: Self, @2: *mut T) -> *mut Self::Output
+unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T, Self_Output>(@1: Self, @2: *const T) -> *const Self_Output
 
-fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self::Output)
+unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T, Self_Output>(@1: Self, @2: *mut T) -> *mut Self_Output
 
-fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self::Output)
+fn core::slice::index::SliceIndex::index<'_0, Self, T, Self_Output>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self_Output)
+
+fn core::slice::index::SliceIndex::index_mut<'_0, Self, T, Self_Output>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self_Output)
 
 
 

--- a/charon/tests/ui/arrays.rs
+++ b/charon/tests/ui/arrays.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 //! Exercise the translation of arrays, with features supported by Eurydice
 
 pub enum AB {

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -14,16 +14,24 @@ trait core::marker::Copy<Self>
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-trait test_crate::Foo<'a, Self>
+trait test_crate::Foo<'a, Self, Self_Item>
 where
-    Self::Item : 'a,
+    Self_Item : 'a,
 {
     parent_clause0 : [@TraitClause0]: core::marker::Copy<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: core::clone::Clone<Self::Item>
-    type Item
-    fn use_item<'_0> = test_crate::Foo::use_item<'a, '_0_0, Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self_Item>
+    parent_clause2 : [@TraitClause2]: core::clone::Clone<Self_Item>
+    fn use_item_required = test_crate::Foo::use_item_required<'a, Self, Self_Item>
+    fn use_item_provided<Clause0_Item, [@TraitClause0]: test_crate::Foo<'_, Self_Item, Clause0_Item>> = test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Self_Item>[@TraitClause0_0]
 }
+
+enum core::option::Option<T>
+  where
+      [@TraitClause0]: core::marker::Sized<T>,
+ =
+|  None()
+|  Some(T)
+
 
 fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
 
@@ -37,14 +45,6 @@ impl<'_0, T> core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_0, T> : co
 {
     parent_clause0 = core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>
 }
-
-enum core::option::Option<T>
-  where
-      [@TraitClause0]: core::marker::Sized<T>,
- =
-|  None()
-|  Some(T)
-
 
 fn core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone<'_0, T>(@1: &'_0 (core::option::Option<T>[@TraitClause0])) -> core::option::Option<T>[@TraitClause0]
 where
@@ -66,31 +66,90 @@ where
     fn clone_from<'_0, '_1> = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5::clone_from<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
-impl<'a, T> test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T)>
+fn test_crate::{impl test_crate::Foo<'a, core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]> for &'a (T)}::use_item_required<'a, T>(@1: core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]) -> core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]; // return
+    let x@1: core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]; // arg #1
+
+    @0 := copy (x@1)
+    return
+}
+
+impl<'a, T> test_crate::{impl test_crate::Foo<'a, core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]> for &'a (T)}<'a, T> : test_crate::Foo<'a, &'a (T), core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_, T>
     parent_clause1 = core::marker::Sized<core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]>
     parent_clause2 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<&'_ (T)>[core::marker::Sized<&'_ (T)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, T>]
-    type Item = core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]
+    fn use_item_required = test_crate::{impl test_crate::Foo<'a, core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]> for &'a (T)}::use_item_required<'a, T>[@TraitClause0]
+}
+
+impl<T> core::option::{impl core::marker::Copy for core::option::Option<T>[@TraitClause0]}#44<T> : core::marker::Copy<core::option::Option<T>[@TraitClause0]>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Copy<T>,
+{
+    parent_clause0 = core::option::{impl core::clone::Clone for core::option::Option<T>[@TraitClause0]}#5<T>[@TraitClause0, @TraitClause1::parent_clause0]
+}
+
+fn test_crate::{impl test_crate::Foo<'a, T> for core::option::Option<T>[@TraitClause0]}#1::use_item_required<'a, T>(@1: T) -> T
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Copy<T>,
+{
+    let @0: T; // return
+    let x@1: T; // arg #1
+
+    @0 := copy (x@1)
+    return
+}
+
+impl<'a, T> test_crate::{impl test_crate::Foo<'a, T> for core::option::Option<T>[@TraitClause0]}#1<'a, T> : test_crate::Foo<'a, core::option::Option<T>[@TraitClause0], T>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Copy<T>,
+{
+    parent_clause0 = core::option::{impl core::marker::Copy for core::option::Option<T>[@TraitClause0]}#44<T>[@TraitClause0, @TraitClause1]
+    parent_clause1 = @TraitClause0
+    parent_clause2 = @TraitClause1::parent_clause0
+    fn use_item_required = test_crate::{impl test_crate::Foo<'a, T> for core::option::Option<T>[@TraitClause0]}#1::use_item_required<'a, T>[@TraitClause0, @TraitClause1]
+}
+
+fn test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Self_Item>(@1: Self_Item) -> Self_Item
+where
+    [@TraitClause0]: test_crate::Foo<'_, Self_Item, Clause0_Item>,
+{
+    let @0: Self_Item; // return
+    let x@1: Self_Item; // arg #1
+
+    @0 := copy (x@1)
+    return
 }
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
-fn test_crate::external_use_item<'a, T>(@1: @TraitClause1::Item) -> @TraitClause1::Item
+fn test_crate::external_use_item<'a, T, Clause1_Item, Clause2_Item>(@1: Clause1_Item) -> Clause1_Item
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::Foo<'_, T>,
+    [@TraitClause1]: test_crate::Foo<'_, T, Clause1_Item>,
+    [@TraitClause2]: test_crate::Foo<'_, Clause1_Item, Clause2_Item>,
 {
-    let @0: @TraitClause1::Item; // return
-    let x@1: @TraitClause1::Item; // arg #1
-    let @2: &'_ (@TraitClause1::Item); // anonymous local
+    let @0: Clause1_Item; // return
+    let x@1: Clause1_Item; // arg #1
+    let @2: &'_ (Clause1_Item); // anonymous local
+    let @3: Clause1_Item; // anonymous local
+    let @4: Clause1_Item; // anonymous local
 
-    @2 := &x@1
-    @0 := @TraitClause1::parent_clause2::clone<'_>(move (@2))
+    @4 := copy (x@1)
+    @3 := @TraitClause1::use_item_provided<Clause2_Item>[@TraitClause2](move (@4))
+    @2 := &@3
+    drop @4
+    @0 := @TraitClause2::parent_clause0::parent_clause0::clone<'_>(move (@2))
     drop @2
-    drop x@1
+    drop @3
     return
 }
 
@@ -102,7 +161,7 @@ fn test_crate::call_fn()
     let @3: (); // anonymous local
 
     @2 := core::option::Option::None {  }
-    @1 := test_crate::external_use_item<'_, &'_ (bool)>[core::marker::Sized<&'_ (bool)>, test_crate::{impl test_crate::Foo<'a> for &'a (T)}<'_, bool>[core::marker::Sized<bool>]](move (@2))
+    @1 := test_crate::external_use_item<'_, &'_ (bool), core::option::Option<&'_ (bool)>[core::marker::Sized<&'_ (bool)>], &'_ (bool)>[core::marker::Sized<&'_ (bool)>, test_crate::{impl test_crate::Foo<'a, core::option::Option<&'a (T)>[core::marker::Sized<&'_ (T)>]> for &'a (T)}<'_, bool>[core::marker::Sized<bool>], test_crate::{impl test_crate::Foo<'a, T> for core::option::Option<T>[@TraitClause0]}#1<'_, &'_ (bool)>[core::marker::Sized<&'_ (bool)>, core::marker::{impl core::marker::Copy for &'_0 (T)}#4<'_, bool>]](move (@2))
     drop @2
     @fake_read(@1)
     drop @1
@@ -112,84 +171,83 @@ fn test_crate::call_fn()
     return
 }
 
-fn test_crate::type_equality<'a, I, J>(@1: @TraitClause2::Item) -> @TraitClause3::Item
+fn test_crate::type_equality<'a, I, J, Clause2_Item>(@1: Clause2_Item) -> Clause2_Item
 where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::marker::Sized<J>,
-    [@TraitClause2]: test_crate::Foo<'_, I>,
-    [@TraitClause3]: test_crate::Foo<'_, J>,
-    @TraitClause3::Item = @TraitClause2::Item,
+    [@TraitClause2]: test_crate::Foo<'_, I, Clause2_Item>,
+    [@TraitClause3]: test_crate::Foo<'_, J, Clause2_Item>,
 {
-    let @0: @TraitClause2::Item; // return
-    let x@1: @TraitClause2::Item; // arg #1
+    let @0: Clause2_Item; // return
+    let x@1: Clause2_Item; // arg #1
 
     @0 := move (x@1)
     drop x@1
     return
 }
 
-trait test_crate::loopy::Bar<Self>
+trait test_crate::loopy::Bar<Self, Self_BarTy>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::BarTy>
-    type BarTy
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_BarTy>
 }
 
-impl test_crate::loopy::{impl test_crate::loopy::Bar for ()} : test_crate::loopy::Bar<()>
+impl test_crate::loopy::{impl test_crate::loopy::Bar<bool> for ()} : test_crate::loopy::Bar<(), bool>
 {
     parent_clause0 = core::marker::Sized<bool>
-    type BarTy = bool
 }
 
 trait test_crate::loopy::Foo<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::FooTy>
     parent_clause1 : [@TraitClause1]: test_crate::loopy::Foo<Self::FooTy>
-    parent_clause2 : [@TraitClause2]: test_crate::loopy::Bar<Self::FooTy>
+    parent_clause2 : [@TraitClause2]: test_crate::loopy::Bar<Self::FooTy, Self::Self_Clause2_BarTy>
     type FooTy
+    type Self_Clause2_BarTy
 }
 
 impl test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1 : test_crate::loopy::Foo<()>
 {
     parent_clause0 = core::marker::Sized<()>
     parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Foo for ()}#1
-    parent_clause2 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
+    parent_clause2 = test_crate::loopy::{impl test_crate::loopy::Bar<bool> for ()}
     type FooTy = ()
+    type Self_Clause2_BarTy = bool
 }
 
 trait test_crate::loopy::Baz<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: test_crate::loopy::Baz<T, T>
-    parent_clause2 : [@TraitClause2]: test_crate::loopy::Bar<T>
+    parent_clause2 : [@TraitClause2]: test_crate::loopy::Bar<T, Self::Self_Clause2_BarTy>
     parent_clause3 : [@TraitClause3]: core::marker::Sized<Self::BazTy>
     type BazTy
+    type Self_Clause2_BarTy
 }
 
 impl test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()}#2 : test_crate::loopy::Baz<(), ()>
 {
     parent_clause0 = core::marker::Sized<()>
     parent_clause1 = test_crate::loopy::{impl test_crate::loopy::Baz<()> for ()}#2
-    parent_clause2 = test_crate::loopy::{impl test_crate::loopy::Bar for ()}
+    parent_clause2 = test_crate::loopy::{impl test_crate::loopy::Bar<bool> for ()}
     parent_clause3 = core::marker::Sized<usize>
     type BazTy = usize
+    type Self_Clause2_BarTy = bool
 }
 
-trait test_crate::loopy_with_generics::Bar<'a, Self, T, U>
+trait test_crate::loopy_with_generics::Bar<'a, Self, T, U, Self_BarTy>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<U>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::BarTy>
-    type BarTy
+    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self_BarTy>
 }
 
-impl<'a, T> test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T> for ()}<'a, T> : test_crate::loopy_with_generics::Bar<'a, (), u8, T>
+impl<'a, T> test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a (T)> for ()}<'a, T> : test_crate::loopy_with_generics::Bar<'a, (), u8, T, &'a (T)>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::Sized<u8>
     parent_clause1 = @TraitClause0
     parent_clause2 = core::marker::Sized<&'_ (T)>
-    type BarTy = &'a (T)
 }
 
 trait test_crate::loopy_with_generics::Foo<'b, Self, T>
@@ -197,8 +255,9 @@ trait test_crate::loopy_with_generics::Foo<'b, Self, T>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::FooTy>
     parent_clause2 : [@TraitClause2]: test_crate::loopy_with_generics::Foo<'_, Self::FooTy, T>
-    parent_clause3 : [@TraitClause3]: test_crate::loopy_with_generics::Bar<'_, Self::FooTy, u8, core::option::Option<T>[Self::parent_clause0]>
+    parent_clause3 : [@TraitClause3]: test_crate::loopy_with_generics::Bar<'_, Self::FooTy, u8, core::option::Option<T>[Self::parent_clause0], Self::Self_Clause3_BarTy>
     type FooTy
+    type Self_Clause3_BarTy
 }
 
 impl test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}#1 : test_crate::loopy_with_generics::Foo<'static, (), u16>
@@ -206,8 +265,9 @@ impl test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo
     parent_clause0 = core::marker::Sized<u16>
     parent_clause1 = core::marker::Sized<()>
     parent_clause2 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}#1
-    parent_clause3 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T> for ()}<'_, core::option::Option<u16>[core::marker::Sized<u16>]>[core::marker::Sized<core::option::Option<u16>[core::marker::Sized<u16>]>]
+    parent_clause3 = test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a (T)> for ()}<'_, core::option::Option<u16>[core::marker::Sized<u16>]>[core::marker::Sized<core::option::Option<u16>[core::marker::Sized<u16>]>]
     type FooTy = ()
+    type Self_Clause3_BarTy = &'_ (core::option::Option<u16>[core::marker::Sized<u16>])
 }
 
 trait core::borrow::Borrow<Self, Borrowed>
@@ -215,59 +275,47 @@ trait core::borrow::Borrow<Self, Borrowed>
     fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
-trait alloc::borrow::ToOwned<Self>
+trait alloc::borrow::ToOwned<Self, Self_Owned>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Owned>
-    parent_clause1 : [@TraitClause1]: core::borrow::Borrow<Self::Owned, Self>
-    type Owned
-    fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
-    fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Owned>
+    parent_clause1 : [@TraitClause1]: core::borrow::Borrow<Self_Owned, Self>
+    fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self, Self_Owned>
+    fn clone_into<'_0, '_1> = alloc::borrow::ToOwned::clone_into<'_0_0, '_0_1, Self, Self_Owned>
 }
 
-enum test_crate::cow::Cow<'a, B>
+enum test_crate::cow::Cow<'a, B, Clause0_Owned>
   where
-      [@TraitClause0]: alloc::borrow::ToOwned<B>,
+      [@TraitClause0]: alloc::borrow::ToOwned<B, Clause0_Owned>,
       B : 'a,
       B : 'a,
  =
 |  Borrowed(&'a (B))
-|  Owned(@TraitClause0::Owned)
+|  Owned(Clause0_Owned)
 
 
-trait test_crate::params::Foo<'a, Self, T>
+trait test_crate::params::Foo<'a, Self, T, Self_X, Self_Item>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::X>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Item>
-    type X
-    type Item
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self_X>
+    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self_Item>
 }
 
-impl<'a, T> test_crate::params::{impl test_crate::params::Foo<'a, core::option::Option<T>[@TraitClause0]> for ()}<'a, T> : test_crate::params::Foo<'a, (), core::option::Option<T>[@TraitClause0]>
+impl<'a, T> test_crate::params::{impl test_crate::params::Foo<'a, core::option::Option<T>[@TraitClause0], &'a (()), &'a ((core::option::Option<T>[@TraitClause0], &'_ (())))> for ()}<'a, T> : test_crate::params::Foo<'a, (), core::option::Option<T>[@TraitClause0], &'a (()), &'a ((core::option::Option<T>[@TraitClause0], &'_ (())))>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::Sized<core::option::Option<T>[@TraitClause0]>
     parent_clause1 = core::marker::Sized<&'_ (())>
     parent_clause2 = core::marker::Sized<&'_ ((core::option::Option<T>[@TraitClause0], &'_ (())))>
-    type X = &'a (())
-    type Item = &'a ((core::option::Option<T>[@TraitClause0], test_crate::params::{impl test_crate::params::Foo<'a, core::option::Option<T>[@TraitClause0]> for ()}<'_, T>[@TraitClause0]::X))
 }
 
-fn test_crate::Foo::use_item<'a, '_1, Self>(@1: &'_1 (Self::Item)) -> &'_1 (Self::Item)
-{
-    let @0: &'_ (Self::Item); // return
-    let x@1: &'_ (Self::Item); // arg #1
-
-    @0 := copy (x@1)
-    return
-}
+fn test_crate::Foo::use_item_required<'a, Self, Self_Item>(@1: Self_Item) -> Self_Item
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
-fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
+fn alloc::borrow::ToOwned::to_owned<'_0, Self, Self_Owned>(@1: &'_0 (Self)) -> Self_Owned
 
-fn alloc::borrow::ToOwned::clone_into<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 mut (Self::Owned))
+fn alloc::borrow::ToOwned::clone_into<'_0, '_1, Self, Self_Owned>(@1: &'_0 (Self), @2: &'_1 mut (Self_Owned))
 
 fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
 

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -42,12 +42,11 @@ where
     fn default = test_crate::{impl core::default::Default for test_crate::Struct<A>[@TraitClause0]}#1::default<A>[@TraitClause0, @TraitClause1]
 }
 
-trait test_crate::Trait<Self, B>
+trait test_crate::Trait<Self, B, Self_Item>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<B>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
-    type Item
-    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::Trait::method<Self, B, C>[@TraitClause0_0]
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self_Item>
+    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::Trait::method<Self, B, C, Self_Item>[@TraitClause0_0]
 }
 
 trait core::clone::Clone<Self>
@@ -63,7 +62,7 @@ trait core::cmp::PartialEq<Self, Rhs>
     fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
-fn test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>()
+fn test_crate::{impl test_crate::Trait<B, (A, B)> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>()
 where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::marker::Sized<B>,
@@ -80,7 +79,7 @@ where
     return
 }
 
-impl<A, B> test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}<A, B> : test_crate::Trait<test_crate::Struct<A>[@TraitClause0], B>
+impl<A, B> test_crate::{impl test_crate::Trait<B, (A, B)> for test_crate::Struct<A>[@TraitClause0]}<A, B> : test_crate::Trait<test_crate::Struct<A>[@TraitClause0], B, (A, B)>
 where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::marker::Sized<B>,
@@ -89,8 +88,7 @@ where
 {
     parent_clause0 = @TraitClause1
     parent_clause1 = core::marker::Sized<(A, B)>
-    type Item = (A, B)
-    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause0_0]
+    fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::{impl test_crate::Trait<B, (A, B)> for test_crate::Struct<A>[@TraitClause0]}::method<A, B, C>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause0_0]
 }
 
 fn core::default::{impl core::default::Default for bool}#1::default() -> bool
@@ -133,7 +131,7 @@ fn test_crate::main()
     @fake_read(_x@1)
     _y@2 := test_crate::{impl core::default::Default for test_crate::Struct<A>[@TraitClause0]}#1::default<bool>[core::marker::Sized<bool>, core::default::{impl core::default::Default for bool}#1]()
     @fake_read(_y@2)
-    @3 := test_crate::{impl test_crate::Trait<B> for test_crate::Struct<A>[@TraitClause0]}::method<u8, bool, alloc::string::String>[core::marker::Sized<u8>, core::marker::Sized<bool>, core::clone::impls::{impl core::clone::Clone for u8}#6, core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19, core::marker::Sized<alloc::string::String>]()
+    @3 := test_crate::{impl test_crate::Trait<B, (A, B)> for test_crate::Struct<A>[@TraitClause0]}::method<u8, bool, alloc::string::String>[core::marker::Sized<u8>, core::marker::Sized<bool>, core::clone::impls::{impl core::clone::Clone for u8}#6, core::cmp::impls::{impl core::cmp::PartialEq<bool> for bool}#19, core::marker::Sized<alloc::string::String>]()
     drop @3
     @4 := ()
     @0 := move (@4)
@@ -143,7 +141,7 @@ fn test_crate::main()
     return
 }
 
-fn test_crate::Trait::method<Self, B, C>()
+fn test_crate::Trait::method<Self, B, C, Self_Item>()
 where
     [@TraitClause0]: core::marker::Sized<C>,
 

--- a/charon/tests/ui/call-to-known-trait-method.rs
+++ b/charon/tests/ui/call-to-known-trait-method.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 //! Test that we pass generics correctly in the `skip_trait_refs_when_known` pass.
 #[derive(Default)]
 struct Struct<A>(A);

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -16,29 +16,28 @@ trait core::marker::Sized<Self>
 
 trait core::marker::Tuple<Self>
 
-trait core::ops::function::FnOnce<Self, Args>
+trait core::ops::function::FnOnce<Self, Args, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
-    type Output
-    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
+    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self_Output>
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>
 }
 
-trait core::ops::function::FnMut<Self, Args>
+trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
 {
-    parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
+    parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args, Self_Clause0_Output>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause0_Output>
 }
 
-trait core::ops::function::Fn<Self, Args>
+trait core::ops::function::Fn<Self, Args, Self_Clause0_Clause0_Output>
 {
-    parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args>
+    parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args, Self_Clause0_Clause0_Output>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>
+    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause0_Clause0_Output>
 }
 
 enum core::option::Option<T>
@@ -49,14 +48,13 @@ enum core::option::Option<T>
 |  Some(T)
 
 
-fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> Self::parent_clause0::parent_clause0::Output
+fn core::ops::function::Fn::call<'_0, Self, Args, Self_Clause0_Clause0_Output>(@1: &'_0 (Self), @2: Args) -> Self_Clause0_Clause0_Output
 
 fn test_crate::map_option<T, F>(@1: core::option::Option<T>[@TraitClause0], @2: F) -> core::option::Option<T>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<F>,
-    [@TraitClause2]: core::ops::function::Fn<F, (T)>,
-    @TraitClause2::parent_clause0::parent_clause0::Output = T,
+    [@TraitClause2]: core::ops::function::Fn<F, (T), T>,
 {
     let @0: core::option::Option<T>[@TraitClause0]; // return
     let x@1: core::option::Option<T>[@TraitClause0]; // arg #1
@@ -136,7 +134,7 @@ fn test_crate::test_map_option1(@1: core::option::Option<u32>[core::marker::Size
     let @2: core::option::Option<u32>[core::marker::Sized<u32>]; // anonymous local
 
     @2 := copy (x@1)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), const (test_crate::incr_u32))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@2), const (test_crate::incr_u32))
     drop @2
     return
 }
@@ -360,7 +358,7 @@ fn test_crate::test_map_option2(@1: core::option::Option<u32>[core::marker::Size
     @fake_read(f@2)
     @4 := copy (x@1)
     @5 := copy (f@2)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@4), move (@5))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@4), move (@5))
     drop @5
     drop @4
     drop f@2
@@ -386,7 +384,7 @@ fn test_crate::test_map_option_id1(@1: core::option::Option<u32>[core::marker::S
     let @2: core::option::Option<u32>[core::marker::Sized<u32>]; // anonymous local
 
     @2 := copy (x@1)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), const (test_crate::id<u32>[core::marker::Sized<u32>]))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@2), const (test_crate::id<u32>[core::marker::Sized<u32>]))
     drop @2
     return
 }
@@ -403,7 +401,7 @@ fn test_crate::test_map_option_id2(@1: core::option::Option<u32>[core::marker::S
     @fake_read(f@2)
     @3 := copy (x@1)
     @4 := copy (f@2)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@3), move (@4))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@3), move (@4))
     drop @4
     drop @3
     drop f@2
@@ -492,7 +490,7 @@ fn test_crate::test_map_option_id_clone(@1: core::option::Option<u32>[core::mark
     let @2: core::option::Option<u32>[core::marker::Sized<u32>]; // anonymous local
 
     @2 := copy (x@1)
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), const (test_crate::id_clone<u32>[core::marker::Sized<u32>, core::clone::impls::{impl core::clone::Clone for u32}#8]))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@2), const (test_crate::id_clone<u32>[core::marker::Sized<u32>, core::clone::impls::{impl core::clone::Clone for u32}#8]))
     drop @2
     return
 }
@@ -519,7 +517,7 @@ fn test_crate::test_map_option3(@1: core::option::Option<u32>[core::marker::Size
 
     @2 := copy (x@1)
     @3 := {test_crate::test_map_option3::closure} {}
-    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32)>](move (@2), move (@3))
+    @0 := test_crate::map_option<u32, fn(u32) -> u32>[core::marker::Sized<u32>, core::marker::Sized<fn(u32) -> u32>, core::ops::function::Fn<fn(u32) -> u32, (u32), u32>](move (@2), move (@3))
     drop @3
     drop @2
     return
@@ -603,7 +601,7 @@ fn test_crate::test_closure_capture(@1: u32, @2: u32) -> u32
     @fake_read(f@3)
     @7 := &*(f@3)
     @8 := (const (0 : u32))
-    @0 := core::ops::function::Fn<fn(u32) -> u32, (u32)>::call<'_>(move (@7), move (@8))
+    @0 := core::ops::function::Fn<fn(u32) -> u32, (u32), u32>::call<'_>(move (@7), move (@8))
     drop @8
     drop @7
     drop @4
@@ -647,7 +645,7 @@ where
     @4 := &*(f@2)
     @6 := move (x@1)
     @5 := (move (@6))
-    @0 := core::ops::function::Fn<fn(T) -> T, (T)>::call<'_>(move (@4), move (@5))
+    @0 := core::ops::function::Fn<fn(T) -> T, (T), T>::call<'_>(move (@4), move (@5))
     drop @6
     drop @6
     drop @5
@@ -673,8 +671,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<F>,
     [@TraitClause2]: core::marker::Sized<U>,
-    [@TraitClause3]: core::ops::function::FnMut<F, (T)>,
-    @TraitClause3::parent_clause0::Output = U,
+    [@TraitClause3]: core::ops::function::FnMut<F, (T), U>,
 
 fn test_crate::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
 {
@@ -685,7 +682,7 @@ fn test_crate::test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : u
 
     @2 := copy (x@1)
     @3 := {test_crate::test_array_map::closure} {}
-    @0 := core::array::{Array<T, const N : usize>}#23::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::marker::Sized<i32>, core::marker::Sized<fn(i32) -> i32>, core::marker::Sized<i32>, core::ops::function::FnMut<fn(i32) -> i32, (i32)>](move (@2), move (@3))
+    @0 := core::array::{Array<T, const N : usize>}#23::map<i32, fn(i32) -> i32, i32, 256 : usize>[core::marker::Sized<i32>, core::marker::Sized<fn(i32) -> i32>, core::marker::Sized<i32>, core::ops::function::FnMut<fn(i32) -> i32, (i32), i32>](move (@2), move (@3))
     drop @3
     drop @2
     return
@@ -769,17 +766,17 @@ where
     @fake_read(clo@2)
     @8 := &clo@2
     @9 := ()
-    @7 := core::ops::function::Fn<fn() -> fn() -> fn() -> T, ()>::call<'_>(move (@8), move (@9))
+    @7 := core::ops::function::Fn<fn() -> fn() -> fn() -> T, (), fn() -> fn() -> T>::call<'_>(move (@8), move (@9))
     @6 := &@7
     drop @9
     drop @8
     @10 := ()
-    @5 := core::ops::function::Fn<fn() -> fn() -> T, ()>::call<'_>(move (@6), move (@10))
+    @5 := core::ops::function::Fn<fn() -> fn() -> T, (), fn() -> T>::call<'_>(move (@6), move (@10))
     @4 := &@5
     drop @10
     drop @6
     @11 := ()
-    @0 := core::ops::function::Fn<fn() -> T, ()>::call<'_>(move (@4), move (@11))
+    @0 := core::ops::function::Fn<fn() -> T, (), T>::call<'_>(move (@4), move (@11))
     drop @11
     drop @4
     drop clo@2
@@ -808,7 +805,7 @@ fn test_crate::BLAH() -> u32
     @fake_read(clo@1)
     @2 := &clo@1
     @3 := ()
-    @0 := core::ops::function::Fn<fn() -> u32, ()>::call<'_>(move (@2), move (@3))
+    @0 := core::ops::function::Fn<fn() -> u32, (), u32>::call<'_>(move (@2), move (@3))
     drop @3
     drop @2
     drop clo@1
@@ -819,9 +816,9 @@ global test_crate::BLAH: u32 = test_crate::BLAH()
 
 fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 
-fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
+fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Self_Clause0_Output>(@1: &'_0 mut (Self), @2: Args) -> Self_Clause0_Output
 
-fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+fn core::ops::function::FnOnce::call_once<Self, Args, Self_Output>(@1: Self, @2: Args) -> Self_Output
 
 
 

--- a/charon/tests/ui/closures.rs
+++ b/charon/tests/ui/closures.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 //@ output=pretty-llbc
 pub fn incr_u32(x: u32) -> u32 {
     x + 1

--- a/charon/tests/ui/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/dictionary_passing_style_woes.out
@@ -2,90 +2,82 @@
 
 trait core::marker::Sized<Self>
 
-trait test_crate::Iterator<Self>
+trait test_crate::Iterator<Self, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    type Item
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Item>
 }
 
-trait test_crate::IntoIterator<Self>
-where
-    Self::parent_clause2::Item = Self::Item,
+trait test_crate::IntoIterator<Self, Self_Item, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::IntoIter>
-    parent_clause2 : [@TraitClause2]: test_crate::Iterator<Self::IntoIter>
-    type Item
-    type IntoIter
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Item>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self_IntoIter>
+    parent_clause2 : [@TraitClause2]: test_crate::Iterator<Self_IntoIter, Self_Item>
 }
 
-impl<I> test_crate::{impl test_crate::IntoIterator for I}<I> : test_crate::IntoIterator<I>
+impl<I, Clause1_Item> test_crate::{impl test_crate::IntoIterator<Clause1_Item, I> for I}<I, Clause1_Item> : test_crate::IntoIterator<I, Clause1_Item, I>
 where
     [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: test_crate::Iterator<I>,
+    [@TraitClause1]: test_crate::Iterator<I, Clause1_Item>,
 {
     parent_clause0 = @TraitClause1::parent_clause0
     parent_clause1 = @TraitClause0
     parent_clause2 = @TraitClause1
-    type Item = @TraitClause1::Item
-    type IntoIter = I
 }
 
-fn test_crate::callee<T>(@1: @TraitClause1::Item) -> test_crate::{impl test_crate::IntoIterator for I}<T>[@TraitClause0, @TraitClause1]::Item
+fn test_crate::callee<T, Clause1_Item>(@1: Clause1_Item) -> Clause1_Item
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::Iterator<T>,
+    [@TraitClause1]: test_crate::Iterator<T, Clause1_Item>,
 {
-    let @0: @TraitClause1::Item; // return
-    let t@1: @TraitClause1::Item; // arg #1
+    let @0: Clause1_Item; // return
+    let t@1: Clause1_Item; // arg #1
 
     @0 := move (t@1)
     drop t@1
     return
 }
 
-fn test_crate::caller<T>(@1: @TraitClause1::Item) -> @TraitClause2::Item
+fn test_crate::caller<T, Clause1_Item, Clause2_Item, Clause2_IntoIter>(@1: Clause1_Item) -> Clause2_Item
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::Iterator<T>,
-    [@TraitClause2]: test_crate::IntoIterator<T>,
+    [@TraitClause1]: test_crate::Iterator<T, Clause1_Item>,
+    [@TraitClause2]: test_crate::IntoIterator<T, Clause2_Item, Clause2_IntoIter>,
 {
-    let @0: @TraitClause2::Item; // return
-    let t@1: @TraitClause1::Item; // arg #1
-    let @2: @TraitClause1::Item; // anonymous local
+    let @0: Clause2_Item; // return
+    let t@1: Clause1_Item; // arg #1
+    let @2: Clause1_Item; // anonymous local
 
     @2 := move (t@1)
-    @0 := test_crate::callee<T>[@TraitClause0, @TraitClause1](move (@2))
+    @0 := test_crate::callee<T, Clause1_Item>[@TraitClause0, @TraitClause1](move (@2))
     drop @2
     drop t@1
     return
 }
 
-trait test_crate::X<Self>
+trait test_crate::X<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Assoc>
-    type Assoc
-    fn method<'_0> = test_crate::X::method<'_0_0, Self>
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Assoc>
+    fn method<'_0> = test_crate::X::method<'_0_0, Self, Self_Assoc>
 }
 
-trait test_crate::A<Self>
+trait test_crate::A<Self, Self_Clause0_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::X<Self>
+    parent_clause0 : [@TraitClause0]: test_crate::X<Self, Self_Clause0_Assoc>
 }
 
-trait test_crate::B<Self>
+trait test_crate::B<Self, Self_Clause0_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: test_crate::X<Self>
+    parent_clause0 : [@TraitClause0]: test_crate::X<Self, Self_Clause0_Assoc>
 }
 
-fn test_crate::X::method<'_0, Self>(@1: &'_0 (Self)) -> Self::Assoc
+fn test_crate::X::method<'_0, Self, Self_Assoc>(@1: &'_0 (Self)) -> Self_Assoc
 
-fn test_crate::a<T>(@1: T) -> @TraitClause1::parent_clause0::Assoc
+fn test_crate::a<T, Clause1_Clause0_Assoc>(@1: T) -> Clause1_Clause0_Assoc
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::A<T>,
+    [@TraitClause1]: test_crate::A<T, Clause1_Clause0_Assoc>,
 {
-    let @0: @TraitClause1::parent_clause0::Assoc; // return
+    let @0: Clause1_Clause0_Assoc; // return
     let x@1: T; // arg #1
     let @2: &'_ (T); // anonymous local
 
@@ -96,12 +88,12 @@ where
     return
 }
 
-fn test_crate::b<T>(@1: T) -> @TraitClause1::parent_clause0::Assoc
+fn test_crate::b<T, Clause1_Clause0_Assoc>(@1: T) -> Clause1_Clause0_Assoc
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::B<T>,
+    [@TraitClause1]: test_crate::B<T, Clause1_Clause0_Assoc>,
 {
-    let @0: @TraitClause1::parent_clause0::Assoc; // return
+    let @0: Clause1_Clause0_Assoc; // return
     let x@1: T; // arg #1
     let @2: &'_ (T); // anonymous local
 
@@ -112,24 +104,24 @@ where
     return
 }
 
-fn test_crate::x<T>(@1: T) -> (@TraitClause1::parent_clause0::Assoc, @TraitClause1::parent_clause0::Assoc)
+fn test_crate::x<T, Clause1_Clause0_Assoc, Clause2_Clause0_Assoc>(@1: T) -> (Clause1_Clause0_Assoc, Clause1_Clause0_Assoc)
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::A<T>,
-    [@TraitClause2]: test_crate::B<T>,
+    [@TraitClause1]: test_crate::A<T, Clause1_Clause0_Assoc>,
+    [@TraitClause2]: test_crate::B<T, Clause2_Clause0_Assoc>,
 {
-    let @0: (@TraitClause1::parent_clause0::Assoc, @TraitClause1::parent_clause0::Assoc); // return
+    let @0: (Clause1_Clause0_Assoc, Clause1_Clause0_Assoc); // return
     let x@1: T; // arg #1
-    let @2: @TraitClause1::parent_clause0::Assoc; // anonymous local
+    let @2: Clause1_Clause0_Assoc; // anonymous local
     let @3: T; // anonymous local
-    let @4: @TraitClause1::parent_clause0::Assoc; // anonymous local
+    let @4: Clause1_Clause0_Assoc; // anonymous local
     let @5: T; // anonymous local
 
     @3 := move (x@1)
-    @2 := test_crate::a<T>[@TraitClause0, @TraitClause1](move (@3))
+    @2 := test_crate::a<T, Clause1_Clause0_Assoc>[@TraitClause0, @TraitClause1](move (@3))
     drop @3
     @5 := move (x@1)
-    @4 := test_crate::b<T>[@TraitClause0, @TraitClause2](move (@5))
+    @4 := test_crate::b<T, Clause2_Clause0_Assoc>[@TraitClause0, @TraitClause2](move (@5))
     drop @5
     @0 := (move (@2), move (@4))
     drop @4

--- a/charon/tests/ui/dictionary_passing_style_woes.rs
+++ b/charon/tests/ui/dictionary_passing_style_woes.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 trait Iterator {
     type Item;
 }

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -61,9 +61,9 @@ fn test_crate::use_foo()
 {
     let @0: (); // return
     let foo@1: (); // local
-    let @2: test_crate::{impl test_crate::Foo for ()}::Type; // anonymous local
-    let @3: &'_ (test_crate::{impl test_crate::Foo for ()}::Type); // anonymous local
-    let @4: &'_ (test_crate::{impl test_crate::Foo for ()}::Type); // anonymous local
+    let @2: u32; // anonymous local
+    let @3: &'_ (u32); // anonymous local
+    let @4: &'_ (u32); // anonymous local
     let @5: &'_ (()); // anonymous local
     let @6: (); // anonymous local
 

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -570,15 +570,15 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> &'_ (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -22,20 +22,20 @@ enum core::option::Option<T>
 |  Some(T)
 
 
-impl<T> test_crate::{impl test_crate::Try for core::option::Option<T>[@TraitClause0]}<T> : test_crate::Try<core::option::Option<T>[@TraitClause0]>
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-{
-    parent_clause0 = test_crate::{impl test_crate::FromResidual<test_crate::{impl test_crate::Try for core::option::Option<T>[@TraitClause0]}<T>[@TraitClause0]::Residual> for core::option::Option<T>[@TraitClause0]}#1<T>[@TraitClause0]
-    parent_clause1 = core::marker::Sized<()>
-    type Residual = ()
-}
-
-impl<T> test_crate::{impl test_crate::FromResidual<test_crate::{impl test_crate::Try for core::option::Option<T>[@TraitClause0]}<T>[@TraitClause0]::Residual> for core::option::Option<T>[@TraitClause0]}#1<T> : test_crate::FromResidual<core::option::Option<T>[@TraitClause0], test_crate::{impl test_crate::Try for core::option::Option<T>[@TraitClause0]}<T>[@TraitClause0]::Residual>
+impl<T> test_crate::{impl test_crate::FromResidual<()> for core::option::Option<T>[@TraitClause0]}#1<T> : test_crate::FromResidual<core::option::Option<T>[@TraitClause0], ()>
 where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     parent_clause0 = core::marker::Sized<()>
+}
+
+impl<T> test_crate::{impl test_crate::Try for core::option::Option<T>[@TraitClause0]}<T> : test_crate::Try<core::option::Option<T>[@TraitClause0]>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    parent_clause0 = test_crate::{impl test_crate::FromResidual<()> for core::option::Option<T>[@TraitClause0]}#1<T>[@TraitClause0]
+    parent_clause1 = core::marker::Sized<()>
+    type Residual = ()
 }
 
 

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -40,7 +40,7 @@ trait core::marker::Copy<Self>
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_, T, const N : usize>[@TraitClause0, @TraitClause1]::Error>[core::marker::Sized<Array<T, const N : usize>>, core::marker::Sized<core::array::TryFromSliceError>]
+fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>[core::marker::Sized<Array<T, const N : usize>>, core::marker::Sized<core::array::TryFromSliceError>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Copy<T>,

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -40,7 +40,7 @@ trait core::marker::Copy<Self>
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
 }
 
-fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7<'_, T, const N : usize>[@TraitClause0, @TraitClause1]::Error>[core::marker::Sized<Array<T, const N : usize>>, core::marker::Sized<core::array::TryFromSliceError>]
+fn core::array::{impl core::convert::TryFrom<&'_0 (Slice<T>)> for Array<T, const N : usize>}#7::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> core::result::Result<Array<T, const N : usize>, core::array::TryFromSliceError>[core::marker::Sized<Array<T, const N : usize>>, core::marker::Sized<core::array::TryFromSliceError>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Copy<T>,

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -586,7 +586,7 @@ where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::iter::range::Step<A>,
 
-unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0]), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<A>[@TraitClause0, @TraitClause1]::Item
+unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0]), @2: usize) -> A
 where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::iter::range::Step<A>,

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -1313,7 +1313,7 @@ where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::iter::range::Step<A>,
 
-unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0]), @2: usize) -> core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<A>[@TraitClause0, @TraitClause1]::Item
+unsafe fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::__iterator_get_unchecked<'_0, A>(@1: &'_0 mut (core::ops::range::Range<A>[@TraitClause0]), @2: usize) -> A
 where
     [@TraitClause0]: core::marker::Sized<A>,
     [@TraitClause1]: core::iter::range::Step<A>,
@@ -1899,31 +1899,7 @@ trait core::slice::index::SliceIndex<Self, T>
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
 }
 
-trait core::ops::index::Index<Self, Idx>
-{
-    type Output
-    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
-}
-
-fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]::Output)
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::marker::Sized<A>,
-    [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
-
-impl<T, I, A> alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A> : core::ops::index::Index<alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2], I>
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::marker::Sized<I>,
-    [@TraitClause2]: core::marker::Sized<A>,
-    [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
-{
-    type Output = @TraitClause3::Output
-    fn index<'_0> = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
-}
-
-fn alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14::index_mut<'_0, T, I, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 mut (alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]::Output)
+fn alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14::index_mut<'_0, T, I, A>(@1: &'_0 mut (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 mut (@TraitClause3::Output)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<I>,
@@ -2164,12 +2140,36 @@ where
 
 fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
+}
+
 fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut (Self::parent_clause0::Output)
 
 trait core::ops::index::IndexMut<Self, Idx>
 {
     parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
     fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx>
+}
+
+fn alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0, T, I, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]), @2: I) -> &'_0 (@TraitClause3::Output)
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::marker::Sized<A>,
+    [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
+
+impl<T, I, A> alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13<T, I, A> : core::ops::index::Index<alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2], I>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::marker::Sized<A>,
+    [@TraitClause3]: core::slice::index::SliceIndex<I, Slice<T>>,
+{
+    type Output = @TraitClause3::Output
+    fn index<'_0> = alloc::vec::{impl core::ops::index::Index<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#13::index<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
 }
 
 impl<T, I, A> alloc::vec::{impl core::ops::index::IndexMut<I> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2]}#14<T, I, A> : core::ops::index::IndexMut<alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause2], I>

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -154,13 +154,7 @@ where
     [@TraitClause4]: core::hash::Hash<K>,
     [@TraitClause5]: core::hash::BuildHasher<S>,
 
-trait core::ops::index::Index<Self, Idx>
-{
-    type Output
-    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
-}
-
-fn std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_0, '_1, K, Q, V, S>(@1: &'_1 (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: &'_0 (Q)) -> &'_1 (std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9<'_, K, Q, V, S>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5, @TraitClause6, @TraitClause7, @TraitClause8]::Output)
+fn std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_0, '_1, K, Q, V, S>(@1: &'_1 (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: &'_0 (Q)) -> &'_1 (V)
 where
     [@TraitClause0]: core::marker::Sized<K>,
     [@TraitClause1]: core::marker::Sized<V>,
@@ -232,6 +226,12 @@ fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map::Has
 }
 
 fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
+
+trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
+}
 
 impl<'_0, K, Q, V, S> std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9<'_0, K, Q, V, S> : core::ops::index::Index<std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2], &'_0 (Q)>
 where

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -96,7 +96,7 @@ trait test_crate::Foo<Self>
     type S
 }
 
-fn test_crate::f<T, U>() -> core::option::Option<@TraitClause2::S>[@TraitClause3::parent_clause0]
+fn test_crate::f<T, U>() -> core::option::Option<@TraitClause3::S>[@TraitClause3::parent_clause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<U>,

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -19,7 +19,7 @@ trait test_crate::MyTryFrom<Self, T>
     fn from<[@TraitClause0]: core::marker::Sized<Self>> = test_crate::MyTryFrom::from<Self, T>[@TraitClause0_0]
 }
 
-fn test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}<'_>::Error>[core::marker::Sized<bool>, core::marker::Sized<()>]
+fn test_crate::{impl test_crate::MyTryFrom<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, ()>[core::marker::Sized<bool>, core::marker::Sized<()>]
 {
     let @0: core::result::Result<bool, ()>[core::marker::Sized<bool>, core::marker::Sized<()>]; // return
     let v@1: &'_ (bool); // arg #1

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.out
@@ -1,0 +1,10 @@
+error: Could not compute the value of Self::Clause1::Clause0::Clause0::Output needed to update generics <Self::Foo, ()> for item Item(TraitDecl(3)).
+       Constraints in scope:
+         - Self::Foo = @Type0_1
+ --> tests/ui/simple/assoc-type-with-fn-bound.rs:9:5
+  |
+9 |     fn call(&self) -> <Self::Foo as FnOnce<()>>::Output;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+ERROR The extraction generated 1 errors

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.rs
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.rs
@@ -1,0 +1,19 @@
+//@ known-failure
+//@ charon-args=--remove-associated-types=*
+// Fails because of bad handling of `Self` clauses. Should be fixed by
+// https://github.com/AeneasVerif/charon/pull/514.
+#![feature(unboxed_closures)]
+
+trait Trait {
+    type Foo: Fn();
+    fn call(&self) -> <Self::Foo as FnOnce<()>>::Output;
+}
+
+impl<F: Fn()> Trait for F {
+    type Foo = F;
+    fn call(&self) -> <Self::Foo as FnOnce<()>>::Output {
+        self()
+    }
+}
+
+fn use_foo() -> <<fn() as Trait>::Foo as FnOnce<()>>::Output {}

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -2,16 +2,14 @@
 
 trait core::marker::Sized<Self>
 
-trait test_crate::Trait<Self>
+trait test_crate::Trait<Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Type>
-    type Type
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Type>
 }
 
-impl test_crate::{impl test_crate::Trait for ()} : test_crate::Trait<()>
+impl test_crate::{impl test_crate::Trait<()> for ()} : test_crate::Trait<(), ()>
 {
     parent_clause0 = core::marker::Sized<()>
-    type Type = ()
 }
 
 struct test_crate::HashMap<S>
@@ -22,11 +20,11 @@ struct test_crate::HashMap<S>
   S,
 }
 
-fn test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<S, Q>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
+fn test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<S, Q, Clause2_Type>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
 where
     [@TraitClause0]: core::marker::Sized<S>,
     [@TraitClause1]: core::marker::Sized<Q>,
-    [@TraitClause2]: test_crate::Trait<Q>,
+    [@TraitClause2]: test_crate::Trait<Q, Clause2_Type>,
 {
     let @0: (); // return
     let _x@1: test_crate::HashMap<S>[@TraitClause0]; // arg #1
@@ -41,11 +39,11 @@ where
     return
 }
 
-fn test_crate::top_level_get<S, Q>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
+fn test_crate::top_level_get<S, Q, Clause2_Type>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
 where
     [@TraitClause0]: core::marker::Sized<S>,
     [@TraitClause1]: core::marker::Sized<Q>,
-    [@TraitClause2]: test_crate::Trait<Q>,
+    [@TraitClause2]: test_crate::Trait<Q, Clause2_Type>,
 {
     let @0: (); // return
     let _x@1: test_crate::HashMap<S>[@TraitClause0]; // arg #1
@@ -74,13 +72,13 @@ fn test_crate::test(@1: test_crate::HashMap<()>[core::marker::Sized<()>])
 
     @3 := move (map@1)
     @4 := ()
-    @2 := test_crate::top_level_get<(), ()>[core::marker::Sized<()>, core::marker::Sized<()>, test_crate::{impl test_crate::Trait for ()}](move (@3), move (@4))
+    @2 := test_crate::top_level_get<(), (), ()>[core::marker::Sized<()>, core::marker::Sized<()>, test_crate::{impl test_crate::Trait<()> for ()}](move (@3), move (@4))
     drop @4
     drop @3
     drop @2
     @6 := move (map@1)
     @7 := ()
-    @5 := test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<(), ()>[core::marker::Sized<()>, core::marker::Sized<()>, test_crate::{impl test_crate::Trait for ()}](move (@6), move (@7))
+    @5 := test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<(), (), ()>[core::marker::Sized<()>, core::marker::Sized<()>, test_crate::{impl test_crate::Trait<()> for ()}](move (@6), move (@7))
     drop @7
     drop @6
     drop @5

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.rs
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 pub trait Trait {
     type Type;
 }

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
@@ -1,9 +1,9 @@
 error: Mismatched method generics:
        params:   
        supplied: [@TraitDecl1<()>]
-  --> tests/ui/simple/fewer-clauses-in-method-impl.2.rs:13:5
+  --> tests/ui/simple/fewer-clauses-in-method-impl.2.rs:14:5
    |
-13 |     <() as Trait>::method()
+14 |     <() as Trait>::method()
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
 

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
@@ -1,0 +1,13 @@
+error: Mismatched method generics:
+       params:   
+       supplied: [@TraitDecl1<()>]
+  --> tests/ui/simple/fewer-clauses-in-method-impl.2.rs:13:5
+   |
+13 |     <() as Trait>::method()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+thread 'rustc' panicked at src/ast/types_utils.rs:116:9:
+assertion failed: args.matches(&self.params)
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ERROR Compilation encountered 0 errors

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.rs
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.rs
@@ -1,0 +1,14 @@
+//@ known-failure
+trait Trait {
+    fn method()
+    where
+        Self: Sized;
+}
+
+impl Trait for () {
+    fn method() {}
+}
+
+fn main() {
+    <() as Trait>::method()
+}

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.rs
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.rs
@@ -1,4 +1,5 @@
 //@ known-failure
+//@ charon-args=--remove-associated-types=*
 trait Trait {
     fn method()
     where

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -1,0 +1,24 @@
+error: Found inconsistent generics after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause1]: core::clone::Clone<T>
+            got: core::marker::Copy<()>: core::marker::Copy<()>
+       Visitor stack:
+         charon_lib::ast::types::GenericArgs
+         charon_lib::ast::expressions::FnPtr
+         charon_lib::ast::gast::FnOperand
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::RawStatement
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         core::result::Result<charon_lib::ast::gast::Body, charon_lib::ast::gast::Opaque>
+         charon_lib::ast::gast::FunDecl
+  --> tests/ui/simple/fewer-clauses-in-method-impl.rs:11:5
+   |
+11 |     <() as Trait>::method::<()>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+ERROR The extraction generated 1 errors

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -15,9 +15,9 @@ error: Found inconsistent generics after transformations:
          charon_lib::ast::gast::Body
          core::result::Result<charon_lib::ast::gast::Body, charon_lib::ast::gast::Opaque>
          charon_lib::ast::gast::FunDecl
-  --> tests/ui/simple/fewer-clauses-in-method-impl.rs:11:5
+  --> tests/ui/simple/fewer-clauses-in-method-impl.rs:12:5
    |
-11 |     <() as Trait>::method::<()>()
+12 |     <() as Trait>::method::<()>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
@@ -1,0 +1,12 @@
+//@ known-failure
+trait Trait {
+    fn method<T: Copy>();
+}
+
+impl Trait for () {
+    fn method<T: Clone>() {}
+}
+
+fn main() {
+    <() as Trait>::method::<()>()
+}

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
@@ -1,4 +1,5 @@
 //@ known-failure
+//@ charon-args=--remove-associated-types=*
 trait Trait {
     fn method<T: Copy>();
 }

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -13,36 +13,34 @@ trait core::marker::Sized<Self>
 
 trait core::marker::Tuple<Self>
 
-trait core::ops::function::FnOnce<Self, Args>
+trait core::ops::function::FnOnce<Self, Args, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
     parent_clause1 : [@TraitClause1]: core::marker::Tuple<Args>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::Output>
-    type Output
-    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
+    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self_Output>
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>
 }
 
-trait core::ops::function::FnMut<Self, Args>
+trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
 {
-    parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
+    parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args, Self_Clause0_Output>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
+    fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause0_Output>
 }
 
-trait core::ops::function::Fn<Self, Args>
+trait core::ops::function::Fn<Self, Args, Self_Clause0_Clause0_Output>
 {
-    parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args>
+    parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args, Self_Clause0_Clause0_Output>
     parent_clause1 : [@TraitClause1]: core::marker::Sized<Args>
     parent_clause2 : [@TraitClause2]: core::marker::Tuple<Args>
-    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>
+    fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause0_Clause0_Output>
 }
 
 fn test_crate::call<'b, F>(@1: F)
 where
     [@TraitClause0]: core::marker::Sized<F>,
-    [@TraitClause1]: core::ops::function::Fn<F, (&'_ (()))>,
-    @TraitClause1::parent_clause0::parent_clause0::Output = &'b (()),
+    [@TraitClause1]: core::ops::function::Fn<F, (&'_ (())), &'b (())>,
 {
     let @0: (); // return
     let @1: F; // arg #1
@@ -61,7 +59,7 @@ fn test_crate::flibidi()
     let @1: (); // anonymous local
     let @2: (); // anonymous local
 
-    @1 := test_crate::call<'_, fn<'a>(&'a (())) -> &'a (())>[core::marker::Sized<fn<'a>(&'a (())) -> &'a (())>, core::ops::function::Fn<fn<'a>(&'a (())) -> &'a (()), (&'_ (()))>](const (test_crate::flabada<'_>))
+    @1 := test_crate::call<'_, fn<'a>(&'a (())) -> &'a (())>[core::marker::Sized<fn<'a>(&'a (())) -> &'a (())>, core::ops::function::Fn<fn<'a>(&'a (())) -> &'a (()), (&'_ (())), &'_ (())>](const (test_crate::flabada<'_>))
     drop @1
     @2 := ()
     @0 := move (@2)
@@ -69,11 +67,11 @@ fn test_crate::flibidi()
     return
 }
 
-fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> Self::parent_clause0::parent_clause0::Output
+fn core::ops::function::Fn::call<'_0, Self, Args, Self_Clause0_Clause0_Output>(@1: &'_0 (Self), @2: Args) -> Self_Clause0_Clause0_Output
 
-fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
+fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Self_Clause0_Output>(@1: &'_0 mut (Self), @2: Args) -> Self_Clause0_Output
 
-fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
+fn core::ops::function::FnOnce::call_once<Self, Args, Self_Output>(@1: Self, @2: Args) -> Self_Output
 
 
 

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.rs
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--remove-associated-types=*
 pub fn flabada<'a>(x: &'a ()) -> &'a () {
     x
 }

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.out
@@ -2,17 +2,15 @@
 
 trait core::marker::Sized<Self>
 
-trait test_crate::Trait<'a, Self>
+trait test_crate::Trait<'a, Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Type>
-    type Type
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Type>
 }
 
 fn test_crate::foo<T>()
 where
     [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: for<'_0> test_crate::Trait<'_0_0, T>,
-    for<'a> @TraitClause1::Type = &'a (()),
+    [@TraitClause1]: for<'_0> test_crate::Trait<'_0_0, T, &'_ (())>,
 {
     let @0: (); // return
     let @1: (); // anonymous local

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.out
@@ -1,0 +1,27 @@
+# Final LLBC before serialization:
+
+trait core::marker::Sized<Self>
+
+trait test_crate::Trait<'a, Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Type>
+    type Type
+}
+
+fn test_crate::foo<T>()
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: for<'_0> test_crate::Trait<'_0_0, T>,
+    for<'a> @TraitClause1::Type = &'a (()),
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.rs
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.rs
@@ -1,7 +1,9 @@
+//@ charon-args=--remove-associated-types=*
 trait Trait<'a> {
     type Type;
 }
 
+// This is incorrectly translated (https://github.com/AeneasVerif/charon/issues/534).
 fn foo<T>()
 where
     T: for<'a> Trait<'a, Type = &'a ()>,

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.rs
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.rs
@@ -1,0 +1,9 @@
+trait Trait<'a> {
+    type Type;
+}
+
+fn foo<T>()
+where
+    T: for<'a> Trait<'a, Type = &'a ()>,
+{
+}

--- a/charon/tests/ui/trait-instance-id.out
+++ b/charon/tests/ui/trait-instance-id.out
@@ -42,6 +42,10 @@ opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
+fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>(@1: Array<T, const N : usize>) -> core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+
 enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -498,16 +502,12 @@ trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     fn size<'_0, [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>> = core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0_0, Self>[@TraitClause0_0]
 }
 
-fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>(@1: Array<T, const N : usize>) -> core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize>[@TraitClause0]::IntoIter
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-
 fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>(@1: I) -> I
 where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>[@TraitClause0])) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]::Item>[@TraitClause0]
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::next<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>[@TraitClause0])) -> core::option::Option<T>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
@@ -519,7 +519,7 @@ fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::arr
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> core::option::Option<core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]::Item>[@TraitClause0]
+fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::last<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> core::option::Option<T>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
@@ -535,7 +535,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<Fold, (Acc, T)>,
     @TraitClause3::parent_clause0::Output = Acc,
 
-unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::__iterator_get_unchecked<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]), @2: usize) -> core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]::Item
+unsafe fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::__iterator_get_unchecked<'_0, T, const N : usize>(@1: &'_0 mut (core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]), @2: usize) -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
@@ -614,7 +614,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (&'_ (T))>,
     @TraitClause3::parent_clause0::Output = bool,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: P) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (T)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: P) -> core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<P>,
@@ -657,7 +657,7 @@ where
     [@TraitClause3]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (&'_ (T)), &'_0_1 (&'_ (T)))>,
     for<'_0, '_1> @TraitClause3::parent_clause0::Output = bool,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'_, T>[@TraitClause0]::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: usize) -> &'_ (T)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
@@ -703,15 +703,15 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::last<'a, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'_, T>[@TraitClause0]::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Chunks<'a, T>[@TraitClause0]), @2: usize) -> &'_ (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
@@ -745,15 +745,15 @@ fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::sli
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::last<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::last<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (Slice<T>)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::nth<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90<'_, T>[@TraitClause0]::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> &'_ (Slice<T>)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -509,7 +509,7 @@ fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1() -> 
 
 global test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1: usize = test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::LEN1()
 
-fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f<'_0, '_1>(@1: &'_0 mut (test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::W), @2: &'_1 (Array<u8, 32 : usize>))
+fn test_crate::{impl test_crate::WithConstTy<32 : usize> for bool}#8::f<'_0, '_1>(@1: &'_0 mut (u64), @2: &'_1 (Array<u8, 32 : usize>))
 {
     let @0: (); // return
     let @1: &'_ mut (u64); // arg #1
@@ -592,7 +592,7 @@ where
     return
 }
 
-fn test_crate::test_where2<T>(@1: @TraitClause1::V)
+fn test_crate::test_where2<T>(@1: u32)
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: test_crate::WithConstTy<T, 32 : usize>,

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -19,7 +19,7 @@ trait test_crate::From<Self, T>
     fn from<[@TraitClause0]: core::marker::Sized<Self>> = test_crate::From::from<Self, T>[@TraitClause0_0]
 }
 
-fn test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, test_crate::{impl test_crate::From<&'_0 (bool)> for bool}<'_>::Error>[core::marker::Sized<bool>, core::marker::Sized<()>]
+fn test_crate::{impl test_crate::From<&'_0 (bool)> for bool}::from<'_0>(@1: &'_0 (bool)) -> core::result::Result<bool, ()>[core::marker::Sized<bool>, core::marker::Sized<()>]
 {
     let @0: core::result::Result<bool, ()>[core::marker::Sized<bool>, core::marker::Sized<()>]; // return
     let v@1: &'_ (bool); // arg #1

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -1,12 +1,6 @@
 # Final LLBC before serialization:
 
-type test_crate::Foo = usize
-
 trait core::marker::Sized<Self>
-
-type test_crate::Generic<'a, T>
-  where
-      [@TraitClause0]: core::marker::Sized<T>, = &'a (T)
 
 trait core::clone::Clone<Self>
 {
@@ -81,14 +75,15 @@ where
     fn clone_into<'_0, '_1> = alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9::clone_into<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
-type test_crate::Generic2<'a, T>
+struct test_crate::Generic2<'a, T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
-      [@TraitClause1]: core::clone::Clone<T>, = alloc::borrow::Cow<'a, Slice<T>>[alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9<T>[@TraitClause0, @TraitClause1]]
-
-type test_crate::GenericWithoutBound<'a, T>
-  where
-      [@TraitClause0]: core::marker::Sized<T>, = alloc::borrow::Cow<'a, Slice<T>>[UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
+      [@TraitClause1]: core::clone::Clone<T>,
+      T : 'a,
+ =
+{
+  alloc::borrow::Cow<'a, Slice<T>>[alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9<T>[@TraitClause0, @TraitClause1]],
+}
 
 fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 

--- a/charon/tests/ui/type_alias.rs
+++ b/charon/tests/ui/type_alias.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-type Foo = usize;
-type Generic<'a, T> = &'a T;
-type Generic2<'a, T: Clone> = Cow<'a, [T]>;
-type GenericWithoutBound<'a, T> = Cow<'a, [T]>;
+// type Foo = usize;
+// type Generic<'a, T> = &'a T;
+// type Generic2<'a, T: Clone> = Cow<'a, [T]>;
+// type GenericWithoutBound<'a, T> = Cow<'a, [T]>;
+struct Generic2<'a, T: Clone>(Cow<'a, [T]>);

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -575,7 +575,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (&'_ (T))>,
     @TraitClause3::parent_clause0::Output = bool,
 
-fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: P) -> core::option::Option<core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'_, T>[@TraitClause0]::Item>[core::marker::Sized<&'_ (T)>]
+fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::find<'a, '_1, T, P>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: P) -> core::option::Option<&'_ (T)>[core::marker::Sized<&'_ (T)>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<P>,
@@ -618,7 +618,7 @@ where
     [@TraitClause3]: for<'_0, '_1> core::ops::function::FnMut<F, (&'_0_0 (&'_ (T)), &'_0_1 (&'_ (T)))>,
     for<'_0, '_1> @TraitClause3::parent_clause0::Output = bool,
 
-unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: usize) -> core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'_, T>[@TraitClause0]::Item
+unsafe fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (core::slice::iter::Iter<'a, T>[@TraitClause0]), @2: usize) -> &'_ (T)
 where
     [@TraitClause0]: core::marker::Sized<T>,
 


### PR DESCRIPTION
This PR introduces a `--remove-associated-types <name pattern>` option that replaces the associated types of the selected traits and converts them into type parameters.

Fixes #127.

This has 4 know limitations today:
- https://github.com/AeneasVerif/charon/issues/531;
- https://github.com/AeneasVerif/charon/issues/513;
- Doesn't yet work with `dyn Trait` (https://github.com/AeneasVerif/charon/issues/123);
- We erase some lifetimes in quantified clauses like `T: for<'a> Trait<'a, Type = &'a ()>` (https://github.com/AeneasVerif/charon/issues/534).

This also has three fundamental limitations that we can't work around:
- We can't handle GATs, as this would require passing type-level functions as type parameters;
- We can't handle `for<'a>` clauses with unconstrained associated types, for the same reason;
- We can't add parameters to self-recursive traits, as this would require an infinite list of parameters.