### PR TITLE
fix(charon CLI): set RUSTUP_WINDOWS_PATH_ADD_BIN=1 on Windows to add rust driver dll to PATH

### DIFF
--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -93,6 +93,15 @@ impl Toolchain {
         cmd.arg("run");
         cmd.arg(&self.channel);
         cmd.arg(program);
+
+        // Add rust driver dll to `PATH` in rustup.
+        // cc
+        // * https://github.com/AeneasVerif/charon/issues/588
+        // * https://github.com/rust-lang/rustup/issues/3825
+        if cfg!(windows) {
+            cmd.env("RUSTUP_WINDOWS_PATH_ADD_BIN", "1");
+        }
+
         cmd
     }
 }


### PR DESCRIPTION


close https://github.com/AeneasVerif/charon/issues/588

cc https://github.com/rust-lang/rustup/issues/3825
cc https://github.com/rust-lang/rustup/issues/4246
cc https://github.com/rust-lang/rustup/issues/4196