### PR TITLE
Continue running passes after an error

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -293,9 +293,6 @@ pub fn transform(ctx: &mut TransformCtx, options: &CliOpts) -> export::CrateData
     for pass in transformation_passes(options) {
         trace!("# Starting pass {}", pass.name());
         pass.run(ctx);
-        if ctx.errors.borrow().has_errors() {
-            break;
-        }
     }
 
     export::CrateData::new(&ctx)

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.out
@@ -7,4 +7,26 @@ error: Could not compute the value of Self::Clause1::Clause0::Clause0::Output ne
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
 
-ERROR Charon failed to translate this code (1 errors)
+error: Found inconsistent generics after transformations:
+       Mismatched type generics:
+       expected: [Self, Args, Self_Output]
+            got: [Self_Foo, ()]
+       Visitor stack:
+         charon_lib::ast::types::GenericArgs
+         charon_lib::ast::types::TraitDeclRef
+         charon_lib::ast::types::RegionBinder<charon_lib::ast::types::TraitDeclRef>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::types::TyKind
+         charon_lib::ast::types::Ty
+         charon_lib::ast::types::FunSig
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 2):
+         0: 
+         1: <'_0, Self, Self_Foo>
+ --> tests/ui/simple/assoc-type-with-fn-bound.rs:9:5
+  |
+9 |     fn call(&self) -> <Self::Foo as FnOnce<()>>::Output;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+ERROR Charon failed to translate this code (2 errors)


### PR DESCRIPTION
Each pass normally leaves the `TranslatedCrate` in a good state, so there's no reason not to keep going on subsequent passes. The exception is the `check_generics` pass, but it's a stopgap anyway.

Should fix https://github.com/AeneasVerif/charon/issues/573.