### PR TITLE
Translate modules like other items

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -102,16 +102,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
 
     pub(crate) fn translate_item(&mut self, item_src: TransItemSource) {
         let trans_id = self.id_map.get(&item_src).copied();
-        if let Some(trans_id) = trans_id
-            && (self
-                .errors
-                .borrow()
-                .ignored_failed_decls
-                .contains(&trans_id)
-                || self.translated.get_item(trans_id).is_some())
-        {
-            return;
-        }
         let rust_id = item_src.to_def_id();
         self.with_def_id(rust_id, trans_id, |mut ctx| {
             let span = ctx.def_span(rust_id);
@@ -134,9 +124,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                     "Thread panicked when extracting item `{rust_id:?}`."
                 ),
             };
-            if let Some(trans_id) = trans_id {
-                ctx.errors.borrow_mut().ignore_failed_decl(trans_id);
-            }
         })
     }
 
@@ -231,6 +218,7 @@ pub fn translate<'tcx, 'ctx>(
         reverse_id_map: Default::default(),
         file_to_id: Default::default(),
         items_to_translate: Default::default(),
+        processed: Default::default(),
         cached_item_metas: Default::default(),
         cached_names: Default::default(),
     };
@@ -256,7 +244,9 @@ pub fn translate<'tcx, 'ctx>(
     // from Rust ids to translated ids.
     while let Some(item_src) = ctx.items_to_translate.pop_first() {
         trace!("About to translate item: {:?}", item_src);
-        ctx.translate_item(item_src);
+        if ctx.processed.insert(item_src) {
+            ctx.translate_item(item_src);
+        }
     }
 
     // Return the context, dropping the hax state and rustc `tcx`.

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -151,7 +151,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                         Err(())
                     }
                 };
-                // let res = ctx.translate_item_aux(rust_id, trans_id);
                 ctx.translate_stack.pop();
                 res
             };
@@ -187,19 +186,19 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 self.translated.type_decls.set_slot(id, ty);
             }
             AnyTransId::Fun(id) => {
-                let fun_decl = bt_ctx.translate_function(id, rust_id, item_meta, &def)?;
+                let fun_decl = bt_ctx.translate_function(id, item_meta, &def)?;
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             AnyTransId::Global(id) => {
-                let global_decl = bt_ctx.translate_global(id, rust_id, item_meta, &def)?;
+                let global_decl = bt_ctx.translate_global(id, item_meta, &def)?;
                 self.translated.global_decls.set_slot(id, global_decl);
             }
             AnyTransId::TraitDecl(id) => {
-                let trait_decl = bt_ctx.translate_trait_decl(id, rust_id, item_meta, &def)?;
+                let trait_decl = bt_ctx.translate_trait_decl(id, item_meta, &def)?;
                 self.translated.trait_decls.set_slot(id, trait_decl);
             }
             AnyTransId::TraitImpl(id) => {
-                let trait_impl = bt_ctx.translate_trait_impl(id, rust_id, item_meta, &def)?;
+                let trait_impl = bt_ctx.translate_trait_impl(id, item_meta, &def)?;
                 self.translated.trait_impls.set_slot(id, trait_impl);
             }
         }

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -91,20 +91,18 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
     // the opaque modules given as arguments actually exist
     fn register_module(&mut self, item_meta: ItemMeta, def: &hax::FullDef) -> Result<(), Error> {
         let opacity = item_meta.opacity;
-        let explore_inside = !(opacity.is_opaque() || opacity.is_invisible());
+        if !opacity.is_transparent() {
+            return Ok(());
+        }
         match def.kind() {
             FullDefKind::InherentImpl { items, .. } => {
-                if explore_inside {
-                    for (_, item_def) in items {
-                        self.register_module_item(item_def.rust_def_id());
-                    }
+                for (_, item_def) in items {
+                    self.register_module_item(item_def.rust_def_id());
                 }
             }
             FullDefKind::Mod { items, .. } => {
-                if explore_inside {
-                    for def_id in items {
-                        self.register_module_item(def_id.into());
-                    }
+                for def_id in items {
+                    self.register_module_item(def_id.into());
                 }
             }
             FullDefKind::ForeignMod { items, .. } => {

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::TyCtxt;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ord;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::path::{Component, PathBuf};
@@ -100,6 +100,8 @@ pub struct TranslateCtx<'tcx> {
     /// The declarations we came accross and which we haven't translated yet. We keep them sorted
     /// to make the output order a bit more stable.
     pub items_to_translate: BTreeSet<TransItemSource>,
+    /// The declaration we've already processed (successfully or not).
+    pub processed: HashSet<TransItemSource>,
     /// Cache the names to compute them only once each.
     pub cached_names: HashMap<DefId, Name>,
     /// Cache the `ItemMeta`s to compute them only once each.

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -98,10 +98,6 @@ pub struct TranslateCtx<'tcx> {
     /// The declarations we came accross and which we haven't translated yet. We keep them sorted
     /// to make the output order a bit more stable.
     pub items_to_translate: BTreeMap<TransItemSource, AnyTransId>,
-    /// Stack of the translations currently happening. Used to avoid cycles where items need to
-    /// translate themselves transitively.
-    // FIXME: we don't use recursive item translation anywhere.
-    pub translate_stack: Vec<AnyTransId>,
     /// Cache the names to compute them only once each.
     pub cached_names: HashMap<DefId, Name>,
     /// Cache the `ItemMeta`s to compute them only once each.

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -32,6 +32,7 @@ pub(crate) use charon_lib::errors::{
 /// `FunDecl` one (for its initializer function).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, VariantIndexArity)]
 pub enum TransItemSource {
+    Module(DefId),
     Global(DefId),
     TraitDecl(DefId),
     TraitImpl(DefId),
@@ -42,7 +43,8 @@ pub enum TransItemSource {
 impl TransItemSource {
     pub(crate) fn to_def_id(&self) -> DefId {
         match self {
-            TransItemSource::Global(id)
+            TransItemSource::Module(id)
+            | TransItemSource::Global(id)
             | TransItemSource::TraitDecl(id)
             | TransItemSource::TraitImpl(id)
             | TransItemSource::Fun(id)
@@ -769,6 +771,10 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                     }
                     TransItemSource::Fun(_) => {
                         AnyTransId::Fun(self.translated.fun_decls.reserve_slot())
+                    }
+                    // Modules don't have a `AnyTransId`.
+                    TransItemSource::Module(_) => {
+                        panic!("Don't pass a module id to `register_id_no_enqueue`")
                     }
                 };
                 // Add the id to the queue of declarations to translate

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -179,8 +179,6 @@ pub struct ErrorCtx {
 
     /// The ids of the external_declarations for which extraction we encountered errors.
     pub external_decls_with_errors: HashSet<AnyTransId>,
-    /// The ids of the declarations we completely failed to extract and had to ignore.
-    pub ignored_failed_decls: HashSet<AnyTransId>,
     /// Graph of dependencies between items: there is an edge from item `a` to item `b` if `b`
     /// registered the id for `a` during its translation. Because we only use this to report errors
     /// on external items, we only record edges where `a` is an external item.
@@ -199,7 +197,6 @@ impl ErrorCtx {
             continue_on_failure,
             error_on_warnings,
             external_decls_with_errors: HashSet::new(),
-            ignored_failed_decls: HashSet::new(),
             external_dep_graph: DepGraph::new(),
             def_id: None,
             def_id_is_local: false,
@@ -254,10 +251,6 @@ impl ErrorCtx {
             panic!("{msg}");
         }
         err
-    }
-
-    pub fn ignore_failed_decl(&mut self, id: AnyTransId) {
-        self.ignored_failed_decls.insert(id);
     }
 
     /// Register the fact that `id` is a dependency of `src` (if `src` is not `None`).

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -652,17 +652,17 @@ fn source_text() -> anyhow::Result<()> {
         .map(|i| i.item_meta().source_text.as_ref().unwrap())
         .collect_vec();
     assert_eq!(sources[0], "fn foo() {\n            panic!()\n        }");
+    assert_eq!(sources[1], "struct Foo { x: usize }");
     assert_eq!(
-        sources[1],
-        "fn baz( x : usize )  ->() { \n            let _ = x;\n                }"
-    );
-    assert_eq!(sources[2], "fn quux () {}");
-    assert_eq!(sources[3], "struct Foo { x: usize }");
-    assert_eq!(
-        sources[4],
+        sources[2],
         "trait Trait {\n            fn method() {}\n        }"
     );
-    assert_eq!(sources[5], "impl Trait for () {}");
+    assert_eq!(sources[3], "impl Trait for () {}");
+    assert_eq!(
+        sources[4],
+        "fn baz( x : usize )  ->() { \n            let _ = x;\n                }"
+    );
+    assert_eq!(sources[5], "fn quux () {}");
     Ok(())
 }
 

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -11,21 +11,6 @@ struct test_crate::V<T, const N : usize>
   x: Array<T, const N : usize>,
 }
 
-fn test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN<T, const N : usize>() -> usize
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-{
-    let @0: usize; // return
-
-    @0 := const (const N : usize)
-    return
-}
-
-global test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN<T, const N : usize>: usize
-  where
-      [@TraitClause0]: core::marker::Sized<T>,
- = test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN()
-
 trait test_crate::HasLen<Self>
 {
     const LEN : usize
@@ -103,6 +88,21 @@ impl test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool
 {
     const LEN = test_crate::{impl test_crate::HasDefaultLen<const N : usize> for Array<bool, const N : usize>}#4::LEN<const N : usize>
 }
+
+fn test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN<T, const N : usize>() -> usize
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: usize; // return
+
+    @0 := const (const N : usize)
+    return
+}
+
+global test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN<T, const N : usize>: usize
+  where
+      [@TraitClause0]: core::marker::Sized<T>,
+ = test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}::LEN()
 
 
 

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -213,6 +213,8 @@ where
     return
 }
 
+fn test_crate::Foo::use_item_required<'a, Self, Self_Item>(@1: Self_Item) -> Self_Item
+
 trait test_crate::loopy::Bar<Self, Self_BarTy>
 {
     parent_clause0 : [@TraitClause0]: core::marker::Sized<Self_BarTy>
@@ -341,8 +343,6 @@ where
     parent_clause1 = core::marker::Sized<&'_ (())>
     parent_clause2 = core::marker::Sized<&'_ ((core::option::Option<T>[@TraitClause0], &'_ (())))>
 }
-
-fn test_crate::Foo::use_item_required<'a, Self, Self_Item>(@1: Self_Item) -> Self_Item
 
 #[lang_item("to_owned_method")]
 pub fn alloc::borrow::ToOwned::to_owned<'_0, Self, Self_Owned>(@1: &'_0 (Self)) -> Self_Owned

--- a/charon/tests/ui/issue-166-self-constructors.out
+++ b/charon/tests/ui/issue-166-self-constructors.out
@@ -5,17 +5,17 @@ enum test_crate::Foo =
 |  B(usize)
 
 
+struct test_crate::Bar<'a> =
+{
+  r: &'a (i32),
+}
+
 pub fn test_crate::{test_crate::Foo}::b() -> test_crate::Foo
 {
     let @0: test_crate::Foo; // return
 
     @0 := test_crate::Foo::B { 0: const (0 : usize) }
     return
-}
-
-struct test_crate::Bar<'a> =
-{
-  r: &'a (i32),
 }
 
 fn test_crate::{test_crate::Bar<'a>}#1::new<'a>(@1: &'a (i32)) -> test_crate::Bar<'a>

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -12,6 +12,8 @@ pub struct test_crate::S<'a, K>
   x: &'a (K),
 }
 
+pub struct test_crate::T = {}
+
 #[lang_item("tuple_trait")]
 pub trait core::marker::Tuple<Self>
 
@@ -61,8 +63,6 @@ where
     @0 := ()
     return
 }
-
-pub struct test_crate::T = {}
 
 pub fn test_crate::{test_crate::T}#1::f<F>()
 where

--- a/charon/tests/ui/issue-73-extern.out
+++ b/charon/tests/ui/issue-73-extern.out
@@ -1,11 +1,5 @@
 # Final LLBC before serialization:
 
-unsafe fn test_crate::foo(@1: i32)
-
-fn test_crate::CONST() -> u8
-
-global test_crate::CONST: u8 = test_crate::CONST()
-
 opaque type test_crate::Type
 
 fn test_crate::use_type<'_0>(@1: &'_0 (test_crate::Type))
@@ -17,6 +11,12 @@ fn test_crate::use_type<'_0>(@1: &'_0 (test_crate::Type))
     @0 := ()
     return
 }
+
+unsafe fn test_crate::foo(@1: i32)
+
+fn test_crate::CONST() -> u8
+
+global test_crate::CONST: u8 = test_crate::CONST()
 
 
 

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -13,6 +13,8 @@ pub struct test_crate::AVLTree<T>
   x: T,
 }
 
+impl test_crate::{impl test_crate::Ord for u32}#1 : test_crate::Ord<u32>
+
 pub fn test_crate::{test_crate::AVLTree<T>[@TraitClause0]}::insert<'_0, T>(@1: &'_0 mut (test_crate::AVLTree<T>[@TraitClause0]))
 where
     [@TraitClause0]: core::marker::Sized<T>,
@@ -23,8 +25,6 @@ where
 
     panic(core::panicking::panic)
 }
-
-impl test_crate::{impl test_crate::Ord for u32}#1 : test_crate::Ord<u32>
 
 pub fn test_crate::test(@1: test_crate::AVLTree<u32>[core::marker::Sized<u32>])
 {

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -1,14 +1,5 @@
 # Final LLBC before serialization:
 
-fn test_crate::foo::bar()
-{
-    let @0: (); // return
-
-    @0 := ()
-    @0 := ()
-    return
-}
-
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
@@ -187,6 +178,15 @@ fn test_crate::foo()
     drop @9
     drop @7
     drop slice@4
+    @0 := ()
+    return
+}
+
+fn test_crate::foo::bar()
+{
+    let @0: (); // return
+
+    @0 := ()
     @0 := ()
     return
 }

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -107,13 +107,9 @@ fn test_crate::foo()
     return
 }
 
-fn test_crate::module::dont_translate_body()
-
 fn test_crate::exclude_me()
 
 struct test_crate::Struct = {}
-
-unsafe fn test_crate::extern_fn(@1: i32)
 
 pub fn core::convert::Into::into<Self, T>(@1: Self) -> T
 
@@ -135,6 +131,10 @@ where
     parent_clause1 = @TraitClause1
     fn into = core::convert::{impl core::convert::Into<U> for T}#3::into<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
+
+fn test_crate::module::dont_translate_body()
+
+unsafe fn test_crate::extern_fn(@1: i32)
 
 
 

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -1,14 +1,5 @@
 # Final LLBC before serialization:
 
-fn test_crate::foo::bar()
-{
-    let @0: (); // return
-
-    @0 := ()
-    @0 := ()
-    return
-}
-
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
@@ -88,6 +79,15 @@ where
 {
     parent_clause0 = @TraitClause0
     fn method<U, [@TraitClause0]: core::marker::Sized<U>> = test_crate::{impl test_crate::Trait<T> for &'_0 (Slice<T>)}#2::method<'_0, T, U>[@TraitClause0, @TraitClause0_0]
+}
+
+fn test_crate::foo::bar()
+{
+    let @0: (); // return
+
+    @0 := ()
+    @0 := ()
+    return
 }
 
 fn test_crate::Trait::method<Self, T, U>()

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -14,8 +14,6 @@ impl test_crate::{impl test_crate::Trait<'a> for &'a (())}<'a> : test_crate::Tra
 
 opaque type test_crate::Foo<'a>
 
-fn test_crate::{test_crate::Foo<'_0>}#1::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
-
 fn test_crate::foo<'_0>(@1: &'_0 (fn<'_0>(&'_0_0 (u32)) -> u32))
 
 fn test_crate::bar<'_0>(@1: &'_0 (fn<'_0>(&'_0_0 (fn<'_0>(&'_0_0 (u32)) -> u32))))
@@ -23,6 +21,8 @@ fn test_crate::bar<'_0>(@1: &'_0 (fn<'_0>(&'_0_0 (fn<'_0>(&'_0_0 (u32)) -> u32))
 fn test_crate::baz<'a>(@1: &'a (fn<'b>(&'a (u32), &'b (fn<'c>(&'a (u32), &'b (u32), &'c (u32)) -> u32))))
 
 fn test_crate::Trait::method<'a, 'b, Self>(@1: &'b (Self)) -> &'b (())
+
+fn test_crate::{test_crate::Foo<'_0>}#1::bar<'_0, '_1>(@1: &'_1 (test_crate::Foo<'_0>)) -> &'_1 (())
 
 
 

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -21,23 +21,6 @@ pub struct test_crate::HashMap<S>
   S,
 }
 
-pub fn test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<S, Q, Clause2_Type>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
-where
-    [@TraitClause0]: core::marker::Sized<S>,
-    [@TraitClause1]: core::marker::Sized<Q>,
-    [@TraitClause2]: test_crate::Trait<Q, Clause2_Type>,
-{
-    let @0: (); // return
-    let _x@1: test_crate::HashMap<S>[@TraitClause0]; // arg #1
-    let _k@2: Q; // arg #2
-
-    @0 := ()
-    drop _k@2
-    drop _x@1
-    @0 := ()
-    return
-}
-
 pub fn test_crate::top_level_get<S, Q, Clause2_Type>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
 where
     [@TraitClause0]: core::marker::Sized<S>,
@@ -70,6 +53,23 @@ pub fn test_crate::test1(@1: test_crate::HashMap<()>[core::marker::Sized<()>])
     drop @3
     drop @2
     @0 := ()
+    @0 := ()
+    return
+}
+
+pub fn test_crate::{test_crate::HashMap<S>[@TraitClause0]}#1::get<S, Q, Clause2_Type>(@1: test_crate::HashMap<S>[@TraitClause0], @2: Q)
+where
+    [@TraitClause0]: core::marker::Sized<S>,
+    [@TraitClause1]: core::marker::Sized<Q>,
+    [@TraitClause2]: test_crate::Trait<Q, Clause2_Type>,
+{
+    let @0: (); // return
+    let _x@1: test_crate::HashMap<S>[@TraitClause0]; // arg #1
+    let _k@2: Q; // arg #2
+
+    @0 := ()
+    drop _k@2
+    drop _x@1
     @0 := ()
     return
 }

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -22,4 +22,20 @@ error: Item `test_crate::Collection` caused errors; ignoring.
   | ^^^^^^^^^^^^^^^^
   |
 
-ERROR Charon failed to translate this code (3 errors)
+thread 'rustc' panicked at /rustc/86d69c705a552236a622eee3fdea94bf13c5f102/compiler/rustc_type_ir/src/binder.rs:697:9:
+type parameter `U/#1` (U/#1/1) out of range when instantiating, args=[()]
+error: Hax panicked when translating `test_crate::{impl#0}`.
+ --> tests/ui/simple/gat-default.rs:9:1
+  |
+9 | impl Collection for () {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+error: Item `test_crate::{impl#0}` caused errors; ignoring.
+ --> tests/ui/simple/gat-default.rs:9:1
+  |
+9 | impl Collection for () {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+ERROR Charon failed to translate this code (5 errors)

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -399,68 +399,6 @@ pub struct test_crate::TestType<T>
   T,
 }
 
-struct test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1 =
-{
-  u64,
-}
-
-fn test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test<'_0>(@1: &'_0 (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1)) -> bool
-{
-    let @0: bool; // return
-    let self@1: &'_ (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1); // arg #1
-    let @2: u64; // anonymous local
-
-    @2 := copy ((*(self@1)).0)
-    @0 := move (@2) > const (1 : u64)
-    drop @2
-    return
-}
-
-pub fn test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test<'_0, T>(@1: &'_0 (test_crate::TestType<T>[@TraitClause0]), @2: T) -> bool
-where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::ToU64<T>,
-{
-    let @0: bool; // return
-    let self@1: &'_ (test_crate::TestType<T>[@TraitClause0]); // arg #1
-    let x@2: T; // arg #2
-    let x@3: u64; // local
-    let @4: T; // anonymous local
-    let y@5: test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1; // local
-    let @6: bool; // anonymous local
-    let @7: u64; // anonymous local
-    let @8: &'_ (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1); // anonymous local
-
-    // Remark: we can't write: impl TestTrait for TestType<T>,
-    // we have to use a *local* parameter (can't use the outer T).
-    // In other words: the parameters used in the items inside
-    // an impl must be bound by the impl block (can't come from outer
-    // blocks).
-    @4 := move (x@2)
-    x@3 := @TraitClause1::to_u64(move (@4))
-    drop @4
-    @fake_read(x@3)
-    y@5 := test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1 { 0: const (0 : u64) }
-    @fake_read(y@5)
-    @7 := copy (x@3)
-    @6 := move (@7) > const (0 : u64)
-    if move (@6) {
-        drop @7
-        @8 := &y@5
-        @0 := test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test<'_>(move (@8))
-        drop @8
-    }
-    else {
-        drop @7
-        @0 := const (false)
-    }
-    drop @6
-    drop y@5
-    drop x@3
-    drop x@2
-    return
-}
-
 pub struct test_crate::BoolWrapper =
 {
   bool,
@@ -1028,28 +966,74 @@ pub fn test_crate::flibidi()
     return
 }
 
-trait test_crate::assoc_ty_trait_ref::SliceIndex<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Output>
-    type Output
-}
-
-fn test_crate::assoc_ty_trait_ref::index<I>() -> @TraitClause1::Output
-where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: test_crate::assoc_ty_trait_ref::SliceIndex<I>,
-{
-    let @0: @TraitClause1::Output; // return
-
-    panic(core::panicking::panic)
-}
-
 pub fn test_crate::BoolTrait::ret_true<'_0, Self>(@1: &'_0 (Self)) -> bool
 {
     let @0: bool; // return
     let self@1: &'_ (Self); // arg #1
 
     @0 := const (true)
+    return
+}
+
+struct test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1 =
+{
+  u64,
+}
+
+fn test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test<'_0>(@1: &'_0 (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1)) -> bool
+{
+    let @0: bool; // return
+    let self@1: &'_ (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1); // arg #1
+    let @2: u64; // anonymous local
+
+    @2 := copy ((*(self@1)).0)
+    @0 := move (@2) > const (1 : u64)
+    drop @2
+    return
+}
+
+pub fn test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test<'_0, T>(@1: &'_0 (test_crate::TestType<T>[@TraitClause0]), @2: T) -> bool
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: test_crate::ToU64<T>,
+{
+    let @0: bool; // return
+    let self@1: &'_ (test_crate::TestType<T>[@TraitClause0]); // arg #1
+    let x@2: T; // arg #2
+    let x@3: u64; // local
+    let @4: T; // anonymous local
+    let y@5: test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1; // local
+    let @6: bool; // anonymous local
+    let @7: u64; // anonymous local
+    let @8: &'_ (test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1); // anonymous local
+
+    // Remark: we can't write: impl TestTrait for TestType<T>,
+    // we have to use a *local* parameter (can't use the outer T).
+    // In other words: the parameters used in the items inside
+    // an impl must be bound by the impl block (can't come from outer
+    // blocks).
+    @4 := move (x@2)
+    x@3 := @TraitClause1::to_u64(move (@4))
+    drop @4
+    @fake_read(x@3)
+    y@5 := test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1 { 0: const (0 : u64) }
+    @fake_read(y@5)
+    @7 := copy (x@3)
+    @6 := move (@7) > const (0 : u64)
+    if move (@6) {
+        drop @7
+        @8 := &y@5
+        @0 := test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::{impl test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestTrait for test_crate::{test_crate::TestType<T>[@TraitClause0]}#6::test::TestType1}::test<'_>(move (@8))
+        drop @8
+    }
+    else {
+        drop @7
+        @0 := const (false)
+    }
+    drop @6
+    drop y@5
+    drop x@3
+    drop x@2
     return
 }
 
@@ -1076,6 +1060,22 @@ pub fn test_crate::CFnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> Self::O
 pub fn test_crate::CFnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> Self::parent_clause0::Output
 
 pub fn test_crate::CFn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> Self::parent_clause0::parent_clause0::Output
+
+trait test_crate::assoc_ty_trait_ref::SliceIndex<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self::Output>
+    type Output
+}
+
+fn test_crate::assoc_ty_trait_ref::index<I>() -> @TraitClause1::Output
+where
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: test_crate::assoc_ty_trait_ref::SliceIndex<I>,
+{
+    let @0: @TraitClause1::Output; // return
+
+    panic(core::panicking::panic)
+}
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> Self::parent_clause0::parent_clause0::Output
 

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,3 +1,17 @@
+error: Constant parameters of non-literal type are not supported
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   |        ^^^^^^^^^^^^
+   |
+
+error: Item `test_crate::foo` caused errors; ignoring.
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
 disabled backtrace
 error[E9999]: Supposely unreachable place in the Rust AST. The label is "TranslateUneval".
               This error report happend because some assumption about the Rust AST was broken.
@@ -29,18 +43,13 @@ error: Hax panicked when translating `test_crate::bar`.
    | |_________________^
    |
 
-error: Constant parameters of non-literal type are not supported
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+error: Item `test_crate::bar` caused errors; ignoring.
+  --> tests/ui/unsupported/advanced-const-generics.rs:18:1
    |
-14 | fn foo<const X: Foo>() -> Foo {
-   |        ^^^^^^^^^^^^
-   |
-
-error: Item `test_crate::foo` caused errors; ignoring.
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
-   |
-14 | fn foo<const X: Foo>() -> Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 | / fn bar<const N: usize>()
+19 | | where
+20 | |     [(); N + 1]:,
+   | |_________________^
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Until now crate translation worked in two phases: recurse through the modules to enqueue all the items we find, then translate enqueued items until exhaustion. This PR makes it so we also manage modules through the item queue. This reduces duplication in item_meta/opacity handling.