### PR TITLE
Rework rustc-args with Config

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -136,6 +136,7 @@ impl Callbacks for CharonCallbacks {
 
         // Mutate other fields in Config
         config::disabled_mir_passes(config);
+        config::release_mode(config);
         config::no_codegen(config);
     }
 

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+mod config;
+
 /// The callbacks for Charon
 pub struct CharonCallbacks {
     pub options: options::CliOpts,
@@ -131,6 +133,9 @@ impl Callbacks for CharonCallbacks {
                 }
             }
         });
+
+        // Mutate other fields in Config
+        config::disabled_mir_passes(config);
     }
 
     /// The MIR is modified in place: borrow-checking requires the "promoted" MIR, which causes the

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -136,6 +136,7 @@ impl Callbacks for CharonCallbacks {
 
         // Mutate other fields in Config
         config::disabled_mir_passes(config);
+        config::no_codegen(config);
     }
 
     /// The MIR is modified in place: borrow-checking requires the "promoted" MIR, which causes the

--- a/charon/src/bin/charon-driver/driver/config.rs
+++ b/charon/src/bin/charon-driver/driver/config.rs
@@ -1,0 +1,55 @@
+//! Mutate the compiler [`Config`], like through
+//! * release / codegen flags
+//! * disabled_mir_passes
+//!
+//! [`Config`]: https://aeneasverif.github.io/charon/rustc/rustc_interface/interface/struct.Config.html
+
+use rustc_interface::Config;
+
+/// Disable all these mir passes.
+pub fn disabled_mir_passes(config: &mut Config) {
+    let disabled_mir_passes = [
+        "AfterConstProp",
+        "AfterGVN",
+        "AfterUnreachableEnumBranching)",
+        "BeforeConstProp",
+        "CheckAlignment",
+        "CopyProp",
+        "CriticalCallEdges",
+        "DataflowConstProp",
+        "DeduplicateBlocks",
+        "DestinationPropagation",
+        "EarlyOtherwiseBranch",
+        "EnumSizeOpt",
+        "GVN",
+        "Initial",
+        "Inline",
+        "InstSimplify",
+        "JumpThreading",
+        "LowerSliceLenCalls",
+        "MatchBranchSimplification",
+        "MentionedItems",
+        "MultipleReturnTerminators",
+        "ReferencePropagation",
+        "RemoveNoopLandingPads",
+        "RemoveStorageMarkers",
+        "RemoveUnneededDrops",
+        "RemoveZsts",
+        "RenameReturnPlace",
+        "ReorderBasicBlocks",
+        "ReorderLocals",
+        "ScalarReplacementOfAggregates",
+        "SimplifyComparisonIntegral",
+        "SimplifyLocals",
+        "SingleUseConsts",
+        "UnreachableEnumBranching",
+        "UnreachablePropagation",
+    ];
+    for pass in disabled_mir_passes {
+        config
+            .opts
+            .unstable_opts
+            .mir_enable_passes
+            .push((pass.to_owned(), false));
+    }
+}

--- a/charon/src/bin/charon-driver/driver/config.rs
+++ b/charon/src/bin/charon-driver/driver/config.rs
@@ -5,7 +5,7 @@
 //! [`Config`]: https://aeneasverif.github.io/charon/rustc/rustc_interface/interface/struct.Config.html
 
 use rustc_interface::Config;
-use rustc_session::config::{OutputType, OutputTypes};
+use rustc_session::config::{OutputType, OutputTypes, Polonius};
 
 /// Disable all these mir passes.
 pub fn disabled_mir_passes(config: &mut Config) {
@@ -77,4 +77,11 @@ pub fn release_mode(config: &mut Config) {
     cg.opt_level = "3".into();
     cg.overflow_checks = Some(false);
     config.opts.debug_assertions = false;
+}
+
+/// -Zpolonius
+pub fn polonius(config: &mut Config, enable: bool) {
+    if enable {
+        config.opts.unstable_opts.polonius = Polonius::Legacy;
+    }
 }

--- a/charon/src/bin/charon-driver/driver/config.rs
+++ b/charon/src/bin/charon-driver/driver/config.rs
@@ -67,3 +67,14 @@ pub fn no_codegen(config: &mut Config) {
     out_types.push((OutputType::Metadata, None));
     *opt_output_types = OutputTypes::new(&out_types);
 }
+
+/// Always compile in release mode: in effect, we want to analyze the released
+/// code. Also, rustc inserts a lot of dynamic checks in debug mode, that we
+/// have to clean. Full list of `--release` flags:
+/// https://doc.rust-lang.org/cargo/reference/profiles.html#release
+pub fn release_mode(config: &mut Config) {
+    let cg = &mut config.opts.cg;
+    cg.opt_level = "3".into();
+    cg.overflow_checks = Some(false);
+    config.opts.debug_assertions = false;
+}

--- a/charon/src/bin/charon-driver/driver/config.rs
+++ b/charon/src/bin/charon-driver/driver/config.rs
@@ -5,6 +5,7 @@
 //! [`Config`]: https://aeneasverif.github.io/charon/rustc/rustc_interface/interface/struct.Config.html
 
 use rustc_interface::Config;
+use rustc_session::config::{OutputType, OutputTypes};
 
 /// Disable all these mir passes.
 pub fn disabled_mir_passes(config: &mut Config) {
@@ -52,4 +53,17 @@ pub fn disabled_mir_passes(config: &mut Config) {
             .mir_enable_passes
             .push((pass.to_owned(), false));
     }
+}
+
+/// Don't even try to codegen. This avoids errors due to checking if the output filename is
+/// available (despite the fact that we won't emit it because we stop compilation early).
+pub fn no_codegen(config: &mut Config) {
+    config.opts.unstable_opts.no_codegen = true;
+
+    // i.e. --emit=metadata
+    let opt_output_types = &mut config.opts.output_types;
+    let mut out_types = vec![];
+    out_types.extend(opt_output_types.iter().map(|(&k, v)| (k, v.clone())));
+    out_types.push((OutputType::Metadata, None));
+    *opt_output_types = OutputTypes::new(&out_types);
 }

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -65,10 +65,6 @@ fn main() {
         Err(_) => Default::default(),
     };
 
-    if options.use_polonius {
-        compiler_args.push("-Zpolonius".to_string());
-    }
-
     // Cargo calls the driver twice. The first call to the driver is with "--crate-name ___" and no
     // source file, for Cargo to retrieve some information about the crate.
     let is_dry_run = arg_values(&origin_args, "--crate-name")
@@ -93,7 +89,7 @@ fn main() {
     if is_dry_run || is_workspace_dependency || !is_target {
         trace!("Skipping charon; running compiler normally instead.");
         // In this case we run the compiler normally.
-        RunCompilerNormallyCallbacks
+        RunCompilerNormallyCallbacks::new(options)
             .run_compiler(compiler_args)
             .unwrap();
         return;

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -99,14 +99,6 @@ fn main() {
         return;
     }
 
-    // Always compile in release mode: in effect, we want to analyze the released
-    // code. Also, rustc inserts a lot of dynamic checks in debug mode, that we
-    // have to clean. Full list of `--release` flags:
-    // https://doc.rust-lang.org/cargo/reference/profiles.html#release
-    compiler_args.push("-Copt-level=3".to_string());
-    compiler_args.push("-Coverflow-checks=false".to_string());
-    compiler_args.push("-Cdebug-assertions=false".to_string());
-
     for extra_flag in options.rustc_args.iter().cloned() {
         compiler_args.push(extra_flag);
     }

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -31,7 +31,6 @@ mod translate;
 
 use crate::driver::{arg_values, CharonCallbacks, CharonFailure, RunCompilerNormallyCallbacks};
 use charon_lib::{logger, options};
-use itertools::Itertools;
 use std::{env, panic};
 
 fn main() {
@@ -116,52 +115,6 @@ fn main() {
     for extra_flag in options.rustc_args.iter().cloned() {
         compiler_args.push(extra_flag);
     }
-
-    let disabled_mir_passes = [
-        "AfterConstProp",
-        "AfterGVN",
-        "AfterUnreachableEnumBranching)",
-        "BeforeConstProp",
-        "CheckAlignment",
-        "CopyProp",
-        "CriticalCallEdges",
-        "DataflowConstProp",
-        "DeduplicateBlocks",
-        "DestinationPropagation",
-        "EarlyOtherwiseBranch",
-        "EnumSizeOpt",
-        "GVN",
-        "Initial",
-        "Inline",
-        "InstSimplify",
-        "JumpThreading",
-        "LowerSliceLenCalls",
-        "MatchBranchSimplification",
-        "MentionedItems",
-        "MultipleReturnTerminators",
-        "ReferencePropagation",
-        "RemoveNoopLandingPads",
-        "RemoveStorageMarkers",
-        "RemoveUnneededDrops",
-        "RemoveZsts",
-        "RenameReturnPlace",
-        "ReorderBasicBlocks",
-        "ReorderLocals",
-        "ScalarReplacementOfAggregates",
-        "SimplifyComparisonIntegral",
-        "SimplifyLocals",
-        "SingleUseConsts",
-        "UnreachableEnumBranching",
-        "UnreachablePropagation",
-    ];
-    // Disable all these mir passes.
-    compiler_args.push(format!(
-        "-Zmir-enable-passes={}",
-        disabled_mir_passes
-            .iter()
-            .map(|p| format!("-{p}"))
-            .format(",")
-    ));
 
     trace!("Compiler arguments: {:?}", compiler_args);
 

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -99,11 +99,6 @@ fn main() {
         return;
     }
 
-    // Don't even try to codegen. This avoids errors due to checking if the output filename is
-    // available (despite the fact that we won't emit it because we stop compilation early).
-    compiler_args.push("-Zno-codegen".to_string());
-    compiler_args.push("--emit=metadata".to_string());
-
     // Always compile in release mode: in effect, we want to analyze the released
     // code. Also, rustc inserts a lot of dynamic checks in debug mode, that we
     // have to clean. Full list of `--release` flags:

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -249,11 +249,7 @@ fn handle_multi_trailing_rs_args() {
         "--crate-name=arrays.rs",
         file,
     ];
-    let err = charon(args, "tests/ui", |stdout, _| {
-        println!("stdout={stdout}");
-        Ok(())
-    })
-    .unwrap_err();
+    let err = charon(args, "tests/ui", |_, _| Ok(())).unwrap_err();
     let err = format!("{err:?}");
     assert!(
         err.contains("invalid character `'.'` in crate name"),

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -260,3 +260,27 @@ fn handle_multi_trailing_rs_args() {
         "{err}"
     );
 }
+
+#[test]
+fn rustc_input_duplicated() {
+    let input = "arrays.rs";
+    let args = &["rustc", "--print-llbc", "--input", input, "--", input];
+    let err = charon(args, "tests/ui", |_, _| Ok(())).unwrap_err();
+    let pat = "error: multiple input filenames provided (first two filenames are `arrays.rs` and `arrays.rs`)";
+    let err = format!("{err:?}");
+    assert!(err.contains(pat), "{err}");
+}
+
+#[test]
+fn charon_input() -> Result<()> {
+    let input = "arrays.rs";
+    let args = &[
+        "rustc",
+        "--print-llbc",
+        "--input",
+        input,
+        "--",
+        "--crate-type=lib",
+    ];
+    charon(args, "tests/ui", |_, _| Ok(()))
+}


### PR DESCRIPTION
close https://github.com/AeneasVerif/charon/issues/587


This PR replaces  string-based argument manipulation of rustc args by functions from `config` submodule where a set of  callbacks takes `&mut Config` to be applied to `<CharonCallbacks as Callbacks>::config`.

