### PR TITLE
Use promoted MIR by default

### DIFF
--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -421,6 +421,8 @@ pub enum RawConstantExpr {
     /// We eliminate this case in a micro-pass.
     #[charon::opaque]
     Adt(Option<VariantId>, Vec<ConstantExpr>),
+    #[charon::opaque]
+    Array(Vec<ConstantExpr>),
     /// The value is a top-level constant/static.
     ///
     /// We eliminate this case in a micro-pass.

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -94,20 +94,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                     .iter()
                     .map(|x| self.translate_constant_expr_to_constant_expr(span, x))
                     .try_collect()?;
-                if let TyKind::Adt(TypeId::Builtin(BuiltinTy::Array), args) = ty.kind()
-                    && let TyKind::Literal(LiteralTy::Integer(IntegerTy::U8)) = args.types[0].kind()
-                {
-                    RawConstantExpr::Literal(Literal::ByteStr(
-                        fields
-                            .iter()
-                            .map(|konst| konst.value.as_literal().unwrap())
-                            .map(|x| x.as_scalar().unwrap().as_u8().unwrap())
-                            .copied()
-                            .collect(),
-                    ))
-                } else {
-                    raise_error!(self, span, "array constants are not supported yet")
-                }
+                RawConstantExpr::Array(fields)
             }
             ConstantExprKind::Tuple { fields } => {
                 let fields: Vec<ConstantExpr> = fields
@@ -230,6 +217,7 @@ impl<'tcx, 'ctx> BodyTransCtx<'tcx, 'ctx> {
                 Ok(ConstGeneric::Global(global_ref.id))
             }
             RawConstantExpr::Adt(..)
+            | RawConstantExpr::Array { .. }
             | RawConstantExpr::RawMemory { .. }
             | RawConstantExpr::TraitConst { .. }
             | RawConstantExpr::Ref(_)

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -13,6 +13,7 @@
 
 // For rustdoc: prevents overflows
 #![recursion_limit = "256"]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(deref_pure_trait)]
 #![feature(if_let_guard)]

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -311,10 +311,8 @@ impl TranslateOptions {
 
         let mir_level = if options.mir_optimized {
             MirLevel::Optimized
-        } else if options.mir_promoted {
-            MirLevel::Promoted
         } else {
-            MirLevel::Built
+            MirLevel::Promoted
         };
 
         let item_opacities = {

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -797,6 +797,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for RawConstantExpr {
                 let values: Vec<String> = values.iter().map(|v| v.fmt_with_ctx(ctx)).collect();
                 format!("ConstAdt {} [{}]", variant_id, values.join(", "))
             }
+            RawConstantExpr::Array(values) => {
+                let values = values.iter().map(|v| v.fmt_with_ctx(ctx)).format(", ");
+                format!("[{}]", values)
+            }
             RawConstantExpr::Global(global_ref) => global_ref.fmt_with_ctx(ctx),
             RawConstantExpr::TraitConst(trait_ref, name) => {
                 format!("{}::{name}", trait_ref.fmt_with_ctx(ctx),)

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -941,8 +941,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                             }
                         }
                     }
-                    AggregateKind::Array(_, len) => {
-                        format!("[{}; {}]", ops_s.join(", "), len.fmt_with_ctx(ctx))
+                    AggregateKind::Array(..) => {
+                        format!("[{}]", ops_s.join(", "))
                     }
                     AggregateKind::Closure(fn_id, generics) => {
                         format!(

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1689,7 +1689,7 @@ impl std::fmt::Display for Literal {
             Literal::Float(v) => write!(f, "{v}"),
             Literal::Bool(v) => write!(f, "{v}"),
             Literal::Char(v) => write!(f, "{v}"),
-            Literal::Str(v) => write!(f, "\"{v}\""),
+            Literal::Str(v) => write!(f, "\"{}\"", v.replace("\\", "\\\\").replace("\n", "\\n")),
             Literal::ByteStr(v) => write!(f, "{v:?}"),
         }
     }

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -106,12 +106,16 @@ fn transform_operand(span: &Span, locals: &mut Locals, nst: &mut Vec<Statement>,
     take_mut::take(op, |op| {
         if let Operand::Const(val) = op {
             let mut new_var = |rvalue, ty| {
-                let var = locals.new_var(None, ty);
-                nst.push(Statement::new(
-                    *span,
-                    RawStatement::Assign(var.clone(), rvalue),
-                ));
-                var
+                if let Rvalue::Use(Operand::Move(place)) = rvalue {
+                    place
+                } else {
+                    let var = locals.new_var(None, ty);
+                    nst.push(Statement::new(
+                        *span,
+                        RawStatement::Assign(var.clone(), rvalue),
+                    ));
+                    var
+                }
             };
             transform_constant_expr(span, val, &mut new_var)
         } else {

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -21,11 +21,10 @@ use super::ctx::UllbcPass;
 ///
 /// Goes fom e.g. `f(T::A(x, y))` to `let a = T::A(x, y); f(a)`.
 /// The function is recursively called on the aggregate fields (e.g. here x and y).
-fn transform_constant_expr<F: FnMut(Ty) -> Place>(
+fn transform_constant_expr(
     span: &Span,
-    nst: &mut Vec<Statement>,
     val: ConstantExpr,
-    make_new_var: &mut F,
+    new_var: &mut impl FnMut(Rvalue, Ty) -> Place,
 ) -> Operand {
     match val.value {
         RawConstantExpr::Literal(_)
@@ -40,51 +39,25 @@ fn transform_constant_expr<F: FnMut(Ty) -> Place>(
             Operand::Const(val)
         }
         RawConstantExpr::Global(global_ref) => {
-            // Introduce an intermediate statement
-            let var = make_new_var(val.ty.clone());
-            nst.push(Statement::new(
-                *span,
-                RawStatement::Assign(var.clone(), Rvalue::Global(global_ref)),
-            ));
-            Operand::Move(var)
+            Operand::Move(new_var(Rvalue::Global(global_ref), val.ty.clone()))
         }
         RawConstantExpr::Ref(box bval) => {
             match bval.value {
-                RawConstantExpr::Global(global_ref) => {
-                    // Introduce an intermediate statement to borrow the static.
-                    let ref_var = make_new_var(val.ty);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(
-                            ref_var.clone(),
-                            Rvalue::GlobalRef(global_ref, RefKind::Shared),
-                        ),
-                    ));
-
-                    // Return the new operand
-                    Operand::Move(ref_var)
-                }
+                RawConstantExpr::Global(global_ref) => Operand::Move(new_var(
+                    Rvalue::GlobalRef(global_ref, RefKind::Shared),
+                    val.ty,
+                )),
                 _ => {
                     // Recurse on the borrowed value
                     let bval_ty = bval.ty.clone();
-                    let bval = transform_constant_expr(span, nst, bval, make_new_var);
+                    let bval = transform_constant_expr(span, bval, new_var);
 
-                    // Introduce an intermediate statement to evaluate the referenced value
-                    let bvar = make_new_var(bval_ty);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(bvar.clone(), Rvalue::Use(bval)),
-                    ));
+                    // Evaluate the referenced value
+                    let bvar = new_var(Rvalue::Use(bval), bval_ty);
 
-                    // Introduce an intermediate statement to borrow the value
-                    let ref_var = make_new_var(val.ty);
-                    let rvalue = Rvalue::Ref(bvar, BorrowKind::Shared);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(ref_var.clone(), rvalue),
-                    ));
+                    // Borrow the value
+                    let ref_var = new_var(Rvalue::Ref(bvar, BorrowKind::Shared), val.ty);
 
-                    // Return the new operand
                     Operand::Move(ref_var)
                 }
             }
@@ -92,79 +65,55 @@ fn transform_constant_expr<F: FnMut(Ty) -> Place>(
         RawConstantExpr::MutPtr(box bval) => {
             match bval.value {
                 RawConstantExpr::Global(global_ref) => {
-                    // Introduce an intermediate statement to borrow the static.
-                    let ref_var = make_new_var(val.ty);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(
-                            ref_var.clone(),
-                            Rvalue::GlobalRef(global_ref, RefKind::Mut),
-                        ),
-                    ));
-
-                    // Return the new operand
-                    Operand::Move(ref_var)
+                    Operand::Move(new_var(Rvalue::GlobalRef(global_ref, RefKind::Mut), val.ty))
                 }
                 _ => {
                     // Recurse on the borrowed value
                     let bval_ty = bval.ty.clone();
-                    let bval = transform_constant_expr(span, nst, bval, make_new_var);
+                    let bval = transform_constant_expr(span, bval, new_var);
 
-                    // Introduce an intermediate statement to evaluate the referenced value
-                    let bvar = make_new_var(bval_ty);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(bvar.clone(), Rvalue::Use(bval)),
-                    ));
+                    // Evaluate the referenced value
+                    let bvar = new_var(Rvalue::Use(bval), bval_ty);
 
-                    // Introduce an intermediate statement to borrow the value
-                    let ref_var = make_new_var(val.ty);
-                    let rvalue = Rvalue::RawPtr(bvar, RefKind::Mut);
-                    nst.push(Statement::new(
-                        *span,
-                        RawStatement::Assign(ref_var.clone(), rvalue),
-                    ));
+                    // Borrow the value
+                    let ref_var = new_var(Rvalue::RawPtr(bvar, RefKind::Mut), val.ty);
 
-                    // Return the new operand
                     Operand::Move(ref_var)
                 }
             }
         }
         RawConstantExpr::Adt(variant, fields) => {
-            // Recurse on the fields
             let fields = fields
                 .into_iter()
-                .map(|f| transform_constant_expr(span, nst, f, make_new_var))
+                .map(|x| transform_constant_expr(span, x, new_var))
                 .collect();
 
-            // Introduce an intermediate assignment for the aggregated ADT
+            // Build an `Aggregate` rvalue.
             let rval = {
                 let (adt_kind, generics) = val.ty.kind().as_adt().unwrap();
                 let aggregate_kind = AggregateKind::Adt(*adt_kind, variant, None, generics.clone());
                 Rvalue::Aggregate(aggregate_kind, fields)
             };
-            let var = make_new_var(val.ty);
-            nst.push(Statement::new(
-                *span,
-                RawStatement::Assign(var.clone(), rval),
-            ));
+            let var = new_var(rval, val.ty);
 
-            // Return the new operand
             Operand::Move(var)
         }
     }
 }
 
-fn transform_operand<F: FnMut(Ty) -> Place>(
-    span: &Span,
-    nst: &mut Vec<Statement>,
-    op: &mut Operand,
-    f: &mut F,
-) {
+fn transform_operand(span: &Span, locals: &mut Locals, nst: &mut Vec<Statement>, op: &mut Operand) {
     // Transform the constant operands (otherwise do nothing)
     take_mut::take(op, |op| {
         if let Operand::Const(val) = op {
-            transform_constant_expr(span, nst, val, f)
+            let mut new_var = |rvalue, ty| {
+                let var = locals.new_var(None, ty);
+                nst.push(Statement::new(
+                    *span,
+                    RawStatement::Assign(var.clone(), rvalue),
+                ));
+                var
+            };
+            transform_constant_expr(span, val, &mut new_var)
         } else {
             op
         }
@@ -174,9 +123,8 @@ fn transform_operand<F: FnMut(Ty) -> Place>(
 pub struct Transform;
 impl UllbcPass for Transform {
     fn transform_body(&self, _ctx: &mut TransformCtx, b: &mut ExprBody) {
-        let mut f = |ty| b.locals.new_var(None, ty);
         body_transform_operands(&mut b.body, |span, nst, op| {
-            transform_operand(span, nst, op, &mut f)
+            transform_operand(span, &mut b.locals, nst, op)
         });
     }
 }

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -86,19 +86,21 @@ fn test_cargo_dependencies::main()
     let @6: (&'_ (u32), &'_ (u32)); // anonymous local
     let @7: &'_ (u32); // anonymous local
     let @8: &'_ (u32); // anonymous local
-    let @9: u32; // anonymous local
-    let left_val@10: &'_ (u32); // local
-    let right_val@11: &'_ (u32); // local
-    let @12: bool; // anonymous local
+    let left_val@9: &'_ (u32); // local
+    let right_val@10: &'_ (u32); // local
+    let @11: bool; // anonymous local
+    let @12: u32; // anonymous local
     let @13: u32; // anonymous local
-    let @14: u32; // anonymous local
-    let kind@15: core::panicking::AssertKind; // local
-    let @16: core::panicking::AssertKind; // anonymous local
+    let kind@14: core::panicking::AssertKind; // local
+    let @15: core::panicking::AssertKind; // anonymous local
+    let @16: &'_ (u32); // anonymous local
     let @17: &'_ (u32); // anonymous local
     let @18: &'_ (u32); // anonymous local
     let @19: &'_ (u32); // anonymous local
-    let @20: &'_ (u32); // anonymous local
-    let @21: core::option::Option<core::fmt::Arguments<'_>>[core::marker::Sized<core::fmt::Arguments<'_>>]; // anonymous local
+    let @20: core::option::Option<core::fmt::Arguments<'_>>[core::marker::Sized<core::fmt::Arguments<'_>>]; // anonymous local
+    let @21: &'_ (u32); // anonymous local
+    let @22: u32; // anonymous local
+    let @23: &'_ (u32); // anonymous local
 
     x@1 := const (0 : u32)
     @fake_read(x@1)
@@ -109,38 +111,39 @@ fn test_cargo_dependencies::main()
     drop @4
     drop @2
     @7 := &x@1
-    @9 := const (1 : u32)
-    @8 := &@9
+    @22 := const (1 : u32)
+    @23 := &@22
+    @21 := move (@23)
+    @8 := &*(@21)
     @6 := (move (@7), move (@8))
     drop @8
     drop @7
     @fake_read(@6)
-    left_val@10 := copy ((@6).0)
-    right_val@11 := copy ((@6).1)
-    @13 := copy (*(left_val@10))
-    @14 := copy (*(right_val@11))
-    @12 := move (@13) == move (@14)
-    if move (@12) {
+    left_val@9 := copy ((@6).0)
+    right_val@10 := copy ((@6).1)
+    @12 := copy (*(left_val@9))
+    @13 := copy (*(right_val@10))
+    @11 := move (@12) == move (@13)
+    if move (@11) {
     }
     else {
-        drop @14
         drop @13
-        kind@15 := core::panicking::AssertKind::Eq {  }
-        @fake_read(kind@15)
-        @16 := move (kind@15)
-        @18 := &*(left_val@10)
-        @17 := &*(@18)
-        @20 := &*(right_val@11)
-        @19 := &*(@20)
-        @21 := core::option::Option::None {  }
+        drop @12
+        kind@14 := core::panicking::AssertKind::Eq {  }
+        @fake_read(kind@14)
+        @15 := move (kind@14)
+        @17 := &*(left_val@9)
+        @16 := &*(@17)
+        @19 := &*(right_val@10)
+        @18 := &*(@19)
+        @20 := core::option::Option::None {  }
         panic(core::panicking::assert_failed)
     }
-    drop @14
     drop @13
     drop @12
-    drop right_val@11
-    drop left_val@10
-    drop @9
+    drop @11
+    drop right_val@10
+    drop left_val@9
     drop @6
     drop @5
     @0 := ()

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -36,14 +36,17 @@ fn test_cargo_toml::main()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'_ (core::option::Option<bool>[core::marker::Sized<bool>]); // anonymous local
-    let @3: core::option::Option<bool>[core::marker::Sized<bool>]; // anonymous local
+    let @3: &'_ (core::option::Option<bool>[core::marker::Sized<bool>]); // anonymous local
+    let @4: core::option::Option<bool>[core::marker::Sized<bool>]; // anonymous local
+    let @5: &'_ (core::option::Option<bool>[core::marker::Sized<bool>]); // anonymous local
 
-    @3 := core::option::Option::Some { 0: const (false) }
-    @2 := &@3
+    @4 := core::option::Option::Some { 0: const (false) }
+    @5 := &@4
+    @3 := move (@5)
+    @2 := &*(@3)
     @1 := core::option::{core::option::Option<T>[@TraitClause0]}::is_some<'_, bool>[core::marker::Sized<bool>](move (@2))
     drop @2
     @fake_read(@1)
-    drop @3
     drop @1
     @0 := ()
     @0 := ()

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -20,7 +20,7 @@ fn unsafe::main()
     let @6: Array<&'_ (Str), 1 : usize>; // anonymous local
 
     @6 := [const ("Hello, world!
-"); 1 : usize]
+")]
     @5 := &@6
     @4 := &*(@5)
     @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -17,16 +17,19 @@ fn unsafe::main()
     let @3: core::fmt::Arguments<'_>; // anonymous local
     let @4: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @5: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @6: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @6: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @7: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @8: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
-    @6 := [const ("Hello, world!\n")]
-    @5 := &@6
+    @7 := [const ("Hello, world!\n")]
+    @8 := &@7
+    @6 := move (@8)
+    @5 := &*(@6)
     @4 := &*(@5)
     @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))
     drop @4
     @2 := std::io::stdio::_print<'_>(move (@3))
     drop @3
-    drop @6
     drop @5
     drop @2
     drop @1

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -19,8 +19,7 @@ fn unsafe::main()
     let @5: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @6: Array<&'_ (Str), 1 : usize>; // anonymous local
 
-    @6 := [const ("Hello, world!
-")]
+    @6 := [const ("Hello, world!\n")]
     @5 := &@6
     @4 := &*(@5)
     @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -718,10 +718,14 @@ pub fn test_crate::const_slice()
     let @1: &'_ (Slice<u32>); // anonymous local
     let @2: &'_ (Array<u32, 2 : usize>); // anonymous local
     let @3: &'_ (Array<u32, 2 : usize>); // anonymous local
-    let @4: Array<u32, 2 : usize>; // anonymous local
+    let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @5: Array<u32, 2 : usize>; // anonymous local
+    let @6: &'_ (Array<u32, 2 : usize>); // anonymous local
 
-    @4 := [const (0 : u32), const (0 : u32)]
-    @3 := &@4
+    @5 := @ArrayRepeat<'_, u32, 2 : usize>(const (0 : u32))
+    @6 := &@5
+    @4 := move (@6)
+    @3 := &*(@4)
     @2 := &*(@3)
     @1 := @ArrayToSliceShared<'_, u32, 2 : usize>(move (@2))
     drop @2
@@ -729,7 +733,6 @@ pub fn test_crate::const_slice()
     drop @3
     drop @1
     @0 := ()
-    drop @4
     @0 := ()
     return
 }

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -708,7 +708,7 @@ pub fn test_crate::const_array() -> Array<u32, 2 : usize>
 {
     let @0: Array<u32, 2 : usize>; // return
 
-    @0 := [const (0 : u32), const (0 : u32); 2 : usize]
+    @0 := [const (0 : u32), const (0 : u32)]
     return
 }
 
@@ -720,7 +720,7 @@ pub fn test_crate::const_slice()
     let @3: &'_ (Array<u32, 2 : usize>); // anonymous local
     let @4: Array<u32, 2 : usize>; // anonymous local
 
-    @4 := [const (0 : u32), const (0 : u32); 2 : usize]
+    @4 := [const (0 : u32), const (0 : u32)]
     @3 := &@4
     @2 := &*(@3)
     @1 := @ArrayToSliceShared<'_, u32, 2 : usize>(move (@2))
@@ -754,7 +754,7 @@ pub fn test_crate::take_all()
     let @15: &'_ mut (Array<u32, 2 : usize>); // anonymous local
     let @16: &'_ mut (Array<u32, 2 : usize>); // anonymous local
 
-    x@1 := [const (0 : u32), const (0 : u32); 2 : usize]
+    x@1 := [const (0 : u32), const (0 : u32)]
     @fake_read(x@1)
     // x is deep copied (copy node appears in Charon, followed by a move)
     @3 := copy (x@1)
@@ -888,16 +888,16 @@ pub fn test_crate::index_all() -> u32
     let @22: &'_ mut (Array<u32, 2 : usize>); // anonymous local
     let @23: &'_ mut (Array<u32, 2 : usize>); // anonymous local
 
-    x@1 := [const (0 : u32), const (0 : u32); 2 : usize]
+    x@1 := [const (0 : u32), const (0 : u32)]
     @fake_read(x@1)
     @3 := const (true)
     if move (@3) {
-        _y@4 := [const (0 : u32), const (0 : u32); 2 : usize]
+        _y@4 := [const (0 : u32), const (0 : u32)]
         @fake_read(_y@4)
         drop _y@4
     }
     else {
-        _z@5 := [const (0 : u32); 1 : usize]
+        _z@5 := [const (0 : u32)]
         @fake_read(_z@5)
         drop _z@5
     }
@@ -1014,7 +1014,7 @@ pub fn test_crate::update_all()
     let @11: &'_ mut (Array<u32, 2 : usize>); // anonymous local
     let @12: &'_ mut (Array<u32, 2 : usize>); // anonymous local
 
-    x@1 := [const (0 : u32), const (0 : u32); 2 : usize]
+    x@1 := [const (0 : u32), const (0 : u32)]
     @fake_read(x@1)
     @3 := copy (x@1)
     @2 := test_crate::update_array(move (@3))
@@ -1055,7 +1055,7 @@ pub fn test_crate::range_all()
     let @6: &'_ mut (Array<u32, 4 : usize>); // anonymous local
     let @7: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // anonymous local
 
-    x@1 := [const (0 : u32), const (0 : u32), const (0 : u32), const (0 : u32); 4 : usize]
+    x@1 := [const (0 : u32), const (0 : u32), const (0 : u32), const (0 : u32)]
     @fake_read(x@1)
     // CONFIRM: there is no way to shrink [T;N] into [T;M] with M<N?
     @6 := &mut x@1
@@ -1137,7 +1137,7 @@ pub fn test_crate::non_copyable_array()
 
     @2 := test_crate::AB::A {  }
     @3 := test_crate::AB::B {  }
-    x@1 := [move (@2), move (@3); 2 : usize]
+    x@1 := [move (@2), move (@3)]
     drop @3
     drop @2
     @fake_read(x@1)
@@ -1316,7 +1316,7 @@ pub fn test_crate::f0()
     let @6: &'_ mut (Slice<u32>); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
-    @4 := [const (1 : u32), const (2 : u32); 2 : usize]
+    @4 := [const (1 : u32), const (2 : u32)]
     @3 := &mut @4
     @2 := &mut *(@3)
     s@1 := @ArrayToSliceMut<'_, u32, 2 : usize>(move (@2))
@@ -1343,7 +1343,7 @@ pub fn test_crate::f1()
     let @3: &'_ mut (Array<u32, 2 : usize>); // anonymous local
     let @4: &'_ mut (u32); // anonymous local
 
-    s@1 := [const (1 : u32), const (2 : u32); 2 : usize]
+    s@1 := [const (1 : u32), const (2 : u32)]
     @fake_read(s@1)
     @2 := const (0 : usize)
     @3 := &mut s@1
@@ -1413,7 +1413,7 @@ pub fn test_crate::f3() -> u32
     let @13: &'_ (Array<u32, 2 : usize>); // anonymous local
     let @14: &'_ (u32); // anonymous local
 
-    a@1 := [const (1 : u32), const (2 : u32); 2 : usize]
+    a@1 := [const (1 : u32), const (2 : u32)]
     @fake_read(a@1)
     @4 := const (0 : usize)
     @13 := &a@1
@@ -1486,11 +1486,11 @@ pub fn test_crate::ite()
     let @10: &'_ mut (Array<u32, 2 : usize>); // anonymous local
     let @11: &'_ mut (Array<u32, 2 : usize>); // anonymous local
 
-    x@1 := [const (0 : u32), const (0 : u32); 2 : usize]
+    x@1 := [const (0 : u32), const (0 : u32)]
     @fake_read(x@1)
     @2 := const (true)
     if move (@2) {
-        y@3 := [const (0 : u32), const (0 : u32); 2 : usize]
+        y@3 := [const (0 : u32), const (0 : u32)]
         @fake_read(y@3)
         @7 := &mut x@1
         @6 := &mut *(@7)

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -640,25 +640,25 @@ where
 {
     let @0: T; // return
     let x@1: T; // arg #1
-    let f@2: &'_ (fn(T) -> T); // local
-    let @3: fn(T) -> T; // anonymous local
+    let f@2: fn(T) -> T; // local
+    let @3: &'_ (fn(T) -> T); // anonymous local
     let @4: &'_ (fn(T) -> T); // anonymous local
     let @5: (T); // anonymous local
     let @6: T; // anonymous local
 
-    @3 := {test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]} {}
-    f@2 := &@3
+    f@2 := {test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]} {}
     @fake_read(f@2)
-    @4 := &*(f@2)
+    @4 := &f@2
+    @3 := &*(@4)
     @6 := move (x@1)
     @5 := (move (@6))
-    @0 := core::ops::function::Fn<fn(T) -> T, (T), T>::call<'_>(move (@4), move (@5))
+    @0 := core::ops::function::Fn<fn(T) -> T, (T), T>::call<'_>(move (@3), move (@5))
     drop @6
     drop @6
     drop @5
-    drop @4
     drop @3
     drop f@2
+    drop @4
     drop x@1
     return
 }

--- a/charon/tests/ui/closures.rs
+++ b/charon/tests/ui/closures.rs
@@ -138,8 +138,8 @@ pub fn test_closure_capture(x: u32, y: u32) -> u32 {
 
 pub fn test_closure_clone<T: Clone>(x: T) -> T {
     #[allow(clippy::redundant_clone)]
-    let f = &|x: T| x.clone();
-    (f)(x)
+    let f = |x: T| x.clone();
+    (&f)(x)
 }
 
 /*// With a `dyn`

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -242,21 +242,23 @@ fn test_crate::foo()
     let @18: &'_ (u32); // anonymous local
     let @19: usize; // anonymous local
     let @20: &'_ (u32); // anonymous local
-    let @21: u32; // anonymous local
-    let left_val@22: &'_ (u32); // local
-    let right_val@23: &'_ (u32); // local
-    let @24: bool; // anonymous local
+    let left_val@21: &'_ (u32); // local
+    let right_val@22: &'_ (u32); // local
+    let @23: bool; // anonymous local
+    let @24: u32; // anonymous local
     let @25: u32; // anonymous local
-    let @26: u32; // anonymous local
-    let kind@27: core::panicking::AssertKind; // local
-    let @28: core::panicking::AssertKind; // anonymous local
+    let kind@26: core::panicking::AssertKind; // local
+    let @27: core::panicking::AssertKind; // anonymous local
+    let @28: &'_ (u32); // anonymous local
     let @29: &'_ (u32); // anonymous local
     let @30: &'_ (u32); // anonymous local
     let @31: &'_ (u32); // anonymous local
-    let @32: &'_ (u32); // anonymous local
-    let @33: core::option::Option<core::fmt::Arguments<'_>>[core::marker::Sized<core::fmt::Arguments<'_>>]; // anonymous local
-    let @34: &'_ (Array<u32, 10 : usize>); // anonymous local
+    let @32: core::option::Option<core::fmt::Arguments<'_>>[core::marker::Sized<core::fmt::Arguments<'_>>]; // anonymous local
+    let @33: &'_ (u32); // anonymous local
+    let @34: u32; // anonymous local
     let @35: &'_ (u32); // anonymous local
+    let @36: &'_ (Array<u32, 10 : usize>); // anonymous local
+    let @37: &'_ (u32); // anonymous local
 
     // Call `default` and destructure the result
     @3 := test_crate::{impl core::default::Default for test_crate::Foo}::default()
@@ -295,41 +297,42 @@ fn test_crate::foo()
     @fake_read(a@15)
     // `assert_eq`
     @19 := const (9 : usize)
-    @34 := &a@15
-    @35 := @ArrayIndexShared<'_, u32, 10 : usize>(move (@34), copy (@19))
-    @18 := &*(@35)
-    @21 := const (9 : u32)
-    @20 := &@21
+    @36 := &a@15
+    @37 := @ArrayIndexShared<'_, u32, 10 : usize>(move (@36), copy (@19))
+    @18 := &*(@37)
+    @34 := const (9 : u32)
+    @35 := &@34
+    @33 := move (@35)
+    @20 := &*(@33)
     @17 := (move (@18), move (@20))
     drop @20
     drop @18
     @fake_read(@17)
-    left_val@22 := copy ((@17).0)
-    right_val@23 := copy ((@17).1)
-    @25 := copy (*(left_val@22))
-    @26 := copy (*(right_val@23))
-    @24 := move (@25) == move (@26)
-    if move (@24) {
+    left_val@21 := copy ((@17).0)
+    right_val@22 := copy ((@17).1)
+    @24 := copy (*(left_val@21))
+    @25 := copy (*(right_val@22))
+    @23 := move (@24) == move (@25)
+    if move (@23) {
     }
     else {
-        drop @26
         drop @25
-        kind@27 := core::panicking::AssertKind::Eq {  }
-        @fake_read(kind@27)
-        @28 := move (kind@27)
-        @30 := &*(left_val@22)
-        @29 := &*(@30)
-        @32 := &*(right_val@23)
-        @31 := &*(@32)
-        @33 := core::option::Option::None {  }
+        drop @24
+        kind@26 := core::panicking::AssertKind::Eq {  }
+        @fake_read(kind@26)
+        @27 := move (kind@26)
+        @29 := &*(left_val@21)
+        @28 := &*(@29)
+        @31 := &*(right_val@22)
+        @30 := &*(@31)
+        @32 := core::option::Option::None {  }
         panic(core::panicking::assert_failed)
     }
-    drop @26
     drop @25
     drop @24
-    drop right_val@23
-    drop left_val@22
-    drop @21
+    drop @23
+    drop right_val@22
+    drop left_val@21
     drop @19
     drop @17
     drop @16

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -395,8 +395,7 @@ fn test_crate::fool()
     let @0: (); // return
     let @1: &'_ (Str); // anonymous local
 
-    @1 := const ("
-    // Fooled ya")
+    @1 := const ("\n    // Fooled ya")
     @fake_read(@1)
     drop @1
     // Fooled ya";

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -31,12 +31,15 @@ pub fn test_crate::{impl test_crate::Foo for ()}::get_ty<'_0>(@1: &'_0 (())) -> 
     let @0: &'_ (u32); // return
     let self@1: &'_ (()); // arg #1
     let @2: &'_ (u32); // anonymous local
-    let @3: u32; // anonymous local
+    let @3: &'_ (u32); // anonymous local
+    let @4: u32; // anonymous local
+    let @5: &'_ (u32); // anonymous local
 
-    @3 := const (42 : u32)
-    @2 := &@3
+    @4 := const (42 : u32)
+    @5 := &@4
+    @3 := move (@5)
+    @2 := &*(@3)
     @0 := &*(@2)
-    drop @3
     drop @2
     return
 }
@@ -182,7 +185,7 @@ where
     let x@2: &'_ (U); // arg #2
     let @3: &'_ (U); // anonymous local
 
-    @3 := copy (x@2)
+    @3 := &*(x@2)
     @0 := test_crate::WrapClone { 0: move (@3) }
     drop @3
     return
@@ -222,13 +225,17 @@ pub fn test_crate::use_wrap()
     let @4: (&'_ (u32)); // anonymous local
     let @5: &'_ (u32); // anonymous local
     let @6: &'_ (u32); // anonymous local
-    let @7: u32; // anonymous local
+    let @7: &'_ (u32); // anonymous local
+    let @8: u32; // anonymous local
+    let @9: &'_ (u32); // anonymous local
 
     f@1 := test_crate::wrap<u32>[core::marker::Sized<u32>]()
     @fake_read(f@1)
     @3 := move (f@1)
-    @7 := const (42 : u32)
-    @6 := &@7
+    @8 := const (42 : u32)
+    @9 := &@8
+    @7 := move (@9)
+    @6 := &*(@7)
     @5 := &*(@6)
     @4 := (move (@5))
     @2 := core::ops::function::FnOnce<fn<'_0>(&'_0_0 (u32)) -> test_crate::WrapClone<&'_0_0 (u32)>[core::marker::Sized<&'_1_0 (u32)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, u32>], (&'_ (u32))> where Output  = test_crate::WrapClone<&'_ (u32)>[core::marker::Sized<&'_ (u32)>, core::clone::impls::{impl core::clone::Clone for &'_0 (T)}#3<'_, u32>]::call_once(move (@3), move (@4))
@@ -236,7 +243,6 @@ pub fn test_crate::use_wrap()
     drop @4
     drop @3
     @fake_read(@2)
-    drop @7
     drop @6
     drop @2
     @0 := ()

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -49,7 +49,7 @@ fn test_crate::foo()
     let _v2@5: alloc::vec::Vec<i32, alloc::alloc::Global>[core::marker::Sized<i32>, core::marker::Sized<alloc::alloc::Global>]; // local
     let @6: Array<i32, 1 : usize>; // anonymous local
 
-    @6 := [const (1 : i32); 1 : usize]
+    @6 := [const (1 : i32)]
     @4 := @BoxNew<Array<i32, 1 : usize>>[core::marker::Sized<alloc::alloc::Global>](move (@6))
     @3 := move (@4)
     @2 := unsize_cast<alloc::boxed::Box<Array<i32, 1 : usize>>[core::marker::Sized<alloc::alloc::Global>], alloc::boxed::Box<Slice<i32>>[core::marker::Sized<alloc::alloc::Global>]>(move (@3))
@@ -84,7 +84,7 @@ pub fn test_crate::bar()
     let @6: Array<test_crate::Foo, 1 : usize>; // anonymous local
 
     @5 := test_crate::Foo {  }
-    @6 := [move (@5); 1 : usize]
+    @6 := [move (@5)]
     @4 := @BoxNew<Array<test_crate::Foo, 1 : usize>>[core::marker::Sized<alloc::alloc::Global>](move (@6))
     drop @5
     @3 := move (@4)

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -40,37 +40,40 @@ fn test_crate::slice_pat2()
     let @0: (); // return
     let array_ref@1: &'_ (Array<i32, 4 : usize>); // local
     let @2: &'_ (Array<i32, 4 : usize>); // anonymous local
-    let @3: Array<i32, 4 : usize>; // anonymous local
-    let _a@4: &'_ (i32); // local
-    let _b@5: &'_ (Array<i32, 2 : usize>); // local
-    let _c@6: &'_ (i32); // local
-    let @7: &'_ (Array<i32, 4 : usize>); // anonymous local
-    let @8: &'_ (i32); // anonymous local
+    let _a@3: &'_ (i32); // local
+    let _b@4: &'_ (Array<i32, 2 : usize>); // local
+    let _c@5: &'_ (i32); // local
+    let @6: &'_ (Array<i32, 4 : usize>); // anonymous local
+    let @7: Array<i32, 4 : usize>; // anonymous local
+    let @8: &'_ (Array<i32, 4 : usize>); // anonymous local
     let @9: &'_ (Array<i32, 4 : usize>); // anonymous local
-    let @10: &'_ (Slice<i32>); // anonymous local
+    let @10: &'_ (i32); // anonymous local
     let @11: &'_ (Array<i32, 4 : usize>); // anonymous local
-    let @12: &'_ (i32); // anonymous local
+    let @12: &'_ (Slice<i32>); // anonymous local
+    let @13: &'_ (Array<i32, 4 : usize>); // anonymous local
+    let @14: &'_ (i32); // anonymous local
 
-    @3 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
-    @2 := &@3
+    @7 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
+    @8 := &@7
+    @6 := move (@8)
+    @2 := &*(@6)
     array_ref@1 := &*(@2)
     @fake_read(array_ref@1)
     drop @2
     @fake_read(array_ref@1)
+    @13 := &*(array_ref@1)
+    @14 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@13), const (0 : usize))
+    _a@3 := &*(@14)
     @11 := &*(array_ref@1)
-    @12 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@11), const (0 : usize))
-    _a@4 := &*(@12)
+    @12 := @ArraySubSliceShared<'_, i32, 4 : usize>(move (@11), const (1 : usize), const (3 : usize))
+    _b@4 := &*(@12)
     @9 := &*(array_ref@1)
-    @10 := @ArraySubSliceShared<'_, i32, 4 : usize>(move (@9), const (1 : usize), const (3 : usize))
-    _b@5 := &*(@10)
-    @7 := &*(array_ref@1)
-    @8 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@7), const (3 : usize))
-    _c@6 := &*(@8)
+    @10 := @ArrayIndexShared<'_, i32, 4 : usize>(move (@9), const (3 : usize))
+    _c@5 := &*(@10)
     @0 := ()
-    drop _c@6
-    drop _b@5
-    drop _a@4
-    drop @3
+    drop _c@5
+    drop _b@4
+    drop _a@3
     drop array_ref@1
     @0 := ()
     return
@@ -82,61 +85,64 @@ fn test_crate::slice_pat3()
     let slice@1: &'_ (Slice<i32>); // local
     let @2: &'_ (Array<i32, 4 : usize>); // anonymous local
     let @3: &'_ (Array<i32, 4 : usize>); // anonymous local
-    let @4: Array<i32, 4 : usize>; // anonymous local
-    let _a@5: &'_ (i32); // local
-    let _b@6: &'_ (Slice<i32>); // local
-    let _c@7: &'_ (i32); // local
+    let _a@4: &'_ (i32); // local
+    let _b@5: &'_ (Slice<i32>); // local
+    let _c@6: &'_ (i32); // local
+    let @7: usize; // anonymous local
     let @8: usize; // anonymous local
-    let @9: usize; // anonymous local
-    let @10: bool; // anonymous local
-    let @11: &'_ (Slice<i32>); // anonymous local
-    let @12: usize; // anonymous local
-    let @13: usize; // anonymous local
-    let @14: &'_ (i32); // anonymous local
-    let @15: &'_ (Slice<i32>); // anonymous local
-    let @16: usize; // anonymous local
-    let @17: usize; // anonymous local
-    let @18: &'_ (Slice<i32>); // anonymous local
-    let @19: &'_ (Slice<i32>); // anonymous local
-    let @20: &'_ (i32); // anonymous local
+    let @9: bool; // anonymous local
+    let @10: &'_ (Array<i32, 4 : usize>); // anonymous local
+    let @11: Array<i32, 4 : usize>; // anonymous local
+    let @12: &'_ (Array<i32, 4 : usize>); // anonymous local
+    let @13: &'_ (Slice<i32>); // anonymous local
+    let @14: usize; // anonymous local
+    let @15: usize; // anonymous local
+    let @16: &'_ (i32); // anonymous local
+    let @17: &'_ (Slice<i32>); // anonymous local
+    let @18: usize; // anonymous local
+    let @19: usize; // anonymous local
+    let @20: &'_ (Slice<i32>); // anonymous local
+    let @21: &'_ (Slice<i32>); // anonymous local
+    let @22: &'_ (i32); // anonymous local
 
-    @4 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
-    @3 := &@4
+    @11 := @ArrayRepeat<'_, i32, 4 : usize>(const (0 : i32))
+    @12 := &@11
+    @10 := move (@12)
+    @3 := &*(@10)
     @2 := &*(@3)
     slice@1 := @ArrayToSliceShared<'_, i32, 4 : usize>(move (@2))
     drop @2
     @fake_read(slice@1)
     drop @3
     @fake_read(slice@1)
-    @8 := len(*(slice@1))
-    @9 := const (2 : usize)
-    @10 := move (@8) >= move (@9)
-    if move (@10) {
+    @7 := len(*(slice@1))
+    @8 := const (2 : usize)
+    @9 := move (@7) >= move (@8)
+    if move (@9) {
     }
     else {
-        drop _c@7
-        drop _b@6
-        drop _a@5
+        drop _c@6
+        drop _b@5
+        drop _a@4
         panic(core::panicking::panic_explicit)
     }
-    @19 := &*(slice@1)
-    @20 := @SliceIndexShared<'_, i32>(move (@19), const (0 : usize))
-    _a@5 := &*(@20)
-    @15 := &*(slice@1)
-    @16 := len(*(slice@1))
-    @17 := copy (@16) - const (1 : usize)
-    @18 := @SliceSubSliceShared<'_, i32>(move (@15), const (1 : usize), copy (@17))
-    _b@6 := &*(@18)
-    @11 := &*(slice@1)
-    @12 := len(*(slice@1))
-    @13 := copy (@12) - const (1 : usize)
-    @14 := @SliceIndexShared<'_, i32>(move (@11), copy (@13))
-    _c@7 := &*(@14)
+    @21 := &*(slice@1)
+    @22 := @SliceIndexShared<'_, i32>(move (@21), const (0 : usize))
+    _a@4 := &*(@22)
+    @17 := &*(slice@1)
+    @18 := len(*(slice@1))
+    @19 := copy (@18) - const (1 : usize)
+    @20 := @SliceSubSliceShared<'_, i32>(move (@17), const (1 : usize), copy (@19))
+    _b@5 := &*(@20)
+    @13 := &*(slice@1)
+    @14 := len(*(slice@1))
+    @15 := copy (@14) - const (1 : usize)
+    @16 := @SliceIndexShared<'_, i32>(move (@13), copy (@15))
+    _c@6 := &*(@16)
     @0 := ()
-    drop _c@7
-    drop _b@6
-    drop _a@5
-    drop @4
+    drop _c@6
+    drop _b@5
+    drop _a@4
     drop slice@1
     @0 := ()
     return

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -87,7 +87,9 @@ fn test_crate::main()
     let @14: fn(&'_ (i32)) -> test_crate::Bar<'_, i32>[core::marker::Sized<i32>]; // anonymous local
     let @15: &'_ (i32); // anonymous local
     let @16: &'_ (i32); // anonymous local
-    let @17: i32; // anonymous local
+    let @17: &'_ (i32); // anonymous local
+    let @18: i32; // anonymous local
+    let @19: &'_ (i32); // anonymous local
 
     f@1 := const (core::option::Option::Some<u8>[core::marker::Sized<u8>])
     @fake_read(f@1)
@@ -118,14 +120,15 @@ fn test_crate::main()
     f@12 := const (test_crate::Bar::Variant<'_, i32>[core::marker::Sized<i32>])
     @fake_read(f@12)
     @14 := copy (f@12)
-    @17 := const (42 : i32)
-    @16 := &@17
+    @18 := const (42 : i32)
+    @19 := &@18
+    @17 := move (@19)
+    @16 := &*(@17)
     @15 := &*(@16)
     @13 := test_crate::Bar::Variant<'_, i32>[core::marker::Sized<i32>](move (@15))
     drop @15
     drop @14
     @fake_read(@13)
-    drop @17
     drop @16
     drop @13
     @0 := ()

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -35,20 +35,26 @@ fn test_crate::main()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
-    let @3: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @3: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
     let @4: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
-    let @5: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @5: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @6: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @7: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @8: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @9: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
 
-    @3 := core::option::Option::Some { 0: const (1 : i32) }
-    @2 := &@3
-    @5 := core::option::Option::Some { 0: const (1 : i32) }
-    @4 := &@5
-    @1 := core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq<'_, '_, i32>[core::marker::Sized<i32>, core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30](move (@2), move (@4))
-    drop @4
+    @6 := core::option::Option::Some { 0: const (1 : i32) }
+    @7 := &@6
+    @5 := move (@7)
+    @2 := &*(@5)
+    @8 := core::option::Option::Some { 0: const (1 : i32) }
+    @9 := &@8
+    @4 := move (@9)
+    @3 := &*(@4)
+    @1 := core::option::{impl core::cmp::PartialEq<core::option::Option<T>[@TraitClause0]> for core::option::Option<T>[@TraitClause0]}#14::eq<'_, '_, i32>[core::marker::Sized<i32>, core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30](move (@2), move (@3))
+    drop @3
     drop @2
     @fake_read(@1)
-    drop @5
-    drop @3
     drop @1
     @0 := ()
     @0 := ()

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -39,21 +39,24 @@ fn test_crate::main()
     let hasher@1: test_crate::DefaultHasher; // local
     let @2: (); // anonymous local
     let @3: &'_ (u32); // anonymous local
-    let @4: u32; // anonymous local
+    let @4: &'_ mut (test_crate::DefaultHasher); // anonymous local
     let @5: &'_ mut (test_crate::DefaultHasher); // anonymous local
-    let @6: &'_ mut (test_crate::DefaultHasher); // anonymous local
+    let @6: &'_ (u32); // anonymous local
+    let @7: u32; // anonymous local
+    let @8: &'_ (u32); // anonymous local
 
     hasher@1 := test_crate::DefaultHasher {  }
     @fake_read(hasher@1)
-    @4 := const (0 : u32)
-    @3 := &@4
-    @6 := &mut hasher@1
-    @5 := &two-phase-mut *(@6)
-    @2 := test_crate::{impl test_crate::Hash for u32}#1::hash<'_, '_, test_crate::DefaultHasher>[core::marker::Sized<test_crate::DefaultHasher>, test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher}](move (@3), move (@5))
-    drop @5
-    drop @3
-    drop @6
+    @7 := const (0 : u32)
+    @8 := &@7
+    @6 := move (@8)
+    @3 := &*(@6)
+    @5 := &mut hasher@1
+    @4 := &two-phase-mut *(@5)
+    @2 := test_crate::{impl test_crate::Hash for u32}#1::hash<'_, '_, test_crate::DefaultHasher>[core::marker::Sized<test_crate::DefaultHasher>, test_crate::{impl test_crate::Hasher for test_crate::DefaultHasher}](move (@3), move (@4))
     drop @4
+    drop @3
+    drop @5
     drop @2
     @0 := ()
     drop hasher@1

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -3388,7 +3388,7 @@ fn test_crate::main()
     let @63: &'_ (i32); // anonymous local
     let @64: core::option::Option<core::fmt::Arguments<'_>>[core::marker::Sized<core::fmt::Arguments<'_>>]; // anonymous local
 
-    a@1 := [const (0 : i32), const (1 : i32), const (2 : i32), const (3 : i32), const (4 : i32), const (5 : i32), const (6 : i32); 7 : usize]
+    a@1 := [const (0 : i32), const (1 : i32), const (2 : i32), const (3 : i32), const (4 : i32), const (5 : i32), const (6 : i32)]
     @fake_read(a@1)
     i@2 := const (0 : i32)
     @fake_read(i@2)

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -85,42 +85,51 @@ fn test_crate::main()
     let @2: (); // anonymous local
     let @3: &'_ (u32); // anonymous local
     let @4: &'_ (u32); // anonymous local
-    let @5: u32; // anonymous local
-    let @6: bool; // anonymous local
+    let @5: bool; // anonymous local
+    let @6: &'_ (()); // anonymous local
     let @7: &'_ (()); // anonymous local
-    let @8: (); // anonymous local
+    let @8: &'_ (()); // anonymous local
     let @9: &'_ (()); // anonymous local
     let @10: &'_ (()); // anonymous local
-    let @11: (); // anonymous local
+    let @11: &'_ (u32); // anonymous local
+    let @12: u32; // anonymous local
+    let @13: &'_ (u32); // anonymous local
+    let @14: (); // anonymous local
+    let @15: &'_ (()); // anonymous local
+    let @16: (); // anonymous local
+    let @17: &'_ (()); // anonymous local
 
     @2 := ()
-    @5 := const (1 : u32)
-    @4 := &@5
+    @12 := const (1 : u32)
+    @13 := &@12
+    @11 := move (@13)
+    @4 := &*(@11)
     @3 := &*(@4)
     @1 := test_crate::{impl test_crate::Trait for ()}::method1(move (@2), move (@3))
     drop @3
     drop @2
     @fake_read(@1)
-    drop @5
     drop @4
     drop @1
     // TODO: this gives incorrect predicates
     // let _ = ().method2(false);
     // Not allowed to use the more precise signature.
     // let _ = ().method2(String::new());
-    @8 := ()
-    @7 := &@8
-    @11 := ()
-    @10 := &@11
-    @9 := &*(@10)
-    @6 := test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1::compare<'_>(move (@7), move (@9))
-    drop @9
+    @14 := ()
+    @15 := &@14
+    @10 := move (@15)
+    @6 := &*(@10)
+    @16 := ()
+    @17 := &@16
+    @9 := move (@17)
+    @8 := &*(@9)
+    @7 := &*(@8)
+    @5 := test_crate::{impl test_crate::MyCompare<&'a (())> for &'a (())}#1::compare<'_>(move (@6), move (@7))
     drop @7
-    @fake_read(@6)
-    drop @11
-    drop @10
-    drop @8
     drop @6
+    @fake_read(@5)
+    drop @8
+    drop @5
     @0 := ()
     @0 := ()
     return
@@ -154,18 +163,21 @@ fn test_crate::call_foo<'e>(@1: &'e (())) -> &'e (())
     let @3: &'_ (()); // anonymous local
     let @4: &'_ (()); // anonymous local
     let @5: &'_ (()); // anonymous local
-    let @6: (); // anonymous local
+    let @6: &'_ (()); // anonymous local
+    let @7: (); // anonymous local
+    let @8: &'_ (()); // anonymous local
 
     // Calls have erased lifetimes so we can't notice the discrepancy if there is one.
     @3 := &*(x@1)
-    @6 := ()
-    @5 := &@6
+    @7 := ()
+    @8 := &@7
+    @6 := move (@8)
+    @5 := &*(@6)
     @4 := &*(@5)
     @2 := test_crate::{impl test_crate::Foo for ()}#2::foo<'_, '_>(move (@3), move (@4))
     @0 := &*(@2)
     drop @4
     drop @3
-    drop @6
     drop @5
     drop @2
     return

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -168,7 +168,7 @@ fn test_crate::foo()
     @fake_read(@1)
     drop @3
     drop @1
-    @7 := [const (false); 1 : usize]
+    @7 := [const (false)]
     @6 := &@7
     @5 := &*(@6)
     slice@4 := @ArrayToSliceShared<'_, bool, 1 : usize>(move (@5))

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -151,42 +151,48 @@ fn test_crate::foo()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
-    let @3: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
-    let slice@4: &'_ (Slice<bool>); // local
+    let slice@3: &'_ (Slice<bool>); // local
+    let @4: &'_ (Array<bool, 1 : usize>); // anonymous local
     let @5: &'_ (Array<bool, 1 : usize>); // anonymous local
-    let @6: &'_ (Array<bool, 1 : usize>); // anonymous local
-    let @7: Array<bool, 1 : usize>; // anonymous local
+    let @6: &'_ (Slice<bool>); // anonymous local
+    let @7: &'_ (Slice<bool>); // anonymous local
     let @8: &'_ (Slice<bool>); // anonymous local
-    let @9: &'_ (Slice<bool>); // anonymous local
-    let @10: &'_ (Slice<bool>); // anonymous local
-    let @11: core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]; // anonymous local
+    let @9: core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]; // anonymous local
+    let @10: &'_ (Array<bool, 1 : usize>); // anonymous local
+    let @11: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @12: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @13: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @14: Array<bool, 1 : usize>; // anonymous local
+    let @15: &'_ (Array<bool, 1 : usize>); // anonymous local
 
-    @3 := core::option::Option::Some { 0: const (0 : i32) }
-    @2 := &@3
+    @12 := core::option::Option::Some { 0: const (0 : i32) }
+    @13 := &@12
+    @11 := move (@13)
+    @2 := &*(@11)
     @1 := core::option::{core::option::Option<T>[@TraitClause0]}::is_some<'_, i32>[core::marker::Sized<i32>](move (@2))
     drop @2
     @fake_read(@1)
-    drop @3
     drop @1
-    @7 := [const (false)]
-    @6 := &@7
-    @5 := &*(@6)
-    slice@4 := @ArrayToSliceShared<'_, bool, 1 : usize>(move (@5))
+    @14 := [const (false)]
+    @15 := &@14
+    @10 := move (@15)
+    @5 := &*(@10)
+    @4 := &*(@5)
+    slice@3 := @ArrayToSliceShared<'_, bool, 1 : usize>(move (@4))
+    drop @4
+    @fake_read(slice@3)
     drop @5
-    @fake_read(slice@4)
-    drop @6
-    @10 := &*(slice@4)
-    @11 := core::ops::range::RangeFrom { start: const (1 : usize) }
-    @9 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_, bool, core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]>[core::marker::Sized<bool>, core::marker::Sized<core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7<bool>[core::marker::Sized<bool>]](move (@10), move (@11))
-    drop @11
-    drop @10
-    @8 := &*(@9)
-    @fake_read(@8)
-    drop @8
-    @0 := ()
+    @8 := &*(slice@3)
+    @9 := core::ops::range::RangeFrom { start: const (1 : usize) }
+    @7 := core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_, bool, core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]>[core::marker::Sized<bool>, core::marker::Sized<core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::RangeFrom<usize>[core::marker::Sized<usize>]}#7<bool>[core::marker::Sized<bool>]](move (@8), move (@9))
     drop @9
+    drop @8
+    @6 := &*(@7)
+    @fake_read(@6)
+    drop @6
+    @0 := ()
     drop @7
-    drop slice@4
+    drop slice@3
     @0 := ()
     return
 }

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -76,32 +76,38 @@ fn test_crate::foo()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
-    let @3: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
-    let @4: u64; // anonymous local
-    let @5: &'_ (Slice<i32>); // anonymous local
+    let @3: u64; // anonymous local
+    let @4: &'_ (Slice<i32>); // anonymous local
+    let @5: &'_ (i32); // anonymous local
     let @6: &'_ (i32); // anonymous local
     let @7: &'_ (i32); // anonymous local
-    let @8: i32; // anonymous local
+    let @8: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @9: core::option::Option<i32>[core::marker::Sized<i32>]; // anonymous local
+    let @10: &'_ (core::option::Option<i32>[core::marker::Sized<i32>]); // anonymous local
+    let @11: i32; // anonymous local
+    let @12: &'_ (i32); // anonymous local
 
-    @3 := core::option::Option::Some { 0: const (0 : i32) }
-    @2 := &@3
+    @9 := core::option::Option::Some { 0: const (0 : i32) }
+    @10 := &@9
+    @8 := move (@10)
+    @2 := &*(@8)
     @1 := core::option::{core::option::Option<T>[@TraitClause0]}::is_some<'_, i32>[core::marker::Sized<i32>](move (@2))
     drop @2
     @fake_read(@1)
-    drop @3
     drop @1
-    @4 := core::convert::{impl core::convert::Into<U> for T}#3::into<u32, u64>[core::marker::Sized<u32>, core::marker::Sized<u64>, core::convert::num::{impl core::convert::From<u32> for u64}#72](const (42 : u32))
-    @fake_read(@4)
-    drop @4
-    @8 := const (0 : i32)
-    @7 := &@8
+    @3 := core::convert::{impl core::convert::Into<U> for T}#3::into<u32, u64>[core::marker::Sized<u32>, core::marker::Sized<u64>, core::convert::num::{impl core::convert::From<u32> for u64}#72](const (42 : u32))
+    @fake_read(@3)
+    drop @3
+    @11 := const (0 : i32)
+    @12 := &@11
+    @7 := move (@12)
     @6 := &*(@7)
-    @5 := core::slice::raw::from_ref<'_, i32>[core::marker::Sized<i32>](move (@6))
-    drop @6
-    @fake_read(@5)
-    drop @8
-    drop @7
+    @5 := &*(@6)
+    @4 := core::slice::raw::from_ref<'_, i32>[core::marker::Sized<i32>](move (@5))
     drop @5
+    @fake_read(@4)
+    drop @6
+    drop @4
     @0 := ()
     @0 := ()
     return

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -22,7 +22,7 @@ fn test_crate::panic2()
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
 
-    @4 := [const ("O no!"); 1 : usize]
+    @4 := [const ("O no!")]
     @3 := &@4
     @2 := &*(@3)
     @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))
@@ -48,7 +48,7 @@ fn test_crate::panic3()
     let @6: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
     let @7: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
 
-    @4 := [const ("O no!"); 1 : usize]
+    @4 := [const ("O no!")]
     @3 := &@4
     @2 := &*(@3)
     @7 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()
@@ -89,7 +89,7 @@ fn test_crate::panic5()
     if move (@2) {
     }
     else {
-        @6 := [const ("assert failed"); 1 : usize]
+        @6 := [const ("assert failed")]
         @5 := &@6
         @4 := &*(@5)
         @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))
@@ -121,7 +121,7 @@ fn test_crate::panic7()
     let @6: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
     let @7: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
 
-    @4 := [const ("internal error: entered unreachable code: can't reach this"); 1 : usize]
+    @4 := [const ("internal error: entered unreachable code: can't reach this")]
     @3 := &@4
     @2 := &*(@3)
     @7 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -20,10 +20,14 @@ fn test_crate::panic2()
     let @1: core::fmt::Arguments<'_>; // anonymous local
     let @2: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @4: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @5: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @6: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
-    @4 := [const ("O no!")]
-    @3 := &@4
+    @5 := [const ("O no!")]
+    @6 := &@5
+    @4 := move (@6)
+    @3 := &*(@4)
     @2 := &*(@3)
     @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))
     drop @2
@@ -43,19 +47,23 @@ fn test_crate::panic3()
     let @1: core::fmt::Arguments<'_>; // anonymous local
     let @2: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @4: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
     let @5: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
-    let @6: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
-    let @7: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
+    let @6: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
+    let @7: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @8: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @9: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
-    @4 := [const ("O no!")]
-    @3 := &@4
+    @8 := [const ("O no!")]
+    @9 := &@8
+    @7 := move (@9)
+    @3 := &*(@7)
     @2 := &*(@3)
-    @7 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()
-    @6 := &@7
-    @5 := &*(@6)
-    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
-    drop @5
+    @6 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()
+    @5 := &@6
+    @4 := &*(@5)
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@4))
+    drop @4
     drop @2
     panic(core::panicking::panic_fmt)
 }
@@ -83,14 +91,18 @@ fn test_crate::panic5()
     let @3: core::fmt::Arguments<'_>; // anonymous local
     let @4: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @5: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @6: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @6: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @7: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @8: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
     @2 := const (false)
     if move (@2) {
     }
     else {
-        @6 := [const ("assert failed")]
-        @5 := &@6
+        @7 := [const ("assert failed")]
+        @8 := &@7
+        @6 := move (@8)
+        @5 := &*(@6)
         @4 := &*(@5)
         @3 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@4))
         drop @4
@@ -116,19 +128,23 @@ fn test_crate::panic7()
     let @1: core::fmt::Arguments<'_>; // anonymous local
     let @2: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @4: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
     let @5: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
-    let @6: &'_ (Array<core::fmt::rt::Argument<'_>, 0 : usize>); // anonymous local
-    let @7: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
+    let @6: Array<core::fmt::rt::Argument<'_>, 0 : usize>; // anonymous local
+    let @7: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @8: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @9: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
-    @4 := [const ("internal error: entered unreachable code: can't reach this")]
-    @3 := &@4
+    @8 := [const ("internal error: entered unreachable code: can't reach this")]
+    @9 := &@8
+    @7 := move (@9)
+    @3 := &*(@7)
     @2 := &*(@3)
-    @7 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()
-    @6 := &@7
-    @5 := &*(@6)
-    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@5))
-    drop @5
+    @6 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::none<'_>()
+    @5 := &@6
+    @4 := &*(@5)
+    @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 1 : usize, 0 : usize>(move (@2), move (@4))
+    drop @4
     drop @2
     panic(core::panicking::panic_fmt)
 }

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -15,7 +15,7 @@ fn test_crate::main()
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
 
-    @4 := [const ("O no"); 1 : usize]
+    @4 := [const ("O no")]
     @3 := &@4
     @2 := &*(@3)
     @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -13,10 +13,14 @@ fn test_crate::main()
     let @1: core::fmt::Arguments<'_>; // anonymous local
     let @2: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
     let @3: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
-    let @4: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @4: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
+    let @5: Array<&'_ (Str), 1 : usize>; // anonymous local
+    let @6: &'_ (Array<&'_ (Str), 1 : usize>); // anonymous local
 
-    @4 := [const ("O no")]
-    @3 := &@4
+    @5 := [const ("O no")]
+    @6 := &@5
+    @4 := move (@6)
+    @3 := &*(@4)
     @2 := &*(@3)
     @1 := core::fmt::{core::fmt::Arguments<'a>}#2::new_const<'_, 1 : usize>(move (@2))
     drop @2

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -153,20 +153,26 @@ pub fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map:
     let @3: &'_ (std::collections::hash::map::HashMap<u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>]); // anonymous local
     let @4: &'_ (u32); // anonymous local
     let @5: &'_ (u32); // anonymous local
-    let @6: u32; // anonymous local
-    let v@7: &'_ (u32); // local
-    let @8: core::option::Option<u32>[core::marker::Sized<u32>]; // anonymous local
-    let @9: &'_ mut (std::collections::hash::map::HashMap<u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>]); // anonymous local
+    let v@6: &'_ (u32); // local
+    let @7: core::option::Option<u32>[core::marker::Sized<u32>]; // anonymous local
+    let @8: &'_ mut (std::collections::hash::map::HashMap<u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>]); // anonymous local
+    let @9: &'_ (u32); // anonymous local
     let @10: &'_ (u32); // anonymous local
-    let @11: &'_ (u32); // anonymous local
-    let @12: &'_ (std::collections::hash::map::HashMap<u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>]); // anonymous local
+    let @11: &'_ (std::collections::hash::map::HashMap<u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>]); // anonymous local
+    let @12: &'_ (u32); // anonymous local
     let @13: &'_ (u32); // anonymous local
     let @14: &'_ (u32); // anonymous local
-    let @15: u32; // anonymous local
+    let @15: &'_ (u32); // anonymous local
+    let @16: u32; // anonymous local
+    let @17: &'_ (u32); // anonymous local
+    let @18: u32; // anonymous local
+    let @19: &'_ (u32); // anonymous local
 
     @3 := &*(map@1)
-    @6 := const (22 : u32)
-    @5 := &@6
+    @16 := const (22 : u32)
+    @17 := &@16
+    @15 := move (@17)
+    @5 := &*(@15)
     @4 := &*(@5)
     @2 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::get<'_, '_, u32, u32, std::hash::random::RandomState, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1, core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::hash::impls::{impl core::hash::Hash for u32}#11, core::cmp::impls::{impl core::cmp::Eq for u32}#43](move (@3), move (@4))
     drop @4
@@ -174,31 +180,31 @@ pub fn test_crate::get_or_insert<'_0>(@1: &'_0 mut (std::collections::hash::map:
     @fake_read(@2)
     match @2 {
         0 => {
-            @9 := &two-phase-mut *(map@1)
-            @8 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::insert<'_, u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@9), const (22 : u32), const (33 : u32))
-            drop @9
+            @8 := &two-phase-mut *(map@1)
+            @7 := std::collections::hash::map::{std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#2::insert<'_, u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@8), const (22 : u32), const (33 : u32))
             drop @8
-            @12 := &*(map@1)
-            @15 := const (22 : u32)
-            @14 := &@15
+            drop @7
+            @11 := &*(map@1)
+            @18 := const (22 : u32)
+            @19 := &@18
+            @14 := move (@19)
             @13 := &*(@14)
-            @11 := std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_, '_, u32, u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@12), move (@13))
-            drop @13
+            @12 := &*(@13)
+            @10 := std::collections::hash::map::{impl core::ops::index::Index<&'_0 (Q)> for std::collections::hash::map::HashMap<K, V, S>[@TraitClause0, @TraitClause1, @TraitClause2]}#9::index<'_, '_, u32, u32, u32, std::hash::random::RandomState>[core::marker::Sized<u32>, core::marker::Sized<u32>, core::marker::Sized<std::hash::random::RandomState>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, core::borrow::{impl core::borrow::Borrow<T> for T}<u32>, core::cmp::impls::{impl core::cmp::Eq for u32}#43, core::hash::impls::{impl core::hash::Hash for u32}#11, std::hash::random::{impl core::hash::BuildHasher for std::hash::random::RandomState}#1](move (@11), move (@12))
             drop @12
-            @10 := &*(@11)
-            @0 := &*(@10)
-            drop @15
-            drop @14
             drop @11
+            @9 := &*(@10)
+            @0 := &*(@9)
+            drop @13
             drop @10
+            drop @9
         },
         1 => {
-            v@7 := copy ((@2 as variant @1).0)
-            @0 := &*(v@7)
-            drop v@7
+            v@6 := copy ((@2 as variant @1).0)
+            @0 := &*(v@6)
+            drop v@6
         },
     }
-    drop @6
     drop @5
     drop @2
     return

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -83,64 +83,67 @@ fn test_crate::ptr_casts()
     let @0: (); // return
     let array_ptr@1: *const Array<u32, 64 : usize>; // local
     let @2: &'_ (Array<u32, 64 : usize>); // anonymous local
-    let @3: Array<u32, 64 : usize>; // anonymous local
-    let @4: *const u32; // anonymous local
-    let @5: *const Array<u32, 64 : usize>; // anonymous local
-    let x@6: u8; // local
-    let x@7: *const u8; // local
-    let @8: &'_ (u8); // anonymous local
+    let @3: *const u32; // anonymous local
+    let @4: *const Array<u32, 64 : usize>; // anonymous local
+    let x@5: u8; // local
+    let x@6: *const u8; // local
+    let @7: &'_ (u8); // anonymous local
+    let @8: *const u8; // anonymous local
     let @9: *const u8; // anonymous local
-    let @10: *const u8; // anonymous local
-    let @11: *mut u8; // anonymous local
-    let @12: *const u8; // anonymous local
-    let @13: usize; // anonymous local
+    let @10: *mut u8; // anonymous local
+    let @11: *const u8; // anonymous local
+    let @12: usize; // anonymous local
+    let @13: *const u8; // anonymous local
     let @14: *const u8; // anonymous local
     let @15: *const u8; // anonymous local
-    let @16: *const u8; // anonymous local
-    let @17: fn(); // anonymous local
+    let @16: fn(); // anonymous local
+    let @17: &'_ (Array<u32, 64 : usize>); // anonymous local
+    let @18: Array<u32, 64 : usize>; // anonymous local
+    let @19: &'_ (Array<u32, 64 : usize>); // anonymous local
 
-    @3 := @ArrayRepeat<'_, u32, 64 : usize>(const (0 : u32))
-    @2 := &@3
+    @18 := @ArrayRepeat<'_, u32, 64 : usize>(const (0 : u32))
+    @19 := &@18
+    @17 := move (@19)
+    @2 := &*(@17)
     array_ptr@1 := &raw const *(@2)
     @fake_read(array_ptr@1)
     drop @2
-    @5 := copy (array_ptr@1)
-    @4 := cast<*const Array<u32, 64 : usize>, *const u32>(move (@5))
-    drop @5
-    @fake_read(@4)
+    @4 := copy (array_ptr@1)
+    @3 := cast<*const Array<u32, 64 : usize>, *const u32>(move (@4))
     drop @4
-    x@6 := const (0 : u8)
+    @fake_read(@3)
+    drop @3
+    x@5 := const (0 : u8)
+    @fake_read(x@5)
+    @7 := &x@5
+    x@6 := &raw const *(@7)
     @fake_read(x@6)
-    @8 := &x@6
-    x@7 := &raw const *(@8)
-    @fake_read(x@7)
-    drop @8
-    @12 := copy (x@7)
-    @11 := cast<*const u8, *mut u8>(move (@12))
-    @10 := cast<*mut u8, *const u8>(move (@11))
-    drop @12
+    drop @7
+    @11 := copy (x@6)
+    @10 := cast<*const u8, *mut u8>(move (@11))
+    @9 := cast<*mut u8, *const u8>(move (@10))
     drop @11
-    @9 := cast<*const u8, *const u8>(move (@10))
     drop @10
-    @fake_read(@9)
+    @8 := cast<*const u8, *const u8>(move (@9))
     drop @9
-    @14 := copy (x@7)
-    @13 := cast<*const u8, usize>(move (@14))
-    drop @14
-    @fake_read(@13)
+    @fake_read(@8)
+    drop @8
+    @13 := copy (x@6)
+    @12 := cast<*const u8, usize>(move (@13))
     drop @13
-    @15 := cast<usize, *const u8>(const (0 : usize))
+    @fake_read(@12)
+    drop @12
+    @14 := cast<usize, *const u8>(const (0 : usize))
+    @fake_read(@14)
+    drop @14
+    @16 := cast<fn(), fn()>(const (test_crate::ptr_casts::foo))
+    @15 := cast<fn(), *const u8>(move (@16))
+    drop @16
     @fake_read(@15)
     drop @15
-    @17 := cast<fn(), fn()>(const (test_crate::ptr_casts::foo))
-    @16 := cast<fn(), *const u8>(move (@17))
-    drop @17
-    @fake_read(@16)
-    drop @16
     @0 := ()
-    drop x@7
     drop x@6
-    drop @3
+    drop x@5
     drop array_ptr@1
     @0 := ()
     return

--- a/charon/tests/ui/simple/const-subslice.out
+++ b/charon/tests/ui/simple/const-subslice.out
@@ -1,0 +1,12 @@
+error: array constants are not supported yet
+ --> tests/ui/simple/const-subslice.rs:4:20
+  |
+4 |       let y: &[u8] = const {
+  |  ____________________^
+5 | |         let x: &[u8] = &[0, 1, 2, 3, 4];
+6 | |         unsafe { std::slice::from_raw_parts(x as *const [u8] as *const u8, 3) }
+7 | |     };
+  | |_____^
+  |
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/const-subslice.out
+++ b/charon/tests/ui/simple/const-subslice.out
@@ -1,12 +1,32 @@
-error: array constants are not supported yet
- --> tests/ui/simple/const-subslice.rs:4:20
-  |
-4 |       let y: &[u8] = const {
-  |  ____________________^
-5 | |         let x: &[u8] = &[0, 1, 2, 3, 4];
-6 | |         unsafe { std::slice::from_raw_parts(x as *const [u8] as *const u8, 3) }
-7 | |     };
-  | |_____^
-  |
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+fn test_crate::main()
+{
+    let @0: (); // return
+    let y@1: &'_ (Slice<u8>); // local
+    let z@2: *const u8; // local
+    let @3: *const Slice<u8>; // anonymous local
+    let @4: usize; // anonymous local
+    let @5: *const u8; // anonymous local
+    let @6: Slice<u8>; // anonymous local
+    let @7: &'_ (Slice<u8>); // anonymous local
+
+    @6 := [const (0 : u8), const (1 : u8), const (2 : u8)]
+    @7 := &@6
+    y@1 := move (@7)
+    @3 := &raw const *(y@1)
+    z@2 := cast<*const Slice<u8>, *const u8>(move (@3))
+    drop @3
+    @5 := copy (z@2)
+    @4 := cast<*const u8, usize>(move (@5))
+    drop @5
+    drop @4
+    @0 := ()
+    drop z@2
+    drop y@1
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/const-subslice.rs
+++ b/charon/tests/ui/simple/const-subslice.rs
@@ -1,0 +1,10 @@
+//@ known-failure
+//@ charon-args=--mir_optimized
+fn main() {
+    let y: &[u8] = const {
+        let x: &[u8] = &[0, 1, 2, 3, 4];
+        unsafe { std::slice::from_raw_parts(x as *const [u8] as *const u8, 3) }
+    };
+    let z: *const u8 = y as *const [u8] as *const u8;
+    let _ = z as usize;
+}

--- a/charon/tests/ui/simple/const-subslice.rs
+++ b/charon/tests/ui/simple/const-subslice.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--mir_optimized
 fn main() {
     let y: &[u8] = const {

--- a/charon/tests/ui/simple/pointee_metadata.out
+++ b/charon/tests/ui/simple/pointee_metadata.out
@@ -129,15 +129,18 @@ fn test_crate::empty_metadata()
     let @1: (*const (), ()); // anonymous local
     let @2: *const u32; // anonymous local
     let @3: &'_ (u32); // anonymous local
-    let @4: u32; // anonymous local
+    let @4: &'_ (u32); // anonymous local
+    let @5: u32; // anonymous local
+    let @6: &'_ (u32); // anonymous local
 
-    @4 := const (0 : u32)
-    @3 := &@4
+    @5 := const (0 : u32)
+    @6 := &@5
+    @4 := move (@6)
+    @3 := &*(@4)
     @2 := &raw const *(@3)
     @1 := core::ptr::const_ptr::{*const T}::to_raw_parts<u32>(move (@2))
     drop @2
     @fake_read(@1)
-    drop @4
     drop @3
     drop @1
     @0 := ()
@@ -152,17 +155,20 @@ fn test_crate::slice_metadata()
     let @2: *const Slice<u32>; // anonymous local
     let @3: *const Array<u32, 2 : usize>; // anonymous local
     let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
-    let @5: Array<u32, 2 : usize>; // anonymous local
+    let @5: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @6: Array<u32, 2 : usize>; // anonymous local
+    let @7: &'_ (Array<u32, 2 : usize>); // anonymous local
 
-    @5 := [const (0 : u32), const (1 : u32)]
-    @4 := &@5
+    @6 := [const (0 : u32), const (1 : u32)]
+    @7 := &@6
+    @5 := move (@7)
+    @4 := &*(@5)
     @3 := &raw const *(@4)
     @2 := unsize_cast<*const Array<u32, 2 : usize>, *const Slice<u32>>(move (@3))
     drop @3
     @1 := core::ptr::const_ptr::{*const T}::to_raw_parts<Slice<u32>>(move (@2))
     drop @2
     @fake_read(@1)
-    drop @5
     drop @4
     drop @1
     @0 := ()

--- a/charon/tests/ui/simple/pointee_metadata.out
+++ b/charon/tests/ui/simple/pointee_metadata.out
@@ -154,7 +154,7 @@ fn test_crate::slice_metadata()
     let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
     let @5: Array<u32, 2 : usize>; // anonymous local
 
-    @5 := [const (0 : u32), const (1 : u32); 2 : usize]
+    @5 := [const (0 : u32), const (1 : u32)]
     @4 := &@5
     @3 := &raw const *(@4)
     @2 := unsize_cast<*const Array<u32, 2 : usize>, *const Slice<u32>>(move (@3))

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -1,0 +1,30 @@
+disabled backtrace
+error[E9999]: Cannot convert constant back to an expression
+              
+              Context:
+               - op: OpTy {
+                  op: Indirect(
+                      MemPlace {
+                          ptr: a2<imm>,
+                          meta: None,
+                          misaligned: None,
+                      },
+                  ),
+                  ty: {closure@tests/ui/simple/promoted-closure.rs:4:6: 4:14},
+              }
+  |
+  = note: ⚠️ This is a bug in Hax's frontend.
+          Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+
+error: Hax panicked when translating `Body { basic_blocks: BasicBlocks { basic_blocks: [BasicBlockData { statements: [StorageLive(_1), StorageLive(_2), _3 = const foo::promoted[0], _2 = copy _3, _1 = copy _2, _0 = copy _1, StorageDead(_2), StorageDead(_1)], terminator: Some(Terminator { source_info: SourceInfo { span: tests/ui/simple/promoted-closure.rs:5:2: 5:2 (#0), scope: scope[0] }, kind: return }), is_cleanup: false }], cache: Cache { predecessors: OnceLock(<uninit>), switch_sources: OnceLock(<uninit>), reverse_postorder: OnceLock(<uninit>), dominators: OnceLock(<uninit>) } }, phase: Runtime(Optimized), pass_count: 1, source: MirSource { instance: Item(test_crate::foo), promoted: None }, source_scopes: [SourceScopeData { span: tests/ui/simple/promoted-closure.rs:3:1: 5:2 (#0), parent_scope: None, inlined: None, inlined_parent_scope: None, local_data: Set(SourceScopeLocalData { lint_root: HirId(test_crate::foo.0) }) }], coroutine: None, local_decls: [LocalDecl { mutability: Mut, local_info: Clear, ty: &'{erased} Closure(test_crate::foo::{closure#0}, [i8, Binder { value: extern "RustCall" fn((u32,)) -> u32, bound_vars: [] }, ()]), user_ty: None, source_info: SourceInfo { span: tests/ui/simple/promoted-closure.rs:3:17: 3:45 (#0), scope: scope[0] } }, LocalDecl { mutability: Not, local_info: Clear, ty: &'{erased} Closure(test_crate::foo::{closure#0}, [i8, Binder { value: extern "RustCall" fn((u32,)) -> u32, bound_vars: [] }, ()]), user_ty: None, source_info: SourceInfo { span: tests/ui/simple/promoted-closure.rs:4:5: 4:16 (#0), scope: scope[0] } }, LocalDecl { mutability: Not, local_info: Clear, ty: &'{erased} Closure(test_crate::foo::{closure#0}, [i8, Binder { value: extern "RustCall" fn((u32,)) -> u32, bound_vars: [] }, ()]), user_ty: None, source_info: SourceInfo { span: tests/ui/simple/promoted-closure.rs:4:5: 4:16 (#0), scope: scope[0] } }, LocalDecl { mutability: Mut, local_info: Clear, ty: &'{erased} Closure(test_crate::foo::{closure#0}, [i8, Binder { value: extern "RustCall" fn((u32,)) -> u32, bound_vars: [] }, ()]), user_ty: None, source_info: SourceInfo { span: tests/ui/simple/promoted-closure.rs:4:5: 4:16 (#0), scope: scope[0] } }], user_type_annotations: [], arg_count: 0, spread_arg: None, var_debug_info: [], span: tests/ui/simple/promoted-closure.rs:3:1: 5:2 (#0), required_consts: Some([]), mentioned_items: Some([]), is_polymorphic: false, injection_phase: None, tainted_by_errors: None, coverage_info_hi: None, function_coverage_info: None }`.
+ --> tests/ui/simple/promoted-closure.rs:3:1
+  |
+3 | / pub fn foo() -> &'static impl Fn(u32) -> u32 {
+4 | |     &|x: u32| x
+5 | | }
+  | |_^
+  |
+
+error: aborting due to 1 previous error
+
+ERROR Code failed to compile

--- a/charon/tests/ui/simple/promoted-closure.rs
+++ b/charon/tests/ui/simple/promoted-closure.rs
@@ -1,0 +1,5 @@
+//@ known-failure
+//@ charon-args=--mir_optimized
+pub fn foo() -> &'static impl Fn(u32) -> u32 {
+    &|x: u32| x
+}

--- a/charon/tests/ui/simple/promoted-literal-addition.out
+++ b/charon/tests/ui/simple/promoted-literal-addition.out
@@ -17,14 +17,5 @@ fn test_crate::two() -> &'static (u32)
     return
 }
 
-fn test_crate::main()
-{
-    let @0: (); // return
-
-    @0 := ()
-    @0 := ()
-    return
-}
-
 
 

--- a/charon/tests/ui/simple/promoted-literal-addition.rs
+++ b/charon/tests/ui/simple/promoted-literal-addition.rs
@@ -2,5 +2,3 @@
 fn two() -> &'static u32 {
     &(1 + 1)
 }
-
-fn main() {}

--- a/charon/tests/ui/simple/promoted-u32-slice.out
+++ b/charon/tests/ui/simple/promoted-u32-slice.out
@@ -1,8 +1,24 @@
-error: array constants are not supported yet
- --> tests/ui/simple/promoted-u32-slice.rs:4:5
-  |
-4 |     &[0, 1, 2, 3]
-  |     ^^^^^^^^^^^^^
-  |
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+pub fn test_crate::foo() -> &'static (Slice<u32>)
+{
+    let @0: &'_ (Slice<u32>); // return
+    let @1: &'_ (Array<u32, 4 : usize>); // anonymous local
+    let @2: &'_ (Array<u32, 4 : usize>); // anonymous local
+    let @3: &'_ (Array<u32, 4 : usize>); // anonymous local
+    let @4: Array<u32, 4 : usize>; // anonymous local
+    let @5: &'_ (Array<u32, 4 : usize>); // anonymous local
+
+    @4 := [const (0 : u32), const (1 : u32), const (2 : u32), const (3 : u32)]
+    @5 := &@4
+    @3 := move (@5)
+    @2 := copy (@3)
+    @1 := copy (@2)
+    @0 := @ArrayToSliceShared<'_, u32, 4 : usize>(move (@1))
+    drop @1
+    drop @2
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/promoted-u32-slice.out
+++ b/charon/tests/ui/simple/promoted-u32-slice.out
@@ -1,0 +1,8 @@
+error: array constants are not supported yet
+ --> tests/ui/simple/promoted-u32-slice.rs:4:5
+  |
+4 |     &[0, 1, 2, 3]
+  |     ^^^^^^^^^^^^^
+  |
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/promoted-u32-slice.rs
+++ b/charon/tests/ui/simple/promoted-u32-slice.rs
@@ -1,0 +1,5 @@
+//@ known-failure
+//@ charon-args=--mir_optimized
+pub fn foo() -> &'static [u32] {
+    &[0, 1, 2, 3]
+}

--- a/charon/tests/ui/simple/promoted-u32-slice.rs
+++ b/charon/tests/ui/simple/promoted-u32-slice.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--mir_optimized
 pub fn foo() -> &'static [u32] {
     &[0, 1, 2, 3]

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -15,28 +15,29 @@ fn test_crate::constant()
     let @0: (); // return
     let _val@1: usize; // local
     let _ref@2: &'_ (usize); // local
-    let @3: usize; // anonymous local
-    let _ref_mut@4: &'_ mut (usize); // local
-    let @5: usize; // anonymous local
+    let _ref_mut@3: &'_ mut (usize); // local
+    let @4: usize; // anonymous local
+    let @5: &'_ (usize); // anonymous local
     let @6: usize; // anonymous local
     let @7: usize; // anonymous local
-    let @8: usize; // anonymous local
+    let @8: &'_ (usize); // anonymous local
+    let @9: usize; // anonymous local
 
     @6 := test_crate::constant::CONST
     _val@1 := move (@6)
     @fake_read(_val@1)
-    @7 := test_crate::constant::CONST
-    @3 := move (@7)
-    _ref@2 := &@3
-    @fake_read(_ref@2)
-    @8 := test_crate::constant::CONST
+    @7 := const (0 : usize)
+    @8 := &@7
     @5 := move (@8)
-    _ref_mut@4 := &mut @5
-    @fake_read(_ref_mut@4)
+    _ref@2 := &*(@5)
+    @fake_read(_ref@2)
+    @9 := test_crate::constant::CONST
+    @4 := move (@9)
+    _ref_mut@3 := &mut @4
+    @fake_read(_ref_mut@3)
     @0 := ()
-    drop @5
-    drop _ref_mut@4
-    drop @3
+    drop @4
+    drop _ref_mut@3
     drop _ref@2
     drop _val@1
     @0 := ()

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -18,7 +18,7 @@ fn test_crate::BAR() -> &'static (Slice<u8>)
     let @3: Array<u8, 5 : usize>; // anonymous local
     let @4: &'_ (Array<u8, 5 : usize>); // anonymous local
 
-    @3 := const ([104, 101, 108, 108, 111])
+    @3 := [const (104 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
     @4 := &@3
     @2 := move (@4)
     @1 := &*(@2)

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -92,8 +92,7 @@ where
     let @11: &'_ (U); // anonymous local
     let @12: U; // anonymous local
 
-    @5 := [const (""), const ("
-")]
+    @5 := [const (""), const ("\n")]
     @4 := &@5
     @3 := &*(@4)
     @12 := @TraitClause4::default()

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -83,38 +83,41 @@ where
     let @2: core::fmt::Arguments<'_>; // anonymous local
     let @3: &'_ (Array<&'_ (Str), 2 : usize>); // anonymous local
     let @4: &'_ (Array<&'_ (Str), 2 : usize>); // anonymous local
-    let @5: Array<&'_ (Str), 2 : usize>; // anonymous local
+    let @5: &'_ (Array<core::fmt::rt::Argument<'_>, 1 : usize>); // anonymous local
     let @6: &'_ (Array<core::fmt::rt::Argument<'_>, 1 : usize>); // anonymous local
-    let @7: &'_ (Array<core::fmt::rt::Argument<'_>, 1 : usize>); // anonymous local
-    let @8: Array<core::fmt::rt::Argument<'_>, 1 : usize>; // anonymous local
-    let @9: core::fmt::rt::Argument<'_>; // anonymous local
+    let @7: Array<core::fmt::rt::Argument<'_>, 1 : usize>; // anonymous local
+    let @8: core::fmt::rt::Argument<'_>; // anonymous local
+    let @9: &'_ (U); // anonymous local
     let @10: &'_ (U); // anonymous local
-    let @11: &'_ (U); // anonymous local
-    let @12: U; // anonymous local
+    let @11: U; // anonymous local
+    let @12: &'_ (Array<&'_ (Str), 2 : usize>); // anonymous local
+    let @13: Array<&'_ (Str), 2 : usize>; // anonymous local
+    let @14: &'_ (Array<&'_ (Str), 2 : usize>); // anonymous local
 
-    @5 := [const (""), const ("\n")]
-    @4 := &@5
+    @13 := [const (""), const ("\n")]
+    @14 := &@13
+    @12 := move (@14)
+    @4 := &*(@12)
     @3 := &*(@4)
-    @12 := @TraitClause4::default()
-    @11 := &@12
-    @10 := &*(@11)
-    @9 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::new_debug<'_, '_, U>[@TraitClause1, @TraitClause5](move (@10))
-    drop @10
-    @8 := [move (@9)]
+    @11 := @TraitClause4::default()
+    @10 := &@11
+    @9 := &*(@10)
+    @8 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::new_debug<'_, '_, U>[@TraitClause1, @TraitClause5](move (@9))
     drop @9
-    @7 := &@8
-    @6 := &*(@7)
-    @2 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 2 : usize, 1 : usize>(move (@3), move (@6))
-    drop @6
+    @7 := [move (@8)]
+    drop @8
+    @6 := &@7
+    @5 := &*(@6)
+    @2 := core::fmt::{core::fmt::Arguments<'a>}#2::new_v1<'_, 2 : usize, 1 : usize>(move (@3), move (@5))
+    drop @5
     drop @3
     @1 := std::io::stdio::_print<'_>(move (@2))
     drop @2
-    drop @12
-    drop @12
     drop @11
-    drop @8
+    drop @11
+    drop @10
     drop @7
-    drop @5
+    drop @6
     drop @4
     drop @1
     @0 := ()

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -93,7 +93,7 @@ where
     let @12: U; // anonymous local
 
     @5 := [const (""), const ("
-"); 2 : usize]
+")]
     @4 := &@5
     @3 := &*(@4)
     @12 := @TraitClause4::default()
@@ -101,7 +101,7 @@ where
     @10 := &*(@11)
     @9 := core::fmt::rt::{core::fmt::rt::Argument<'_0>}#1::new_debug<'_, '_, U>[@TraitClause1, @TraitClause5](move (@10))
     drop @10
-    @8 := [move (@9); 1 : usize]
+    @8 := [move (@9)]
     drop @9
     @7 := &@8
     @6 := &*(@7)

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -49,7 +49,7 @@ fn test_crate::foo()
     let @21: alloc::string::String; // anonymous local
     let @22: &'_ (alloc::string::String); // anonymous local
 
-    array@1 := [const (0 : i32), const (0 : i32); 2 : usize]
+    array@1 := [const (0 : i32), const (0 : i32)]
     @fake_read(array@1)
     @4 := &array@1
     @3 := &*(@4)

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -34,30 +34,33 @@ fn test_crate::main()
     let slice@1: &'_ (Slice<i32>); // local
     let @2: &'_ (Array<i32, 1 : usize>); // anonymous local
     let @3: &'_ (Array<i32, 1 : usize>); // anonymous local
-    let @4: Array<i32, 1 : usize>; // anonymous local
-    let @5: core::option::Option<&'_ (i32)>[core::marker::Sized<&'_ (i32)>]; // anonymous local
-    let @6: &'_ mut (core::slice::iter::Iter<'_, i32>[core::marker::Sized<i32>]); // anonymous local
-    let @7: core::slice::iter::Iter<'_, i32>[core::marker::Sized<i32>]; // anonymous local
-    let @8: &'_ (Slice<i32>); // anonymous local
+    let @4: core::option::Option<&'_ (i32)>[core::marker::Sized<&'_ (i32)>]; // anonymous local
+    let @5: &'_ mut (core::slice::iter::Iter<'_, i32>[core::marker::Sized<i32>]); // anonymous local
+    let @6: core::slice::iter::Iter<'_, i32>[core::marker::Sized<i32>]; // anonymous local
+    let @7: &'_ (Slice<i32>); // anonymous local
+    let @8: &'_ (Array<i32, 1 : usize>); // anonymous local
+    let @9: Array<i32, 1 : usize>; // anonymous local
+    let @10: &'_ (Array<i32, 1 : usize>); // anonymous local
 
-    @4 := [const (0 : i32)]
-    @3 := &@4
+    @9 := [const (0 : i32)]
+    @10 := &@9
+    @8 := move (@10)
+    @3 := &*(@8)
     @2 := &*(@3)
     slice@1 := @ArrayToSliceShared<'_, i32, 1 : usize>(move (@2))
     drop @2
     @fake_read(slice@1)
     drop @3
-    @8 := &*(slice@1)
-    @7 := core::slice::{Slice<T>}::iter<'_, i32>[core::marker::Sized<i32>](move (@8))
-    @6 := &two-phase-mut @7
-    drop @8
-    @5 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next<'_, '_, i32>[core::marker::Sized<i32>](move (@6))
-    drop @6
-    @fake_read(@5)
+    @7 := &*(slice@1)
+    @6 := core::slice::{Slice<T>}::iter<'_, i32>[core::marker::Sized<i32>](move (@7))
+    @5 := &two-phase-mut @6
     drop @7
+    @4 := core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}#182::next<'_, '_, i32>[core::marker::Sized<i32>](move (@5))
     drop @5
-    @0 := ()
+    @fake_read(@4)
+    drop @6
     drop @4
+    @0 := ()
     drop slice@1
     @0 := ()
     return

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -40,7 +40,7 @@ fn test_crate::main()
     let @7: core::slice::iter::Iter<'_, i32>[core::marker::Sized<i32>]; // anonymous local
     let @8: &'_ (Slice<i32>); // anonymous local
 
-    @4 := [const (0 : i32); 1 : usize]
+    @4 := [const (0 : i32)]
     @3 := &@4
     @2 := &*(@3)
     slice@1 := @ArrayToSliceShared<'_, i32, 1 : usize>(move (@2))


### PR DESCRIPTION
This is a big step towards #543. This was enabled in large part by the recent [MIR constants rework in hax](https://github.com/cryspen/hax/pull/1337).