### PR TITLE
Restart PR CIs on push to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: "Build and test"
+
 on:
   # Run the checks on the latest commit from `main`
   push:
@@ -8,7 +10,7 @@ on:
   pull_request:
   # Runs the check when a PR is added to the merge queue.
   merge_group:
-  # Makes it possible to run the forkflow by hand from GItHub's interface.
+  # Makes it possible to run the forkflow by hand from GitHub's interface.
   workflow_dispatch:
 
 # Cancel previous versions of this job that are still running.
@@ -33,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # deep clone in order to get access to other commits
-      - run: nix develop --command ./scripts/ci-check-version-number.sh
+      - run: nix develop '.#ci' --command ./scripts/ci-check-version-number.sh
 
   aeneas:
     needs: [nix]

--- a/.github/workflows/rerun-pr-jobs-on-push.yml
+++ b/.github/workflows/rerun-pr-jobs-on-push.yml
@@ -1,0 +1,26 @@
+# On each push to `main`, this restarts all the workflow runs associated with
+# open PRs, to ensure they're always up-to-date.
+name: "Rerun PR jobs on push to main"
+
+on:
+  # Triggered when commits are added to the `main` branch.
+  push:
+    branches:
+      - main
+  # Makes it possible to run the forkflow by hand from GitHub's interface.
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  checks: write
+
+jobs:
+  rerun-pr-jobs-on-push:
+    runs-on: [self-hosted, linux, nix]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - run: nix develop '.#ci' --command ./scripts/ci-rerun-pr-jobs.sh

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,12 @@
             self.packages.${system}.charon-ml
           ];
         };
+        devShells.ci = pkgs.mkShell {
+          packages = [
+            pkgs.jq
+            pkgs.gitAndTools.gh
+          ];
+        };
         checks = {
           default = charon-ml-tests;
           inherit charon-ml-tests charon-check-fmt charon-check-no-rustc

--- a/scripts/ci-rerun-pr-jobs.sh
+++ b/scripts/ci-rerun-pr-jobs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Lists the workflow runs associated with open PRs and re-runs them all
+gh pr list --base main --json isDraft,statusCheckRollup \
+    | jq -r '.[].statusCheckRollup[].detailsUrl | capture("https://github.com/AeneasVerif/charon/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+") | .run_id' \
+    | sort | uniq \
+    | while read run; do gh run rerun "$run"; done


### PR DESCRIPTION
This makes it so whenever we merge a PR, all the CI checks of open PRs are restarted. That way, Ci checks should always be based on the latest `main` commit.

If that works, that would remove the need for the "Require branches to be up to date before merging" PR requirement.