### PR TITLE
feat: add `charon cargo [charon options] -- [cargo check options]` subcommand

### DIFF
--- a/charon/src/bin/charon/cli_rework/cargo.rs
+++ b/charon/src/bin/charon/cli_rework/cargo.rs
@@ -1,0 +1,12 @@
+use charon_lib::options::CliOpts;
+
+/// Usage: `charon cargo [charon options] -- [cargo build options]`
+#[derive(clap::Args, Debug)]
+pub struct CargoArgs {
+    #[command(flatten)]
+    pub opts: CliOpts,
+
+    /// Args that `cargo build` accepts.
+    #[arg(last = true)]
+    pub cargo: Vec<String>,
+}

--- a/charon/src/bin/charon/cli_rework/mod.rs
+++ b/charon/src/bin/charon/cli_rework/mod.rs
@@ -2,26 +2,52 @@ use charon_lib::options::CliOpts;
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
+/// `charon cargo`
+mod cargo;
+
 #[derive(Debug, Parser)]
 #[clap(name = "Charon")]
-pub struct Cli {
+struct Cli {
     // Makes CliOpts parsable.
     // This should be removed once subcommands are fully implemented.
     #[command(flatten)]
-    pub opts: CliOpts,
+    opts: CliOpts,
 
     #[command(subcommand)]
-    pub command: Option<Charon>,
+    command: Option<Charon>,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum Charon {
+enum Charon {
     PrettyPrint(PrettyPrintArgs),
+    Cargo(cargo::CargoArgs),
 }
 
 /// Read a llbc or ullbc file and pretty print it.
 #[derive(Args, Debug)]
-pub struct PrettyPrintArgs {
+struct PrettyPrintArgs {
     /// Single file path to llbc or ullbc
-    pub file: PathBuf,
+    file: PathBuf,
+}
+
+/// The meaning of return value:
+/// * Ok(None) => Early exit since charon is done
+/// * Ok(Some(_)) => Back to original logics before subcommands are implemented
+/// * Err(_) => Early exit due to error
+pub fn run() -> anyhow::Result<Option<CliOpts>> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Charon::PrettyPrint(pretty_print)) => {
+            let krate = charon_lib::deserialize_llbc(&pretty_print.file)?;
+            println!("{krate}");
+            return Ok(None);
+        }
+        Some(Charon::Cargo(subcmd_cargo)) => {
+            let mut options = subcmd_cargo.opts;
+            options.cargo_args = subcmd_cargo.cargo;
+            Ok(Some(options))
+        }
+        _ => Ok(Some(cli.opts)),
+    }
 }

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -34,7 +34,6 @@
 #![register_tool(charon)]
 
 use anyhow::bail;
-use clap::Parser;
 use options::CHARON_ARGS;
 use serde::Deserialize;
 use std::env;
@@ -160,22 +159,15 @@ pub fn main() -> anyhow::Result<()> {
     // Initialize the logger
     logger::initialize_logger();
 
-    let cli = cli_rework::Cli::parse();
+    // Parse the command-line
+    trace!("Arguments: {:?}", env::args());
 
-    match cli.command {
-        Some(cli_rework::Charon::PrettyPrint(pretty_print)) => {
-            let krate = charon_lib::deserialize_llbc(&pretty_print.file)?;
-            println!("{krate}");
-            return Ok(());
-        }
-        _ => (),
-    }
+    let mut options = match cli_rework::run()? {
+        Some(options) => options,
+        None => return Ok(()),
+    };
 
     // ******* Old cli args parsing *******
-
-    // Parse the command-line
-    let mut options = cli.opts;
-    trace!("Arguments: {:?}", std::env::args());
     options.validate();
 
     // FIXME: when using rustup, ensure the toolchain has the right components installed.

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -9,15 +9,6 @@ use crate::{ast::*, errors::ErrorCtx, name_matcher::NamePattern, raise_error, re
 /// when calling charon-driver from cargo-charon.
 pub const CHARON_ARGS: &str = "CHARON_ARGS";
 
-// Makes CliOpts parsable. This should be removed once subcommands are fully implemented.
-#[derive(Debug, clap::Parser)]
-#[clap(name = "Charon")]
-#[charon::rename("cli_options")]
-pub struct OldCliOpts {
-    #[command(flatten)]
-    pub opts: CliOpts,
-}
-
 // This structure is used to store the command-line instructions.
 // We automatically derive a command-line parser based on this structure.
 // Note that the doc comments are used to generate the help message when using


### PR DESCRIPTION
ref https://github.com/AeneasVerif/charon/issues/582

```bash
$ charon --help
Usage: charon [OPTIONS] [COMMAND]

Commands:
  pretty-print  Read a llbc or ullbc file and pretty print it
  cargo         Usage: `charon cargo [charon options] -- [cargo build options]`
  help          Print this message or the help of the given subcommand(s)

Options:
      --ullbc
          Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
    ...
```

```bash
$ charon cargo --help
Usage: `charon cargo [charon options] -- [cargo build options]`

Usage: charon cargo [OPTIONS] [-- <CARGO>...]

Arguments:
  [CARGO]...  Args that `cargo build` accepts

Options:
      --ullbc
          Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
    ...
```

```bash
$ charon cargo -- --help
Compile a local package and all of its dependencies

Usage: cargo.exe build [OPTIONS]

Options:
      --future-incompat-report   Outputs a future incompatibility report at the end of the build
      --message-format <FMT>     Error format
  -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
  -q, --quiet                    Do not print cargo log messages
      --color <WHEN>             Coloring: auto, always, never
      --config <KEY=VALUE|PATH>  Override a configuration value
  -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
  -h, --help                     Print help

Package Selection:
  -p, --package [<SPEC>]  Package to build (see `cargo help pkgid`)
  ...
```