### PR TITLE
Use `TransItemSource` more in crate translation

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -151,7 +151,6 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                         Err(())
                     }
                 };
-                // let res = ctx.translate_item_aux(rust_id, trans_id);
                 ctx.translate_stack.pop();
                 res
             };
@@ -187,19 +186,19 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 self.translated.type_decls.set_slot(id, ty);
             }
             AnyTransId::Fun(id) => {
-                let fun_decl = bt_ctx.translate_function(id, rust_id, item_meta, &def)?;
+                let fun_decl = bt_ctx.translate_function(id, item_meta, &def)?;
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             AnyTransId::Global(id) => {
-                let global_decl = bt_ctx.translate_global(id, rust_id, item_meta, &def)?;
+                let global_decl = bt_ctx.translate_global(id, item_meta, &def)?;
                 self.translated.global_decls.set_slot(id, global_decl);
             }
             AnyTransId::TraitDecl(id) => {
-                let trait_decl = bt_ctx.translate_trait_decl(id, rust_id, item_meta, &def)?;
+                let trait_decl = bt_ctx.translate_trait_decl(id, item_meta, &def)?;
                 self.translated.trait_decls.set_slot(id, trait_decl);
             }
             AnyTransId::TraitImpl(id) => {
-                let trait_impl = bt_ctx.translate_trait_impl(id, rust_id, item_meta, &def)?;
+                let trait_impl = bt_ctx.translate_trait_impl(id, item_meta, &def)?;
                 self.translated.trait_impls.set_slot(id, trait_impl);
             }
         }

--- a/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate_to_ullbc.rs
@@ -91,20 +91,18 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
     // the opaque modules given as arguments actually exist
     fn register_module(&mut self, item_meta: ItemMeta, def: &hax::FullDef) -> Result<(), Error> {
         let opacity = item_meta.opacity;
-        let explore_inside = !(opacity.is_opaque() || opacity.is_invisible());
+        if !opacity.is_transparent() {
+            return Ok(());
+        }
         match def.kind() {
             FullDefKind::InherentImpl { items, .. } => {
-                if explore_inside {
-                    for (_, item_def) in items {
-                        self.register_module_item(item_def.rust_def_id());
-                    }
+                for (_, item_def) in items {
+                    self.register_module_item(item_def.rust_def_id());
                 }
             }
             FullDefKind::Mod { items, .. } => {
-                if explore_inside {
-                    for def_id in items {
-                        self.register_module_item(def_id.into());
-                    }
+                for def_id in items {
+                    self.register_module_item(def_id.into());
                 }
             }
             FullDefKind::ForeignMod { items, .. } => {

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::TyCtxt;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ord;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::path::{Component, PathBuf};
@@ -98,6 +98,8 @@ pub struct TranslateCtx<'tcx> {
     /// The declarations we came accross and which we haven't translated yet. We keep them sorted
     /// to make the output order a bit more stable.
     pub items_to_translate: BTreeSet<TransItemSource>,
+    /// The declaration we've already processed (successfully or not).
+    pub processed: HashSet<TransItemSource>,
     /// Cache the names to compute them only once each.
     pub cached_names: HashMap<DefId, Name>,
     /// Cache the `ItemMeta`s to compute them only once each.

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -98,10 +98,6 @@ pub struct TranslateCtx<'tcx> {
     /// The declarations we came accross and which we haven't translated yet. We keep them sorted
     /// to make the output order a bit more stable.
     pub items_to_translate: BTreeMap<TransItemSource, AnyTransId>,
-    /// Stack of the translations currently happening. Used to avoid cycles where items need to
-    /// translate themselves transitively.
-    // FIXME: we don't use recursive item translation anywhere.
-    pub translate_stack: Vec<AnyTransId>,
     /// Cache the names to compute them only once each.
     pub cached_names: HashMap<DefId, Name>,
     /// Cache the `ItemMeta`s to compute them only once each.

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -179,8 +179,6 @@ pub struct ErrorCtx {
 
     /// The ids of the external_declarations for which extraction we encountered errors.
     pub external_decls_with_errors: HashSet<AnyTransId>,
-    /// The ids of the declarations we completely failed to extract and had to ignore.
-    pub ignored_failed_decls: HashSet<AnyTransId>,
     /// Graph of dependencies between items: there is an edge from item `a` to item `b` if `b`
     /// registered the id for `a` during its translation. Because we only use this to report errors
     /// on external items, we only record edges where `a` is an external item.
@@ -199,7 +197,6 @@ impl ErrorCtx {
             continue_on_failure,
             error_on_warnings,
             external_decls_with_errors: HashSet::new(),
-            ignored_failed_decls: HashSet::new(),
             external_dep_graph: DepGraph::new(),
             def_id: None,
             def_id_is_local: false,
@@ -254,10 +251,6 @@ impl ErrorCtx {
             panic!("{msg}");
         }
         err
-    }
-
-    pub fn ignore_failed_decl(&mut self, id: AnyTransId) {
-        self.ignored_failed_decls.insert(id);
     }
 
     /// Register the fact that `id` is a dependency of `src` (if `src` is not `None`).

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -22,4 +22,20 @@ error: Item `test_crate::Collection` caused errors; ignoring.
   | ^^^^^^^^^^^^^^^^
   |
 
-ERROR Charon failed to translate this code (3 errors)
+thread 'rustc' panicked at /rustc/86d69c705a552236a622eee3fdea94bf13c5f102/compiler/rustc_type_ir/src/binder.rs:697:9:
+type parameter `U/#1` (U/#1/1) out of range when instantiating, args=[()]
+error: Hax panicked when translating `test_crate::{impl#0}`.
+ --> tests/ui/simple/gat-default.rs:9:1
+  |
+9 | impl Collection for () {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+error: Item `test_crate::{impl#0}` caused errors; ignoring.
+ --> tests/ui/simple/gat-default.rs:9:1
+  |
+9 | impl Collection for () {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+ERROR Charon failed to translate this code (5 errors)

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -1,3 +1,17 @@
+error: Constant parameters of non-literal type are not supported
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   |        ^^^^^^^^^^^^
+   |
+
+error: Item `test_crate::foo` caused errors; ignoring.
+  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
+   |
+14 | fn foo<const X: Foo>() -> Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
 disabled backtrace
 error[E9999]: Supposely unreachable place in the Rust AST. The label is "TranslateUneval".
               This error report happend because some assumption about the Rust AST was broken.
@@ -29,18 +43,13 @@ error: Hax panicked when translating `test_crate::bar`.
    | |_________________^
    |
 
-error: Constant parameters of non-literal type are not supported
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:8
+error: Item `test_crate::bar` caused errors; ignoring.
+  --> tests/ui/unsupported/advanced-const-generics.rs:18:1
    |
-14 | fn foo<const X: Foo>() -> Foo {
-   |        ^^^^^^^^^^^^
-   |
-
-error: Item `test_crate::foo` caused errors; ignoring.
-  --> tests/ui/unsupported/advanced-const-generics.rs:14:1
-   |
-14 | fn foo<const X: Foo>() -> Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 | / fn bar<const N: usize>()
+19 | | where
+20 | |     [(); N + 1]:,
+   | |_________________^
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
This is in preparation for promoted constants, which don't correspond to a single rust `DefId`.