### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1727316705,
-        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,12 @@
           touch $out
         '';
 
+        # Test usage of charon via nix, to ensure the paths are set up correctly.
+        test-charon-via-nix = pkgs.runCommand "test-charon-via-nix" { } ''
+          echo "fn main() {}" > foo.rs
+          ${charon}/bin/charon rustc --no-serialize --print-llbc -- foo.rs > $out
+        '';
+
         # A utility that extracts the llbc of a crate using charon. This uses
         # `crane` to handle dependencies and toolchain management.
         extractCrateWithCharon = { name, src, charonFlags ? "", craneExtraArgs ? { } }:
@@ -134,7 +140,7 @@
         checks = {
           default = charon-ml-tests;
           inherit charon-ml-tests charon-check-fmt charon-check-no-rustc
-            charon-ml-check-fmt check-generated-ml;
+            charon-ml-check-fmt check-generated-ml test-charon-via-nix;
         };
 
         # Export this function so that users of charon can use it in nix. This

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     nixpkgs-ocaml.follows = "nixpkgs";
     rust-overlay = {
       # We pin a specific commit because we require a relatively recent version
-      # and flake dependents don't look at flake.lock.
+      # and flake dependents don't look at our flake.lock.
       url = "github:oxalica/rust-overlay/275c824ed9e90e7fd4f96d187bde3670062e721f";
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/nix/charon-ml.nix
+++ b/nix/charon-ml.nix
@@ -53,7 +53,7 @@ let
     buildInputs = [
       ocamlPackages.dune_3
       ocamlPackages.ocaml
-      ocamlPackages.ocamlformat
+      ocamlPackages.ocamlformat_0_26_2
     ];
     buildPhase = ''
       if ! dune build @fmt; then

--- a/nix/charon.nix
+++ b/nix/charon.nix
@@ -6,7 +6,6 @@
 , rustToolchain
 , stdenv
 , zlib
-,
 }:
 
 let
@@ -48,6 +47,7 @@ craneLib.buildPackage (
       ''
         wrapProgram $out/bin/charon \
           --set CHARON_TOOLCHAIN_IS_IN_PATH 1 \
+          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ rustToolchain ]}" \
           --prefix PATH : "${lib.makeBinPath [ rustToolchain ]}"
       ''
       + (lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
Update the pinned nixpkgs version. The rust toolchain must have changed because it no longer set up the dylib paths in charon-driver; that's fixed now.