### PR TITLE
Represent global accesses via places

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.76"
+let supported_charon_version = "0.1.77"

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -55,6 +55,9 @@ let projection_elem_to_string (env : 'a fmt_env) (sub : string)
 let rec place_to_string (env : 'a fmt_env) (p : place) : string =
   match p.kind with
   | PlaceLocal var_id -> local_id_to_string env var_id
+  | PlaceGlobal global_ref ->
+      let generics = generic_args_to_string env global_ref.global_generics in
+      "global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
   | PlaceProjection (subplace, pe) ->
       let subplace = place_to_string env subplace in
       projection_elem_to_string env subplace pe
@@ -188,17 +191,6 @@ let rvalue_to_string (env : 'a fmt_env) (rv : rvalue) : string =
           (ty_to_string env ty
           :: List.map (const_generic_to_string env) const_generics)
       ^ ">(" ^ place_to_string env place ^ ")"
-  | Global global_ref ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
-  | GlobalRef (global_ref, RShared) ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "&global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
-  | GlobalRef (global_ref, RMut) ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "&raw mut global "
-      ^ global_decl_id_to_string env global_ref.global_id
-      ^ generics
   | Aggregate (akind, ops) -> (
       let ops = List.map (operand_to_string env) ops in
       match akind with

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -18,8 +18,12 @@ module FunDeclId = Types.FunDeclId
 type place = { kind : place_kind; ty : ty }
 
 and place_kind =
-  | PlaceLocal of local_id
-  | PlaceProjection of place * projection_elem
+  | PlaceLocal of local_id  (** A local variable in a function body. *)
+  | PlaceGlobal of global_decl_ref
+      (** A global (const or static).
+          Not present in MIR; introduced in [simplify_constants.rs].
+       *)
+  | PlaceProjection of place * projection_elem  (** A subplace of a place. *)
 
 (** Note that we don't have the equivalent of "downcasts".
     Downcasts are actually necessary, for instance when initializing enumeration
@@ -305,15 +309,6 @@ and rvalue =
 
           Remark: in case of closures, the aggregated value groups the closure id
           together with its state.
-       *)
-  | Global of global_decl_ref
-      (** Copy the value of the referenced global.
-          Not present in MIR; introduced in [simplify_constants.rs].
-       *)
-  | GlobalRef of global_decl_ref * ref_kind
-      (** Reference the value of the global. This has type `&T` or `*mut T` depending on desired
-          mutability.
-          Not present in MIR; introduced in [simplify_constants.rs].
        *)
   | Len of place * ty * const_generic option
       (** Length of a memory location. The run-time length of e.g. a vector or a slice is

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -45,6 +45,9 @@ and place_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Local", local) ] ->
         let* local = local_id_of_json ctx local in
         Ok (PlaceLocal local)
+    | `Assoc [ ("Global", global) ] ->
+        let* global = global_decl_ref_of_json ctx global in
+        Ok (PlaceGlobal global)
     | `Assoc [ ("Projection", `List [ x_0; x_1 ]) ] ->
         let* x_0 = box_of_json place_of_json ctx x_0 in
         let* x_1 = projection_elem_of_json ctx x_1 in
@@ -304,13 +307,6 @@ and rvalue_of_json (ctx : of_json_ctx) (js : json) : (rvalue, string) result =
         let* x_0 = aggregate_kind_of_json ctx x_0 in
         let* x_1 = list_of_json operand_of_json ctx x_1 in
         Ok (Aggregate (x_0, x_1))
-    | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_ref_of_json ctx global in
-        Ok (Global global)
-    | `Assoc [ ("GlobalRef", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = global_decl_ref_of_json ctx x_0 in
-        let* x_1 = ref_kind_of_json ctx x_1 in
-        Ok (GlobalRef (x_0, x_1))
     | `Assoc [ ("Len", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = place_of_json ctx x_0 in
         let* x_1 = ty_of_json ctx x_1 in

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.76"
+version = "0.1.77"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.76"
+version = "0.1.77"
 authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -27,7 +27,12 @@ pub struct Place {
 )]
 #[charon::variants_prefix("Place")]
 pub enum PlaceKind {
+    /// A local variable in a function body.
     Local(LocalId),
+    /// A global (const or static).
+    /// Not present in MIR; introduced in [simplify_constants.rs].
+    Global(GlobalDeclRef),
+    /// A subplace of a place.
     Projection(Box<Place>, ProjectionElem),
 }
 
@@ -531,13 +536,6 @@ pub enum Rvalue {
     /// Remark: in case of closures, the aggregated value groups the closure id
     /// together with its state.
     Aggregate(AggregateKind, Vec<Operand>),
-    /// Copy the value of the referenced global.
-    /// Not present in MIR; introduced in [simplify_constants.rs].
-    Global(GlobalDeclRef),
-    /// Reference the value of the global. This has type `&T` or `*mut T` depending on desired
-    /// mutability.
-    /// Not present in MIR; introduced in [simplify_constants.rs].
-    GlobalRef(GlobalDeclRef, RefKind),
     /// Length of a memory location. The run-time length of e.g. a vector or a slice is
     /// represented differently (but pretty-prints the same, FIXME).
     /// Should be seen as a function of signature:

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -9,6 +9,12 @@ impl Place {
             ty,
         }
     }
+    pub fn new_global(gref: GlobalDeclRef, ty: Ty) -> Place {
+        Place {
+            kind: PlaceKind::Global(gref),
+            ty,
+        }
+    }
 
     pub fn ty(&self) -> &Ty {
         &self.ty
@@ -29,13 +35,15 @@ impl Place {
     }
 
     #[deprecated(note = "use `local_id` instead")]
-    pub fn var_id(&self) -> LocalId {
+    pub fn var_id(&self) -> Option<LocalId> {
         self.local_id()
     }
-    pub fn local_id(&self) -> LocalId {
+    /// If this is a subplace of a local, return its id. If it comes from a global, return `None`.
+    pub fn local_id(&self) -> Option<LocalId> {
         match &self.kind {
-            PlaceKind::Local(var_id) => *var_id,
+            PlaceKind::Local(var_id) => Some(*var_id),
             PlaceKind::Projection(subplace, _) => subplace.local_id(),
+            PlaceKind::Global(_) => None,
         }
     }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -717,6 +717,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Place {
     fn fmt_with_ctx(&self, ctx: &C) -> String {
         match &self.kind {
             PlaceKind::Local(var_id) => ctx.format_object(*var_id),
+            PlaceKind::Global(global_ref) => global_ref.fmt_with_ctx(ctx),
             PlaceKind::Projection(subplace, projection) => {
                 let sub = subplace.fmt_with_ctx(ctx);
                 match projection {
@@ -957,13 +958,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                         )
                     }
                 }
-            }
-            Rvalue::Global(global_ref) => global_ref.fmt_with_ctx(ctx),
-            Rvalue::GlobalRef(global_ref, RefKind::Shared) => {
-                format!("&{}", global_ref.fmt_with_ctx(ctx))
-            }
-            Rvalue::GlobalRef(global_ref, RefKind::Mut) => {
-                format!("&raw mut {}", global_ref.fmt_with_ctx(ctx))
             }
             Rvalue::Len(place, ..) => format!("len({})", place.fmt_with_ctx(ctx)),
             Rvalue::Repeat(op, _ty, cg) => {

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -211,8 +211,8 @@ impl VisitBodyMut for IndexVisitor<'_> {
             | Discriminant(..)
             | Len(..) => self.visit_inner_with_mutability(x, false),
 
-            Use(_) | NullaryOp(..) | UnaryOp(..) | BinaryOp(..) | Aggregate(..) | Global(..)
-            | GlobalRef(..) | Repeat(..) | ShallowInitBox(..) => self.visit_inner(x),
+            Use(_) | NullaryOp(..) | UnaryOp(..) | BinaryOp(..) | Aggregate(..) | Repeat(..)
+            | ShallowInitBox(..) => self.visit_inner(x),
         }
     }
 }

--- a/charon/src/transform/prettify_cfg.rs
+++ b/charon/src/transform/prettify_cfg.rs
@@ -27,7 +27,8 @@ impl Transform {
             content: second_abort @ RawStatement::Abort(_),
             ..
         }, ..] = seq
-            && locals[call.dest.local_id()].ty.kind().is_never()
+            && let Some(local_id) = call.dest.as_local()
+            && locals[local_id].ty.kind().is_never()
         {
             *second_abort = RawStatement::Nop;
             return Vec::new();

--- a/charon/src/transform/reconstruct_boxes.rs
+++ b/charon/src/transform/reconstruct_boxes.rs
@@ -46,8 +46,7 @@ impl Transform {
                 && arg0 == size
                 && arg1 == align
                 && call_malloc.dest == *alloc_use
-                && box_make.is_local()
-                && let var_id = box_make.local_id()
+                && let Some(var_id) = box_make.as_local()
                 && let TyKind::Adt(TypeId::Builtin(BuiltinTy::Box), generics) =
                     locals[var_id].ty.kind()
             {

--- a/charon/src/transform/remove_dynamic_checks.rs
+++ b/charon/src/transform/remove_dynamic_checks.rs
@@ -225,7 +225,7 @@ fn remove_dynamic_checks(_ctx: &mut TransformCtx, statements: &mut [Statement]) 
                 && let Some((sub, ProjectionElem::Field(FieldProjKind::Tuple(2), p_id))) =
                     cond.as_projection()
                 && sub.is_local()
-                && cond.local_id() == result.local_id()
+                && sub.local_id() == result.local_id()
                 && p_id.index() == 1
                 && *expected == false =>
         {

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -360,11 +360,9 @@ pub fn test_crate::thing()
     let @2: u32; // anonymous local
     let @3: (); // anonymous local
     let @4: u32; // anonymous local
-    let @5: u32; // anonymous local
 
     // This comment belongs above the assignment to `x` and not above intermediate computations.
-    @5 := test_crate::CONSTANT
-    @2 := move (@5) >> const (3 : i32)
+    @2 := move (test_crate::CONSTANT) >> const (3 : i32)
     x@1 := move (@2) + const (12 : u32)
     drop @2
     @fake_read(x@1)

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -17,10 +17,8 @@ pub global core::num::{u32}#8::MAX: u32 = core::num::{u32}#8::MAX()
 pub fn test_crate::X1() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := core::num::{u32}#8::MAX
-    @0 := move (@1)
+    @0 := move (core::num::{u32}#8::MAX)
     return
 }
 
@@ -185,10 +183,8 @@ pub fn test_crate::unwrap_y() -> i32
 {
     let @0: i32; // return
     let @1: test_crate::Wrap<i32>[core::marker::Sized<i32>]; // anonymous local
-    let @2: test_crate::Wrap<i32>[core::marker::Sized<i32>]; // anonymous local
 
-    @2 := test_crate::Y
-    @1 := move (@2)
+    @1 := move (test_crate::Y)
     @0 := copy ((@1).value)
     drop @1
     return
@@ -217,10 +213,8 @@ global test_crate::get_z1::Z1: i32 = test_crate::get_z1::Z1()
 pub fn test_crate::get_z1() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    @1 := test_crate::get_z1::Z1
-    @0 := move (@1)
+    @0 := move (test_crate::get_z1::Z1)
     return
 }
 
@@ -253,10 +247,8 @@ pub global test_crate::Q1: i32 = test_crate::Q1()
 pub fn test_crate::Q2() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    @1 := test_crate::Q1
-    @0 := move (@1)
+    @0 := move (test_crate::Q1)
     return
 }
 
@@ -265,10 +257,8 @@ pub global test_crate::Q2: i32 = test_crate::Q2()
 pub fn test_crate::Q3() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    @1 := test_crate::Q2
-    @0 := test_crate::add(move (@1), const (3 : i32))
+    @0 := test_crate::add(move (test_crate::Q2), const (3 : i32))
     return
 }
 
@@ -279,15 +269,11 @@ pub fn test_crate::get_z2() -> i32
     let @0: i32; // return
     let @1: i32; // anonymous local
     let @2: i32; // anonymous local
-    let @3: i32; // anonymous local
-    let @4: i32; // anonymous local
 
     @2 := test_crate::get_z1()
-    @3 := test_crate::Q3
-    @1 := test_crate::add(move (@2), move (@3))
+    @1 := test_crate::add(move (@2), move (test_crate::Q3))
     drop @2
-    @4 := test_crate::Q1
-    @0 := test_crate::add(move (@4), move (@1))
+    @0 := test_crate::add(move (test_crate::Q1), move (@1))
     drop @1
     return
 }
@@ -323,10 +309,8 @@ pub global test_crate::S2: u32 = test_crate::S2()
 pub fn test_crate::S3() -> test_crate::Pair<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]
 {
     let @0: test_crate::Pair<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]; // return
-    let @1: test_crate::Pair<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]; // anonymous local
 
-    @1 := test_crate::P3
-    @0 := move (@1)
+    @0 := move (test_crate::P3)
     return
 }
 
@@ -370,10 +354,8 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 {
     let @0: usize; // return
-    let @1: usize; // anonymous local
 
-    @1 := test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}#1::LEN<T, const N : usize>[@TraitClause0]
-    @0 := move (@1)
+    @0 := move (test_crate::{test_crate::V<T, const N : usize>[@TraitClause0]}#1::LEN<T, const N : usize>[@TraitClause0])
     return
 }
 

--- a/charon/tests/ui/foreign-constant.out
+++ b/charon/tests/ui/foreign-constant.out
@@ -7,10 +7,8 @@ pub global foreign_constant_aux::CONSTANT: u8 = foreign_constant_aux::CONSTANT()
 fn test_crate::foo() -> u8
 {
     let @0: u8; // return
-    let @1: u8; // anonymous local
 
-    @1 := foreign_constant_aux::CONSTANT
-    @0 := move (@1)
+    @0 := move (foreign_constant_aux::CONSTANT)
     return
 }
 

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -203,10 +203,8 @@ pub global core::num::{usize}#11::MAX: usize = core::num::{usize}#11::MAX()
 fn test_crate::max() -> usize
 {
     let @0: usize; // return
-    let @1: usize; // anonymous local
 
-    @1 := core::num::{usize}#11::MAX
-    @0 := move (@1)
+    @0 := move (core::num::{usize}#11::MAX)
     return
 }
 

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -161,18 +161,16 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
     let @43: usize; // anonymous local
     let @44: i16; // anonymous local
     let @45: usize; // anonymous local
-    let @46: i16; // anonymous local
-    let @47: i16; // anonymous local
+    let @46: &'_ (Slice<u8>); // anonymous local
+    let @47: &'_ (u8); // anonymous local
     let @48: &'_ (Slice<u8>); // anonymous local
     let @49: &'_ (u8); // anonymous local
     let @50: &'_ (Slice<u8>); // anonymous local
     let @51: &'_ (u8); // anonymous local
-    let @52: &'_ (Slice<u8>); // anonymous local
-    let @53: &'_ (u8); // anonymous local
+    let @52: &'_ mut (Slice<i16>); // anonymous local
+    let @53: &'_ mut (i16); // anonymous local
     let @54: &'_ mut (Slice<i16>); // anonymous local
     let @55: &'_ mut (i16); // anonymous local
-    let @56: &'_ mut (Slice<i16>); // anonymous local
-    let @57: &'_ mut (i16); // anonymous local
 
     sampled@3 := const (0 : usize)
     @fake_read(sampled@3)
@@ -196,25 +194,25 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
             1 => {
                 bytes@13 := copy ((@10 as variant @1).0)
                 @16 := const (0 : usize)
-                @52 := &*(bytes@13)
-                @53 := @SliceIndexShared<'_, u8>(move (@52), copy (@16))
-                @15 := copy (*(@53))
+                @50 := &*(bytes@13)
+                @51 := @SliceIndexShared<'_, u8>(move (@50), copy (@16))
+                @15 := copy (*(@51))
                 b1@14 := cast<u8, i16>(move (@15))
                 drop @15
                 @fake_read(b1@14)
                 drop @16
                 @19 := const (1 : usize)
-                @50 := &*(bytes@13)
-                @51 := @SliceIndexShared<'_, u8>(move (@50), copy (@19))
-                @18 := copy (*(@51))
+                @48 := &*(bytes@13)
+                @49 := @SliceIndexShared<'_, u8>(move (@48), copy (@19))
+                @18 := copy (*(@49))
                 b2@17 := cast<u8, i16>(move (@18))
                 drop @18
                 @fake_read(b2@17)
                 drop @19
                 @22 := const (2 : usize)
-                @48 := &*(bytes@13)
-                @49 := @SliceIndexShared<'_, u8>(move (@48), copy (@22))
-                @21 := copy (*(@49))
+                @46 := &*(bytes@13)
+                @47 := @SliceIndexShared<'_, u8>(move (@46), copy (@22))
+                @21 := copy (*(@47))
                 b3@20 := cast<u8, i16>(move (@21))
                 drop @21
                 @fake_read(b3@20)
@@ -240,8 +238,7 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
                 drop @29
                 @fake_read(d2@28)
                 @35 := copy (d1@23)
-                @46 := test_crate::FIELD_MODULUS
-                @34 := move (@35) < move (@46)
+                @34 := move (@35) < move (test_crate::FIELD_MODULUS)
                 if move (@34) {
                     drop @35
                     @37 := copy (sampled@3)
@@ -250,9 +247,9 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
                         drop @37
                         @38 := copy (d1@23)
                         @39 := copy (sampled@3)
-                        @54 := &mut *(result@2)
-                        @55 := @SliceIndexMut<'_, i16>(move (@54), copy (@39))
-                        *(@55) := move (@38)
+                        @52 := &mut *(result@2)
+                        @53 := @SliceIndexMut<'_, i16>(move (@52), copy (@39))
+                        *(@53) := move (@38)
                         drop @38
                         drop @39
                         sampled@3 := copy (sampled@3) + const (1 : usize)
@@ -268,8 +265,7 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
                 drop @34
                 drop @33
                 @41 := copy (d2@28)
-                @47 := test_crate::FIELD_MODULUS
-                @40 := move (@41) < move (@47)
+                @40 := move (@41) < move (test_crate::FIELD_MODULUS)
                 if move (@40) {
                     drop @41
                     @43 := copy (sampled@3)
@@ -278,9 +274,9 @@ fn test_crate::f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> 
                         drop @43
                         @44 := copy (d2@28)
                         @45 := copy (sampled@3)
-                        @56 := &mut *(result@2)
-                        @57 := @SliceIndexMut<'_, i16>(move (@56), copy (@45))
-                        *(@57) := move (@44)
+                        @54 := &mut *(result@2)
+                        @55 := @SliceIndexMut<'_, i16>(move (@54), copy (@45))
+                        *(@55) := move (@44)
                         drop @44
                         drop @45
                         sampled@3 := copy (sampled@3) + const (1 : usize)

--- a/charon/tests/ui/issue-507-cfg.out
+++ b/charon/tests/ui/issue-507-cfg.out
@@ -17,7 +17,6 @@ fn test_crate::f0()
     let @2: (); // anonymous local
     let @3: bool; // anonymous local
     let x@4: u8; // local
-    let @5: u8; // anonymous local
 
     @1 := const (0 : i32) < const (1 : i32)
     if move (@1) {
@@ -28,8 +27,7 @@ fn test_crate::f0()
         }
         drop @3
         drop @2
-        @5 := test_crate::CONST
-        x@4 := move (@5)
+        x@4 := move (test_crate::CONST)
         @fake_read(x@4)
         @0 := ()
         drop x@4
@@ -59,7 +57,6 @@ fn test_crate::f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
     let x@12: u8; // local
     let @13: (); // anonymous local
     let @14: (); // anonymous local
-    let @15: u8; // anonymous local
 
     previous_true_hints_seen@2 := const (0 : usize)
     @fake_read(previous_true_hints_seen@2)
@@ -90,8 +87,7 @@ fn test_crate::f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
                 @10 := move (@11) < const (1 : i32)
                 if move (@10) {
                     drop @11
-                    @15 := test_crate::CONST
-                    x@12 := move (@15)
+                    x@12 := move (test_crate::CONST)
                     @fake_read(x@12)
                     drop x@12
                     drop @10

--- a/charon/tests/ui/remove-dynamic-checks.out
+++ b/charon/tests/ui/remove-dynamic-checks.out
@@ -462,10 +462,8 @@ pub global test_crate::FOO: u32 = test_crate::FOO()
 pub fn test_crate::_#8() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (1 : u32) + move (@1)
+    @0 := const (1 : u32) + move (test_crate::FOO)
     return
 }
 
@@ -474,10 +472,8 @@ pub global test_crate::_#8: u32 = test_crate::_#8()
 pub fn test_crate::_#9() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (10 : u32) - move (@1)
+    @0 := const (10 : u32) - move (test_crate::FOO)
     return
 }
 
@@ -486,10 +482,8 @@ pub global test_crate::_#9: u32 = test_crate::_#9()
 pub fn test_crate::_#10() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) * move (@1)
+    @0 := const (2 : u32) * move (test_crate::FOO)
     return
 }
 
@@ -498,10 +492,8 @@ pub global test_crate::_#10: u32 = test_crate::_#10()
 pub fn test_crate::_#11() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) >> move (@1)
+    @0 := const (2 : u32) >> move (test_crate::FOO)
     return
 }
 
@@ -510,10 +502,8 @@ pub global test_crate::_#11: u32 = test_crate::_#11()
 pub fn test_crate::_#12() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) << move (@1)
+    @0 := const (2 : u32) << move (test_crate::FOO)
     return
 }
 
@@ -522,10 +512,8 @@ pub global test_crate::_#12: u32 = test_crate::_#12()
 pub fn test_crate::_#13() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) % move (@1)
+    @0 := const (2 : u32) % move (test_crate::FOO)
     return
 }
 
@@ -534,10 +522,8 @@ pub global test_crate::_#13: u32 = test_crate::_#13()
 pub fn test_crate::_#14() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) / move (@1)
+    @0 := const (2 : u32) / move (test_crate::FOO)
     return
 }
 
@@ -556,10 +542,8 @@ global test_crate::div_signed_with_constant::FOO: i32 = test_crate::div_signed_w
 fn test_crate::div_signed_with_constant() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    @1 := test_crate::div_signed_with_constant::FOO
-    @0 := move (@1) / const (2 : i32)
+    @0 := move (test_crate::div_signed_with_constant::FOO) / const (2 : i32)
     return
 }
 

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -102,12 +102,9 @@ pub fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1
     let @4: u32; // anonymous local
     let @5: u32; // anonymous local
     let @6: u32; // anonymous local
-    let @7: u32; // anonymous local
-    let @8: u32; // anonymous local
 
     @4 := copy (((*(f@2)).options).flags)
-    @7 := core::fmt::flags::DEBUG_LOWER_HEX_FLAG
-    @3 := move (@4) & move (@7)
+    @3 := move (@4) & move (core::fmt::flags::DEBUG_LOWER_HEX_FLAG)
     drop @4
     switch move (@3) {
         0 : u32 => {
@@ -120,8 +117,7 @@ pub fn core::fmt::num::{impl core::fmt::Debug for u32}#86::fmt<'_0, '_1, '_2>(@1
     }
     drop @3
     @6 := copy (((*(f@2)).options).flags)
-    @8 := core::fmt::flags::DEBUG_UPPER_HEX_FLAG
-    @5 := move (@6) & move (@8)
+    @5 := move (@6) & move (core::fmt::flags::DEBUG_UPPER_HEX_FLAG)
     drop @6
     switch move (@5) {
         0 : u32 => {

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -44,8 +44,6 @@ fn test_crate::literal_casts()
     let @3: f64; // anonymous local
     let @4: u64; // anonymous local
     let @5: f64; // anonymous local
-    let @6: f64; // anonymous local
-    let @7: f32; // anonymous local
 
     @1 := cast<u64, u8>(const (0 : u64))
     @fake_read(@1)
@@ -56,12 +54,10 @@ fn test_crate::literal_casts()
     @3 := cast<u64, f64>(const (0 : u64))
     @fake_read(@3)
     drop @3
-    @6 := core::f64::{f64}::MIN
-    @4 := cast<f64, u64>(move (@6))
+    @4 := cast<f64, u64>(move (core::f64::{f64}::MIN))
     @fake_read(@4)
     drop @4
-    @7 := core::f32::{f32}::MAX
-    @5 := cast<f32, f64>(move (@7))
+    @5 := cast<f32, f64>(move (core::f32::{f32}::MAX))
     @fake_read(@5)
     drop @5
     @0 := ()

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -18,19 +18,13 @@ fn test_crate::constant()
     let @3: usize; // anonymous local
     let _ref_mut@4: &'_ mut (usize); // local
     let @5: usize; // anonymous local
-    let @6: usize; // anonymous local
-    let @7: usize; // anonymous local
-    let @8: usize; // anonymous local
 
-    @6 := test_crate::constant::CONST
-    _val@1 := move (@6)
+    _val@1 := move (test_crate::constant::CONST)
     @fake_read(_val@1)
-    @7 := test_crate::constant::CONST
-    @3 := move (@7)
+    @3 := move (test_crate::constant::CONST)
     _ref@2 := &@3
     @fake_read(_ref@2)
-    @8 := test_crate::constant::CONST
-    @5 := move (@8)
+    @5 := move (test_crate::constant::CONST)
     _ref_mut@4 := &mut @5
     @fake_read(_ref_mut@4)
     @0 := ()

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -927,10 +927,8 @@ where
     [@TraitClause2]: test_crate::Trait<T>,
 {
     let @0: core::result::Result<T, i32>[@TraitClause0, core::marker::Sized<i32>]; // return
-    let @1: core::result::Result<T, i32>[@TraitClause0, core::marker::Sized<i32>]; // anonymous local
 
-    @1 := test_crate::{test_crate::Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
-    @0 := move (@1)
+    @0 := move (test_crate::{test_crate::Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO<T, U>[@TraitClause0, @TraitClause1, @TraitClause2])
     return
 }
 
@@ -941,10 +939,8 @@ where
     [@TraitClause2]: test_crate::Trait<U>,
 {
     let @0: core::result::Result<U, i32>[@TraitClause1, core::marker::Sized<i32>]; // return
-    let @1: core::result::Result<U, i32>[@TraitClause1, core::marker::Sized<i32>]; // anonymous local
 
-    @1 := test_crate::{test_crate::Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO<U, T>[@TraitClause1, @TraitClause0, @TraitClause2]
-    @0 := move (@1)
+    @0 := move (test_crate::{test_crate::Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO<U, T>[@TraitClause1, @TraitClause0, @TraitClause2])
     return
 }
 


### PR DESCRIPTION
Globals (statics and consts) in MIR can be accessed either by copying the value or taking a reference/pointer to them. They very much behave like places, but until now we had a special-case rvalue for each of these possible operations. This PR represents globals as a `Place` instead, just like locals.