### PR TITLE
Fix error when the output binary name is taken

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -42,13 +42,8 @@ fn set_mir_options(config: &mut Config) {
 /// available (despite the fact that we won't emit it because we stop compilation early).
 fn set_no_codegen(config: &mut Config) {
     config.opts.unstable_opts.no_codegen = true;
-
-    // i.e. --emit=metadata
-    let opt_output_types = &mut config.opts.output_types;
-    let mut out_types = vec![];
-    out_types.extend(opt_output_types.iter().map(|(&k, v)| (k, v.clone())));
-    out_types.push((OutputType::Metadata, None));
-    *opt_output_types = OutputTypes::new(&out_types);
+    // Only emit metadata.
+    config.opts.output_types = OutputTypes::new(&[(OutputType::Metadata, None)]);
 }
 
 /// Always compile in release mode: in effect, we want to analyze the released

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -287,6 +287,5 @@ fn charon_input() -> Result<()> {
 fn filename_conflict() -> Result<()> {
     let input = "./ui/simple/match-on-float.rs";
     let args = &["rustc", "--no-serialize", "--", input, "--crate-name=ui"];
-    charon(args, "tests", |_, _| Ok(())).unwrap_err();
-    Ok(())
+    charon(args, "tests", |_, _| Ok(()))
 }

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -280,3 +280,13 @@ fn charon_input() -> Result<()> {
     ];
     charon(args, "tests/ui", |_, _| Ok(()))
 }
+
+#[test]
+/// Ensure we don't error if the path where the binary file would go in a normal rustc invocation
+/// is taken. Charon doesn't emit a binary so doesn't care.
+fn filename_conflict() -> Result<()> {
+    let input = "./ui/simple/match-on-float.rs";
+    let args = &["rustc", "--no-serialize", "--", input, "--crate-name=ui"];
+    charon(args, "tests", |_, _| Ok(())).unwrap_err();
+    Ok(())
+}


### PR DESCRIPTION
That was the motivation for `--emit=metadata`, which we incorrectly translated in https://github.com/AeneasVerif/charon/pull/615. The actual desired behavior is to emit _only_ metadata.