### PR TITLE
Always error on generics mismatches

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -24,7 +24,7 @@ use std::{fmt, mem};
 
 // Re-export to avoid having to fix imports.
 pub(crate) use charon_lib::errors::{
-    error_assert, raise_error, register_error, DepSource, ErrorCtx,
+    error_assert, raise_error, register_error, DepSource, ErrorCtx, Level,
 };
 
 /// The id of an untranslated item. Note that a given `DefId` may show up as multiple different
@@ -290,10 +290,10 @@ where
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx> {
     /// Span an error and register the error.
-    pub fn span_err(&self, span: Span, msg: &str) -> Error {
+    pub fn span_err(&self, span: Span, msg: &str, level: Level) -> Error {
         self.errors
             .borrow_mut()
-            .span_err(&self.translated, span, msg)
+            .span_err(&self.translated, span, msg, level)
     }
 
     /// Register a file if it is a "real" file and was not already registered
@@ -912,8 +912,8 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
         }
     }
 
-    pub fn span_err(&self, span: Span, msg: &str) -> Error {
-        self.t_ctx.span_err(span, msg)
+    pub fn span_err(&self, span: Span, msg: &str, level: Level) -> Error {
+        self.t_ctx.span_err(span, msg, level)
     }
 
     pub(crate) fn translate_span_from_hax(&mut self, rspan: &hax::Span) -> Span {

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -6,9 +6,9 @@ use std::{borrow::Cow, fmt::Display};
 
 use crate::{
     ast::*,
+    errors::Level,
     formatter::{FmtCtx, IntoFormatter, PushBinder},
     pretty::FmtWithCtx,
-    register_error,
 };
 
 use super::{ctx::TransformPass, TransformCtx};
@@ -29,9 +29,7 @@ struct CheckGenericsVisitor<'a> {
 
 impl CheckGenericsVisitor<'_> {
     fn error(&self, message: impl Display) {
-        register_error!(
-            self.ctx,
-            self.span,
+        let msg = format!(
             "Found inconsistent generics {}:\n{message}\n\
             Visitor stack:\n  {}\n\
             Binding stack (depth {}):\n  {}",
@@ -43,6 +41,8 @@ impl CheckGenericsVisitor<'_> {
                 .map(|(i, params)| format!("{i}: {params}"))
                 .join("\n  "),
         );
+        // This is a fatal error: the output llbc is inconsistent and should not be used.
+        self.ctx.span_err(self.span, &msg, Level::Error);
     }
 
     /// For pretty error printing. This can print values that we encounter because we track binders

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use crate::errors::ErrorCtx;
+use crate::errors::{ErrorCtx, Level};
 use crate::formatter::{FmtCtx, IntoFormatter};
 use crate::llbc_ast;
 use crate::options::TranslateOptions;
@@ -142,10 +142,10 @@ impl<'ctx> TransformCtx {
     }
 
     /// Span an error and register the error.
-    pub(crate) fn span_err(&self, span: Span, msg: &str) -> Error {
+    pub(crate) fn span_err(&self, span: Span, msg: &str, level: Level) -> Error {
         self.errors
             .borrow_mut()
-            .span_err(&self.translated, span, msg)
+            .span_err(&self.translated, span, msg, level)
     }
 
     pub(crate) fn opacity_for_name(&self, name: &Name) -> ItemOpacity {

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -69,9 +69,8 @@ impl Transform {
                     }) => None,
                 };
                 let Some(variants) = variants else {
-                    // An error occurred. We can't keep the `Rvalue::Discriminant` around so we
-                    // `Nop` the discriminant read.
-                    block.statements[i].content = RawStatement::Nop;
+                    block.statements[i].content =
+                        RawStatement::Error("unsupported raw discriminant read".to_owned());
                     return;
                 };
 


### PR DESCRIPTION
Most charon "errors" are simply unsupported features whose only consequence is an item being not translated. It is therefore fine to display them as warnings. Generics mismatches however indicate an inconsistency in the translated code, which should therefore not be used. This PR makes generic mismatches into a real error that will make charon indicate a failure.

Fixes https://github.com/AeneasVerif/charon/issues/570.

cc @sonmarcho 