### PR TITLE
Add option to pretty-print existing llbc file

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.65"
+let supported_charon_version = "0.1.66"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -394,6 +394,8 @@ and cli_options = {
         This is needed if you want to define a custom entry point (to only
         extract part of a crate for instance).
      *)
+  read_llbc : path_buf option;
+      (** Read an llbc file and pretty-print it. This is a terrible API, we should use subcommands. *)
   dest_dir : path_buf option;
       (** The destination directory. Files will be generated as `<dest_dir>/<crate_name>.{u}llbc`,
         unless `dest_file` is set. `dest_dir` defaults to the current directory.

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1618,6 +1618,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("mir_optimized", mir_optimized);
           ("crate_name", crate_name);
           ("input_file", input_file);
+          ("read_llbc", read_llbc);
           ("dest_dir", dest_dir);
           ("dest_file", dest_file);
           ("use_polonius", use_polonius);
@@ -1647,6 +1648,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* mir_optimized = bool_of_json ctx mir_optimized in
         let* crate_name = option_of_json string_of_json ctx crate_name in
         let* input_file = option_of_json path_buf_of_json ctx input_file in
+        let* read_llbc = option_of_json path_buf_of_json ctx read_llbc in
         let* dest_dir = option_of_json path_buf_of_json ctx dest_dir in
         let* dest_file = option_of_json path_buf_of_json ctx dest_file in
         let* use_polonius = bool_of_json ctx use_polonius in
@@ -1679,6 +1681,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              mir_optimized;
              crate_name;
              input_file;
+             read_llbc;
              dest_dir;
              dest_file;
              use_polonius;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.65"
+version = "0.1.66"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -23,9 +23,6 @@ name = "charon-driver"
 path = "src/bin/charon-driver/main.rs"
 
 [[bin]]
-# The rustc driver. The resulting binary dynamically links to rust dylibs
-# including `librustc_driver.so`. Do not call directly, call charon instead to
-# let it set up the right paths.
 name = "generate-ml"
 path = "src/bin/generate-ml/main.rs"
 

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -33,15 +33,6 @@
 // For when we use charon on itself
 #![register_tool(charon)]
 
-// We must not link with the `charon_lib` crate because that would make `charon` need to
-// dynamically link to `librustc_driver.so` etc. The `charon` binary must be runnable _before_
-// setting up the correct toolchain paths.
-#[path = "../../logger.rs"]
-mod logger;
-#[path = "../../options.rs"]
-mod options;
-mod toml_config;
-
 use anyhow::bail;
 use clap::Parser;
 use options::{CliOpts, CHARON_ARGS};
@@ -50,6 +41,12 @@ use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::Command;
+
+use charon_lib::logger;
+use charon_lib::options;
+use charon_lib::trace;
+
+mod toml_config;
 
 // Store the toolchain details directly in the binary.
 static PINNED_TOOLCHAIN: &str = include_str!("../../../rust-toolchain");

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -41,6 +41,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::Command;
+use std::process::ExitStatus;
 
 use charon_lib::logger;
 use charon_lib::options;
@@ -174,7 +175,11 @@ pub fn main() -> anyhow::Result<()> {
         });
     let host = &rustc_version.host;
 
-    let exit_status = if options.no_cargo {
+    let exit_status = if let Some(llbc_file) = options.read_llbc {
+        let krate = charon_lib::deserialize_llbc(&llbc_file)?;
+        println!("{krate}");
+        ExitStatus::default()
+    } else if options.no_cargo {
         if !options.cargo_args.is_empty() {
             bail!("Option `--cargo-arg` is not compatible with `--no-cargo`")
         }

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -44,3 +44,21 @@ pub use transform::{graphs, reorder_decls, ullbc_to_llbc};
 
 /// The version of the crate, as defined in `Cargo.toml`.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Read a `.llbc` file.
+pub fn deserialize_llbc(path: &std::path::Path) -> anyhow::Result<ast::TranslatedCrate> {
+    use crate::export::CrateData;
+    use anyhow::Context;
+    use serde::Deserialize;
+    use std::fs::File;
+    use std::io::BufReader;
+    let file = File::open(&path)
+        .with_context(|| format!("Failed to read llbc file {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    // Deserialize without recursion limit.
+    deserializer.disable_recursion_limit();
+    // Grow stack space as needed.
+    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+    Ok(CrateData::deserialize(deserializer)?.translated)
+}

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -52,6 +52,10 @@ pub struct CliOpts {
     #[clap(long = "input", value_parser)]
     #[serde(default)]
     pub input_file: Option<PathBuf>,
+    /// Read an llbc file and pretty-print it. This is a terrible API, we should use subcommands.
+    #[clap(long = "read-llbc", value_parser)]
+    #[serde(default)]
+    pub read_llbc: Option<PathBuf>,
     /// The destination directory. Files will be generated as `<dest_dir>/<crate_name>.{u}llbc`,
     /// unless `dest_file` is set. `dest_dir` defaults to the current directory.
     #[clap(long = "dest", value_parser)]


### PR DESCRIPTION
We can now call `charon --read-llbc <path/to/file.llbc>` which will pretty-print the crate contents to stdout.