### PR TITLE
Suggest `opam install . --deps-only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,7 @@ and install OPAM on the way (same instructions).
 
 For Charon-ML, we use **OCaml 4.13.1**: `opam switch create 4.13.1+options`
 
-The dependencies can be installed with the following command:
-
-```
-opam install ppx_deriving visitors easy_logging zarith yojson core_unix odoc menhir unionFind
-```
+The dependencies can be installed with `opam install . --deps-only`.
 
 You can then run `make build-charon-ml` to build the ML library, or even simply
 `make` to build the whole project (Rust and OCaml). Finally, you can run the

--- a/charon.opam
+++ b/charon.opam
@@ -15,8 +15,10 @@ homepage: "https://github.com/AeneasVerif/charon"
 bug-reports: "https://github.com/AeneasVerif/charon/issues"
 depends: [
   "dune" {>= "3.7"}
+  "core_unix"
   "easy_logging"
   "ppx_deriving"
+  "unionFind"
   "visitors"
   "yojson"
   "zarith"

--- a/dune-project
+++ b/dune-project
@@ -32,8 +32,10 @@
    verification projects.  Its purpose is to process Rust .rs files and convert
    them into files easy to handle by program verifiers.")
  (depends
+   core_unix
    easy_logging
    ppx_deriving
+   unionFind
    visitors
    yojson
    zarith


### PR DESCRIPTION
This command will install the dependencies listed in the `*.opam` files, which are kept in sync with the `dune-project` file. The dune-project file still has to be hand-maintained, but this is still an improvement over maintaining a separate list in the README.