### PR TITLE
Track lang items

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.70"
+let supported_charon_version = "0.1.71"

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -772,13 +772,17 @@ and item_meta_of_json (ctx : of_json_ctx) (js : json) :
           ("attr_info", attr_info);
           ("is_local", is_local);
           ("opacity", _);
+          ("lang_item", lang_item);
         ] ->
         let* name = name_of_json ctx name in
         let* span = span_of_json ctx span in
         let* source_text = option_of_json string_of_json ctx source_text in
         let* attr_info = attr_info_of_json ctx attr_info in
         let* is_local = bool_of_json ctx is_local in
-        Ok ({ name; span; source_text; attr_info; is_local } : item_meta)
+        let* lang_item = option_of_json string_of_json ctx lang_item in
+        Ok
+          ({ name; span; source_text; attr_info; is_local; lang_item }
+            : item_meta)
     | _ -> Error "")
 
 and file_name_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -496,6 +496,8 @@ and item_meta = {
   attr_info : attr_info;  (** Attributes and visibility. *)
   is_local : bool;
       (** `true` if the type decl is a local type decl, `false` if it comes from an external crate. *)
+  lang_item : string option;
+      (** If the item is built-in, record its internal builtin identifier. *)
 }
 
 and disambiguator = (Disambiguator.id[@visitors.opaque])

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.70"
+version = "0.1.71"
 authors = ["Son Ho <hosonmarc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -226,6 +226,9 @@ pub struct ItemMeta {
     #[charon::opaque]
     #[drive(skip)]
     pub opacity: ItemOpacity,
+    /// If the item is built-in, record its internal builtin identifier.
+    #[drive(skip)]
+    pub lang_item: Option<String>,
 }
 
 /// A filename.

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -528,6 +528,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
         let span = self.translate_span_from_hax(span);
         let attr_info = self.translate_attr_info(def);
         let is_local = def.def_id.is_local;
+        let lang_item = def
+            .lang_item
+            .clone()
+            .or_else(|| def.diagnostic_item.clone());
 
         let opacity = if self.is_extern_item(def)
             || attr_info.attributes.iter().any(|attr| attr.is_opaque())
@@ -545,6 +549,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
             attr_info,
             is_local,
             opacity,
+            lang_item,
         };
         self.cached_item_metas
             .insert(def.rust_def_id(), item_meta.clone());

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -623,7 +623,12 @@ impl ItemMeta {
     {
         let name = self.name.fmt_with_ctx(ctx);
         let vis = if self.attr_info.public { "pub " } else { "" };
-        format!("{tab}{vis}{keyword} {name}")
+        let lang_item = self
+            .lang_item
+            .as_ref()
+            .map(|id| format!("{tab}#[lang_item(\"{id}\")]\n"))
+            .unwrap_or_default();
+        format!("{lang_item}{tab}{vis}{keyword} {name}")
     }
 }
 

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -13,10 +13,13 @@ fn test_cargo_dependencies::silly_incr::closure(@1: (), @2: u32) -> u32
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -58,6 +61,7 @@ pub enum core::panicking::AssertKind =
 |  Match()
 
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -66,6 +70,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -16,6 +16,7 @@ pub fn test_crate::incr<'_0>(@1: &'_0 mut (u32))
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn test_crate::array_to_shared_slice_<'_0, T>(@1: &'_0 (Array<T, 32 : usize>)) -> &'_0 (Slice<T>)
@@ -49,6 +50,7 @@ where
     return
 }
 
+#[lang_item("slice_len_fn")]
 pub fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -229,6 +231,7 @@ where
     return
 }
 
+#[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
   where
       [@TraitClause0]: core::marker::Sized<Idx>,
@@ -240,6 +243,7 @@ pub struct core::ops::range::Range<Idx>
 
 pub trait core::slice::index::private_slice_index::Sealed<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -248,6 +252,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("SliceIndex")]
 pub trait core::slice::index::SliceIndex<Self, T, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
@@ -398,6 +403,7 @@ pub fn test_crate::array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>
     return
 }
 
+#[lang_item("index")]
 pub trait core::ops::index::Index<Self, Idx, Self_Output>
 {
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx, Self_Output>
@@ -447,6 +453,7 @@ pub fn test_crate::array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>)
     return
 }
 
+#[lang_item("index_mut")]
 pub trait core::ops::index::IndexMut<Self, Idx, Self_Clause0_Output>
 {
     parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx, Self_Clause0_Output>

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 struct test_crate::V<T, const N : usize>

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -1,13 +1,16 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -24,6 +27,7 @@ where
     fn use_item_provided<Clause0_Item, [@TraitClause0]: test_crate::Foo<'a, Self_Item, Clause0_Item>> = test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Self_Item>[@TraitClause0_0]
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -32,6 +36,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("noop_method_clone")]
 pub fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
 
 impl core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T> : core::clone::Clone<&'_0 (T)>
@@ -152,6 +157,7 @@ where
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn test_crate::external_use_item<'a, T, Clause1_Item, Clause2_Item>(@1: Clause1_Item) -> Clause1_Item
@@ -292,11 +298,13 @@ impl test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo
     type Self_Clause3_BarTy = &'_ (core::option::Option<u16>[core::marker::Sized<u16>])
 }
 
+#[lang_item("Borrow")]
 pub trait core::borrow::Borrow<Self, Borrowed>
 {
     fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
+#[lang_item("ToOwned")]
 pub trait alloc::borrow::ToOwned<Self, Self_Owned>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_Owned>
@@ -336,6 +344,7 @@ where
 
 fn test_crate::Foo::use_item_required<'a, Self, Self_Item>(@1: Self_Item) -> Self_Item
 
+#[lang_item("to_owned_method")]
 pub fn alloc::borrow::ToOwned::to_owned<'_0, Self, Self_Owned>(@1: &'_0 (Self)) -> Self_Owned
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 struct test_crate::Struct<A>
@@ -10,12 +11,14 @@ struct test_crate::Struct<A>
   A,
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn test_crate::{impl core::default::Default for test_crate::Struct<A>[@TraitClause0]}#1::default<A>() -> test_crate::Struct<A>[@TraitClause0]
@@ -49,12 +52,14 @@ trait test_crate::Trait<Self, B, Self_Item>
     fn method<C, [@TraitClause0]: core::marker::Sized<C>> = test_crate::Trait::method<Self, B, C, Self_Item>[@TraitClause0_0]
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
@@ -95,6 +100,7 @@ impl core::default::{impl core::default::Default for bool}#1 : core::default::De
     fn default = core::default::{impl core::default::Default for bool}#1::default
 }
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 pub fn core::clone::impls::{impl core::clone::Clone for u8}#6::clone<'_0>(@1: &'_0 (u8)) -> u8
@@ -136,8 +142,10 @@ fn test_crate::Trait::method<Self, B, C, Self_Item>()
 where
     [@TraitClause0]: core::marker::Sized<C>,
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -12,10 +12,13 @@ pub fn test_crate::incr_u32(@1: u32) -> u32
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -24,6 +27,7 @@ pub trait core::ops::function::FnOnce<Self, Args, Self_Output>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args, Self_Clause0_Output>
@@ -32,6 +36,7 @@ pub trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause0_Output>
 }
 
+#[lang_item("r#fn")]
 pub trait core::ops::function::Fn<Self, Args, Self_Clause0_Clause0_Output>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args, Self_Clause0_Clause0_Output>
@@ -40,6 +45,7 @@ pub trait core::ops::function::Fn<Self, Args, Self_Clause0_Clause0_Output>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause0_Clause0_Output>
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -408,12 +414,14 @@ pub fn test_crate::test_map_option_id2(@1: core::option::Option<u32>[core::marke
     return
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 pub fn test_crate::id_clone<T>(@1: T) -> T

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -10,8 +10,10 @@ fn test_crate::function_call(@1: u32)
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("slice_len_fn")]
 pub fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -129,6 +131,7 @@ struct test_crate::Foo =
   y: u32,
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -202,6 +205,7 @@ pub enum core::panicking::AssertKind =
 |  Match()
 
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -210,6 +214,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
@@ -400,6 +405,7 @@ fn test_crate::fool()
     return
 }
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 impl core::default::{impl core::default::Default for u32}#7 : core::default::Default<u32>

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -78,6 +78,7 @@ pub fn test_crate::mk_pair0(@1: u32, @2: u32) -> (u32, u32)
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub struct test_crate::Pair<T1, T2>

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn test_crate::choose<'a, T>(@1: bool, @2: &'a mut (T), @3: &'a mut (T)) -> &'a mut (T)
@@ -120,6 +121,7 @@ pub fn test_crate::use_incr()
     return
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 pub enum test_crate::CList<T>

--- a/charon/tests/ui/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/dictionary_passing_style_woes.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::Iterator<Self, Self_Item>
@@ -104,12 +105,14 @@ where
     return
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -143,6 +146,7 @@ where
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -1,11 +1,14 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Formatter")]
 pub opaque type core::fmt::Formatter<'a>
   where
       'a : 'a,
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -17,11 +20,13 @@ pub enum core::result::Result<T, E>
 
 pub struct core::fmt::Error = {}
 
+#[lang_item("Display")]
 pub trait core::fmt::Display<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 fn test_crate::construct<T>(@1: T) -> alloc::boxed::Box<dyn (exists(TODO))>[core::marker::Sized<alloc::alloc::Global>]
@@ -30,6 +35,7 @@ where
     [@TraitClause1]: core::fmt::Display<T>,
     T : 'static,
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 pub fn alloc::string::{impl alloc::string::ToString for T}#32::to_string<'_0, T>(@1: &'_0 (T)) -> alloc::string::String
@@ -73,8 +79,10 @@ fn test_crate::bar<'_0>(@1: &'_0 (dyn (exists(TODO))))
     return
 }
 
+#[lang_item("to_string_method")]
 pub fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::string::String
 
+#[lang_item("ToString")]
 pub trait alloc::string::ToString<Self>
 {
     fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("mem_swap")]
 pub fn core::mem::swap<'_0, '_1, T>(@1: &'_0 mut (T), @2: &'_1 mut (T))
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -25,12 +27,14 @@ where
     return
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -48,6 +52,7 @@ pub trait core::num::nonzero::ZeroablePrimitive<Self>
     type NonZeroInner
 }
 
+#[lang_item("NonZero")]
 pub opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -93,6 +98,7 @@ impl core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for u32}#20
     type NonZeroInner = core::num::nonzero::private::NonZeroU32Inner
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -106,6 +112,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::num::nonzero::ZeroablePrimitive<T>,
 
+#[lang_item("option_unwrap")]
 pub fn core::option::{core::option::Option<T>[@TraitClause0]}::unwrap<T>(@1: core::option::Option<T>[@TraitClause0]) -> T
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -125,13 +132,16 @@ pub fn test_crate::test_new_non_zero_u32(@1: u32) -> core::num::nonzero::NonZero
     return
 }
 
+#[lang_item("Vec")]
 pub opaque type alloc::vec::Vec<T, A>
   where
       [@TraitClause0]: core::marker::Sized<T>,
       [@TraitClause1]: core::marker::Sized<A>,
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
+#[lang_item("vec_new")]
 pub fn alloc::vec::{alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]}::new<T>() -> alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -199,6 +209,7 @@ pub fn test_crate::incr<'_0>(@1: &'_0 mut (core::cell::Cell<u32>))
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/find-sized-clause.out
+++ b/charon/tests/ui/find-sized-clause.out
@@ -2,8 +2,10 @@
 
 trait test_crate::Trait<Self>
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -119,6 +121,7 @@ pub fn test_crate::RPITIT::make_foo<Self>() -> Self::
 
 pub fn test_crate::Foo::get_ty<'_0, Self>(@1: &'_0 (Self)) -> &'_0 (Self::Type)
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 fn test_crate::use_tait<T>()
@@ -161,6 +164,7 @@ pub struct test_crate::WrapClone<T>
   T,
 }
 
+#[lang_item("noop_method_clone")]
 pub fn core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3::clone<'_0, '_1, T>(@1: &'_1 (&'_0 (T))) -> &'_0 (T)
 
 impl core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_0, T> : core::clone::Clone<&'_0 (T)>
@@ -194,8 +198,10 @@ where
     return
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -18,6 +18,7 @@ pub fn issue_114_opaque_bodies_aux::inline_sometimes() -> u32
 
 pub fn issue_114_opaque_bodies_aux::inline_never() -> u32
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn issue_114_opaque_bodies_aux::inline_generic<T>() -> u32
@@ -56,6 +57,7 @@ fn test_crate::use_inlines() -> u32
     return
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -122,13 +124,16 @@ fn test_crate::convert(@1: i32) -> i64
     return
 }
 
+#[lang_item("NonNull")]
 pub struct core::ptr::non_null::NonNull<T> =
 {
   pointer: *const T,
 }
 
+#[lang_item("phantom_data")]
 pub struct core::marker::PhantomData<T> = {}
 
+#[lang_item("ptr_unique")]
 pub struct core::ptr::unique::Unique<T> =
 {
   pointer: core::ptr::non_null::NonNull<T>,
@@ -160,6 +165,7 @@ struct alloc::raw_vec::RawVec<T, A>
   _marker: core::marker::PhantomData<T>,
 }
 
+#[lang_item("Vec")]
 pub struct alloc::vec::Vec<T, A>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -170,6 +176,7 @@ pub struct alloc::vec::Vec<T, A>
   len: usize,
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 fn test_crate::vec(@1: alloc::vec::Vec<u32, alloc::alloc::Global>[core::marker::Sized<u32>, core::marker::Sized<alloc::alloc::Global>])
@@ -203,6 +210,7 @@ fn test_crate::max() -> usize
     return
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
@@ -223,8 +231,10 @@ where
     return
 }
 
+#[lang_item("from_fn")]
 pub fn core::convert::From::from<Self, T>(@1: T) -> Self
 
+#[lang_item("From")]
 pub trait core::convert::From<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -239,8 +249,10 @@ impl core::convert::num::{impl core::convert::From<i32> for i64}#83 : core::conv
     fn from = core::convert::num::{impl core::convert::From<i32> for i64}#83::from
 }
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("cmp_partialeq_ne")]
 pub fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 {
     let @0: bool; // return

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -2,8 +2,10 @@
 
 struct test_crate::Foo = {}
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -25,6 +27,7 @@ impl test_crate::{impl core::clone::Clone for test_crate::Foo} : core::clone::Cl
     fn clone<'_0> = test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0_0>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -102,6 +105,7 @@ where
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -1,25 +1,31 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Vec")]
 pub opaque type alloc::vec::Vec<T, A>
   where
       [@TraitClause0]: core::marker::Sized<T>,
       [@TraitClause1]: core::marker::Sized<A>,
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
+#[lang_item("slice_into_vec")]
 pub fn alloc::slice::{Slice<T>}::into_vec<T, A>(@1: alloc::boxed::Box<Slice<T>>[@TraitClause1]) -> alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<A>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("vec_from_elem")]
 pub fn alloc::vec::from_elem<T>(@1: T, @2: usize) -> alloc::vec::Vec<T, alloc::alloc::Global>[@TraitClause0, core::marker::Sized<alloc::alloc::Global>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -97,8 +103,10 @@ pub fn test_crate::bar()
     return
 }
 
+#[lang_item("exchange_malloc")]
 unsafe fn alloc::alloc::exchange_malloc(@1: usize, @2: usize) -> *mut u8
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -65,6 +65,7 @@ fn test_crate::FIELD_MODULUS() -> i16
 
 global test_crate::FIELD_MODULUS: i16 = test_crate::FIELD_MODULUS()
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub opaque type core::slice::iter::Chunks<'a, T>
@@ -73,6 +74,7 @@ pub opaque type core::slice::iter::Chunks<'a, T>
       T : 'a,
       T : 'a,
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -85,6 +87,7 @@ pub fn core::slice::{Slice<T>}::chunks<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -315,8 +318,10 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
     return
 }
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -342,16 +347,20 @@ where
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -361,6 +370,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -369,6 +379,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -376,6 +387,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -391,6 +403,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -419,12 +432,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -436,28 +451,33 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
     fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -465,6 +485,7 @@ pub trait core::cmp::Ord<Self>
     fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -490,24 +511,32 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -522,6 +551,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::FromResidual<Self, R>
@@ -14,6 +15,7 @@ pub trait test_crate::Try<Self>
     type Residual
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub struct test_crate::S<'a, K>
@@ -11,8 +12,10 @@ pub struct test_crate::S<'a, K>
   x: &'a (K),
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -22,6 +25,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -24,6 +26,7 @@ fn test_crate::F() -> fn(u8) -> core::option::Option<u8>[core::marker::Sized<u8>
 
 global test_crate::F: fn(u8) -> core::option::Option<u8>[core::marker::Sized<u8>] = test_crate::F()
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 struct test_crate::Foo =
@@ -50,6 +53,7 @@ fn test_crate::Foo(@1: u32, @2: alloc::string::String) -> test_crate::Foo
     return
 }
 
+#[lang_item("string_new")]
 pub fn alloc::string::{alloc::string::String}::new() -> alloc::string::String
 
 fn test_crate::Bar::Variant<'a, T>(@1: &'a (T)) -> test_crate::Bar<'a, T>[@TraitClause0]

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -1,11 +1,13 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub opaque type core::iter::sources::from_fn::FromFn<F>
   where
       [@TraitClause0]: core::marker::Sized<F>,
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -23,8 +25,10 @@ fn test_crate::sparse_transitions::closure<'a, '_1>(@1: &'_1 mut (())) -> core::
     return
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -34,6 +38,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::Trait<Self>
@@ -8,6 +9,7 @@ pub trait test_crate::Trait<Self>
     type AssocType
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -25,6 +27,7 @@ pub trait test_crate::C<Self, T>
     parent_clause0 : [@TraitClause0]: core::marker::Sized<T>
 }
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -49,8 +52,10 @@ pub type test_crate::S2<I, F>
       [@TraitClause0]: core::marker::Sized<I>,
       [@TraitClause1]: core::marker::Sized<F>, = test_crate::S<I, F>[@TraitClause0, @TraitClause1, UNKNOWN(Could not find a clause for `Binder { value: <I as std::iter::Iterator>, bound_vars: [] }` in the current context: `Unimplemented`), UNKNOWN(Could not find a clause for `Binder { value: <F as C<<I as std::iter::Iterator>::Item>>, bound_vars: [] }` in the current context: `Unimplemented`)]
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -63,14 +68,17 @@ where
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -80,6 +88,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -88,6 +97,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -95,6 +105,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -110,6 +121,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -138,12 +150,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -155,28 +169,33 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
     fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -184,6 +203,7 @@ pub trait core::cmp::Ord<Self>
     fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -209,24 +229,32 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -241,12 +269,14 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
     @TraitClause1::Item = A,
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 pub fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -13,6 +15,7 @@ pub enum core::result::Result<T, E>
 
 pub opaque type core::array::TryFromSliceError
 
+#[lang_item("TryFrom")]
 pub trait core::convert::TryFrom<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -28,12 +31,14 @@ where
     [@TraitClause1]: core::marker::Sized<U>,
     [@TraitClause2]: core::convert::TryFrom<U, T>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -69,12 +74,14 @@ impl core::marker::{impl core::marker::Copy for u8}#38 : core::marker::Copy<u8>
     parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8}#6
 }
 
+#[lang_item("Formatter")]
 pub opaque type core::fmt::Formatter<'a>
   where
       'a : 'a,
 
 pub struct core::fmt::Error = {}
 
+#[lang_item("Debug")]
 pub trait core::fmt::Debug<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
@@ -115,6 +122,7 @@ pub fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
 
 pub fn core::convert::TryInto::try_into<Self, T>(@1: Self) -> core::result::Result<T, Self::Error>[Self::parent_clause1, Self::parent_clause2]
 
+#[lang_item("TryInto")]
 pub trait core::convert::TryInto<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -137,8 +145,10 @@ where
     fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
+#[lang_item("try_from_fn")]
 pub fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[Self::parent_clause0, Self::parent_clause2]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -13,6 +15,7 @@ pub enum core::result::Result<T, E>
 
 pub opaque type core::array::TryFromSliceError
 
+#[lang_item("TryFrom")]
 pub trait core::convert::TryFrom<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -28,12 +31,14 @@ where
     [@TraitClause1]: core::marker::Sized<U>,
     [@TraitClause2]: core::convert::TryFrom<U, T>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -69,12 +74,14 @@ impl core::marker::{impl core::marker::Copy for u8}#38 : core::marker::Copy<u8>
     parent_clause0 = core::clone::impls::{impl core::clone::Clone for u8}#6
 }
 
+#[lang_item("Formatter")]
 pub opaque type core::fmt::Formatter<'a>
   where
       'a : 'a,
 
 pub struct core::fmt::Error = {}
 
+#[lang_item("Debug")]
 pub trait core::fmt::Debug<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
@@ -115,6 +122,7 @@ fn test_crate::trait_error<'_0>(@1: &'_0 (Slice<u8>))
 
 pub fn core::convert::TryInto::try_into<Self, T>(@1: Self) -> core::result::Result<T, Self::Error>[Self::parent_clause1, Self::parent_clause2]
 
+#[lang_item("TryInto")]
 pub trait core::convert::TryInto<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -137,8 +145,10 @@ where
     fn try_into = core::convert::{impl core::convert::TryInto<U> for T}#6::try_into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
+#[lang_item("try_from_fn")]
 pub fn core::convert::TryFrom::try_from<Self, T>(@1: T) -> core::result::Result<Self, Self::Error>[Self::parent_clause0, Self::parent_clause2]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -10,10 +10,13 @@ fn test_crate::map::closure<'_0>(@1: &'_0 mut (()), @2: i32) -> i32
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -23,6 +26,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -62,6 +66,7 @@ pub fn test_crate::array<const LEN : usize>() -> Array<u8, const LEN : usize>
     return
 }
 
+#[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
   where
       [@TraitClause0]: core::marker::Sized<Idx>,
@@ -71,6 +76,7 @@ pub struct core::ops::range::Range<Idx>
   end: Idx,
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -79,6 +85,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -91,23 +98,27 @@ where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
@@ -243,10 +254,12 @@ pub enum core::panicking::AssertKind =
 |  Match()
 
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
+#[lang_item("slice_len_fn")]
 pub fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -332,8 +345,10 @@ fn test_crate::select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
     return
 }
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -359,6 +374,7 @@ where
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
@@ -371,17 +387,22 @@ pub fn core::iter::range::Step::forward_checked<Self>(@1: Self, @2: usize) -> co
 
 pub fn core::iter::range::Step::backward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>[Self::parent_clause0]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -395,8 +416,10 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -404,6 +427,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -419,6 +443,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -447,12 +472,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -464,6 +491,7 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -483,12 +511,16 @@ pub trait core::iter::traits::accum::Product<Self, A>
     fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -503,6 +535,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -1,13 +1,16 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
@@ -29,6 +32,7 @@ struct test_crate::Override<T>
   T,
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -37,6 +41,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -68,6 +73,7 @@ where
     return
 }
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 fn test_crate::{impl test_crate::GenericTrait<core::option::Option<T>[@TraitClause0]> for test_crate::Override<T>[@TraitClause0]}::provided<T, U>(@1: core::option::Option<T>[@TraitClause0], @2: U)
@@ -213,6 +219,7 @@ where
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -10,6 +12,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
@@ -57,6 +60,7 @@ struct test_crate::Foo =
   u32,
 }
 
+#[lang_item("structural_peq")]
 pub trait core::marker::StructuralPartialEq<Self>
 
 impl test_crate::{impl core::marker::StructuralPartialEq for test_crate::Foo} : core::marker::StructuralPartialEq<test_crate::Foo>
@@ -82,12 +86,14 @@ impl test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo
     fn eq<'_0, '_1> = test_crate::{impl core::cmp::PartialEq<test_crate::Foo> for test_crate::Foo}#1::eq<'_0_0, '_0_1>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
@@ -124,6 +130,7 @@ impl test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Fo
     fn partial_cmp<'_0, '_1> = test_crate::{impl core::cmp::PartialOrd<test_crate::Foo> for test_crate::Foo}#2::partial_cmp<'_0_0, '_0_1>
 }
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 impl core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14<T> : core::cmp::PartialEq<core::option::Option<T>[@TraitClause0], core::option::Option<T>[@TraitClause0]>
@@ -134,6 +141,7 @@ where
     fn eq<'_0, '_1> = core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
 pub fn core::cmp::impls::{impl core::cmp::PartialEq<u32> for u32}#24::eq<'_0, '_1>(@1: &'_0 (u32), @2: &'_1 (u32)) -> bool

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -6,6 +6,7 @@ pub struct test_crate::DefaultHasher = {}
 
 impl test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher} : test_crate::Hasher<test_crate::DefaultHasher>
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::Hash<Self>

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -5,14 +5,17 @@ enum test_crate::Foo =
 |  B()
 
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -131,6 +134,7 @@ fn test_crate::main()
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
+++ b/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::Trait1<Self>

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::Trait1<Self>

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -2,6 +2,7 @@
 
 pub trait test_crate::Ord<Self>
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub struct test_crate::AVLTree<T>

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -1,11 +1,14 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("ArrayIntoIter")]
 pub opaque type core::array::iter::IntoIter<T, const N : usize>
   where
       [@TraitClause0]: core::marker::Sized<T>,
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -14,6 +17,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("SliceIter")]
 pub opaque type core::slice::iter::Iter<'a, T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -38,6 +42,7 @@ pub enum core::panicking::AssertKind =
 |  Match()
 
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
@@ -46,6 +51,7 @@ pub fn core::array::iter::{impl core::iter::traits::collect::IntoIterator for Ar
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -55,6 +61,7 @@ pub enum core::result::Result<T, E>
 |  Err(E)
 
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -62,6 +69,7 @@ pub trait core::clone::Clone<Self>
     fn clone_from<'_0, '_1> = core::clone::Clone::clone_from<'_0_0, '_0_1, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -79,6 +87,7 @@ pub trait core::num::nonzero::ZeroablePrimitive<Self>
     type NonZeroInner
 }
 
+#[lang_item("NonZero")]
 pub opaque type core::num::nonzero::NonZero<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -144,8 +153,10 @@ pub opaque type core::iter::adapters::zip::Zip<A, B>
       [@TraitClause0]: core::marker::Sized<A>,
       [@TraitClause1]: core::marker::Sized<B>,
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -155,6 +166,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -178,6 +190,7 @@ pub opaque type core::iter::adapters::filter_map::FilterMap<I, F>
       [@TraitClause0]: core::marker::Sized<I>,
       [@TraitClause1]: core::marker::Sized<F>,
 
+#[lang_item("Enumerate")]
 pub opaque type core::iter::adapters::enumerate::Enumerate<I>
   where
       [@TraitClause0]: core::marker::Sized<I>,
@@ -220,6 +233,7 @@ pub opaque type core::iter::adapters::inspect::Inspect<I, F>
       [@TraitClause0]: core::marker::Sized<I>,
       [@TraitClause1]: core::marker::Sized<F>,
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -235,6 +249,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -257,30 +272,35 @@ where
     type TryType
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
     fn ne<'_0, '_1> = core::cmp::PartialEq::ne<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
     fn assert_receiver_is_total_eq<'_0> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_0, Self>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
@@ -291,6 +311,7 @@ pub trait core::cmp::PartialOrd<Self, Rhs>
     fn ge<'_0, '_1> = core::cmp::PartialOrd::ge<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -317,6 +338,7 @@ pub opaque type core::iter::adapters::cycle::Cycle<I>
   where
       [@TraitClause0]: core::marker::Sized<I>,
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -400,6 +422,7 @@ pub trait core::iter::traits::iterator::Iterator<Self>
     fn __iterator_get_unchecked<'_0, [@TraitClause0]: core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[@TraitClause0_0]
 }
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -424,6 +447,7 @@ pub opaque type core::iter::adapters::intersperse::IntersperseWith<I, G>
       [@TraitClause1]: core::marker::Sized<G>,
       [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
 
+#[lang_item("IterPeekable")]
 pub opaque type core::iter::adapters::peekable::Peekable<I>
   where
       [@TraitClause0]: core::marker::Sized<I>,
@@ -448,6 +472,7 @@ pub opaque type core::iter::adapters::map_windows::MapWindows<I, F, const N : us
       [@TraitClause1]: core::marker::Sized<F>,
       [@TraitClause2]: core::iter::traits::iterator::Iterator<I>,
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -464,6 +489,7 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend_one_unchecked<'_0, [@TraitClause0]: core::marker::Sized<Self>> = core::iter::traits::collect::Extend::extend_one_unchecked<'_0_0, Self, A>[@TraitClause0_0]
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -576,6 +602,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<G, ()>,
     @TraitClause3::parent_clause0::Output = T,
 
+#[lang_item("IteratorMap")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::map<T, B, F, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0], @2: F) -> core::iter::adapters::map::Map<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -593,6 +620,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (T)>,
     @TraitClause3::parent_clause0::Output = (),
 
+#[lang_item("iter_filter")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::filter<T, P, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0], @2: P) -> core::iter::adapters::filter::Filter<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -610,6 +638,7 @@ where
     [@TraitClause4]: core::ops::function::FnMut<F, (T)>,
     @TraitClause4::parent_clause0::Output = core::option::Option<B>[@TraitClause1],
 
+#[lang_item("enumerate_method")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::enumerate<T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> core::iter::adapters::enumerate::Enumerate<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -708,6 +737,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>,
 
+#[lang_item("iterator_collect_fn")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::collect<T, B, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> B
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -945,6 +975,7 @@ where
     [@TraitClause10]: core::iter::traits::iterator::Iterator<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>,
     core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]::Item = (A, B),
 
+#[lang_item("iter_copied")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::copied<'a, T, T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> core::iter::adapters::copied::Copied<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -955,6 +986,7 @@ where
     T : 'a,
     core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2<T, const N : usize>[@TraitClause0]::Item = &'a (T),
 
+#[lang_item("iter_cloned")]
 pub fn core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::cloned<'a, T, T, const N : usize>(@1: core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]) -> core::iter::adapters::cloned::Cloned<core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1198,6 +1230,7 @@ where
     fn __iterator_get_unchecked<'_0> = core::array::iter::{impl core::iter::traits::iterator::Iterator for core::array::iter::IntoIter<T, const N : usize>[@TraitClause0]}#2::__iterator_get_unchecked<'_0_0, T, const N : usize>[@TraitClause0]
 }
 
+#[lang_item("slice_iter")]
 pub fn core::slice::{Slice<T>}::iter<'_0, T>(@1: &'_0 (Slice<T>)) -> core::slice::iter::Iter<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1265,6 +1298,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<G, ()>,
     @TraitClause3::parent_clause0::Output = &'a (T),
 
+#[lang_item("IteratorMap")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::map<'a, T, B, F>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0], @2: F) -> core::iter::adapters::map::Map<core::slice::iter::Iter<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1282,6 +1316,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (&'_ (T))>,
     @TraitClause3::parent_clause0::Output = (),
 
+#[lang_item("iter_filter")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::filter<'a, T, P>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0], @2: P) -> core::iter::adapters::filter::Filter<core::slice::iter::Iter<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1299,6 +1334,7 @@ where
     [@TraitClause4]: core::ops::function::FnMut<F, (&'a (T))>,
     @TraitClause4::parent_clause0::Output = core::option::Option<B>[@TraitClause1],
 
+#[lang_item("enumerate_method")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::enumerate<'a, T>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0]) -> core::iter::adapters::enumerate::Enumerate<core::slice::iter::Iter<'a, T>[@TraitClause0]>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1397,6 +1433,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<core::slice::iter::Iter<'a, T>[@TraitClause0]>,
 
+#[lang_item("iterator_collect_fn")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::collect<'a, T, B>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0]) -> B
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1634,6 +1671,7 @@ where
     [@TraitClause10]: core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, T>[@TraitClause0]>,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'a, T>[@TraitClause0]::Item = (A, B),
 
+#[lang_item("iter_copied")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::copied<'a, 'a, T, T>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0]) -> core::iter::adapters::copied::Copied<core::slice::iter::Iter<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1644,6 +1682,7 @@ where
     T : 'a,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182<'a, T>[@TraitClause0]::Item = &'a (T),
 
+#[lang_item("iter_cloned")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::cloned<'a, 'a, T, T>(@1: core::slice::iter::Iter<'a, T>[@TraitClause0]) -> core::iter::adapters::cloned::Cloned<core::slice::iter::Iter<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1956,6 +1995,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<G, ()>,
     @TraitClause3::parent_clause0::Output = &'a (Slice<T>),
 
+#[lang_item("IteratorMap")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::map<'a, T, B, F>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0], @2: F) -> core::iter::adapters::map::Map<core::slice::iter::Chunks<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1973,6 +2013,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (&'a (Slice<T>))>,
     @TraitClause3::parent_clause0::Output = (),
 
+#[lang_item("iter_filter")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::filter<'a, T, P>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0], @2: P) -> core::iter::adapters::filter::Filter<core::slice::iter::Chunks<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -1990,6 +2031,7 @@ where
     [@TraitClause4]: core::ops::function::FnMut<F, (&'a (Slice<T>))>,
     @TraitClause4::parent_clause0::Output = core::option::Option<B>[@TraitClause1],
 
+#[lang_item("enumerate_method")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::enumerate<'a, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::iter::adapters::enumerate::Enumerate<core::slice::iter::Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2088,6 +2130,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<core::slice::iter::Chunks<'a, T>[@TraitClause0]>,
 
+#[lang_item("iterator_collect_fn")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::collect<'a, T, B>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> B
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2326,6 +2369,7 @@ where
     [@TraitClause10]: core::iter::traits::iterator::Iterator<core::slice::iter::Chunks<'a, T>[@TraitClause0]>,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'a, T>[@TraitClause0]::Item = (A, B),
 
+#[lang_item("iter_copied")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::copied<'a, 'a, T, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::iter::adapters::copied::Copied<core::slice::iter::Chunks<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2336,6 +2380,7 @@ where
     T : 'a,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71<'a, T>[@TraitClause0]::Item = &'a (T),
 
+#[lang_item("iter_cloned")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Chunks<'a, T>[@TraitClause0]}#71::cloned<'a, 'a, T, T>(@1: core::slice::iter::Chunks<'a, T>[@TraitClause0]) -> core::iter::adapters::cloned::Cloned<core::slice::iter::Chunks<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2646,6 +2691,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<G, ()>,
     @TraitClause3::parent_clause0::Output = &'a (Slice<T>),
 
+#[lang_item("IteratorMap")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::map<'a, T, B, F>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0], @2: F) -> core::iter::adapters::map::Map<core::slice::iter::ChunksExact<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2663,6 +2709,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (&'a (Slice<T>))>,
     @TraitClause3::parent_clause0::Output = (),
 
+#[lang_item("iter_filter")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::filter<'a, T, P>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0], @2: P) -> core::iter::adapters::filter::Filter<core::slice::iter::ChunksExact<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2680,6 +2727,7 @@ where
     [@TraitClause4]: core::ops::function::FnMut<F, (&'a (Slice<T>))>,
     @TraitClause4::parent_clause0::Output = core::option::Option<B>[@TraitClause1],
 
+#[lang_item("enumerate_method")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::enumerate<'a, T>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> core::iter::adapters::enumerate::Enumerate<core::slice::iter::ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -2778,6 +2826,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Sized<core::slice::iter::ChunksExact<'a, T>[@TraitClause0]>,
 
+#[lang_item("iterator_collect_fn")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::collect<'a, T, B>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> B
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -3016,6 +3065,7 @@ where
     [@TraitClause10]: core::iter::traits::iterator::Iterator<core::slice::iter::ChunksExact<'a, T>[@TraitClause0]>,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90<'a, T>[@TraitClause0]::Item = (A, B),
 
+#[lang_item("iter_copied")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::copied<'a, 'a, T, T>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> core::iter::adapters::copied::Copied<core::slice::iter::ChunksExact<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -3026,6 +3076,7 @@ where
     T : 'a,
     core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90<'a, T>[@TraitClause0]::Item = &'a (T),
 
+#[lang_item("iter_cloned")]
 pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::ChunksExact<'a, T>[@TraitClause0]}#90::cloned<'a, 'a, T, T>(@1: core::slice::iter::ChunksExact<'a, T>[@TraitClause0]) -> core::iter::adapters::cloned::Cloned<core::slice::iter::ChunksExact<'a, T>[@TraitClause0]>[@TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -3531,6 +3582,7 @@ fn test_crate::main()
     return
 }
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 impl core::array::iter::{impl core::iter::traits::collect::IntoIterator for Array<T, const N : usize>}<T, const N : usize> : core::iter::traits::collect::IntoIterator<Array<T, const N : usize>>
@@ -3558,10 +3610,12 @@ where
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
 pub fn core::ops::arith::AddAssign::add_assign<'_0, Self, Rhs>(@1: &'_0 mut (Self), @2: Rhs)
 
+#[lang_item("add_assign")]
 pub trait core::ops::arith::AddAssign<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Rhs>
@@ -3598,6 +3652,7 @@ where
 
 pub fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(@1: &'_0 mut (Self), @2: usize) -> core::result::Result<(), core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>[core::marker::Sized<()>, core::marker::Sized<core::num::nonzero::NonZero<usize>[core::marker::Sized<usize>, core::num::nonzero::{impl core::num::nonzero::ZeroablePrimitive for usize}#26]>]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
@@ -3641,6 +3696,7 @@ where
     [@TraitClause2]: core::ops::function::FnMut<G, ()>,
     @TraitClause2::parent_clause0::Output = Self::Item,
 
+#[lang_item("IteratorMap")]
 pub fn core::iter::traits::iterator::Iterator::map<Self, B, F>(@1: Self, @2: F) -> core::iter::adapters::map::Map<Self, F>[@TraitClause2, @TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<B>,
@@ -3656,6 +3712,7 @@ where
     [@TraitClause2]: core::ops::function::FnMut<F, (Self::Item)>,
     @TraitClause2::parent_clause0::Output = (),
 
+#[lang_item("iter_filter")]
 pub fn core::iter::traits::iterator::Iterator::filter<Self, P>(@1: Self, @2: P) -> core::iter::adapters::filter::Filter<Self, P>[@TraitClause1, @TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<P>,
@@ -3671,6 +3728,7 @@ where
     [@TraitClause3]: core::ops::function::FnMut<F, (Self::Item)>,
     @TraitClause3::parent_clause0::Output = core::option::Option<B>[@TraitClause0],
 
+#[lang_item("enumerate_method")]
 pub fn core::iter::traits::iterator::Iterator::enumerate<Self>(@1: Self) -> core::iter::adapters::enumerate::Enumerate<Self>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<Self>,
@@ -3755,6 +3813,7 @@ pub fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(@1: &'_0 mut (S
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
+#[lang_item("iterator_collect_fn")]
 pub fn core::iter::traits::iterator::Iterator::collect<Self, B>(@1: Self) -> B
 where
     [@TraitClause0]: core::marker::Sized<B>,
@@ -3959,6 +4018,7 @@ where
     [@TraitClause9]: core::iter::traits::iterator::Iterator<Self>,
     Self::Item = (A, B),
 
+#[lang_item("iter_copied")]
 pub fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(@1: Self) -> core::iter::adapters::copied::Copied<Self>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -3968,6 +4028,7 @@ where
     T : 'a,
     Self::Item = &'a (T),
 
+#[lang_item("iter_cloned")]
 pub fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(@1: Self) -> core::iter::adapters::cloned::Cloned<Self>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -4103,16 +4164,21 @@ where
     [@TraitClause4]: core::cmp::PartialOrd<K, K>,
     @TraitClause3::parent_clause0::Output = K,
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("cmp_partialeq_ne")]
 pub fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("cmp_ord_max")]
 pub fn core::cmp::Ord::max<Self>(@1: Self, @2: Self) -> Self
 where
     [@TraitClause0]: core::marker::Sized<Self>,
 
+#[lang_item("cmp_ord_min")]
 pub fn core::cmp::Ord::min<Self>(@1: Self, @2: Self) -> Self
 where
     [@TraitClause0]: core::marker::Sized<Self>,
@@ -4123,22 +4189,31 @@ where
 
 pub fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(@1: &'_0 (Self))
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("cmp_partialord_lt")]
 pub fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("cmp_partialord_le")]
 pub fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("cmp_partialord_gt")]
 pub fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("cmp_partialord_ge")]
 pub fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size<'_0, Self>(@1: &'_0 (Self)) -> usize
@@ -4157,6 +4232,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -657,8 +657,10 @@ pub fn test_crate::test_loops()
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
   where
       [@TraitClause0]: core::marker::Sized<Idx>,
@@ -668,6 +670,7 @@ pub struct core::ops::range::Range<Idx>
   end: Idx,
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -676,6 +679,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -688,23 +692,27 @@ where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
@@ -1149,11 +1157,13 @@ pub fn test_crate::sum_array<const N : usize>(@1: Array<u32, const N : usize>) -
     return
 }
 
+#[lang_item("Vec")]
 pub opaque type alloc::vec::Vec<T, A>
   where
       [@TraitClause0]: core::marker::Sized<T>,
       [@TraitClause1]: core::marker::Sized<A>,
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 pub fn alloc::vec::{alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#1::len<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1])) -> usize
@@ -1163,6 +1173,7 @@ where
 
 pub trait core::slice::index::private_slice_index::Sealed<Self>
 
+#[lang_item("SliceIndex")]
 pub trait core::slice::index::SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
@@ -1382,8 +1393,10 @@ where
     }
 }
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -1409,8 +1422,10 @@ where
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+#[lang_item("index")]
 pub trait core::ops::index::Index<Self, Idx>
 {
     type Output
@@ -1419,6 +1434,7 @@ pub trait core::ops::index::Index<Self, Idx>
 
 pub fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut (Self::parent_clause0::Output)
 
+#[lang_item("index_mut")]
 pub trait core::ops::index::IndexMut<Self, Idx>
 {
     parent_clause0 : [@TraitClause0]: core::ops::index::Index<Self, Idx>
@@ -1460,17 +1476,22 @@ pub fn core::iter::range::Step::forward_checked<Self>(@1: Self, @2: usize) -> co
 
 pub fn core::iter::range::Step::backward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>[Self::parent_clause0]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -1484,10 +1505,13 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -1497,6 +1521,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -1505,6 +1530,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -1512,6 +1538,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -1527,6 +1554,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -1555,12 +1583,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -1572,6 +1602,7 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -1591,16 +1622,20 @@ pub trait core::iter::traits::accum::Product<Self, A>
     fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -1615,6 +1650,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -24,6 +24,7 @@ pub fn test_crate::test1(@1: test_crate::E1) -> bool
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn test_crate::id<T>(@1: T) -> T

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -1,13 +1,16 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -179,6 +182,7 @@ fn test_crate::MyCompare::compare<Self, Other>(@1: Self, @2: Other) -> bool
 
 fn test_crate::Foo::foo<'a, 'b, Self>(@1: &'a (()), @2: &'b (())) -> &'a (())
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -9,6 +9,7 @@ fn test_crate::foo::bar()
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::Trait<Self, T>
@@ -17,8 +18,10 @@ trait test_crate::Trait<Self, T>
     fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::Trait::method<Self, T, U>[@TraitClause0_0]
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -69,6 +72,7 @@ where
     fn method<V, [@TraitClause0]: core::marker::Sized<V>> = test_crate::{impl test_crate::Trait<alloc::boxed::Box<T>[core::marker::Sized<alloc::alloc::Global>]> for core::option::Option<U>[@TraitClause1]}#1::method<T, U, V>[@TraitClause0, @TraitClause1, @TraitClause0_0]
 }
 
+#[lang_item("RangeFrom")]
 pub struct core::ops::range::RangeFrom<Idx>
   where
       [@TraitClause0]: core::marker::Sized<Idx>,
@@ -83,6 +87,7 @@ where
 
 pub trait core::slice::index::private_slice_index::Sealed<Self>
 
+#[lang_item("SliceIndex")]
 pub trait core::slice::index::SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
@@ -192,6 +197,7 @@ where
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
 
+#[lang_item("index")]
 pub trait core::ops::index::Index<Self, Idx>
 {
     type Output

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub struct test_crate::Pair<T1, T2>
@@ -12,6 +13,7 @@ pub struct test_crate::Pair<T1, T2>
   y: T2,
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 pub enum test_crate::List<T>
@@ -605,14 +607,17 @@ pub fn test_crate::read_then_incr<'_0>(@1: &'_0 mut (u32)) -> u32
     return
 }
 
+#[lang_item("deref")]
 pub trait core::ops::deref::Deref<Self>
 {
     type Target
     fn deref<'_0> = core::ops::deref::Deref::deref<'_0_0, Self>
 }
 
+#[lang_item("deref_mut_method")]
 pub fn core::ops::deref::DerefMut::deref_mut<'_0, Self>(@1: &'_0 mut (Self)) -> &'_0 mut (Self::parent_clause0::Target)
 
+#[lang_item("deref_mut")]
 pub trait core::ops::deref::DerefMut<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::deref::Deref<Self>
@@ -635,6 +640,7 @@ where
     fn deref_mut<'_0> = alloc::boxed::{impl core::ops::deref::DerefMut for alloc::boxed::Box<T>[@TraitClause0]}#39::deref_mut<'_0_0, T, A>[@TraitClause0]
 }
 
+#[lang_item("deref_method")]
 pub fn core::ops::deref::Deref::deref<'_0, Self>(@1: &'_0 (Self)) -> &'_0 (Self::Target)
 
 

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -29,6 +31,7 @@ where
     return
 }
 
+#[lang_item("From")]
 pub trait core::convert::From<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -36,6 +39,7 @@ pub trait core::convert::From<Self, T>
     fn from = core::convert::From::from<Self, T>
 }
 
+#[lang_item("from_fn")]
 pub fn core::convert::From::from<Self, T>(@1: T) -> Self
 
 pub fn core::convert::{impl core::convert::Into<U> for T}#3::into<T, U>(@1: T) -> U
@@ -113,6 +117,7 @@ unsafe fn test_crate::extern_fn(@1: i32)
 
 pub fn core::convert::Into::into<Self, T>(@1: Self) -> T
 
+#[lang_item("Into")]
 pub trait core::convert::Into<Self, T>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>

--- a/charon/tests/ui/opaque-trait.out
+++ b/charon/tests/ui/opaque-trait.out
@@ -133,6 +133,7 @@ impl test_crate::{impl test_crate::Trait for u8} : test_crate::Trait<u8>
     fn method2 = test_crate::{impl test_crate::Trait for u8}::method2
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 fn test_crate::Trait::method1<Self>()

--- a/charon/tests/ui/opaque_attribute.out
+++ b/charon/tests/ui/opaque_attribute.out
@@ -19,8 +19,10 @@ impl test_crate::{impl test_crate::BoolTrait for bool} : test_crate::BoolTrait<b
     fn get_bool<'_0> = test_crate::{impl test_crate::BoolTrait for bool}::get_bool<'_0_0>
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -7,6 +7,7 @@ fn test_crate::panic1()
     panic(core::panicking::panic_explicit)
 }
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
@@ -29,6 +30,7 @@ fn test_crate::panic2()
     panic(core::panicking::panic_fmt)
 }
 
+#[lang_item("format_argument")]
 pub opaque type core::fmt::rt::Argument<'a>
 
 pub fn core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_0>() -> Array<core::fmt::rt::Argument<'_0>, 0 : usize>

--- a/charon/tests/ui/params.out
+++ b/charon/tests/ui/params.out
@@ -14,6 +14,7 @@ struct test_crate::SStatic =
   x: &'static (u32),
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 enum test_crate::E0<'a, 'b, T1, T2>
@@ -26,6 +27,7 @@ enum test_crate::E0<'a, 'b, T1, T2>
 |  V1(&'a mut (T1), &'b mut (T2))
 
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 enum test_crate::E1<'a, 'b, T1, T2>

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("HashMap")]
 pub opaque type std::collections::hash::map::HashMap<K, V, S>
   where
       [@TraitClause0]: core::marker::Sized<K>,
@@ -10,6 +12,7 @@ pub opaque type std::collections::hash::map::HashMap<K, V, S>
 
 pub opaque type std::hash::random::RandomState
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -18,11 +21,13 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
@@ -34,6 +39,7 @@ pub trait core::hash::Hasher<Self>
     fn write<'_0, '_1> = core::hash::Hasher::write<'_0_0, '_0_1, Self>
 }
 
+#[lang_item("Hash")]
 pub trait core::hash::Hash<Self>
 {
     fn hash<'_0, '_1, H, [@TraitClause0]: core::marker::Sized<H>, [@TraitClause1]: core::hash::Hasher<H>> = core::hash::Hash::hash<'_0_0, '_0_1, Self, H>[@TraitClause0_0, @TraitClause0_1]
@@ -47,6 +53,7 @@ pub trait core::hash::BuildHasher<Self>
     fn build_hasher<'_0> = core::hash::BuildHasher::build_hasher<'_0_0, Self>
 }
 
+#[lang_item("Borrow")]
 pub trait core::borrow::Borrow<Self, Borrowed>
 {
     fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
@@ -108,6 +115,7 @@ impl std::hash::random::{impl core::hash::BuildHasher for std::hash::random::Ran
     fn build_hasher<'_0> = std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1::build_hasher<'_0_0>
 }
 
+#[lang_item("noop_method_borrow")]
 pub fn core::borrow::{impl core::borrow::Borrow<T> for T}::borrow<'_0, T>(@1: &'_0 (T)) -> &'_0 (T)
 
 impl core::borrow::{impl core::borrow::Borrow<T> for T}<T> : core::borrow::Borrow<T, T>
@@ -115,6 +123,7 @@ impl core::borrow::{impl core::borrow::Borrow<T> for T}<T> : core::borrow::Borro
     fn borrow<'_0> = core::borrow::{impl core::borrow::Borrow<T> for T}::borrow<'_0_0, T>
 }
 
+#[lang_item("hashmap_insert")]
 pub fn std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::insert<'_0, K, V, S>(@1: &'_0 mut (std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]), @2: K, @3: V) -> core::option::Option<V>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized<K>,
@@ -197,6 +206,7 @@ pub fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map:
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
 
+#[lang_item("index")]
 pub trait core::ops::index::Index<Self, Idx>
 {
     type Output
@@ -227,6 +237,7 @@ pub fn core::hash::Hasher::finish<'_0, Self>(@1: &'_0 (Self)) -> u64
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(@1: &'_0 (Self), @2: &'_1 mut (H))

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -22,6 +24,7 @@ fn test_crate::wrap<'a>(@1: &'a (u32)) -> core::option::Option<&'a (u32)>[core::
     return
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -42,8 +45,10 @@ where
     return
 }
 
+#[lang_item("RefCell")]
 pub opaque type core::cell::RefCell<T>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -53,6 +58,7 @@ pub enum core::result::Result<T, E>
 |  Err(E)
 
 
+#[lang_item("RefCellRef")]
 pub opaque type core::cell::Ref<'b, T>
   where
       T : 'b,
@@ -106,6 +112,7 @@ where
     panic(core::panicking::panic)
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -1,9 +1,12 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -13,6 +16,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -49,6 +53,7 @@ where
     return
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -68,6 +73,7 @@ pub fn test_crate::f<'a>(@1: &'a (())) -> core::option::Option<(&'a (u8))>[core:
 
 pub trait test_crate::Trait<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -77,6 +83,7 @@ pub enum core::result::Result<T, E>
 |  Err(E)
 
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -84,6 +91,7 @@ pub trait core::iter::traits::iterator::Iterator<Self>
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>
 }
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -96,12 +104,14 @@ where
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -114,16 +124,20 @@ where
     [@TraitClause2]: for<'a> core::iter::traits::collect::IntoIterator<&'a (core::result::Result<T, U>[@TraitClause0, @TraitClause1])>,
     [@TraitClause3]: for<'a> core::marker::Copy<@TraitClause2::Item>,
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -131,6 +145,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -146,6 +161,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -174,12 +190,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -191,28 +209,33 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
     fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -240,18 +263,25 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -266,6 +296,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -30,6 +30,7 @@ impl test_crate::{impl test_crate::BoolTrait for bool} : test_crate::BoolTrait<b
     fn ret_true<'_0> = test_crate::{impl test_crate::BoolTrait for bool}::ret_true<'_0_0>
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn test_crate::test_bool_trait<T>(@1: bool) -> bool

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -11,6 +13,7 @@ pub enum core::result::Result<T, E>
 |  Err(E)
 
 
+#[lang_item("format_alignment")]
 pub enum core::fmt::rt::Alignment =
 |  Left()
 |  Right()
@@ -18,6 +21,7 @@ pub enum core::fmt::rt::Alignment =
 |  Unknown()
 
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -26,6 +30,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("Formatter")]
 pub struct core::fmt::Formatter<'a>
   where
       'a : 'a,
@@ -41,6 +46,7 @@ pub struct core::fmt::Formatter<'a>
 
 pub struct core::fmt::Error = {}
 
+#[lang_item("Debug")]
 pub trait core::fmt::Debug<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
@@ -153,6 +159,7 @@ impl core::fmt::num::{impl core::fmt::LowerHex for u32}#60 : core::fmt::LowerHex
 
 pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (core::fmt::Formatter<'_2>)) -> core::result::Result<(), core::fmt::Error>[core::marker::Sized<()>, core::marker::Sized<core::fmt::Error>]
 
+#[lang_item("Display")]
 pub trait core::fmt::Display<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -9,6 +9,7 @@ fn test_crate::foo::bar()
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::Trait<Self, T>
@@ -17,8 +18,10 @@ trait test_crate::Trait<Self, T>
     fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::Trait::method<Self, T, U>[@TraitClause0_0]
 }
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -210,8 +210,10 @@ fn test_crate::fn_casts()
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 fn test_crate::boxes()
@@ -271,6 +273,7 @@ fn test_crate::STEAL2() -> Array<(), 13 : usize>
 
 global test_crate::STEAL2: Array<(), 13 : usize> = test_crate::STEAL2()
 
+#[lang_item("mem_size_of")]
 pub fn core::mem::size_of<T>() -> usize
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -332,6 +335,7 @@ where
     return
 }
 
+#[lang_item("exchange_malloc")]
 unsafe fn alloc::alloc::exchange_malloc(@1: usize, @2: usize) -> *mut u8
 
 

--- a/charon/tests/ui/send_bound.out
+++ b/charon/tests/ui/send_bound.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Send")]
 pub trait core::marker::Send<Self>
 
 fn test_crate::foo<M>(@1: M)

--- a/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
+++ b/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::HasOutput<Self, Self_Output>

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::Trait<Self, Self_Type>

--- a/charon/tests/ui/simple/call-method-via-supertrait-bound.out
+++ b/charon/tests/ui/simple/call-method-via-supertrait-bound.out
@@ -12,6 +12,7 @@ trait test_crate::HasMethod<Self>
     fn method<'_0> = test_crate::HasMethod::method<'_0_0, Self>
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 fn test_crate::{impl test_crate::HasMethod for T}::method<'_0, T>(@1: &'_0 (T))

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -1,13 +1,16 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -49,6 +52,7 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::marker::Copy<T>,
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
 

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::HasType<Self, Self_Type>
@@ -12,6 +13,7 @@ trait test_crate::HasMethod<Self>
     fn method<Clause0_Type, [@TraitClause0]: test_crate::HasType<Self, Clause0_Type>> = test_crate::HasMethod::method<Self, Clause0_Type>[@TraitClause0_0]
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
@@ -5,8 +5,10 @@ pub trait test_crate::BoolTrait<Self>
     fn foo<'_0> = test_crate::BoolTrait::foo<'_0_0, Self>
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/simple/generic-impl-with-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-method.out
@@ -5,6 +5,7 @@ pub trait test_crate::Trait<Self>
     fn method<'_0> = test_crate::Trait::method<'_0_0, Self>
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub fn test_crate::{impl test_crate::Trait for T}::method<'_0, T>(@1: &'_0 (T))

--- a/charon/tests/ui/simple/method-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/method-with-assoc-type-constraint.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::IntoIterator<Self, Self_Item>

--- a/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
+++ b/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub trait test_crate::opaque::Iterator<Self>

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -9,10 +9,13 @@ pub fn test_crate::flabada<'a>(@1: &'a (())) -> &'a (())
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -21,6 +24,7 @@ pub trait core::ops::function::FnOnce<Self, Args, Self_Output>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args, Self_Clause0_Output>
@@ -29,6 +33,7 @@ pub trait core::ops::function::FnMut<Self, Args, Self_Clause0_Output>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause0_Output>
 }
 
+#[lang_item("r#fn")]
 pub trait core::ops::function::Fn<Self, Args, Self_Clause0_Clause0_Output>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args, Self_Clause0_Clause0_Output>

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::Trait<'a, Self, Self_Type>

--- a/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::HasAssoc<Self>

--- a/charon/tests/ui/skip-borrowck.out
+++ b/charon/tests/ui/skip-borrowck.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 fn test_crate::choose<'a, T>(@1: bool, @2: &'a mut (T), @3: &'a mut (T)) -> &'a mut (T)

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -30,6 +30,7 @@ fn test_crate::BAR() -> &'static (Slice<u8>)
 
 global test_crate::BAR: &'static (Slice<u8>) = test_crate::BAR()
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 pub fn alloc::string::{impl alloc::string::ToString for Str}#102::to_string<'_0>(@1: &'_0 (Str)) -> alloc::string::String
@@ -54,8 +55,10 @@ fn test_crate::main()
     return
 }
 
+#[lang_item("to_string_method")]
 pub fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> alloc::string::String
 
+#[lang_item("ToString")]
 pub trait alloc::string::ToString<Self>
 {
     fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -54,8 +54,10 @@ pub fn test_crate::test_bool_trait_bool(@1: bool) -> bool
     return
 }
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -613,6 +615,7 @@ where
     return
 }
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 pub trait test_crate::ParentTrait0<Self>
@@ -888,6 +891,7 @@ pub struct test_crate::Foo<T, U>
   y: U,
 }
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -966,8 +970,10 @@ pub fn test_crate::flabada<'a>(@1: &'a (())) -> test_crate::Wrapper<(bool, &'a (
     panic(core::panicking::panic)
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -977,6 +983,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -985,6 +992,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("r#fn")]
 pub trait core::ops::function::Fn<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnMut<Self, Args>

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -1,18 +1,22 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("Borrow")]
 pub trait core::borrow::Borrow<Self, Borrowed>
 {
     fn borrow<'_0> = core::borrow::Borrow::borrow<'_0_0, Self, Borrowed>
 }
 
+#[lang_item("ToOwned")]
 pub trait alloc::borrow::ToOwned<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Owned>
@@ -21,6 +25,7 @@ pub trait alloc::borrow::ToOwned<Self>
     fn to_owned<'_0> = alloc::borrow::ToOwned::to_owned<'_0_0, Self>
 }
 
+#[lang_item("Cow")]
 pub enum alloc::borrow::Cow<'a, B>
   where
       [@TraitClause0]: alloc::borrow::ToOwned<B>,
@@ -31,11 +36,13 @@ pub enum alloc::borrow::Cow<'a, B>
 |  Owned(@TraitClause0::Owned)
 
 
+#[lang_item("Vec")]
 pub opaque type alloc::vec::Vec<T, A>
   where
       [@TraitClause0]: core::marker::Sized<T>,
       [@TraitClause1]: core::marker::Sized<A>,
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
 pub fn alloc::slice::{impl core::borrow::Borrow<Slice<T>> for alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1]}#5::borrow<'_0, T, A>(@1: &'_0 (alloc::vec::Vec<T, A>[@TraitClause0, @TraitClause1])) -> &'_0 (Slice<T>)
@@ -77,8 +84,10 @@ struct test_crate::Generic2<'a, T>
   alloc::borrow::Cow<'a, Slice<T>>[alloc::slice::{impl alloc::borrow::ToOwned for Slice<T>}#9<T>[@TraitClause0, @TraitClause1]],
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("to_owned_method")]
 pub fn alloc::borrow::ToOwned::to_owned<'_0, Self>(@1: &'_0 (Self)) -> Self::Owned
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(@1: &'_0 (Self)) -> &'_0 (Borrowed)

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -1,5 +1,6 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 trait test_crate::Left<Self, T>
@@ -18,16 +19,19 @@ trait test_crate::Join<Self, U>
     fn test = test_crate::Join::test<Self, U>
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("Formatter")]
 pub opaque type core::fmt::Formatter<'a>
   where
       'a : 'a,
 
+#[lang_item("Result")]
 pub enum core::result::Result<T, E>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -39,17 +43,21 @@ pub enum core::result::Result<T, E>
 
 pub struct core::fmt::Error = {}
 
+#[lang_item("Debug")]
 pub trait core::fmt::Debug<Self>
 {
     fn fmt<'_0, '_1, '_2> = core::fmt::Debug::fmt<'_0_0, '_0_1, '_0_2, Self>
 }
 
+#[lang_item("format_arguments")]
 pub opaque type core::fmt::Arguments<'a>
   where
       'a : 'a,
 
+#[lang_item("format_argument")]
 pub opaque type core::fmt::rt::Argument<'a>
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::new_debug<'_0, '_1, T>(@1: &'_1 (T)) -> core::fmt::rt::Argument<'_1>

--- a/charon/tests/ui/ullbc-control-flow.out
+++ b/charon/tests/ui/ullbc-control-flow.out
@@ -1,7 +1,9 @@
 # Final ULLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
   where
       [@TraitClause0]: core::marker::Sized<Idx>,
@@ -11,6 +13,7 @@ pub struct core::ops::range::Range<Idx>
   end: Idx,
 }
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -19,6 +22,7 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -31,23 +35,27 @@ where
     [@TraitClause0]: core::marker::Sized<I>,
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
@@ -335,8 +343,10 @@ pub fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
     }
 }
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -362,6 +372,7 @@ where
     fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}#1::into_iter<I>[@TraitClause0, @TraitClause1]
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::option::Option<usize>[core::marker::Sized<usize>]
@@ -370,17 +381,22 @@ pub fn core::iter::range::Step::forward_checked<Self>(@1: Self, @2: usize) -> co
 
 pub fn core::iter::range::Step::backward_checked<Self>(@1: Self, @2: usize) -> core::option::Option<Self>[Self::parent_clause0]
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -394,10 +410,13 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -407,6 +426,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -415,6 +435,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -422,6 +443,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -437,6 +459,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -465,12 +488,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -482,6 +507,7 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -501,16 +527,20 @@ pub trait core::iter::traits::accum::Product<Self, A>
     fn product<I, [@TraitClause0]: core::marker::Sized<I>, [@TraitClause1]: core::iter::traits::iterator::Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -525,6 +555,7 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,

--- a/charon/tests/ui/unsafe-impl-send.out
+++ b/charon/tests/ui/unsafe-impl-send.out
@@ -5,6 +5,7 @@ struct test_crate::Foo =
   *const (),
 }
 
+#[lang_item("Send")]
 pub trait core::marker::Send<Self>
 
 impl test_crate::{impl core::marker::Send for test_crate::Foo} : core::marker::Send<test_crate::Foo>

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -1,9 +1,11 @@
 # Final LLBC before serialization:
 
+#[lang_item("ptr_null")]
 pub fn core::ptr::null<T>() -> *const T
 where
     [@TraitClause0]: core::ptr::metadata::Thin<T>,
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
 pub unsafe fn core::ptr::const_ptr::{*const T}::read<T>(@1: *const T) -> T

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -1,19 +1,24 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("global_alloc_ty")]
 pub struct alloc::alloc::Global = {}
 
+#[lang_item("Rc")]
 pub opaque type alloc::rc::Rc<T, A>
   where
       [@TraitClause0]: core::marker::Sized<A>,
 
+#[lang_item("String")]
 pub opaque type alloc::string::String
 
 pub fn alloc::rc::{alloc::rc::Rc<T, alloc::alloc::Global>[core::marker::Sized<alloc::alloc::Global>]}#8::new<T>(@1: T) -> alloc::rc::Rc<T, alloc::alloc::Global>[core::marker::Sized<alloc::alloc::Global>]
 where
     [@TraitClause0]: core::marker::Sized<T>,
 
+#[lang_item("string_new")]
 pub fn alloc::string::{alloc::string::String}::new() -> alloc::string::String
 
 pub fn alloc::string::{impl core::clone::Clone for alloc::string::String}#6::clone<'_0>(@1: &'_0 (alloc::string::String)) -> alloc::string::String
@@ -110,8 +115,10 @@ fn test_crate::foo()
     return
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -1,7 +1,9 @@
 # Final LLBC before serialization:
 
+#[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
+#[lang_item("Option")]
 pub enum core::option::Option<T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
@@ -10,12 +12,14 @@ pub enum core::option::Option<T>
 |  Some(T)
 
 
+#[lang_item("SliceIter")]
 pub opaque type core::slice::iter::Iter<'a, T>
   where
       [@TraitClause0]: core::marker::Sized<T>,
       T : 'a,
       T : 'a,
 
+#[lang_item("slice_iter")]
 pub fn core::slice::{Slice<T>}::iter<'_0, T>(@1: &'_0 (Slice<T>)) -> core::slice::iter::Iter<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -59,8 +63,10 @@ fn test_crate::main()
     return
 }
 
+#[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(@1: &'_0 mut (Self)) -> core::option::Option<Self::Item>[Self::parent_clause0]
 
+#[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Item>
@@ -77,6 +83,7 @@ where
     fn next<'_0> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next<'a, '_0_0, T>[@TraitClause0]
 }
 
+#[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
     Self::parent_clause2::Item = Self::Item,
@@ -89,14 +96,17 @@ where
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>
 }
 
+#[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>
 }
 
+#[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
+#[lang_item("fn_once")]
 pub trait core::ops::function::FnOnce<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Args>
@@ -106,6 +116,7 @@ pub trait core::ops::function::FnOnce<Self, Args>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>
 }
 
+#[lang_item("fn_mut")]
 pub trait core::ops::function::FnMut<Self, Args>
 {
     parent_clause0 : [@TraitClause0]: core::ops::function::FnOnce<Self, Args>
@@ -114,6 +125,7 @@ pub trait core::ops::function::FnMut<Self, Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>
 }
 
+#[lang_item("FromIterator")]
 pub trait core::iter::traits::collect::FromIterator<Self, A>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
@@ -121,6 +133,7 @@ pub trait core::iter::traits::collect::FromIterator<Self, A>
     fn from_iter<T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::FromIterator::from_iter<Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("FromResidual")]
 pub trait core::ops::try_trait::FromResidual<Self, R>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<R>
@@ -136,6 +149,7 @@ pub enum core::ops::control_flow::ControlFlow<B, C>
 |  Break(B)
 
 
+#[lang_item("Try")]
 pub trait core::ops::try_trait::Try<Self>
 {
     parent_clause0 : [@TraitClause0]: core::ops::try_trait::FromResidual<Self, Self::Residual>
@@ -164,12 +178,14 @@ pub trait core::iter::traits::collect::Extend<Self, A>
     fn extend<'_0, T, [@TraitClause0]: core::marker::Sized<T>, [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>, @TraitClause1_1::Item = A> = core::iter::traits::collect::Extend::extend<'_0_0, Self, A, T>[@TraitClause0_0, @TraitClause0_1]
 }
 
+#[lang_item("Default")]
 pub trait core::default::Default<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
     fn default = core::default::Default::default<Self>
 }
 
+#[lang_item("DoubleEndedIterator")]
 pub trait core::iter::traits::double_ended::DoubleEndedIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
@@ -181,28 +197,33 @@ pub trait core::iter::traits::exact_size::ExactSizeIterator<Self>
     parent_clause0 : [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>
 }
 
+#[lang_item("eq")]
 pub trait core::cmp::PartialEq<Self, Rhs>
 {
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Eq")]
 pub trait core::cmp::Eq<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
 }
 
+#[lang_item("Ordering")]
 pub enum core::cmp::Ordering =
 |  Less()
 |  Equal()
 |  Greater()
 
 
+#[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
     fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
 }
 
+#[lang_item("Ord")]
 pub trait core::cmp::Ord<Self>
 {
     parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
@@ -210,6 +231,7 @@ pub trait core::cmp::Ord<Self>
     fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
 }
 
+#[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
     parent_clause0 : [@TraitClause0]: core::clone::Clone<Self>
@@ -235,24 +257,32 @@ pub trait core::iter::adapters::zip::TrustedRandomAccessNoCoerce<Self>
     const MAY_HAVE_SIDE_EFFECT : bool
 }
 
+#[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
 
+#[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
+#[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
 
+#[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
 
+#[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::Output
 
+#[lang_item("from_output")]
 pub fn core::ops::try_trait::Try::from_output<Self>(@1: Self::Output) -> Self
 
+#[lang_item("branch")]
 pub fn core::ops::try_trait::Try::branch<Self>(@1: Self) -> core::ops::control_flow::ControlFlow<Self::Residual, Self::Output>[Self::parent_clause0::parent_clause0, Self::parent_clause1]
 
+#[lang_item("from_residual")]
 pub fn core::ops::try_trait::FromResidual::from_residual<Self, R>(@1: R) -> Self
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(@1: I) -> Self
@@ -267,12 +297,14 @@ where
     [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
     @TraitClause1::Item = A,
 
+#[lang_item("from_iter_fn")]
 pub fn core::iter::traits::collect::FromIterator::from_iter<Self, A, T>(@1: T) -> Self
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: core::iter::traits::collect::IntoIterator<T>,
     @TraitClause1::Item = A,
 
+#[lang_item("into_iter")]
 pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(@1: Self) -> Self::IntoIter
 
 pub fn core::iter::traits::collect::Extend::extend<'_0, Self, A, T>(@1: &'_0 mut (Self), @2: T)


### PR DESCRIPTION
This records which items are builtins that rustc knows about. These are called "lang items", the list of which can be found [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/lang_items/enum.LangItem.html), and is a much more convenient way to recognize built-ins than the name matcher, when available.

(I'm cheating a little bit and mixing lang items with diagnostic items so we can have more of them; it's the same idea).

cc @sonmarcho @msprotz this may be of interest.