### PR TITLE
rustc-tests: Sort the supported tests for a more useful report

### DIFF
--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -289,9 +289,8 @@ fn main() {
         Err(err) => {
             log::error!("{err}");
             let exit_code = match err {
-                CharonFailure::CharonError(_)
-                | CharonFailure::RustcError
-                | CharonFailure::Serialize => 1,
+                CharonFailure::CharonError(_) | CharonFailure::Serialize => 1,
+                CharonFailure::RustcError => 2,
                 // This is a real panic, exit with the standard rust panic error code.
                 CharonFailure::Panic => 101,
             };

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -288,7 +288,7 @@ fn main() {
         Ok(()) => {
             if error_count != 0 {
                 let msg = format!("The extraction generated {} warnings", error_count);
-                log::warn!("{}", msg);
+                eprintln!("warning: {}", msg);
             }
         }
         Err(err) => {

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -129,6 +129,11 @@ fn main() {
         return;
     }
 
+    // Don't even try to codegen. This avoids errors due to checking if the output filename is
+    // available (despite the fact that we won't emit it because we stop compilation early).
+    compiler_args.push("-Zno-codegen".to_string());
+    compiler_args.push("--emit=metadata".to_string());
+
     // Always compile in release mode: in effect, we want to analyze the released
     // code. Also, rustc inserts a lot of dynamic checks in debug mode, that we
     // have to clean. Full list of `--release` flags:

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -63,7 +63,6 @@ let
       || has_magic_comment 'rustc-env' "$FILE"\
       || has_magic_comment 'compile-flags' "$FILE" \
       || has_magic_comment 'edition' "$FILE"\
-      || [[ "$FILE" == "test-results/meta/no_std-extern-libc.rs" ]]\
       ; then
         result="unsupported-build-settings"
     elif has_feature 'generic_const_exprs' "$FILE" \
@@ -108,6 +107,13 @@ let
     status="$(cat "$FILE.charon-status")"
     if echo "$status" | grep -q '^unsupported'; then
         result="⊘ $status"
+    elif false \
+      || [[ "$FILE" == "test-results/cfg/assume-incomplete-release/auxiliary/ver-cfg-rel.rs" ]]\
+      || [[ "$FILE" == "test-results/macros/auxiliary/macro-comma-support.rs" ]]\
+      || [[ "$FILE" == "test-results/meta/no_std-extern-libc.rs" ]]\
+      || [[ "$FILE" == "test-results/parser/issues/auxiliary/issue-21146-inc.rs" ]]\
+      ; then
+        result="⊘ unsupported-build-settings"
     elif [ $status -eq 124 ]; then
         result="❌ timeout"
     elif [ $status -eq 101 ] || [ $status -eq 255 ]; then

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -122,7 +122,7 @@ let
         if [ -f ${"$"}{FILE%.rs}.stderr ]; then
             expected="failure in rustc"
         else
-            expected=success
+            expected="success"
         fi
         if [ $status -eq 0 ]; then
             got="success"
@@ -155,7 +155,7 @@ let
         if ! [[ $extras == "" ]]; then
             extras=" ($extras)"
         fi
-        result="$status expected: $expected, got: $got$extras"
+        result="$(printf "$status expected: %-18s  got: $got$extras" "$expected")"
     fi
 
     echo "$FILE: $result"

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -14,8 +14,8 @@
 let
   # The rustc commit we use to get the tests. We should update it every now and
   # then to match the version of rustc we're using.
-  tests_commit = "65ea825f4021eaf77f1b25139969712d65b435a4";
-  tests_hash = "sha256-0dsWuGcWjQpj/N4iG6clCzM8kjrDjE+dQfyL3iuBGiY=";
+  tests_commit = "86d69c705a552236a622eee3fdea94bf13c5f102";
+  tests_hash = "sha256-1TMO4+rdOCYF1QWs5FDqQ1magzx8lmkOajlvuEh0Moc=";
 
   rustc-test-suite = fetchFromGitHub {
     owner = "rust-lang";

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -101,7 +101,7 @@ let
         result="❌ panic"
     else
         if [ -f ${"$"}{FILE%.rs}.stderr ]; then
-            expected=failure
+            expected="failure in rustc"
         else
             expected=success
         fi
@@ -109,21 +109,22 @@ let
             got="success"
         else
             got="failure"
+            if grep -q 'error.E9999' "$FILE.charon-output"; then
+                got="$got in hax frontend"
+            elif [ $status -eq 2 ]; then
+                got="$got in rustc"
+            else
+                # This won't happen since we don't pass `--error-on-warnings`.
+                got="$got in charon"
+            fi
         fi
 
-        extras=""
         if [[ $expected == $got ]]; then
             status="✅"
         else
             status="❌"
-            if [[ $expected == "success" ]]; then
-                if grep -q 'error.E9999' "$FILE.charon-output"; then
-                    got="$got in hax frontend"
-                else
-                    got="$got in charon"
-                fi
-            fi
         fi
+        extras=""
         if [[ $expected == "success" ]]; then
             if [ -e "$FILE.llbc" ]; then
                 extras="with llbc output"

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -153,6 +153,11 @@ let
         if [[ $expected == "success" ]]; then
             if [ -e "$FILE.llbc" ]; then
                 extras="with llbc output"
+                if grep -q 'The extraction generated .* warnings' "$FILE.charon-output"; then
+                    extras="$extras and warnings"
+                else
+                    extras="$extras and no warnings"
+                fi
             else
                 extras="without llbc output"
                 status="❌"

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -118,9 +118,6 @@ let
     elif grep -q 'error.E0463' "$FILE.charon-output"; then
         # "Can't find crate" error.
         result="⊘ unsupported-build-settings"
-    elif grep -q 'error: the generated executable.*conflicts' "$FILE.charon-output"; then
-        # Annoying filename conflicts, should try to avoid somehow.
-        result="⊘ unsupported-build-settings"
     else
         if [ -f ${"$"}{FILE%.rs}.stderr ]; then
             expected="failure in rustc"

--- a/nix/rustc-tests.nix
+++ b/nix/rustc-tests.nix
@@ -117,7 +117,11 @@ let
     elif [ $status -eq 124 ]; then
         result="❌ timeout"
     elif [ $status -eq 101 ] || [ $status -eq 255 ]; then
-        result="❌ panic"
+        if grep -q 'fatal runtime error: stack overflow' "$FILE.charon-output"; then
+            result="❌ stack overflow"
+        else
+            result="❌ panic"
+        fi
     elif grep -q 'error.E0601' "$FILE.charon-output"; then
         # That's the "`main` not found" error we get on auxiliary files.
         result="⊘ unsupported-build-settings"


### PR DESCRIPTION
Report after this PR:
```text
Summary of the results:
   4845  ⊘ unsupported-build-settings
    311  ⊘ unsupported-feature
   7323  ✅ expected: failure in rustc    got: failure in rustc
   4376  ✅ expected: success             got: success (with llbc output and no warnings)
    344  ✅ expected: success             got: success (with llbc output and warnings)
     96  ❌ expected: failure in rustc    got: failure in hax frontend
    392  ❌ expected: failure in rustc    got: success
     33  ❌ expected: success             got: failure in hax frontend (without llbc output)
      8  ❌ panic
     30  ❌ stack overflow
     19  ❌ timeout
```