### PR TITLE
Clarify uses of `Vector::len`

### DIFF
--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -85,14 +85,20 @@ impl ProjectionElem {
                         let type_decl = type_decls.get(*type_decl_id).ok_or(())?;
                         let (type_id, generics) = ty.as_adt().ok_or(())?;
                         assert!(TypeId::Adt(*type_decl_id) == type_id);
-                        assert!(generics.regions.len() == type_decl.generics.regions.len());
-                        assert!(generics.types.len() == type_decl.generics.types.len());
                         assert!(
-                            generics.const_generics.len()
-                                == type_decl.generics.const_generics.len()
+                            generics.regions.elem_count()
+                                == type_decl.generics.regions.elem_count()
                         );
                         assert!(
-                            generics.trait_refs.len() == type_decl.generics.trait_clauses.len()
+                            generics.types.elem_count() == type_decl.generics.types.elem_count()
+                        );
+                        assert!(
+                            generics.const_generics.elem_count()
+                                == type_decl.generics.const_generics.elem_count()
+                        );
+                        assert!(
+                            generics.trait_refs.elem_count()
+                                == type_decl.generics.trait_clauses.elem_count()
                         );
                         use TypeDeclKind::*;
                         match &type_decl.kind {

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -1107,7 +1107,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
             .0;
         // Iterate over the binders, starting from the outermost.
         for (dbid, bl) in self.binding_levels.iter_enumerated().rev() {
-            let num_clauses_bound_at_this_level = bl.params.trait_clauses.len();
+            let num_clauses_bound_at_this_level = bl.params.trait_clauses.elem_count();
             if id < num_clauses_bound_at_this_level || dbid == innermost_item_binder_id {
                 let id = TraitClauseId::from_usize(id);
                 return Ok(DeBruijnVar::bound(dbid, id));

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -289,7 +289,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                                 // This case only happens in some MIR levels
                                 assert!(!boxes_are_desugared(self.t_ctx.options.mir_level));
                                 assert!(generics.regions.is_empty());
-                                assert!(generics.types.len() == 1);
+                                assert!(generics.types.elem_count() == 1);
                                 assert!(generics.const_generics.is_empty());
                             }
                             _ => {
@@ -308,7 +308,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             Tuple(id) => {
                                 let (_, generics) = subplace.ty().kind().as_adt().unwrap();
                                 let field_id = translate_field_id(*id);
-                                let proj_kind = FieldProjKind::Tuple(generics.types.len());
+                                let proj_kind = FieldProjKind::Tuple(generics.types.elem_count());
                                 ProjectionElem::Field(proj_kind, field_id)
                             }
                             Adt {
@@ -327,7 +327,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                                         assert!(generics.regions.is_empty());
                                         assert!(variant.is_none());
                                         assert!(generics.const_generics.is_empty());
-                                        let proj_kind = FieldProjKind::Tuple(generics.types.len());
+                                        let proj_kind =
+                                            FieldProjKind::Tuple(generics.types.elem_count());
 
                                         ProjectionElem::Field(proj_kind, field_id)
                                     }
@@ -336,7 +337,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
 
                                         // Some more sanity checks
                                         assert!(generics.regions.is_empty());
-                                        assert!(generics.types.len() == 1);
+                                        assert!(generics.types.elem_count() == 1);
                                         assert!(generics.const_generics.is_empty());
                                         assert!(variant_id.is_none());
                                         assert!(field_id == FieldId::ZERO);
@@ -556,7 +557,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                             // destination type. At runtime, the converse happens: the length
                             // materializes into the fat pointer.
                             assert!(
-                                generics.types.len() == 1 && generics.const_generics.len() == 1
+                                generics.types.elem_count() == 1
+                                    && generics.const_generics.elem_count() == 1
                             );
                             assert!(generics.types[0] == generics1.types[0]);
                             assert!(kind1 == kind2);

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -158,7 +158,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 // TODO: do this in a micro-pass
                 if let TypeId::Builtin(builtin_ty) = type_id {
                     let used_args = builtins::type_to_used_params(builtin_ty);
-                    error_assert!(self, span, generics.types.len() == used_args.len());
+                    error_assert!(self, span, generics.types.elem_count() == used_args.len());
                     let types = std::mem::take(&mut generics.types)
                         .into_iter()
                         .zip(used_args)

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -195,7 +195,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
                 }
                 TypeId::Builtin(BuiltinTy::Box) => expr.insert(0, "box_of_json".to_owned()),
                 TypeId::Tuple => {
-                    let name = match generics.types.len() {
+                    let name = match generics.types.elem_count() {
                         2 => "pair_of_json".to_string(),
                         3 => "triple_of_json".to_string(),
                         len => format!("tuple_{len}_of_json"),
@@ -356,7 +356,8 @@ fn type_decl_to_json_deserializer(ctx: &GenerateCtx, decl: &TypeDecl) -> String 
             build_branch(ctx, "`Null", fields, "()")
         }
         TypeDeclKind::Struct(fields)
-            if fields.len() == 1 && fields[0].name.as_ref().is_some_and(|name| name == "_raw") =>
+            if fields.elem_count() == 1
+                && fields[0].name.as_ref().is_some_and(|name| name == "_raw") =>
         {
             // These are the special strongly-typed integers.
             let short_name = decl
@@ -372,7 +373,7 @@ fn type_decl_to_json_deserializer(ctx: &GenerateCtx, decl: &TypeDecl) -> String 
             format!("| x -> {short_name}.id_of_json ctx x")
         }
         TypeDeclKind::Struct(fields)
-            if fields.len() == 1
+            if fields.elem_count() == 1
                 && (fields[0].name.is_none()
                     || decl
                         .item_meta
@@ -458,7 +459,7 @@ fn type_decl_to_json_deserializer(ctx: &GenerateCtx, decl: &TypeDecl) -> String 
                         let mut fields = variant.fields.clone();
                         let inner_pat = if fields.iter().all(|f| f.name.is_none()) {
                             // Tuple variant
-                            if variant.fields.len() == 1 {
+                            if variant.fields.elem_count() == 1 {
                                 let var = make_ocaml_ident(&variant.name);
                                 fields[0].name = Some(var.clone());
                                 var
@@ -581,7 +582,8 @@ fn type_decl_to_ocaml_decl(ctx: &GenerateCtx, decl: &TypeDecl, co_rec: bool) -> 
         }
         TypeDeclKind::Struct(fields) if fields.is_empty() => "unit".to_string(),
         TypeDeclKind::Struct(fields)
-            if fields.len() == 1 && fields[0].name.as_ref().is_some_and(|name| name == "_raw") =>
+            if fields.elem_count() == 1
+                && fields[0].name.as_ref().is_some_and(|name| name == "_raw") =>
         {
             // These are the special strongly-typed integers.
             let short_name = decl
@@ -597,7 +599,7 @@ fn type_decl_to_ocaml_decl(ctx: &GenerateCtx, decl: &TypeDecl, co_rec: bool) -> 
             format!("{short_name}.id [@visitors.opaque]")
         }
         TypeDeclKind::Struct(fields)
-            if fields.len() == 1
+            if fields.elem_count() == 1
                 && (fields[0].name.is_none()
                     || decl
                         .item_meta

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -209,10 +209,10 @@ impl PatTy {
             return true;
         }
         // We don't include regions in patterns.
-        if pats.len() != generics.types.len() + generics.const_generics.len() {
+        if pats.len() != generics.types.elem_count() + generics.const_generics.elem_count() {
             return false;
         }
-        let (type_pats, const_pats) = pats.split_at(generics.types.len());
+        let (type_pats, const_pats) = pats.split_at(generics.types.elem_count());
         let types_match = generics
             .types
             .iter()

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -67,7 +67,7 @@ impl CheckGenericsVisitor<'_> {
         A: for<'a> FmtWithCtx<FmtA>,
         B: for<'a> FmtWithCtx<FmtB>,
     {
-        if a.len() == b.len() {
+        if a.elem_count() == b.elem_count() {
             a.iter().zip(b.iter()).for_each(|(x, y)| check_inner(x, y));
         } else {
             let a = a.iter().map(|x| x.fmt_with_ctx(a_fmt)).join(", ");

--- a/charon/src/transform/duplicate_return.rs
+++ b/charon/src/transform/duplicate_return.rs
@@ -53,8 +53,7 @@ impl UllbcPass for Transform {
         // for this (remark: in the end, it makes the return block dangling).
         // We do this in two steps.
         // First, introduce fresh ids.
-        assert!(usize::from(b.body.next_id()) == b.body.len());
-        let mut generator = Generator::new_with_init_value(b.body.len());
+        let mut generator = Generator::new_with_init_value(b.body.next_id().index());
         let mut new_spans = Vec::new();
         b.body.dyn_visit_in_body_mut(|bid: &mut BlockId| {
             if let Some(span) = returns.get(bid) {

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -1,5 +1,4 @@
 use derive_generic_visitor::*;
-use index_vec::Idx;
 use itertools::Itertools;
 use std::collections::HashSet;
 
@@ -14,46 +13,47 @@ struct RemoveMarkersVisitor {
 
 // Remove clauses and trait refs that mention the offending traits. This relies on the fact that
 // `Vector::remove` does not shift indices: it simply leaves an empty slot.
+// FIXME: this is a footgun, it caused at least https://github.com/AeneasVerif/charon/issues/561.
 impl VisitAstMut for RemoveMarkersVisitor {
     fn enter_generic_params(&mut self, args: &mut GenericParams) {
         let trait_clauses = &mut args.trait_clauses;
-        for i in 0..trait_clauses.len() {
+        for i in trait_clauses.all_indices() {
             let clause = &trait_clauses[i];
             if self.exclude.contains(&clause.trait_.skip_binder.trait_id) {
-                trait_clauses.remove(<_ as Idx>::from_usize(i));
+                trait_clauses.remove(i);
             }
         }
     }
     fn enter_generic_args(&mut self, args: &mut GenericArgs) {
         let trait_refs = &mut args.trait_refs;
-        for i in 0..trait_refs.len() {
+        for i in trait_refs.all_indices() {
             let tref = &trait_refs[i];
             if self
                 .exclude
                 .contains(&tref.trait_decl_ref.skip_binder.trait_id)
             {
-                trait_refs.remove(<_ as Idx>::from_usize(i));
+                trait_refs.remove(i);
             }
         }
     }
     fn enter_trait_decl(&mut self, tdecl: &mut TraitDecl) {
         let trait_clauses = &mut tdecl.parent_clauses;
-        for i in 0..trait_clauses.len() {
+        for i in trait_clauses.all_indices() {
             let clause = &trait_clauses[i];
             if self.exclude.contains(&clause.trait_.skip_binder.trait_id) {
-                trait_clauses.remove(<_ as Idx>::from_usize(i));
+                trait_clauses.remove(i);
             }
         }
     }
     fn enter_trait_impl(&mut self, timpl: &mut TraitImpl) {
         let trait_refs = &mut timpl.parent_trait_refs;
-        for i in 0..trait_refs.len() {
+        for i in trait_refs.all_indices() {
             let tref = &trait_refs[i];
             if self
                 .exclude
                 .contains(&tref.trait_decl_ref.skip_binder.trait_id)
             {
-                trait_refs.remove(<_ as Idx>::from_usize(i));
+                trait_refs.remove(i);
             }
         }
     }

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -21,7 +21,7 @@ impl UllbcPass for Transform {
             if let Ok(body) = &mut decl.body {
                 let body = body.as_unstructured().unwrap();
                 // If the whole body is only a call to this specific panic function.
-                if body.body.len() == 1
+                if body.body.elem_count() == 1
                     && let Some(block) = body.body.iter().next()
                     && block.statements.is_empty()
                     && let RawTerminator::Abort(AbortKind::Panic(name)) = &block.terminator.content

--- a/charon/src/transform/update_closure_signatures.rs
+++ b/charon/src/transform/update_closure_signatures.rs
@@ -78,7 +78,7 @@ fn transform_function(_ctx: &TransformCtx, def: &mut FunDecl) -> Result<(), Erro
             let body = body.as_unstructured_mut().unwrap();
 
             // Update the type of the local 1 (which is the closure)
-            assert!(body.locals.vars.len() > 1);
+            assert!(body.locals.vars.elem_count() > 1);
             let state_var = &mut body.locals.vars[1];
             state_var.ty = inputs[0].clone();
             state_var.name = Some("state".to_string());
@@ -86,7 +86,7 @@ fn transform_function(_ctx: &TransformCtx, def: &mut FunDecl) -> Result<(), Erro
             // Update the body, and in particular the accesses to the states
             // TODO: translate to ADT field access
             // TODO: handle directly during translation
-            let num_fields = info.state.len();
+            let num_fields = info.state.elem_count();
             body.body.dyn_visit_in_body_mut(|pe: &mut ProjectionElem| {
                 if let ProjectionElem::Field(pk @ FieldProjKind::ClosureState, _) = pe {
                     *pk = FieldProjKind::Tuple(num_fields);

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -258,7 +258,11 @@ fn predicate_origins() -> anyhow::Result<()> {
             panic!("Item `{item_name}` not found. Available items: \n{keys}")
         };
         let clauses = &item.generics.trait_clauses;
-        assert_eq!(origins.len(), clauses.len(), "failed for {item_name}");
+        assert_eq!(
+            origins.len(),
+            clauses.elem_count(),
+            "failed for {item_name}"
+        );
         for (clause, (expected_origin, expected_trait_name)) in clauses.iter().zip(origins) {
             let trait_name = trait_name(&crate_data, clause.trait_.skip_binder.trait_id);
             assert_eq!(trait_name, expected_trait_name, "failed for {item_name}");

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
@@ -1,0 +1,48 @@
+# Final LLBC before serialization:
+
+trait test_crate::HasAssoc<Self>
+{
+    type Assoc
+}
+
+trait test_crate::Trait<Self>
+{
+    fn default_method<T, [@TraitClause1]: test_crate::HasAssoc<T>> = test_crate::Trait::default_method<Self, T>[@TraitClause0_1]
+}
+
+fn test_crate::{impl test_crate::Trait for T}::default_method<T, T>() -> @TraitClause2::Assoc
+where
+    [@TraitClause2]: test_crate::HasAssoc<T>,
+{
+    let @0: @TraitClause2::Assoc; // return
+
+    panic(core::panicking::panic)
+}
+
+impl<T> test_crate::{impl test_crate::Trait for T}<T> : test_crate::Trait<T>
+{
+    fn default_method<T, [@TraitClause1]: test_crate::HasAssoc<T>> = test_crate::{impl test_crate::Trait for T}::default_method<T, T>[@TraitClause0_1]
+}
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+
+    @1 := ()
+    @0 := move (@1)
+    @0 := ()
+    return
+}
+
+fn test_crate::Trait::default_method<Self, T>() -> @TraitClause1::Assoc
+where
+    [@TraitClause1]: test_crate::HasAssoc<T>,
+{
+    let @0: @TraitClause1::Assoc; // return
+
+    panic(core::panicking::panic)
+}
+
+
+

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.rs
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.rs
@@ -1,0 +1,17 @@
+//@ charon-args=--hide-marker-traits
+// https://github.com/AeneasVerif/charon/issues/561
+use std::marker::PhantomData;
+
+trait HasAssoc {
+    type Assoc;
+}
+trait Trait {
+    fn default_method<T: HasAssoc>() -> T::Assoc {
+        todo!()
+    }
+}
+
+// The `Sized` trait is the culprit.
+impl<T: Sized> Trait for T {}
+
+fn main() {}


### PR DESCRIPTION
The fact that the vector need not be contiguous is a footgun, we should fix that. Fixes https://github.com/AeneasVerif/charon/issues/561.