### PR TITLE
Don't manage the sysroot ourselves

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -23,6 +23,8 @@ Tracked here: https://github.com/AeneasVerif/charon/issues/142
 
 ## Missing information in the translated output
 
+- Bodies of functions in foreign crates often cause errors (https://github.com/AeneasVerif/charon/issues/543);
+- Bodies of std functions (https://github.com/AeneasVerif/charon/issues/545);
 - Drops (https://github.com/AeneasVerif/charon/issues/152);
 - Layout information (https://github.com/AeneasVerif/charon/issues/581);
 - Lifetime information inside function bodies (not planned).


### PR DESCRIPTION
As noted in https://github.com/cryspen/hax/issues/1358, passing `--sysroot` ourselves is not needed, and in fact we can remove all the manual sysroot handling.