### PR TITLE
Add `TyKind::Error` to avoid mismatched generics

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.72"
+let supported_charon_version = "0.1.73"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -986,6 +986,7 @@ and ty_to_pattern_aux (ctx : 'fun_body ctx) (c : to_pat_config)
   | TRawPtr (ty, RShared) -> ERawPtr (Not, ty_to_pattern_aux ctx c m ty)
   | TDynTrait _ -> raise (Failure "Unimplemented: DynTrait")
   | TNever -> raise (Failure "Unimplemented: Never")
+  | TError _ -> EVar None
 
 and trait_ref_item_with_generics_to_pattern (ctx : 'fun_body ctx)
     (c : to_pat_config) (m : constraints) (trait_ref : T.trait_ref)

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -247,6 +247,7 @@ and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
       in
       inputs ^ ty_to_string env output
   | TDynTrait _ -> "dyn (TODO)"
+  | TError msg -> "type_error (\"" ^ msg ^ "\")"
 
 and params_to_string (env : 'a fmt_env) (is_tuple : bool)
     (generics : generic_args) : string =
@@ -479,7 +480,7 @@ let type_decl_to_string (env : 'a fmt_env) (def : type_decl) : string =
       else "union " ^ name ^ params ^ clauses ^ "{}"
   | Alias ty -> "type " ^ name ^ params ^ clauses ^ " = " ^ ty_to_string env ty
   | Opaque -> "opaque type " ^ name ^ params ^ clauses
-  | TError err -> "error(\"" ^ err ^ "\")"
+  | TDeclError err -> "error(\"" ^ err ^ "\")"
 
 let adt_variant_to_string (env : 'a fmt_env) (def_id : TypeDeclId.id)
     (variant_id : VariantId.id) : string =

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -361,7 +361,7 @@ let type_decl_get_instantiated_variants_fields_types (def : type_decl)
     | Enum variants ->
         List.mapi (fun i v -> (Some (VariantId.of_int i), v.fields)) variants
     | Struct fields | Union fields -> [ (None, fields) ]
-    | Alias _ | Opaque | TError _ ->
+    | Alias _ | Opaque | TDeclError _ ->
         raise
           (Failure
              ("Can't retrieve the variants of non-adt type: "

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1279,7 +1279,7 @@ and type_decl_kind_of_json (ctx : of_json_ctx) (js : json) :
         Ok (Alias alias)
     | `Assoc [ ("Error", error) ] ->
         let* error = string_of_json ctx error in
-        Ok (TError error)
+        Ok (TDeclError error)
     | _ -> Error "")
 
 and variant_of_json (ctx : of_json_ctx) (js : json) : (variant, string) result =
@@ -1432,6 +1432,9 @@ and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
             ctx arrow
         in
         Ok (TArrow arrow)
+    | `Assoc [ ("Error", error) ] ->
+        let* error = string_of_json ctx error in
+        Ok (TError error)
     | _ -> Error "")
 
 and builtin_ty_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -427,6 +427,7 @@ and ty =
           arrow types can only contain generic lifetime parameters
           (no generic types), no predicates, etc.
        *)
+  | TError of string  (** A type that could not be computed or was incorrect. *)
 
 (** Builtin types identifiers.
 
@@ -675,7 +676,7 @@ and type_decl_kind =
       (** An alias to another type. This only shows up in the top-level list of items, as rustc
           inlines uses of type aliases everywhere else.
        *)
-  | TError of string
+  | TDeclError of string
       (** Used if an error happened during the extraction, and we don't panic
           on error.
        *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.72"
+version = "0.1.73"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.72"
+version = "0.1.73"
 authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -84,7 +84,7 @@ impl ProjectionElem {
                         args.types.get(TypeVarId::new(0)).unwrap().clone()
                     }
                     Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(_)
-                    | Arrow(..) => {
+                    | Arrow(..) | Error(..) => {
                         // Type error
                         return Err(());
                     }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -384,7 +384,7 @@ pub enum TypeDeclKind {
     Alias(Ty),
     /// Used if an error happened during the extraction, and we don't panic
     /// on error.
-    #[charon::rename("TError")]
+    #[charon::rename("TDeclError")]
     #[drive(skip)]
     Error(String),
 }
@@ -698,6 +698,9 @@ pub enum TyKind {
     /// arrow types can only contain generic lifetime parameters
     /// (no generic types), no predicates, etc.
     Arrow(RegionBinder<(Vec<Ty>, Ty)>),
+    /// A type that could not be computed or was incorrect.
+    #[drive(skip)]
+    Error(String),
 }
 
 /// Builtin types identifiers.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,6 +1,8 @@
 //! This file groups everything which is linked to implementations about [crate::types]
 use crate::ast::*;
+use crate::formatter::FmtCtx;
 use crate::ids::Vector;
+use crate::pretty::FmtWithCtx;
 use derive_generic_visitor::*;
 use std::collections::HashSet;
 use std::convert::Infallible;
@@ -377,6 +379,22 @@ impl GenericArgs {
 impl GenericsSource {
     pub fn item<I: Into<AnyTransId>>(id: I) -> Self {
         Self::Item(id.into())
+    }
+
+    /// Return a path that represents the target item.
+    pub fn item_name(&self, translated: &TranslatedCrate, fmt_ctx: &FmtCtx) -> String {
+        match self {
+            GenericsSource::Item(id) => translated.item_name(*id).unwrap().fmt_with_ctx(fmt_ctx),
+            GenericsSource::Method(trait_id, method_name) => format!(
+                "{}::{method_name}",
+                translated
+                    .item_name(*trait_id)
+                    .unwrap()
+                    .fmt_with_ctx(fmt_ctx),
+            ),
+            GenericsSource::Builtin => format!("<built-in>"),
+            GenericsSource::Other => format!("<unknown>"),
+        }
     }
 }
 

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -109,7 +109,8 @@ impl Pattern {
             | TyKind::RawPtr(..)
             | TyKind::TraitType(..)
             | TyKind::DynTrait(..)
-            | TyKind::Arrow(..) => false,
+            | TyKind::Arrow(..)
+            | TyKind::Error(..) => false,
         }
     }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1453,6 +1453,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                     format!("fn{regions}({inputs}) -> {output}")
                 }
             }
+            TyKind::Error(msg) => format!("type_error(\"{msg}\")"),
         }
     }
 }

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -1007,24 +1007,7 @@ impl UpdateItemBody<'_> {
                     path = path.on_tref(&tref);
                 }
                 let fmt_ctx = &self.ctx.into_fmt();
-                let item_name = match &args.target {
-                    GenericsSource::Item(id) => self
-                        .ctx
-                        .translated
-                        .item_name(*id)
-                        .unwrap()
-                        .fmt_with_ctx(fmt_ctx),
-                    GenericsSource::Method(trait_id, method_name) => format!(
-                        "{}::{method_name}",
-                        self.ctx
-                            .translated
-                            .item_name(*trait_id)
-                            .unwrap()
-                            .fmt_with_ctx(fmt_ctx),
-                    ),
-                    GenericsSource::Builtin => format!("<built-in>"),
-                    GenericsSource::Other => format!("<unknown>"),
-                };
+                let item_name = args.target.item_name(&self.ctx.translated, fmt_ctx);
                 register_error!(
                     self.ctx,
                     self.span,

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -999,8 +999,8 @@ impl UpdateItemBody<'_> {
                     &args.trait_refs[clause_id].kind
                 }
             };
-            if let Some(ty) = self.lookup_path_on_trait_ref(&path, &base_tref) {
-                args.types.push(ty.clone());
+            let ty = if let Some(ty) = self.lookup_path_on_trait_ref(&path, &base_tref) {
+                ty.clone()
             } else {
                 let mut path = path;
                 if let Some(tref) = base_tref.to_path() {
@@ -1020,7 +1020,9 @@ impl UpdateItemBody<'_> {
                         .map(|(path, ty)| format!("  - {path} = {}", ty.fmt_with_ctx(fmt_ctx)))
                         .join("\n"),
                 );
-            }
+                TyKind::Error(format!("Can't compute {path}")).into_ty()
+            };
+            args.types.push(ty);
         }
     }
 

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.out
@@ -7,26 +7,4 @@ error: Could not compute the value of Self::Clause1::Clause0::Clause0::Output ne
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
 
-error: Found inconsistent generics after transformations:
-       Mismatched type generics:
-       expected: [Self, Args, Self_Output]
-            got: [Self_Foo, ()]
-       Visitor stack:
-         charon_lib::ast::types::GenericArgs
-         charon_lib::ast::types::TraitDeclRef
-         charon_lib::ast::types::RegionBinder<charon_lib::ast::types::TraitDeclRef>
-         charon_lib::ast::types::TraitRef
-         charon_lib::ast::types::TyKind
-         charon_lib::ast::types::Ty
-         charon_lib::ast::types::FunSig
-         charon_lib::ast::gast::FunDecl
-       Binding stack (depth 2):
-         0: 
-         1: <'_0, Self, Self_Foo>
- --> tests/ui/simple/assoc-type-with-fn-bound.rs:9:5
-  |
-9 |     fn call(&self) -> <Self::Foo as FnOnce<()>>::Output;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-
-ERROR Charon failed to translate this code (2 errors)
+ERROR Charon failed to translate this code (1 errors)

--- a/docs/what_charon_does_for_you.md
+++ b/docs/what_charon_does_for_you.md
@@ -11,7 +11,7 @@ TODO: explain each item
 - Reconstruct control-flow;
 - Hide the distinction between early- and late-bound lifetime variables;
 - Make non-overriden default methods in impl blocks appear as normal methods;
-- `--expand-associated-types` transforms associated types into type parameters so you can ignore
+- `--remove-associated-types` transforms associated types into type parameters so you can ignore
   their existence in the majority of cases;
 - Handle trait method implementations that have a more general signature than as declared in the trait (WIP: https://github.com/AeneasVerif/charon/issues/513);
 - Represent closures as normal structs that implement the `Fn*` traits (WIP: https://github.com/AeneasVerif/charon/issues/194);


### PR DESCRIPTION
This is much better than emitting code with incorrect generics and asking the check_generics pass to catch it. We can at least emit well-formed code.