### PR TITLE
Remove --crate cli arg and cleanup weird --input handling

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.71"
+let supported_charon_version = "0.1.72"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -88,7 +88,6 @@ and gtranslated_crate_of_json
     | `Assoc
         [
           ("crate_name", name);
-          ("real_crate_name", _);
           ("options", options);
           ("all_ids", _);
           ("item_names", _);

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -373,10 +373,6 @@ and cli_options = {
   mir_promoted : bool;  (** Extract the promoted MIR instead of the built MIR *)
   mir_optimized : bool;
       (** Extract the optimized MIR instead of the built MIR *)
-  crate_name : string option;
-      (** Provide a custom name for the compiled crate (ignore the name computed
-        by Cargo)
-     *)
   input_file : path_buf option;
       (** The input file (the entry point of the crate to extract).
         This is needed if you want to define a custom entry point (to only

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1607,7 +1607,6 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("bin", bin);
           ("mir_promoted", mir_promoted);
           ("mir_optimized", mir_optimized);
-          ("crate_name", crate_name);
           ("input_file", input_file);
           ("read_llbc", read_llbc);
           ("dest_dir", dest_dir);
@@ -1639,7 +1638,6 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* bin = option_of_json string_of_json ctx bin in
         let* mir_promoted = bool_of_json ctx mir_promoted in
         let* mir_optimized = bool_of_json ctx mir_optimized in
-        let* crate_name = option_of_json string_of_json ctx crate_name in
         let* input_file = option_of_json path_buf_of_json ctx input_file in
         let* read_llbc = option_of_json path_buf_of_json ctx read_llbc in
         let* dest_dir = option_of_json path_buf_of_json ctx dest_dir in
@@ -1674,7 +1672,6 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              bin;
              mir_promoted;
              mir_optimized;
-             crate_name;
              input_file;
              read_llbc;
              dest_dir;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.71"
+version = "0.1.72"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.71"
+version = "0.1.72"
 authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -99,13 +99,9 @@ pub enum AnyTransItemMut<'ctx> {
 /// The data of a translated crate.
 #[derive(Default, Clone, Drive, DriveMut, Serialize, Deserialize)]
 pub struct TranslatedCrate {
-    /// The name that the user requested for the crate. This may differ from what rustc reports as
-    /// the name of the crate.
+    /// The name of the crate.
     #[drive(skip)]
     pub crate_name: String,
-    /// The name of the crate according to rustc.
-    #[drive(skip)]
-    pub real_crate_name: String,
 
     /// The options used when calling Charon. It is useful for the applications
     /// which consumed the serialized code, to check that Charon was called with

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -210,38 +210,6 @@ pub fn arg_values<'a, T: Deref<Target = str>>(
     }
 }
 
-/// Given a list of arguments, return the index of the source rust file.
-/// This works by looking for the first argument matching *.rs, while
-/// checking there is at most one such argument.
-///
-/// Note that the driver is sometimes called without a source, for Cargo to
-/// retrieve information about the crate for instance.
-pub fn get_args_source_index<T: Deref<Target = str>>(args: &[T]) -> Option<usize> {
-    let indices: Vec<usize> = args
-        .iter()
-        .enumerate()
-        .filter_map(|(i, s)| if s.ends_with(".rs") { Some(i) } else { None })
-        .collect();
-    assert!(indices.len() <= 1);
-    if indices.len() == 1 {
-        Some(indices[0])
-    } else {
-        None
-    }
-}
-
-/// Given a list of arguments, return the index of the crate name
-pub fn get_args_crate_index<T: Deref<Target = str>>(args: &[T]) -> Option<usize> {
-    args.iter()
-        .enumerate()
-        .find(|(_i, s)| Deref::deref(*s) == "--crate-name")
-        .map(|(i, _)| {
-            assert!(i + 1 < args.len()); // Sanity check
-                                         // The argument giving the crate name is the next one
-            i + 1
-        })
-}
-
 /// Calculate the list of passes we will run on the crate before outputting it.
 pub fn transformation_passes(options: &CliOpts) -> Vec<Pass> {
     let mut passes: Vec<Pass> = vec![];

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -240,13 +240,8 @@ pub fn translate<'tcx, 'ctx>(
     let crate_def_id: hax::DefId = rustc_span::def_id::CRATE_DEF_ID
         .to_def_id()
         .sinto(&hax_state);
-    let real_crate_name = crate_def_id.krate.clone();
-    let requested_crate_name: String = options
-        .crate_name
-        .as_ref()
-        .unwrap_or(&real_crate_name)
-        .clone();
-    trace!("# Crate: {}", requested_crate_name);
+    let crate_name = crate_def_id.krate.clone();
+    trace!("# Crate: {}", crate_name);
 
     let mut error_ctx = ErrorCtx::new(!options.abort_on_error, options.error_on_warnings);
     let translate_options = TranslateOptions::new(&mut error_ctx, options);
@@ -257,9 +252,8 @@ pub fn translate<'tcx, 'ctx>(
         options: translate_options,
         errors: RefCell::new(error_ctx),
         translated: TranslatedCrate {
-            crate_name: requested_crate_name,
+            crate_name,
             options: options.clone(),
-            real_crate_name,
             ..TranslatedCrate::default()
         },
         id_map: Default::default(),

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -129,6 +129,9 @@ pub fn main() -> Result<()> {
             options = toml.apply(options);
             options.validate();
         }
+        if options.input_file.is_some() {
+            panic!("Option `--input` is only available for `charon rustc`");
+        }
         let mut cmd = toolchain::in_toolchain("cargo")?;
 
         // Tell cargo to use the driver for all the crates in the workspace. There's no option for

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -173,7 +173,7 @@ impl PatElem {
             ) => {
                 // `crate` is a special keyword that referes to the current crate.
                 let same_ident =
-                    pat_ident == ident || (pat_ident == "crate" && ident == &ctx.real_crate_name);
+                    pat_ident == ident || (pat_ident == "crate" && ident == &ctx.crate_name);
                 same_ident && PatTy::matches_generics(ctx, generics, args)
             }
             (PatElem::Impl(_pat), PathElem::Impl(ImplElem::Ty(..), _)) => {

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -41,11 +41,6 @@ pub struct CliOpts {
     #[clap(long = "mir_optimized")]
     #[serde(default)]
     pub mir_optimized: bool,
-    /// Provide a custom name for the compiled crate (ignore the name computed
-    /// by Cargo)
-    #[clap(long = "crate")]
-    #[serde(default)]
-    pub crate_name: Option<String>,
     /// The input file (the entry point of the crate to extract).
     /// This is needed if you want to define a custom entry point (to only
     /// extract part of a crate for instance).

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -238,3 +238,28 @@ fn charon_rust_target() -> Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn handle_multi_trailing_rs_args() {
+    let file = "arrays.rs";
+    // FIXME: charon fails to handle multiple rustc args that trail with .rs
+    // cc https://github.com/AeneasVerif/charon/issues/403#issuecomment-2729549999
+    // But it will be fixed soon.
+    let args = &[
+        "rustc",
+        "--print-llbc",
+        "--",
+        "--crate-name=arrays.rs",
+        file,
+    ];
+    let err = charon(args, "tests/ui", |stdout, _| {
+        println!("stdout={stdout}");
+        Ok(())
+    })
+    .unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("driver.rs:225:5:\\nassertion failed: indices.len() <= 1"),
+        "{err}"
+    );
+}

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -242,9 +242,6 @@ fn charon_rust_target() -> Result<()> {
 #[test]
 fn handle_multi_trailing_rs_args() {
     let file = "arrays.rs";
-    // FIXME: charon fails to handle multiple rustc args that trail with .rs
-    // cc https://github.com/AeneasVerif/charon/issues/403#issuecomment-2729549999
-    // But it will be fixed soon.
     let args = &[
         "rustc",
         "--print-llbc",
@@ -259,7 +256,7 @@ fn handle_multi_trailing_rs_args() {
     .unwrap_err();
     let err = format!("{err:?}");
     assert!(
-        err.contains("driver.rs:225:5:\\nassertion failed: indices.len() <= 1"),
+        err.contains("invalid character `'.'` in crate name"),
         "{err}"
     );
 }

--- a/charon/tests/ui.rs
+++ b/charon/tests/ui.rs
@@ -182,7 +182,7 @@ fn perform_test(test_case: &Case, action: Action) -> anyhow::Result<()> {
 
     cmd.arg("--error-on-warnings");
     cmd.arg("--print-llbc");
-    cmd.arg("--crate=test_crate");
+    cmd.arg("--rustc-flag=--crate-name=test_crate");
     cmd.arg("--rustc-flag=--crate-type=rlib");
     cmd.arg("--rustc-flag=--allow=unused"); // Removes noise
     cmd.arg("--input");


### PR DESCRIPTION
This was left over from a long time ago, before the `charon`/`charon-driver` split was clear.

Fixes https://github.com/AeneasVerif/charon/issues/403.