### PR TITLE
Replace calls to the discriminant_value intrinsic with appropriate MIR

### DIFF
--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -6,6 +6,7 @@
 use crate::errors::register_error;
 use crate::formatter::IntoFormatter;
 use crate::llbc_ast::*;
+use crate::name_matcher::NamePattern;
 use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
 use itertools::Itertools;
@@ -13,138 +14,192 @@ use std::collections::{HashMap, HashSet};
 
 use super::ctx::LlbcPass;
 
+/// Generate `match _y { 0 => { _x = 0 }, 1 => { _x = 1; }, .. }`.
+fn generate_discr_assignment(
+    span: Span,
+    variants: &Vector<VariantId, Variant>,
+    scrutinee: &Place,
+    dest: &Place,
+) -> RawStatement {
+    let targets = variants
+        .iter_indexed_values()
+        .map(|(id, variant)| {
+            let discr_value = Rvalue::Use(Operand::Const(variant.discriminant.to_constant()));
+            let statement = Statement::new(span, RawStatement::Assign(dest.clone(), discr_value));
+            (vec![id], statement.into_block())
+        })
+        .collect();
+    RawStatement::Switch(Switch::Match(scrutinee.clone(), targets, None))
+}
+
 pub struct Transform;
 impl Transform {
-    fn update_block(ctx: &mut TransformCtx, block: &mut Block) {
+    fn update_block(
+        ctx: &mut TransformCtx,
+        block: &mut Block,
+        discriminant_intrinsic: Option<FunDeclId>,
+    ) {
         // Iterate through the statements.
         for i in 0..block.statements.len() {
             let suffix = &mut block.statements[i..];
-            if let [Statement {
-                content: RawStatement::Assign(dest, Rvalue::Discriminant(p, adt_id)),
-                span: span1,
-                ..
-            }, rest @ ..] = suffix
-            {
-                // The destination should be a variable
-                assert!(dest.is_local());
+            match suffix {
+                [Statement {
+                    content: RawStatement::Assign(dest, Rvalue::Discriminant(p, adt_id)),
+                    span: span1,
+                    ..
+                }, rest @ ..] => {
+                    // The destination should be a variable
+                    assert!(dest.is_local());
 
-                // Lookup the type of the scrutinee
-                let tkind = ctx.translated.type_decls.get(*adt_id).map(|x| &x.kind);
-                let Some(TypeDeclKind::Enum(variants)) = tkind else {
-                    match tkind {
-                        // This can happen if the type was declared as invisible or opaque.
-                        None | Some(TypeDeclKind::Opaque) => {
-                            let name = ctx.translated.item_name(*adt_id).unwrap();
-                            register_error!(
-                                ctx,
-                                block.span,
-                                "reading the discriminant of an opaque enum. \
+                    // Lookup the type of the scrutinee
+                    let tkind = ctx.translated.type_decls.get(*adt_id).map(|x| &x.kind);
+                    let Some(TypeDeclKind::Enum(variants)) = tkind else {
+                        match tkind {
+                            // This can happen if the type was declared as invisible or opaque.
+                            None | Some(TypeDeclKind::Opaque) => {
+                                let name = ctx.translated.item_name(*adt_id).unwrap();
+                                register_error!(
+                                    ctx,
+                                    block.span,
+                                    "reading the discriminant of an opaque enum. \
                                     Add `--include {}` to the `charon` arguments \
                                     to translate this enum.",
-                                name.fmt_with_ctx(&ctx.into_fmt())
-                            );
+                                    name.fmt_with_ctx(&ctx.into_fmt())
+                                );
+                            }
+                            // Don't double-error
+                            Some(TypeDeclKind::Error(..)) => {}
+                            Some(_) => {
+                                register_error!(
+                                    ctx,
+                                    block.span,
+                                    "reading the discriminant of a non-enum type"
+                                );
+                            }
                         }
-                        // Don't double-error
-                        Some(TypeDeclKind::Error(..)) => {}
-                        Some(_) => {
-                            register_error!(
-                                ctx,
-                                block.span,
-                                "reading the discriminant of a non-enum type"
-                            );
-                        }
-                    }
-                    block.statements[i].content = RawStatement::Error(
-                        "error reading the discriminant of this type".to_owned(),
-                    );
-                    return;
-                };
+                        block.statements[i].content = RawStatement::Error(
+                            "error reading the discriminant of this type".to_owned(),
+                        );
+                        return;
+                    };
 
-                // We look for a `SwitchInt` just after the discriminant read.
-                match rest {
-                    [Statement {
-                        content:
-                            RawStatement::Switch(switch @ Switch::SwitchInt(Operand::Move(_), ..)),
-                        ..
-                    }, ..] => {
-                        // Convert between discriminants and variant indices. Remark: the discriminant can
-                        // be of any *signed* integer type (`isize`, `i8`, etc.).
-                        let discr_to_id: HashMap<ScalarValue, VariantId> = variants
-                            .iter_indexed_values()
-                            .map(|(id, variant)| (variant.discriminant, id))
-                            .collect();
+                    // We look for a `SwitchInt` just after the discriminant read.
+                    match rest {
+                        [Statement {
+                            content:
+                                RawStatement::Switch(switch @ Switch::SwitchInt(Operand::Move(_), ..)),
+                            ..
+                        }, ..] => {
+                            // Convert between discriminants and variant indices. Remark: the discriminant can
+                            // be of any *signed* integer type (`isize`, `i8`, etc.).
+                            let discr_to_id: HashMap<ScalarValue, VariantId> = variants
+                                .iter_indexed_values()
+                                .map(|(id, variant)| (variant.discriminant, id))
+                                .collect();
 
-                        take_mut::take(switch, |switch| {
-                            let (Operand::Move(op_p), _, targets, otherwise) =
-                                switch.to_switch_int().unwrap()
-                            else {
-                                unreachable!()
-                            };
-                            assert!(op_p.is_local() && op_p.var_id() == dest.var_id());
+                            take_mut::take(switch, |switch| {
+                                let (Operand::Move(op_p), _, targets, otherwise) =
+                                    switch.to_switch_int().unwrap()
+                                else {
+                                    unreachable!()
+                                };
+                                assert!(op_p.is_local() && op_p.var_id() == dest.var_id());
 
-                            let mut covered_discriminants: HashSet<ScalarValue> =
-                                HashSet::default();
-                            let targets = targets
-                                .into_iter()
-                                .map(|(v, e)| {
-                                    (
-                                        v.into_iter()
+                                let mut covered_discriminants: HashSet<ScalarValue> =
+                                    HashSet::default();
+                                let targets = targets
+                                    .into_iter()
+                                    .map(|(v, e)| {
+                                        let targets = v
+                                            .into_iter()
                                             .filter_map(|discr| {
                                                 covered_discriminants.insert(discr);
                                                 discr_to_id.get(&discr).or_else(|| {
                                                     register_error!(
                                                         ctx,
                                                         block.span,
-                                                        "Found incorrect discriminant {discr} for enum {adt_id}"
+                                                        "Found incorrect discriminant \
+                                                        {discr} for enum {adt_id}"
                                                     );
                                                     None
                                                 })
                                             })
                                             .copied()
-                                            .collect_vec(),
-                                        e,
-                                    )
-                                })
-                                .collect_vec();
-                            // Filter the otherwise branch if it is not necessary.
-                            let covers_all = covered_discriminants.len() == discr_to_id.len();
-                            let otherwise = if covers_all { None } else { Some(otherwise) };
+                                            .collect_vec();
+                                        (targets, e)
+                                    })
+                                    .collect_vec();
+                                // Filter the otherwise branch if it is not necessary.
+                                let covers_all = covered_discriminants.len() == discr_to_id.len();
+                                let otherwise = if covers_all { None } else { Some(otherwise) };
 
-                            // Replace the old switch with a match.
-                            Switch::Match(p.clone(), targets, otherwise)
-                        });
-                        // `Nop` the discriminant read.
-                        block.statements[i].content = RawStatement::Nop;
-                    }
-                    _ => {
-                        // The discriminant read is not followed by a `SwitchInt`. This can happen
-                        // in optimized MIR. We replace `_x = Discr(_y)` with `match _y { 0 => { _x
-                        // = 0 }, 1 => { _x = 1; }, .. }`.
-                        let targets = variants
-                            .iter_indexed_values()
-                            .map(|(id, variant)| {
-                                let discr_value =
-                                    Rvalue::Use(Operand::Const(variant.discriminant.to_constant()));
-                                let statement = Statement::new(
-                                    *span1,
-                                    RawStatement::Assign(dest.clone(), discr_value),
-                                );
-                                (vec![id], statement.into_block())
-                            })
-                            .collect();
-                        block.statements[i].content =
-                            RawStatement::Switch(Switch::Match(p.clone(), targets, None))
+                                // Replace the old switch with a match.
+                                Switch::Match(p.clone(), targets, otherwise)
+                            });
+                            // `Nop` the discriminant read.
+                            block.statements[i].content = RawStatement::Nop;
+                        }
+                        _ => {
+                            // The discriminant read is not followed by a `SwitchInt`. This can happen
+                            // in optimized MIR. We replace `_x = Discr(_y)` with `match _y { 0 => { _x
+                            // = 0 }, 1 => { _x = 1; }, .. }`.
+                            block.statements[i].content =
+                                generate_discr_assignment(*span1, variants, p, dest)
+                        }
                     }
                 }
+                // Replace calls of `core::intrinsics::discriminant_value` on a known enum with the
+                // appropriate MIR.
+                [Statement {
+                    content: RawStatement::Call(call),
+                    span: span1,
+                    ..
+                }, ..]
+                    if let Some(discriminant_intrinsic) = discriminant_intrinsic
+                        // Detect a call to the intrinsic...
+                        && let FnOperand::Regular(fn_ptr) = &call.func
+                        && let FunIdOrTraitMethodRef::Fun(FunId::Regular(fun_id)) = fn_ptr.func
+                        && fun_id == discriminant_intrinsic
+                        // on a known enum...
+                        && let ty = &fn_ptr.generics.types[0]
+                        && let TyKind::Adt(TypeId::Adt(type_id), _) = *ty.kind()
+                        && let Some(TypeDeclKind::Enum(variants)) =
+                            ctx.translated.type_decls.get(type_id).map(|x| &x.kind)
+                        // passing it a reference.
+                        && let Operand::Move(p) = &call.args[0]
+                        && let TyKind::Ref(_, sub_ty, _) = p.ty().kind() =>
+                {
+                    let p = p.clone().project(ProjectionElem::Deref, sub_ty.clone());
+                    block.statements[i].content =
+                        generate_discr_assignment(*span1, variants, &p, &call.dest)
+                }
+                _ => {}
             }
         }
     }
 }
 
+const DISCRIMINANT_INTRINSIC: &str = "core::intrinsics::discriminant_value";
+
 impl LlbcPass for Transform {
-    fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
-        b.body.visit_blocks_bwd(|block: &mut Block| {
-            Transform::update_block(ctx, block);
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        let pat = NamePattern::parse(DISCRIMINANT_INTRINSIC).unwrap();
+        let discriminant_intrinsic: Option<FunDeclId> = ctx
+            .translated
+            .item_names
+            .iter()
+            .find(|(_, name)| pat.matches(&ctx.translated, name))
+            .and_then(|(id, _)| id.as_fun())
+            .copied();
+
+        ctx.for_each_fun_decl(|ctx, decl| {
+            if let Ok(body) = &mut decl.body {
+                let body = body.as_structured_mut().unwrap();
+                self.log_before_body(ctx, &decl.item_meta.name, Ok(&*body));
+                body.body.visit_blocks_bwd(|block: &mut Block| {
+                    Transform::update_block(ctx, block, discriminant_intrinsic);
+                });
+            };
         });
     }
 }

--- a/charon/tests/ui/simple/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/simple/mem-discriminant-from-derive.out
@@ -16,6 +16,115 @@ pub trait core::cmp::PartialEq<Self, Rhs>
     fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
 }
 
+pub fn core::cmp::impls::{impl core::cmp::PartialEq<&'_0 (B)> for &'_1 (A)}#9::eq<'_0, '_1, '_2, '_3, A, B>(@1: &'_2 (&'_1 (A)), @2: &'_3 (&'_0 (B))) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialEq<A, B>,
+
+pub fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
+
+impl core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22 : core::cmp::PartialEq<u8, u8>
+{
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0_0, '_0_1>
+}
+
+pub fn test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1::eq<'_0, '_1>(@1: &'_0 (test_crate::Enum), @2: &'_1 (test_crate::Enum)) -> bool
+{
+    let @0: bool; // return
+    let self@1: &'_ (test_crate::Enum); // arg #1
+    let other@2: &'_ (test_crate::Enum); // arg #2
+    let __self_discr@3: isize; // local
+    let @4: &'_ (test_crate::Enum); // anonymous local
+    let __arg1_discr@5: isize; // local
+    let @6: &'_ (test_crate::Enum); // anonymous local
+    let @7: bool; // anonymous local
+    let @8: isize; // anonymous local
+    let @9: isize; // anonymous local
+    let @10: (&'_ (test_crate::Enum), &'_ (test_crate::Enum)); // anonymous local
+    let @11: &'_ (test_crate::Enum); // anonymous local
+    let @12: &'_ (test_crate::Enum); // anonymous local
+    let __self_0@13: &'_ (u8); // local
+    let __arg1_0@14: &'_ (u8); // local
+    let @15: &'_ (&'_ (u8)); // anonymous local
+    let @16: &'_ (&'_ (u8)); // anonymous local
+
+    @4 := &*(self@1)
+    match *(@4) {
+        0 => {
+            __self_discr@3 := const (0 : isize)
+        },
+        1 => {
+            __self_discr@3 := const (1 : isize)
+        },
+    }
+    drop @4
+    @fake_read(__self_discr@3)
+    @6 := &*(other@2)
+    match *(@6) {
+        0 => {
+            __arg1_discr@5 := const (0 : isize)
+        },
+        1 => {
+            __arg1_discr@5 := const (1 : isize)
+        },
+    }
+    drop @6
+    @fake_read(__arg1_discr@5)
+    @8 := copy (__self_discr@3)
+    @9 := copy (__arg1_discr@5)
+    @7 := move (@8) == move (@9)
+    if move (@7) {
+        drop @9
+        drop @8
+        @11 := copy (self@1)
+        @12 := copy (other@2)
+        @10 := (move (@11), move (@12))
+        drop @12
+        drop @11
+        @fake_read(@10)
+        match *((@10).0) {
+            0 => {
+                match *((@10).1) {
+                    0 => {
+                        __self_0@13 := &(*((@10).0) as variant @0).0
+                        __arg1_0@14 := &(*((@10).1) as variant @0).0
+                        @15 := &__self_0@13
+                        @16 := &__arg1_0@14
+                        @0 := core::cmp::impls::{impl core::cmp::PartialEq<&'_0 (B)> for &'_1 (A)}#9::eq<'_, '_, '_, '_, u8, u8>[core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22](move (@15), move (@16))
+                        drop @16
+                        drop @15
+                        drop __arg1_0@14
+                        drop __self_0@13
+                    },
+                    _ => {
+                        @0 := const (true)
+                    },
+                }
+            },
+            _ => {
+                @0 := const (true)
+            },
+        }
+        drop @10
+    }
+    else {
+        drop @9
+        drop @8
+        @0 := const (false)
+    }
+    drop @7
+    drop __arg1_discr@5
+    drop __self_discr@3
+    return
+}
+
+impl test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1 : core::cmp::PartialEq<test_crate::Enum, test_crate::Enum>
+{
+    fn eq<'_0, '_1> = test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1::eq<'_0_0, '_0_1>
+}
+
+#[lang_item("cmp_partialeq_eq")]
+pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
@@ -101,101 +210,6 @@ pub trait core::marker::DiscriminantKind<Self>
 pub fn core::intrinsics::discriminant_value<'_0, T>(@1: &'_0 (T)) -> core::marker::DiscriminantKind<T>::Discriminant
 where
     [@TraitClause0]: core::marker::Sized<T>,
-
-pub fn core::cmp::impls::{impl core::cmp::PartialEq<&'_0 (B)> for &'_1 (A)}#9::eq<'_0, '_1, '_2, '_3, A, B>(@1: &'_2 (&'_1 (A)), @2: &'_3 (&'_0 (B))) -> bool
-where
-    [@TraitClause0]: core::cmp::PartialEq<A, B>,
-
-pub fn core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0, '_1>(@1: &'_0 (u8), @2: &'_1 (u8)) -> bool
-
-impl core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22 : core::cmp::PartialEq<u8, u8>
-{
-    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22::eq<'_0_0, '_0_1>
-}
-
-pub fn test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1::eq<'_0, '_1>(@1: &'_0 (test_crate::Enum), @2: &'_1 (test_crate::Enum)) -> bool
-{
-    let @0: bool; // return
-    let self@1: &'_ (test_crate::Enum); // arg #1
-    let other@2: &'_ (test_crate::Enum); // arg #2
-    let __self_discr@3: isize; // local
-    let @4: &'_ (test_crate::Enum); // anonymous local
-    let __arg1_discr@5: isize; // local
-    let @6: &'_ (test_crate::Enum); // anonymous local
-    let @7: bool; // anonymous local
-    let @8: isize; // anonymous local
-    let @9: isize; // anonymous local
-    let @10: (&'_ (test_crate::Enum), &'_ (test_crate::Enum)); // anonymous local
-    let @11: &'_ (test_crate::Enum); // anonymous local
-    let @12: &'_ (test_crate::Enum); // anonymous local
-    let __self_0@13: &'_ (u8); // local
-    let __arg1_0@14: &'_ (u8); // local
-    let @15: &'_ (&'_ (u8)); // anonymous local
-    let @16: &'_ (&'_ (u8)); // anonymous local
-
-    @4 := &*(self@1)
-    __self_discr@3 := core::intrinsics::discriminant_value<'_, test_crate::Enum>[core::marker::Sized<test_crate::Enum>](move (@4))
-    drop @4
-    @fake_read(__self_discr@3)
-    @6 := &*(other@2)
-    __arg1_discr@5 := core::intrinsics::discriminant_value<'_, test_crate::Enum>[core::marker::Sized<test_crate::Enum>](move (@6))
-    drop @6
-    @fake_read(__arg1_discr@5)
-    @8 := copy (__self_discr@3)
-    @9 := copy (__arg1_discr@5)
-    @7 := move (@8) == move (@9)
-    if move (@7) {
-        drop @9
-        drop @8
-        @11 := copy (self@1)
-        @12 := copy (other@2)
-        @10 := (move (@11), move (@12))
-        drop @12
-        drop @11
-        @fake_read(@10)
-        match *((@10).0) {
-            0 => {
-                match *((@10).1) {
-                    0 => {
-                        __self_0@13 := &(*((@10).0) as variant @0).0
-                        __arg1_0@14 := &(*((@10).1) as variant @0).0
-                        @15 := &__self_0@13
-                        @16 := &__arg1_0@14
-                        @0 := core::cmp::impls::{impl core::cmp::PartialEq<&'_0 (B)> for &'_1 (A)}#9::eq<'_, '_, '_, '_, u8, u8>[core::cmp::impls::{impl core::cmp::PartialEq<u8> for u8}#22](move (@15), move (@16))
-                        drop @16
-                        drop @15
-                        drop __arg1_0@14
-                        drop __self_0@13
-                    },
-                    _ => {
-                        @0 := const (true)
-                    },
-                }
-            },
-            _ => {
-                @0 := const (true)
-            },
-        }
-        drop @10
-    }
-    else {
-        drop @9
-        drop @8
-        @0 := const (false)
-    }
-    drop @7
-    drop __arg1_discr@5
-    drop __self_discr@3
-    return
-}
-
-impl test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1 : core::cmp::PartialEq<test_crate::Enum, test_crate::Enum>
-{
-    fn eq<'_0, '_1> = test_crate::{impl core::cmp::PartialEq<test_crate::Enum> for test_crate::Enum}#1::eq<'_0_0, '_0_1>
-}
-
-#[lang_item("cmp_partialeq_eq")]
-pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
 
 impl core::cmp::impls::{impl core::cmp::PartialEq<&'_0 (B)> for &'_1 (A)}#9<'_0, '_1, A, B> : core::cmp::PartialEq<&'_1 (A), &'_0 (B)>
 where


### PR DESCRIPTION
[This intrinsic](https://doc.rust-lang.org/beta/core/intrinsics/fn.discriminant_value.html) is used in `derive(PartialEq)` for enums, hence shows up a lot. It's also tricky to handle because of its reliance on the built-in associated type `DiscriminantKind::Discriminant`. Replacing it here is not a complete solution but makes for a smoother experience for users of Charon.