### PR TITLE
Monomorphize code via `--monomorphize`

### DIFF
--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -1029,7 +1029,7 @@ and const_generic_to_pattern (ctx : ctx) (c : to_pat_config) (m : constraints)
 
 and generic_args_to_pattern (ctx : ctx) (c : to_pat_config) (m : constraints)
     (generics : T.generic_args) : generic_args =
-  let { regions; types; const_generics; trait_refs = _ } : T.generic_args =
+  let ({ regions; types; const_generics; trait_refs = _ } : T.generic_args) =
     generics
   in
   let regions = List.map (region_to_pattern m) regions in

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -371,7 +371,7 @@ let trait_clause_to_string (env : 'a fmt_env) (clause : trait_clause) : string =
 
 let generic_params_to_strings (env : 'a fmt_env) (generics : generic_params) :
     string list * string list =
-  let { regions; types; const_generics; trait_clauses; _ } : generic_params =
+  let ({ regions; types; const_generics; trait_clauses; _ } : generic_params) =
     generics
   in
   let regions = List.map region_var_to_string regions in

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -399,6 +399,7 @@ and cli_options = {
   skip_borrowck : bool;
       (** If activated, this skips borrow-checking of the crate. *)
   no_code_duplication : bool;
+  monomorphize : bool;
   extract_opaque_bodies : bool;
       (** Usually we skip the bodies of foreign methods and structs with private fields. When this
         flag is on, we don't.

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1611,6 +1611,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("use_polonius", use_polonius);
           ("skip_borrowck", skip_borrowck);
           ("no_code_duplication", no_code_duplication);
+          ("monomorphize", monomorphize);
           ("extract_opaque_bodies", extract_opaque_bodies);
           ("translate_all_methods", translate_all_methods);
           ("include", include_);
@@ -1643,6 +1644,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* use_polonius = bool_of_json ctx use_polonius in
         let* skip_borrowck = bool_of_json ctx skip_borrowck in
         let* no_code_duplication = bool_of_json ctx no_code_duplication in
+        let* monomorphize = bool_of_json ctx monomorphize in
         let* extract_opaque_bodies = bool_of_json ctx extract_opaque_bodies in
         let* translate_all_methods = bool_of_json ctx translate_all_methods in
         let* included = list_of_json string_of_json ctx include_ in
@@ -1678,6 +1680,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              use_polonius;
              skip_borrowck;
              no_code_duplication;
+             monomorphize;
              extract_opaque_bodies;
              translate_all_methods;
              included;

--- a/charon.opam
+++ b/charon.opam
@@ -9,6 +9,9 @@ description: """
    Charon. Charon acts as an interface between the rustc compiler and program
    verification projects.  Its purpose is to process Rust .rs files and convert
    them into files easy to handle by program verifiers."""
+maintainer: [
+  "Son Ho" "Jonathan Protzenko" "Aymeric Fromherz" "Sidney Congard"
+]
 authors: ["Son Ho" "Jonathan Protzenko" "Aymeric Fromherz" "Sidney Congard"]
 license: "Apache-2.0"
 homepage: "https://github.com/AeneasVerif/charon"

--- a/charon/src/ids/vector.rs
+++ b/charon/src/ids/vector.rs
@@ -264,6 +264,17 @@ where
         self.vector.indices()
     }
 
+    pub fn retain(&mut self, mut f: impl FnMut(&mut T) -> bool) {
+        self.vector.iter_mut().for_each(|opt| {
+            if let Some(x) = opt {
+                if !f(x) {
+                    *opt = None;
+                    self.elem_count -= 1;
+                }
+            }
+        });
+    }
+
     /// Like `Vec::split_off`.
     pub fn split_off(&mut self, at: usize) -> Self {
         let mut ret = Self {

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -88,7 +88,7 @@ pub struct CliOpts {
               b0: switch x [true -> goto b1; false -> goto b2]
               b1: y := 0; goto b3
               b2: y := 1; goto b3
-              b3: return y      
+              b3: return y
               ```
 
             We want to reconstruct the control-flow as:
@@ -120,6 +120,9 @@ pub struct CliOpts {
     "))]
     #[serde(default)]
     pub no_code_duplication: bool,
+    #[clap(long = "monomorphize")]
+    #[serde(default)]
+    pub monomorphize: bool,
     /// Usually we skip the bodies of foreign methods and structs with private fields. When this
     /// flag is on, we don't.
     #[clap(long = "extract-opaque-bodies")]
@@ -285,6 +288,8 @@ pub struct TranslateOptions {
     /// Whether to hide the `Sized`, `Sync`, `Send` and `Unpin` marker traits anywhere they show
     /// up.
     pub hide_marker_traits: bool,
+    /// Monomorphize functions.
+    pub monomorphize: bool,
     /// Do not merge the chains of gotos.
     pub no_merge_goto_chains: bool,
     /// Print the llbc just after control-flow reconstruction.
@@ -365,6 +370,7 @@ impl TranslateOptions {
             mir_level,
             no_code_duplication: options.no_code_duplication,
             hide_marker_traits: options.hide_marker_traits,
+            monomorphize: options.monomorphize,
             no_merge_goto_chains: options.no_merge_goto_chains,
             print_built_llbc: options.print_built_llbc,
             item_opacities,

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -13,6 +13,7 @@ pub mod inline_local_panic_functions;
 pub mod insert_assign_return_unit;
 pub mod lift_associated_item_clauses;
 pub mod merge_goto_chains;
+pub mod monomorphize;
 pub mod ops_to_function_calls;
 pub mod prettify_cfg;
 pub mod reconstruct_asserts;
@@ -127,6 +128,8 @@ pub static ULLBC_PASSES: &[Pass] = &[
     // # Micro-pass: remove the drops of locals whose type is `Never` (`!`). This
     // is in preparation of the next transformation.
     UnstructuredBody(&remove_drop_never::Transform),
+    // Monomorphize the functions and types.
+    UnstructuredBody(&monomorphize::Transform),
 ];
 
 /// Body cleanup passes after control flow reconstruction.

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -1,9 +1,73 @@
 //! # Micro-pass: monomorphize all functions and types; at the end of this pass, all functions and types are monomorphic.
+use std::collections::{HashMap, HashSet};
 
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
 
 use super::ctx::UllbcPass;
+
+struct PassData {
+    // Map of (poly item, generic args) -> mono item
+    // None indicates the item hasn't been monomorphized yet
+    items: HashMap<(AnyTransId, GenericArgs), Option<AnyTransId>>,
+    worklist: Vec<AnyTransId>,
+    visited: HashSet<AnyTransId>,
+}
+
+impl PassData {
+    fn new() -> Self {
+        PassData {
+            items: HashMap::new(),
+            worklist: Vec::new(),
+            visited: HashSet::new(),
+        }
+    }
+}
+
+fn find_uses_in_body(data: &mut PassData, body: &ExprBody) {
+    body.locals.vars.iter().for_each(|var| match var.ty.kind() {
+        TyKind::Adt(TypeId::Adt(id), gargs) => {
+            if gargs.is_empty() {
+                return;
+            }
+
+            let key = (AnyTransId::Type(*id), gargs.clone());
+            data.items.entry(key).or_insert(None);
+        }
+        TyKind::Adt(TypeId::Tuple, _) => {}
+        TyKind::Literal(_) => {}
+        ty => warn!("Unhandled type kind {:?}", ty),
+    });
+
+    body.body.iter().for_each(|block| {
+        block
+            .statements
+            .iter()
+            .for_each(|stmt| match &stmt.content {
+                RawStatement::Call(Call {
+                    func: FnOperand::Regular(FnPtr { func, generics }),
+                    ..
+                }) => match func {
+                    FunIdOrTraitMethodRef::Fun(FunId::Regular(fun_id)) => {
+                        let key = (AnyTransId::Fun(*fun_id), generics.clone());
+                        data.items.entry(key).or_insert(None);
+                    }
+                    FunIdOrTraitMethodRef::Trait(..) => {
+                        warn!("Monomorphization doesn't reach traits yet.")
+                    }
+                    // These can't be monomorphized, since they're builtins
+                    FunIdOrTraitMethodRef::Fun(FunId::Builtin(..)) => {}
+                },
+                _ => {}
+            });
+    });
+}
+
+fn find_uses_in_type(_data: &mut PassData, _ty: &TypeDeclKind) {}
+
+fn path_for_generics(gargs: &GenericArgs) -> PathElem {
+    PathElem::Ident(gargs.to_string(), Disambiguator::ZERO)
+}
 
 pub struct Transform;
 impl UllbcPass for Transform {
@@ -41,6 +105,106 @@ impl UllbcPass for Transform {
         //      arguments to the item.
         //    b. Mark the item as visited
 
+        // Final list of monomorphized items: { (poly item, generic args) -> mono item }
+        let mut data = PassData::new();
+
+        let empty_gargs = GenericArgs::empty(GenericsSource::Other);
+
+        // Find the roots of the mono item graph
+        for (id, item) in ctx.translated.all_items_with_ids() {
+            match item {
+                AnyTransItem::Fun(f) if f.signature.generics.is_empty() => {
+                    data.items.insert((id, empty_gargs.clone()), Some(id));
+                    data.worklist.push(id);
+                }
+                _ => {}
+            }
+        }
+
+        // Iterate over worklist -- these items are always monomorphic!
+        while let Some(id) = data.worklist.pop() {
+            if data.visited.contains(&id) {
+                continue;
+            }
+            data.visited.insert(id);
+
+            // 1. Find new uses
+            let Some(item) = ctx.translated.get_item(id) else {
+                continue;
+            };
+            match item {
+                AnyTransItem::Fun(f) => {
+                    // assert!(
+                    //     f.signature.generics.is_empty(),
+                    //     "Non-monomorphic item in worklist"
+                    // );
+                    let Ok(body) = f
+                        .body
+                        .as_ref()
+                        .map(|body| body.as_unstructured().unwrap())
+                        .map_err(|opaque| *opaque)
+                    else {
+                        continue;
+                    };
+
+                    find_uses_in_body(&mut data, body)
+                }
+                AnyTransItem::Type(t) => {
+                    // assert!(t.generics.is_empty(), "Non-monomorphic item in worklist");
+                    find_uses_in_type(&mut data, &t.kind)
+                }
+                item => todo!("Unhandled monomorphisation target: {:?}", item),
+            };
+
+            // 2. Iterate through all newly discovered uses
+            for ((id, gargs), mono) in data.items.iter_mut() {
+                if mono.is_some() {
+                    continue;
+                }
+
+                // a. Monomorphize the items if they're polymorphic, add them to the worklist
+                let new_mono = match id {
+                    AnyTransId::Fun(fun_id) => 'id_match: {
+                        let fun = ctx.translated.fun_decls.get(*fun_id).unwrap();
+
+                        if gargs.is_empty() {
+                            break 'id_match AnyTransId::Fun(*fun_id);
+                        }
+
+                        let mut fun_sub = fun.clone().substitute(gargs);
+                        fun_sub.signature.generics = GenericParams::empty();
+
+                        let fun_id_sub = ctx.translated.fun_decls.reserve_slot();
+                        fun_sub.def_id = fun_id_sub;
+                        ctx.translated.fun_decls.set_slot(fun_id_sub, fun_sub);
+
+                        AnyTransId::Fun(fun_id_sub)
+                    }
+                    AnyTransId::Type(typ_id) => 'id_match: {
+                        let typ = ctx.translated.type_decls.get(*typ_id).unwrap();
+
+                        if gargs.is_empty() {
+                            break 'id_match AnyTransId::Type(*typ_id);
+                        }
+
+                        let mut typ_sub = typ.clone().substitute(gargs);
+                        typ_sub.generics = GenericParams::empty();
+                        typ_sub.item_meta.name.name.push(path_for_generics(gargs));
+
+                        let typ_id_sub = ctx.translated.type_decls.reserve_slot();
+                        typ_sub.def_id = typ_id_sub;
+                        ctx.translated.type_decls.set_slot(typ_id_sub, typ_sub);
+
+                        AnyTransId::Type(typ_id_sub)
+                    }
+                    _ => todo!("Unhandled monomorphization target ID {:?}", id),
+                };
+                *mono = Some(new_mono);
+                data.worklist.push(new_mono);
+            }
+
+            // 3. Substitute all generics with the monomorphized versions
+        }
     }
 
     fn name(&self) -> &str {

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -1,0 +1,49 @@
+//! # Micro-pass: monomorphize all functions and types; at the end of this pass, all functions and types are monomorphic.
+
+use crate::transform::TransformCtx;
+use crate::ullbc_ast::*;
+
+use super::ctx::UllbcPass;
+
+pub struct Transform;
+impl UllbcPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        // Check the option which instructs to ignore this pass
+        if !ctx.options.monomorphize {
+            return;
+        }
+
+        // From https://doc.rust-lang.org/nightly/nightly-rustc/rustc_monomorphize/collector/index.html#general-algorithm
+        //
+        // The purpose of the algorithm implemented in this module is to build the mono item
+        // graph for the current crate. It runs in two phases:
+        // 1. Discover the roots of the graph by traversing the HIR of the crate.
+        // 2. Starting from the roots, find uses by inspecting the MIR representation of the
+        //    item corresponding to a given node, until no more new nodes are found.
+        //
+        // The roots of the mono item graph correspond to the public non-generic syntactic
+        // items in the source code. We find them by walking the HIR of the crate, and whenever
+        // we hit upon a public function, method, or static item, we create a mono item
+        // consisting of the items DefId and, since we only consider non-generic items, an
+        // empty type-parameters set.
+        //
+        // Given a mono item node, we can discover uses by inspecting its MIR. We walk the MIR
+        // to find other mono items used by each mono item. Since the mono item we are
+        // currently at is always monomorphic, we also know the concrete type arguments of its
+        // used mono items. The specific forms a use can take in MIR are quite diverse: it
+        // includes calling functions/methods, taking a reference to a function/method, drop
+        // glue, and unsizing casts.
+
+        // In our version of the algorithm, we do the following:
+        // 1. Find all the roots, adding them to the worklist.
+        // 2. For each item in the worklist:
+        //    a. Find all the items it uses, adding them to the worklist and the generic
+        //      arguments to the item.
+        //    b. Mark the item as visited
+
+    }
+
+    fn name(&self) -> &str {
+        "monomorphize"
+    }
+}

--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,13 @@
   "Aymeric Fromherz"
   "Sidney Congard")
 
+
+(maintainers
+  "Son Ho"
+  "Jonathan Protzenko"
+  "Aymeric Fromherz"
+  "Sidney Congard")
+
 (license Apache-2.0)
 
 (package

--- a/name_matcher_parser.opam
+++ b/name_matcher_parser.opam
@@ -3,6 +3,9 @@ opam-version: "2.0"
 version: "0.1"
 synopsis: "Parser to define name matchers"
 description: ""
+maintainer: [
+  "Son Ho" "Jonathan Protzenko" "Aymeric Fromherz" "Sidney Congard"
+]
 authors: ["Son Ho" "Jonathan Protzenko" "Aymeric Fromherz" "Sidney Congard"]
 license: "Apache-2.0"
 homepage: "https://github.com/AeneasVerif/charon"


### PR DESCRIPTION
##### Not anywhere near done, but I'll probably work on this in parallel as I need to cover more code -- for now I'm doing the bare minimum.

Add monomorphisation, by applying an algorithm similar [to what rustc does](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_monomorphize/collector/index.html#general-algorithm):
1. Find roots (public monomorphic functions)
2. Generate monomorphic items:
    1. Find uses of other items within the item (e.g. the function's body, the struct's fields...)
    2. For all used items that are polymorphic, make a monomorphic copy with the generic arguments substituted, if one doesn't exist already.
    3. Substitute these uses with the monomorphic version, which is added to the discovered items.
3. Remove all polymorphic items; if they were used anywhere, they have already been monomorphized and substituted.

Note a consequence of this algorithm is that it does dead code removal of polymorphic items; any unused polymorphic item will have 0 monomorphic items created, and will thus be removed.

Added a `--monomorphize` flag to do this.