### PR TITLE
feat: add `charon rustc [charon options] -- [rustc options]`

### DIFF
--- a/charon/src/bin/charon/cli_rework/mod.rs
+++ b/charon/src/bin/charon/cli_rework/mod.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 /// `charon cargo`
 mod cargo;
+/// `charon rustc`
+mod rustc;
 
 #[derive(Debug, Parser)]
 #[clap(name = "Charon")]
@@ -21,6 +23,7 @@ struct Cli {
 enum Charon {
     PrettyPrint(PrettyPrintArgs),
     Cargo(cargo::CargoArgs),
+    Rustc(rustc::RustcArgs),
 }
 
 /// Read a llbc or ullbc file and pretty print it.
@@ -46,6 +49,13 @@ pub fn run() -> anyhow::Result<Option<CliOpts>> {
         Some(Charon::Cargo(subcmd_cargo)) => {
             let mut options = subcmd_cargo.opts;
             options.cargo_args = subcmd_cargo.cargo;
+            Ok(Some(options))
+        }
+        Some(Charon::Rustc(subcmd_rustc)) => {
+            let mut options = subcmd_rustc.opts;
+            options.rustc_args = subcmd_rustc.rustc;
+            // invoke charon-driver without cargo
+            options.no_cargo = true;
             Ok(Some(options))
         }
         _ => Ok(Some(cli.opts)),

--- a/charon/src/bin/charon/cli_rework/rustc.rs
+++ b/charon/src/bin/charon/cli_rework/rustc.rs
@@ -1,0 +1,12 @@
+use charon_lib::options::CliOpts;
+
+/// Usage: `charon cargo [charon options] -- [rustc options]`
+#[derive(clap::Args, Debug)]
+pub struct RustcArgs {
+    #[command(flatten)]
+    pub opts: CliOpts,
+
+    /// Args that `rustc` accepts.
+    #[arg(last = true)]
+    pub rustc: Vec<String>,
+}

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -89,16 +89,17 @@ pub fn main() -> Result<()> {
         ExitStatus::default()
     } else if options.no_cargo {
         if !options.cargo_args.is_empty() {
-            bail!("Option `--cargo-arg` is not compatible with `--no-cargo`")
+            bail!("Option `--cargo-arg` is not compatible with `--no-cargo` or `charon rustc`")
         }
 
         // Run just the driver.
         let mut cmd = toolchain::driver_cmd()?;
 
-        for arg in std::mem::take(&mut options.rustc_args) {
-            cmd.arg(arg);
-        }
+        // Extract rustc args and pass as cli args to charon-driver.
+        // `Take` is needed, because charon-driver add options.rustc_args to compiled_args.
+        cmd.args(std::mem::take(&mut options.rustc_args));
 
+        // Pass CHARON_ARGS to charon-driver.
         cmd.env(CHARON_ARGS, serde_json::to_string(&options).unwrap());
 
         // Make sure the build target is explicitly set. This is needed to detect which crates are

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -95,17 +95,26 @@ pub fn main() -> Result<()> {
         // Run just the driver.
         let mut cmd = toolchain::driver_cmd()?;
 
+        // Detect if an arg if specified in cargo_args, like in `-- arg` or `--rustc-args=arg`.
+        let is_specified = |arg| {
+            let mut iter = options.rustc_args.iter();
+            iter.any(|input| input.starts_with(arg))
+        };
+
+        // Don't set target if it is specified by user.
+        if !is_specified("--target") {
+            // Make sure the build target is explicitly set. This is needed to detect which crates are
+            // proc-macro/build-script in `charon-driver`.
+            cmd.arg("--target");
+            cmd.arg(host);
+        }
+
         // Extract rustc args and pass as cli args to charon-driver.
         // `Take` is needed, because charon-driver add options.rustc_args to compiled_args.
         cmd.args(std::mem::take(&mut options.rustc_args));
 
         // Pass CHARON_ARGS to charon-driver.
         cmd.env(CHARON_ARGS, serde_json::to_string(&options).unwrap());
-
-        // Make sure the build target is explicitly set. This is needed to detect which crates are
-        // proc-macro/build-script in `charon-driver`.
-        cmd.arg("--target");
-        cmd.arg(host);
 
         if let Some(input_file) = &options.input_file {
             cmd.arg(input_file);

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -181,3 +181,26 @@ fn charon_cargo_target() -> Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn charon_rustc() -> Result<()> {
+    let path = "tests/cargo/workspace/crate1/src/lib.rs";
+    let args = &["rustc", "--print-llbc", "--", "--crate-type=lib", path];
+
+    // Call rustc without specifying --crate-name, so default to lib as the name.
+    let fn_ = "pub fn lib::random_number";
+
+    charon(args, ".", |stdout, cmd| {
+        ensure!(
+            stdout.contains(fn_),
+            "Output of `{cmd}` is:\n{stdout:?}\nIt doesn't contain {fn_:?}."
+        );
+
+        let count_fn = stdout.matches("fn").count();
+        ensure!(
+            count_fn == 1,
+            "Output of `{cmd}` is:\n{stdout:?}\nThe count of `fn` should only be one."
+        );
+        Ok(())
+    })
+}

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -223,12 +223,11 @@ fn charon_rust_target() -> Result<()> {
         "--target",
         target,
     ];
-    // FIXME: due to charon passes target anyway, it conflicts with `-- --target`.
-    // error: Option 'target' given more than once. ERROR Code failed to compile
     let [stdout, rustc_cmd] = charon(args, ".", |stdout, cmd| Ok([stdout, cmd]))?;
 
     let dir = "tests/cargo/multi-targets";
     let args = &["cargo", "--print-llbc", "--", "--target", target];
+    // Suppose outputs from cargo and rustc queries are the same...
     charon(args, dir, |desired, cargo_cmd| {
         ensure!(
             desired == stdout,


### PR DESCRIPTION
cc #582 

```bash
$ charon --help
Usage: charon [OPTIONS] [COMMAND]

Commands:
  pretty-print  Read a llbc or ullbc file and pretty print it
  cargo         Usage: `charon cargo [charon options] -- [cargo build options]`
  rustc         Usage: `charon cargo [charon options] -- [rustc options]`
  help          Print this message or the help of the given subcommand(s)

Options:
      --ullbc
          Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
...
```

```bash
$ charon rustc --help
Usage: `charon cargo [charon options] -- [rustc options]`

Usage: charon rustc [OPTIONS] [-- <RUSTC>...]

Arguments:
  [RUSTC]...  Args that `rustc` accepts

Options:
      --ullbc
          Extract the unstructured LLBC (i.e., don't reconstruct the control-flow)
...
```

```bash
$ charon rustc -- --help
Usage: rustc [OPTIONS] INPUT

Options:
    -h, --help          Display this message
        --cfg SPEC      Configure the compilation environment.
                        SPEC supports the syntax `NAME[="VALUE"]`.
        --check-cfg SPEC
                        Provide list of expected cfgs for checking
    -L [KIND=]PATH      Add a directory to the library search path. The
                        optional KIND can be one of dependency, crate, native,
                        framework, or all (the default).
...
```