### PR TITLE
Add `Binop::{Cmp,Offset}`, `BuiltinFunId::PtrFromParts`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.76"
+let supported_charon_version = "0.1.77"

--- a/charon-ml/src/ExpressionsUtils.ml
+++ b/charon-ml/src/ExpressionsUtils.ml
@@ -18,5 +18,6 @@ let binop_can_fail (binop : binop) : bool =
   | Gt
   | CheckedAdd
   | CheckedSub
-  | CheckedMul -> false
-  | Div | Rem | Add | Sub | Mul | Shl | Shr -> true
+  | CheckedMul
+  | Cmp -> false
+  | Div | Rem | Add | Sub | Mul | Shl | Shr | Offset -> true

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -686,6 +686,9 @@ let builtin_fun_id_to_string (fid : E.builtin_fun_id) : string =
       let op = if is_range then "SubSlice" else "Index" in
       let mutability = PrintTypes.ref_kind_to_string mutability in
       ty ^ op ^ mutability
+  | PtrFromParts mut ->
+      let mut = if mut = RMut then "_mut" else "" in
+      "std::ptr::from_raw_parts" ^ mut
 
 let match_fn_ptr (ctx : 'fun_body ctx) (c : match_config) (p : pattern)
     (func : E.fn_ptr) : bool =

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -104,6 +104,8 @@ let binop_to_string (binop : binop) : string =
   | CheckedMul -> "checked.*"
   | Shl -> "<<"
   | Shr -> ">>"
+  | Cmp -> "cmp"
+  | Offset -> "offset"
 
 let builtin_fun_id_to_string (aid : builtin_fun_id) : string =
   match aid with

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -118,6 +118,9 @@ let builtin_fun_id_to_string (aid : builtin_fun_id) : string =
       let op = if is_range then "SubSlice" else "Index" in
       let mutability = ref_kind_to_string mutability in
       "@" ^ ty ^ op ^ mutability
+  | PtrFromParts mut ->
+      let mut = if mut = RMut then "_mut" else "" in
+      "std::ptr::from_raw_parts" ^ mut
 
 let fun_id_to_string (env : 'a fmt_env) (fid : fun_id) : string =
   match fid with

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -119,8 +119,8 @@ let builtin_fun_id_to_string (aid : builtin_fun_id) : string =
       let mutability = ref_kind_to_string mutability in
       "@" ^ ty ^ op ^ mutability
   | PtrFromParts mut ->
-      let mut = if mut = RMut then "_mut" else "" in
-      "std::ptr::from_raw_parts" ^ mut
+      let mut = if mut = RMut then "Mut" else "" in
+      "@PtrFromParts" ^ mut
 
 let fun_id_to_string (env : 'a fmt_env) (fid : fun_id) : string =
   match fid with

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -138,6 +138,10 @@ and binop =
   | CheckedMul  (** Like `CheckedAdd`. *)
   | Shl  (** Fails if the shift is bigger than the bit-size of the type. *)
   | Shr  (** Fails if the shift is bigger than the bit-size of the type. *)
+  | Offset
+      (** `BinOp(Offset, ptr, n)` for `ptr` a pointer to type `T` offsets `ptr` by `n * size_of::<T>()`. *)
+  | Cmp
+      (** `BinOp(Cmp, a, b)` returns `-1u8` if `a < b`, `0u8` if `a == b`, and `1u8` if `a > b`. *)
 
 and operand =
   | Copy of place

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -190,6 +190,12 @@ and builtin_fun_id =
           - `fn SliceSubSliceMut<T>(&mut [T], usize, usize) -> &mut [T]`
           - etc
        *)
+  | PtrFromParts of ref_kind
+      (** Build a raw pointer, from a data pointer and metadata. The metadata can be unit, if
+          building a thin pointer.
+
+          Converted from [AggregateKind::RawPtr]
+       *)
 
 (** One of 8 built-in indexing operations. *)
 and builtin_index_op = {

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -198,6 +198,9 @@ and builtin_fun_id_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Index", index) ] ->
         let* index = builtin_index_op_of_json ctx index in
         Ok (Index index)
+    | `Assoc [ ("PtrFromParts", ptr_from_parts) ] ->
+        let* ptr_from_parts = ref_kind_of_json ctx ptr_from_parts in
+        Ok (PtrFromParts ptr_from_parts)
     | _ -> Error "")
 
 and builtin_index_op_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -158,6 +158,8 @@ and binop_of_json (ctx : of_json_ctx) (js : json) : (binop, string) result =
     | `String "CheckedMul" -> Ok CheckedMul
     | `String "Shl" -> Ok Shl
     | `String "Shr" -> Ok Shr
+    | `String "Offset" -> Ok Offset
+    | `String "Cmp" -> Ok Cmp
     | _ -> Error "")
 
 and operand_of_json (ctx : of_json_ctx) (js : json) : (operand, string) result =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.76"
+version = "0.1.77"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.76"
+version = "0.1.77"
 authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -339,6 +339,11 @@ pub enum BuiltinFunId {
     /// - `fn SliceSubSliceMut<T>(&mut [T], usize, usize) -> &mut [T]`
     /// - etc
     Index(BuiltinIndexOp),
+    /// Build a raw pointer, from a data pointer and metadata. The metadata can be unit, if
+    /// building a thin pointer.
+    ///
+    /// Converted from [AggregateKind::RawPtr]
+    PtrFromParts(RefKind),
 }
 
 /// One of 8 built-in indexing operations.
@@ -610,4 +615,9 @@ pub enum AggregateKind {
     /// Aggregated values for closures group the function id together with its
     /// state.
     Closure(FunDeclId, GenericArgs),
+    /// Construct a raw pointer from a pointer value, and its metadata (can be unit, if building
+    /// a thin pointer). The type is the type of the pointee.
+    /// We lower this to a builtin function call in [crate::ops_to_function_calls].
+    #[charon::opaque]
+    RawPtr(Ty, RefKind),
 }

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -246,7 +246,10 @@ pub enum BinOp {
     Shl,
     /// Fails if the shift is bigger than the bit-size of the type.
     Shr,
-    // No Offset binary operation: this is an operation on raw pointers
+    /// `BinOp(Offset, ptr, n)` for `ptr` a pointer to type `T` offsets `ptr` by `n * size_of::<T>()`.
+    Offset,
+    /// `BinOp(Cmp, a, b)` returns `-1u8` if `a < b`, `0u8` if `a == b`, and `1u8` if `a > b`.
+    Cmp,
 }
 
 #[derive(

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -53,7 +53,7 @@ fn translate_borrow_kind(borrow_kind: hax::BorrowKind) -> BorrowKind {
 }
 
 impl<'tcx, 'ctx> TranslateCtx<'tcx> {
-    fn translate_binaryop_kind(&mut self, span: Span, binop: hax::BinOp) -> Result<BinOp, Error> {
+    fn translate_binaryop_kind(&mut self, _span: Span, binop: hax::BinOp) -> Result<BinOp, Error> {
         Ok(match binop {
             hax::BinOp::BitXor => BinOp::BitXor,
             hax::BinOp::BitAnd => BinOp::BitAnd,
@@ -74,12 +74,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
             hax::BinOp::MulWithOverflow => BinOp::CheckedMul,
             hax::BinOp::Shl => BinOp::Shl,
             hax::BinOp::Shr => BinOp::Shr,
-            hax::BinOp::Cmp => {
-                raise_error!(self, span, "Unsupported binary operation: Cmp")
-            }
-            hax::BinOp::Offset => {
-                raise_error!(self, span, "Unsupported binary operation: offset")
-            }
+            hax::BinOp::Cmp => BinOp::Cmp,
+            hax::BinOp::Offset => BinOp::Offset,
         })
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1583,6 +1583,8 @@ impl std::fmt::Display for BinOp {
             BinOp::CheckedMul => write!(f, "checked.*"),
             BinOp::Shl => write!(f, "<<"),
             BinOp::Shr => write!(f, ">>"),
+            BinOp::Cmp => write!(f, "cmp"),
+            BinOp::Offset => write!(f, "offset"),
         }
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -956,6 +956,13 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                             ops_s.join(", ")
                         )
                     }
+                    AggregateKind::RawPtr(_, rmut) => {
+                        let mutability = match rmut {
+                            RefKind::Shared => "const",
+                            RefKind::Mut => "mut ",
+                        };
+                        format!("*{} ({})", mutability, ops_s.join(", "))
+                    }
                 }
             }
             Rvalue::Global(global_ref) => global_ref.fmt_with_ctx(ctx),
@@ -1612,6 +1619,10 @@ impl std::fmt::Display for BuiltinFunId {
                 let op = if is_range { "SubSlice" } else { "Index" };
                 let mutability = mutability.variant_name();
                 &format!("{ty}{op}{mutability}")
+            }
+            BuiltinFunId::PtrFromParts(mutability) => {
+                let mutability = mutability.variant_name();
+                &format!("PtrFromParts{mutability}")
             }
         };
         f.write_str(name)

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -196,14 +196,15 @@ impl VisitAst for CheckGenericsVisitor<'_> {
 
     fn visit_aggregate_kind(&mut self, agg: &AggregateKind) -> ControlFlow<Self::Break> {
         match agg {
-            AggregateKind::Adt(..) => self.visit_inner(agg)?,
+            AggregateKind::Adt(..) | AggregateKind::Array(..) | AggregateKind::RawPtr(..) => {
+                self.visit_inner(agg)?
+            }
             AggregateKind::Closure(_id, args) => {
                 // TODO(#194): handle closure generics properly
                 // This does not visit the args themselves, only their contents, because we mess up
                 // closure generics for now.
                 self.visit_inner(args)?
             }
-            AggregateKind::Array(..) => self.visit_inner(agg)?,
         }
         Continue(())
     }

--- a/charon/src/transform/ops_to_function_calls.rs
+++ b/charon/src/transform/ops_to_function_calls.rs
@@ -52,6 +52,25 @@ fn transform_st(s: &mut Statement) {
                 dest: p.clone(),
             });
         }
+        // Transform the raw pointer aggregate to a function call
+        RawStatement::Assign(p, Rvalue::Aggregate(AggregateKind::RawPtr(ty, is_mut), ops)) => {
+            let id = BuiltinFunId::PtrFromParts(is_mut.clone());
+            let func = FunIdOrTraitMethodRef::mk_builtin(id);
+            let generics = GenericArgs::new(
+                vec![Region::Erased].into(),
+                vec![ty.clone()].into(),
+                vec![].into(),
+                vec![].into(),
+                GenericsSource::Builtin,
+            );
+
+            let func = FnOperand::Regular(FnPtr { func, generics });
+            s.content = RawStatement::Call(Call {
+                func,
+                args: ops.clone(),
+                dest: p.clone(),
+            });
+        }
         _ => {}
     }
 }

--- a/charon/tests/ui/from-raw-parts.out
+++ b/charon/tests/ui/from-raw-parts.out
@@ -1,0 +1,601 @@
+# Final LLBC before serialization:
+
+#[lang_item("sized")]
+pub trait core::marker::Sized<Self>
+
+#[lang_item("Range")]
+pub struct core::ops::range::Range<Idx>
+  where
+      [@TraitClause0]: core::marker::Sized<Idx>,
+ =
+{
+  start: Idx,
+  end: Idx,
+}
+
+#[lang_item("index")]
+pub trait core::ops::index::Index<Self, Idx>
+{
+    type Output
+    fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>
+}
+
+pub fn core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, const N : usize>), @2: I) -> &'_0 (@TraitClause2::Output)
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::ops::index::Index<Slice<T>, I>,
+
+pub trait core::slice::index::private_slice_index::Sealed<Self>
+
+#[lang_item("Option")]
+pub enum core::option::Option<T>
+  where
+      [@TraitClause0]: core::marker::Sized<T>,
+ =
+|  None()
+|  Some(T)
+
+
+#[lang_item("SliceIndex")]
+pub trait core::slice::index::SliceIndex<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: core::slice::index::private_slice_index::Sealed<Self>
+    type Output
+    fn get<'_0> = core::slice::index::SliceIndex::get<'_0_0, Self, T>
+    fn get_mut<'_0> = core::slice::index::SliceIndex::get_mut<'_0_0, Self, T>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>
+    fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>
+    fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>
+}
+
+pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (Self::Output)
+
+pub fn core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+{
+    let @0: &'_ (@TraitClause2::Output); // return
+    let self@1: &'_ (Slice<T>); // arg #1
+    let index@2: I; // arg #2
+
+    @0 := @TraitClause2::index<'_>(move (index@2), move (self@1))
+    return
+}
+
+impl core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<T, I> : core::ops::index::Index<Slice<T>, I>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::slice::index::SliceIndex<I, Slice<T>>,
+{
+    type Output = @TraitClause2::Output
+    fn index<'_0> = core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+}
+
+impl core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#1 : core::slice::index::private_slice_index::Sealed<core::ops::range::Range<usize>[core::marker::Sized<usize>]>
+
+pub fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> core::option::Option<&'_0 (Slice<T>)>[core::marker::Sized<&'_0 (Slice<T>)>]
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]; // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: &'_ (Slice<T>); // arg #2
+    let @3: core::option::Option<usize>[core::marker::Sized<usize>]; // anonymous local
+    let self@4: usize; // local
+    let rhs@5: usize; // local
+    let new_len@6: usize; // local
+    let @7: bool; // anonymous local
+    let @8: usize; // anonymous local
+    let @9: &'_ (Slice<T>); // anonymous local
+    let @10: *const Slice<T>; // anonymous local
+    let @11: *const Slice<T>; // anonymous local
+    let @12: bool; // anonymous local
+    let @13: usize; // anonymous local
+    let @14: *const T; // anonymous local
+    let @15: *const T; // anonymous local
+    let @16: core::option::Option<&'_ (Slice<T>)>[core::marker::Sized<&'_ (Slice<T>)>]; // anonymous local
+
+    self@4 := copy ((self@1).end)
+    rhs@5 := copy ((self@1).start)
+    @12 := copy (self@4) < copy (rhs@5)
+    if move (@12) {
+        drop @12
+        drop @3
+        @16 := core::option::Option::None {  }
+        @0 := move (@16)
+    }
+    else {
+        @13 := copy (self@4) - copy (rhs@5)
+        @3 := core::option::Option::Some { 0: move (@13) }
+        drop @13
+        drop @12
+        new_len@6 := copy ((@3 as variant @1).0)
+        @8 := ptr_metadata(copy (slice@2))
+        @7 := copy (self@4) <= move (@8)
+        if move (@7) {
+            drop @8
+            @11 := &raw const *(slice@2)
+            @15 := cast<*const Slice<T>, *const T>(copy (@11))
+            @14 := copy (@15) offset copy (rhs@5)
+            drop @15
+            @10 := @PtrFromPartsShared<'_, Slice<T>>(copy (@14), copy (new_len@6))
+            drop @14
+            drop @11
+            @9 := &*(@10)
+            @0 := core::option::Option::Some { 0: copy (@9) }
+            drop @10
+            drop @3
+        }
+        else {
+            drop @8
+            drop @3
+            @16 := core::option::Option::None {  }
+            @0 := move (@16)
+        }
+    }
+    drop @7
+    return
+}
+
+pub fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> core::option::Option<&'_0 mut (Slice<T>)>[core::marker::Sized<&'_0 mut (Slice<T>)>]
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: core::option::Option<&'_ mut (Slice<T>)>[core::marker::Sized<&'_ mut (Slice<T>)>]; // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: &'_ mut (Slice<T>); // arg #2
+    let @3: core::option::Option<usize>[core::marker::Sized<usize>]; // anonymous local
+    let self@4: usize; // local
+    let rhs@5: usize; // local
+    let new_len@6: usize; // local
+    let @7: bool; // anonymous local
+    let @8: usize; // anonymous local
+    let @9: &'_ mut (Slice<T>); // anonymous local
+    let @10: *mut Slice<T>; // anonymous local
+    let ptr@11: *mut Slice<T>; // local
+    let @12: bool; // anonymous local
+    let @13: usize; // anonymous local
+    let @14: *mut T; // anonymous local
+    let @15: *mut T; // anonymous local
+    let @16: core::option::Option<&'_ mut (Slice<T>)>[core::marker::Sized<&'_ mut (Slice<T>)>]; // anonymous local
+
+    self@4 := copy ((self@1).end)
+    rhs@5 := copy ((self@1).start)
+    @12 := copy (self@4) < copy (rhs@5)
+    if move (@12) {
+        drop @12
+        drop @3
+        @16 := core::option::Option::None {  }
+        @0 := move (@16)
+    }
+    else {
+        @13 := copy (self@4) - copy (rhs@5)
+        @3 := core::option::Option::Some { 0: move (@13) }
+        drop @13
+        drop @12
+        new_len@6 := copy ((@3 as variant @1).0)
+        @8 := ptr_metadata(copy (slice@2))
+        @7 := copy (self@4) <= move (@8)
+        if move (@7) {
+            drop @8
+            ptr@11 := &raw mut *(slice@2)
+            @15 := cast<*mut Slice<T>, *mut T>(copy (ptr@11))
+            @14 := copy (@15) offset copy (rhs@5)
+            drop @15
+            @10 := @PtrFromPartsMut<'_, Slice<T>>(copy (@14), copy (new_len@6))
+            drop @14
+            drop ptr@11
+            @9 := &mut *(@10)
+            @0 := core::option::Option::Some { 0: copy (@9) }
+            drop @10
+            drop @3
+        }
+        else {
+            drop @8
+            drop @3
+            @16 := core::option::Option::None {  }
+            @0 := move (@16)
+        }
+    }
+    drop @7
+    return
+}
+
+#[lang_item("panic_nounwind")]
+pub fn core::panicking::panic_nounwind(@1: &'static (Str)) -> !
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked::precondition_check(@1: usize, @2: usize, @3: usize)
+{
+    let @0: (); // return
+    let start@1: usize; // arg #1
+    let end@2: usize; // arg #2
+    let len@3: usize; // arg #3
+    let @4: bool; // anonymous local
+    let @5: bool; // anonymous local
+    let @6: !; // anonymous local
+
+    @4 := copy (end@2) >= copy (start@1)
+    if move (@4) {
+        @5 := copy (end@2) <= copy (len@3)
+        if move (@5) {
+            drop @5
+            drop @4
+            @0 := ()
+            return
+        }
+        else {
+        }
+    }
+    else {
+    }
+    @6 := core::panicking::panic_nounwind(const ("unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+}
+
+pub unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *const Slice<T>) -> *const Slice<T>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: *const Slice<T>; // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: *const Slice<T>; // arg #2
+    let @3: bool; // anonymous local
+    let @4: (); // anonymous local
+    let @5: usize; // anonymous local
+    let @6: usize; // anonymous local
+    let @7: usize; // anonymous local
+    let new_len@8: usize; // local
+    let @9: usize; // anonymous local
+    let offset@10: usize; // local
+    let @11: *const T; // anonymous local
+    let @12: *const T; // anonymous local
+
+    @3 := ub_checks<bool>
+    if move (@3) {
+        @5 := copy ((self@1).start)
+        @6 := copy ((self@1).end)
+        @7 := ptr_metadata(copy (slice@2))
+        @4 := core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked::precondition_check(move (@5), move (@6), move (@7))
+        drop @7
+        drop @6
+        drop @5
+    }
+    else {
+    }
+    drop @3
+    @9 := copy ((self@1).end)
+    offset@10 := copy ((self@1).start)
+    new_len@8 := move (@9) - copy (offset@10)
+    drop @9
+    @12 := cast<*const Slice<T>, *const T>(copy (slice@2))
+    @11 := copy (@12) offset copy (offset@10)
+    drop @12
+    @0 := @PtrFromPartsShared<'_, Slice<T>>(copy (@11), copy (new_len@8))
+    drop @11
+    return
+}
+
+fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut::precondition_check(@1: usize, @2: usize, @3: usize)
+{
+    let @0: (); // return
+    let start@1: usize; // arg #1
+    let end@2: usize; // arg #2
+    let len@3: usize; // arg #3
+    let @4: bool; // anonymous local
+    let @5: bool; // anonymous local
+    let @6: !; // anonymous local
+
+    @4 := copy (end@2) >= copy (start@1)
+    if move (@4) {
+        @5 := copy (end@2) <= copy (len@3)
+        if move (@5) {
+            drop @5
+            drop @4
+            @0 := ()
+            return
+        }
+        else {
+        }
+    }
+    else {
+    }
+    @6 := core::panicking::panic_nounwind(const ("unsafe precondition(s) violated: slice::get_unchecked_mut requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+}
+
+pub unsafe fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: *mut Slice<T>) -> *mut Slice<T>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: *mut Slice<T>; // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: *mut Slice<T>; // arg #2
+    let @3: bool; // anonymous local
+    let @4: (); // anonymous local
+    let @5: usize; // anonymous local
+    let @6: usize; // anonymous local
+    let @7: usize; // anonymous local
+    let new_len@8: usize; // local
+    let @9: usize; // anonymous local
+    let offset@10: usize; // local
+    let @11: *mut T; // anonymous local
+    let @12: *mut T; // anonymous local
+
+    @3 := ub_checks<bool>
+    if move (@3) {
+        @5 := copy ((self@1).start)
+        @6 := copy ((self@1).end)
+        @7 := ptr_metadata(copy (slice@2))
+        @4 := core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut::precondition_check(move (@5), move (@6), move (@7))
+        drop @7
+        drop @6
+        drop @5
+    }
+    else {
+    }
+    drop @3
+    @9 := copy ((self@1).end)
+    offset@10 := copy ((self@1).start)
+    new_len@8 := move (@9) - copy (offset@10)
+    drop @9
+    @12 := cast<*mut Slice<T>, *mut T>(copy (slice@2))
+    @11 := copy (@12) offset copy (offset@10)
+    drop @12
+    @0 := @PtrFromPartsMut<'_, Slice<T>>(copy (@11), copy (new_len@8))
+    drop @11
+    return
+}
+
+fn core::slice::index::slice_end_index_len_fail::do_panic::runtime(@1: usize, @2: usize) -> !
+
+fn core::slice::index::slice_end_index_len_fail::do_panic(@1: usize, @2: usize) -> !
+{
+    let @0: !; // return
+    let index@1: usize; // arg #1
+    let len@2: usize; // arg #2
+
+    @0 := core::slice::index::slice_end_index_len_fail::do_panic::runtime(move (index@1), move (len@2))
+}
+
+fn core::slice::index::slice_end_index_len_fail(@1: usize, @2: usize) -> !
+{
+    let @0: !; // return
+    let index@1: usize; // arg #1
+    let len@2: usize; // arg #2
+    let @3: usize; // anonymous local
+    let @4: usize; // anonymous local
+
+    @3 := copy (index@1)
+    @4 := copy (len@2)
+    @0 := core::slice::index::slice_end_index_len_fail::do_panic(move (@3), move (@4))
+}
+
+fn core::slice::index::slice_index_order_fail::do_panic::runtime(@1: usize, @2: usize) -> !
+
+fn core::slice::index::slice_index_order_fail::do_panic(@1: usize, @2: usize) -> !
+{
+    let @0: !; // return
+    let index@1: usize; // arg #1
+    let end@2: usize; // arg #2
+
+    @0 := core::slice::index::slice_index_order_fail::do_panic::runtime(move (index@1), move (end@2))
+}
+
+fn core::slice::index::slice_index_order_fail(@1: usize, @2: usize) -> !
+{
+    let @0: !; // return
+    let index@1: usize; // arg #1
+    let end@2: usize; // arg #2
+    let @3: usize; // anonymous local
+    let @4: usize; // anonymous local
+
+    @3 := copy (index@1)
+    @4 := copy (end@2)
+    @0 := core::slice::index::slice_index_order_fail::do_panic(move (@3), move (@4))
+}
+
+pub fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: &'_ (Slice<T>); // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: &'_ (Slice<T>); // arg #2
+    let @3: !; // anonymous local
+    let new_len@4: usize; // local
+    let @5: core::option::Option<usize>[core::marker::Sized<usize>]; // anonymous local
+    let self@6: usize; // local
+    let rhs@7: usize; // local
+    let @8: bool; // anonymous local
+    let @9: usize; // anonymous local
+    let @10: !; // anonymous local
+    let @11: *const Slice<T>; // anonymous local
+    let @12: *const Slice<T>; // anonymous local
+    let @13: bool; // anonymous local
+    let @14: usize; // anonymous local
+    let @15: *const T; // anonymous local
+    let @16: *const T; // anonymous local
+
+    self@6 := copy ((self@1).end)
+    rhs@7 := copy ((self@1).start)
+    @13 := copy (self@6) < copy (rhs@7)
+    if move (@13) {
+    }
+    else {
+        @14 := copy (self@6) - copy (rhs@7)
+        @5 := core::option::Option::Some { 0: move (@14) }
+        drop @14
+        drop @13
+        new_len@4 := copy ((@5 as variant @1).0)
+        drop @5
+        @9 := ptr_metadata(copy (slice@2))
+        @8 := copy (self@6) > copy (@9)
+        if move (@8) {
+        }
+        else {
+            drop @8
+            @12 := &raw const *(slice@2)
+            @16 := cast<*const Slice<T>, *const T>(copy (@12))
+            @15 := copy (@16) offset copy (rhs@7)
+            drop @16
+            @11 := @PtrFromPartsShared<'_, Slice<T>>(copy (@15), copy (new_len@4))
+            drop @15
+            drop @12
+            @0 := &*(@11)
+            drop @11
+            return
+        }
+        @10 := core::slice::index::slice_end_index_len_fail(move (self@6), move (@9))
+    }
+    drop @13
+    drop @5
+    @3 := core::slice::index::slice_index_order_fail(move (rhs@7), move (self@6))
+}
+
+pub fn core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0, T>(@1: core::ops::range::Range<usize>[core::marker::Sized<usize>], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: &'_ mut (Slice<T>); // return
+    let self@1: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // arg #1
+    let slice@2: &'_ mut (Slice<T>); // arg #2
+    let @3: !; // anonymous local
+    let new_len@4: usize; // local
+    let @5: core::option::Option<usize>[core::marker::Sized<usize>]; // anonymous local
+    let self@6: usize; // local
+    let rhs@7: usize; // local
+    let @8: bool; // anonymous local
+    let @9: usize; // anonymous local
+    let @10: !; // anonymous local
+    let @11: *mut Slice<T>; // anonymous local
+    let ptr@12: *mut Slice<T>; // local
+    let @13: bool; // anonymous local
+    let @14: usize; // anonymous local
+    let @15: *mut T; // anonymous local
+    let @16: *mut T; // anonymous local
+
+    self@6 := copy ((self@1).end)
+    rhs@7 := copy ((self@1).start)
+    @13 := copy (self@6) < copy (rhs@7)
+    if move (@13) {
+    }
+    else {
+        @14 := copy (self@6) - copy (rhs@7)
+        @5 := core::option::Option::Some { 0: move (@14) }
+        drop @14
+        drop @13
+        new_len@4 := copy ((@5 as variant @1).0)
+        drop @5
+        @9 := ptr_metadata(copy (slice@2))
+        @8 := copy (self@6) > copy (@9)
+        if move (@8) {
+        }
+        else {
+            drop @8
+            ptr@12 := &raw mut *(slice@2)
+            @16 := cast<*mut Slice<T>, *mut T>(copy (ptr@12))
+            @15 := copy (@16) offset copy (rhs@7)
+            drop @16
+            @11 := @PtrFromPartsMut<'_, Slice<T>>(copy (@15), copy (new_len@4))
+            drop @15
+            drop ptr@12
+            @0 := &mut *(@11)
+            drop @11
+            return
+        }
+        @10 := core::slice::index::slice_end_index_len_fail(move (self@6), move (@9))
+    }
+    drop @13
+    drop @5
+    @3 := core::slice::index::slice_index_order_fail(move (rhs@7), move (self@6))
+}
+
+impl core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<T> : core::slice::index::SliceIndex<core::ops::range::Range<usize>[core::marker::Sized<usize>], Slice<T>>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    parent_clause0 = core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#1
+    type Output = Slice<T>
+    fn get<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get<'_0_0, T>[@TraitClause0]
+    fn get_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_mut<'_0_0, T>[@TraitClause0]
+    fn get_unchecked = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index<'_0_0, T>[@TraitClause0]
+    fn index_mut<'_0> = core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4::index_mut<'_0_0, T>[@TraitClause0]
+}
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let array@1: Array<i32, 6 : usize>; // local
+    let slice@2: &'_ (Slice<i32>); // local
+    let @3: &'_ (Slice<i32>); // anonymous local
+    let @4: &'_ (Array<i32, 6 : usize>); // anonymous local
+    let @5: core::ops::range::Range<usize>[core::marker::Sized<usize>]; // anonymous local
+    let @6: (); // anonymous local
+    let @7: bool; // anonymous local
+    let @8: i32; // anonymous local
+    let @9: usize; // anonymous local
+    let @10: &'_ (Slice<i32>); // anonymous local
+    let @11: &'_ (i32); // anonymous local
+
+    array@1 := [const (1 : i32), const (2 : i32), const (3 : i32), const (4 : i32), const (5 : i32), const (6 : i32)]
+    @fake_read(array@1)
+    @4 := &array@1
+    @5 := core::ops::range::Range { start: const (2 : usize), end: const (5 : usize) }
+    @3 := core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_, i32, core::ops::range::Range<usize>[core::marker::Sized<usize>], 6 : usize>[core::marker::Sized<i32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::ops::index::Index<I> for Slice<T>}<i32, core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<i32>, core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::slice::index::{impl core::slice::index::SliceIndex<Slice<T>> for core::ops::range::Range<usize>[core::marker::Sized<usize>]}#4<i32>[core::marker::Sized<i32>]]](move (@4), move (@5))
+    drop @5
+    drop @4
+    slice@2 := &*(@3)
+    @fake_read(slice@2)
+    @9 := const (0 : usize)
+    @10 := &*(slice@2)
+    @11 := @SliceIndexShared<'_, i32>(move (@10), copy (@9))
+    @8 := copy (*(@11))
+    @7 := move (@8) == const (3 : i32)
+    if move (@7) {
+    }
+    else {
+        drop @8
+        drop @9
+        panic(core::panicking::panic)
+    }
+    drop @8
+    drop @9
+    drop @7
+    drop @6
+    @0 := ()
+    drop @3
+    drop slice@2
+    drop array@1
+    @0 := ()
+    return
+}
+
+pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (Self::Output)
+
+impl core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15<T, I, const N : usize> : core::ops::index::Index<Array<T, const N : usize>, I>
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: core::marker::Sized<I>,
+    [@TraitClause2]: core::ops::index::Index<Slice<T>, I>,
+{
+    type Output = @TraitClause2::Output
+    fn index<'_0> = core::array::{impl core::ops::index::Index<I> for Array<T, const N : usize>}#15::index<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
+}
+
+pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> core::option::Option<&'_0 (Self::Output)>[core::marker::Sized<&'_0 (Self::Output)>]
+
+pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> core::option::Option<&'_0 mut (Self::Output)>[core::marker::Sized<&'_0 mut (Self::Output)>]
+
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(@1: Self, @2: *const T) -> *const Self::Output
+
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(@1: Self, @2: *mut T) -> *mut Self::Output
+
+pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(@1: Self, @2: &'_0 mut (T)) -> &'_0 mut (Self::Output)
+
+
+

--- a/charon/tests/ui/from-raw-parts.rs
+++ b/charon/tests/ui/from-raw-parts.rs
@@ -1,4 +1,3 @@
-//@ charon-args=--include main
 //@ charon-args=--include core::slice::index::_
 
 fn main() {

--- a/charon/tests/ui/from-raw-parts.rs
+++ b/charon/tests/ui/from-raw-parts.rs
@@ -1,0 +1,8 @@
+//@ charon-args=--include main
+//@ charon-args=--include core::slice::index::_
+
+fn main() {
+    let array = [1, 2, 3, 4, 5, 6];
+    let slice = &array[2..5];
+    assert!(slice[0] == 3);
+}

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -1,0 +1,160 @@
+# Final LLBC before serialization:
+
+#[lang_item("sized")]
+pub trait core::marker::Sized<Self>
+
+pub fn core::slice::{Slice<T>}::as_ptr<'_0, T>(@1: &'_0 (Slice<T>)) -> *const T
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+
+pub fn core::intrinsics::cold_path()
+
+#[lang_item("panic_nounwind")]
+pub fn core::panicking::panic_nounwind(@1: &'static (Str)) -> !
+
+fn core::ptr::const_ptr::{*const T}::offset::precondition_check(@1: *const (), @2: isize, @3: usize)
+{
+    let @0: (); // return
+    let this@1: *const (); // arg #1
+    let count@2: isize; // arg #2
+    let size@3: usize; // arg #3
+    let @4: bool; // anonymous local
+    let @5: !; // anonymous local
+    let rhs@6: isize; // local
+    let self@7: usize; // local
+    let @8: i64; // anonymous local
+    let b@9: bool; // local
+    let @10: (i64, bool); // anonymous local
+    let @11: i64; // anonymous local
+    let @12: i64; // anonymous local
+    let byte_offset@13: isize; // local
+    let @14: (); // anonymous local
+    let @15: usize; // anonymous local
+    let overflow@16: bool; // local
+    let @17: bool; // anonymous local
+    let @18: bool; // anonymous local
+    let @19: (u64, bool); // anonymous local
+    let @20: u64; // anonymous local
+    let @21: u64; // anonymous local
+
+    rhs@6 := cast<usize, isize>(copy (size@3))
+    @11 := cast<isize, i64>(copy (count@2))
+    @12 := cast<isize, i64>(copy (rhs@6))
+    @10 := move (@11) checked.* move (@12)
+    drop @12
+    drop @11
+    @8 := copy ((@10).0)
+    b@9 := copy ((@10).1)
+    drop @10
+    byte_offset@13 := cast<i64, isize>(copy (@8))
+    drop @8
+    if copy (b@9) {
+        @14 := core::intrinsics::cold_path()
+        drop b@9
+        drop rhs@6
+        drop overflow@16
+    }
+    else {
+        drop b@9
+        drop rhs@6
+        self@7 := transmute<*const (), usize>(copy (this@1))
+        @15 := cast<isize, usize>(copy (byte_offset@13))
+        @20 := cast<usize, u64>(copy (self@7))
+        @21 := cast<usize, u64>(copy (@15))
+        @19 := move (@20) checked.+ move (@21)
+        drop @21
+        drop @20
+        @18 := copy ((@19).1)
+        drop @19
+        drop @15
+        @17 := copy (byte_offset@13) < const (0 : isize)
+        overflow@16 := copy (@18) ^ move (@17)
+        drop @17
+        drop @18
+        drop self@7
+        @4 := ~(copy (overflow@16))
+        drop overflow@16
+        if move (@4) {
+            drop @4
+            @0 := ()
+            return
+        }
+        else {
+        }
+    }
+    @5 := core::panicking::panic_nounwind(const ("unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+}
+
+pub unsafe fn core::ptr::const_ptr::{*const T}::offset<T>(@1: *const T, @2: isize) -> *const T
+where
+    [@TraitClause0]: core::marker::Sized<T>,
+{
+    let @0: *const T; // return
+    let self@1: *const T; // arg #1
+    let count@2: isize; // arg #2
+    let @3: bool; // anonymous local
+    let @4: (); // anonymous local
+    let @5: *const (); // anonymous local
+    let @6: usize; // anonymous local
+
+    @3 := ub_checks<bool>
+    if move (@3) {
+        @5 := cast<*const T, *const ()>(copy (self@1))
+        @6 := size_of<T>
+        @4 := core::ptr::const_ptr::{*const T}::offset::precondition_check(move (@5), copy (count@2), move (@6))
+        drop @6
+        drop @5
+    }
+    else {
+    }
+    drop @3
+    @0 := copy (self@1) offset copy (count@2)
+    return
+}
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let s@1: Array<i32, 2 : usize>; // local
+    let ptr@2: *const i32; // local
+    let @3: &'_ (Slice<i32>); // anonymous local
+    let @4: &'_ (Array<i32, 2 : usize>); // anonymous local
+    let @5: (); // anonymous local
+    let @6: bool; // anonymous local
+    let @7: i32; // anonymous local
+    let @8: *const i32; // anonymous local
+    let @9: *const i32; // anonymous local
+
+    s@1 := [const (11 : i32), const (42 : i32)]
+    @fake_read(s@1)
+    @4 := &s@1
+    @3 := @ArrayToSliceShared<'_, i32, 2 : usize>(move (@4))
+    drop @4
+    ptr@2 := core::slice::{Slice<T>}::as_ptr<'_, i32>[core::marker::Sized<i32>](move (@3))
+    drop @3
+    @fake_read(ptr@2)
+    @9 := copy (ptr@2)
+    @8 := core::ptr::const_ptr::{*const T}::offset<i32>[core::marker::Sized<i32>](move (@9), const (1 : isize))
+    drop @9
+    @7 := copy (*(@8))
+    @6 := move (@7) == const (42 : i32)
+    if move (@6) {
+    }
+    else {
+        drop @7
+        drop @8
+        panic(core::panicking::panic)
+    }
+    drop @7
+    drop @8
+    drop @6
+    drop @5
+    @0 := ()
+    drop ptr@2
+    drop s@1
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/ptr-offset.rs
+++ b/charon/tests/ui/ptr-offset.rs
@@ -1,0 +1,10 @@
+//@ charon-args=--include main
+//@ charon-args=--include core::ptr::const_ptr::_::offset
+
+fn main() {
+    let s = [11, 42];
+    let ptr = s.as_ptr();
+    unsafe {
+        assert!(*ptr.offset(1) == 42);
+    }
+}

--- a/charon/tests/ui/ptr-offset.rs
+++ b/charon/tests/ui/ptr-offset.rs
@@ -1,4 +1,3 @@
-//@ charon-args=--include main
 //@ charon-args=--include core::ptr::const_ptr::_::offset
 
 fn main() {

--- a/charon/tests/ui/simple-cmp.out
+++ b/charon/tests/ui/simple-cmp.out
@@ -1,0 +1,135 @@
+# Final LLBC before serialization:
+
+#[lang_item("Ordering")]
+pub enum core::cmp::Ordering =
+|  Less()
+|  Equal()
+|  Greater()
+
+
+pub fn core::cmp::impls::{impl core::cmp::Ord for i32}#77::cmp<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::cmp::Ordering
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let x@1: i32; // local
+    let y@2: i32; // local
+    let @3: core::cmp::Ordering; // anonymous local
+    let @4: &'_ (i32); // anonymous local
+    let @5: &'_ (i32); // anonymous local
+    let @6: &'_ (i32); // anonymous local
+
+    x@1 := const (11 : i32)
+    @fake_read(x@1)
+    y@2 := const (22 : i32)
+    @fake_read(y@2)
+    @4 := &x@1
+    @6 := &y@2
+    @5 := &*(@6)
+    @3 := core::cmp::impls::{impl core::cmp::Ord for i32}#77::cmp<'_, '_>(move (@4), move (@5))
+    drop @5
+    drop @4
+    @fake_read(@3)
+    drop @6
+    drop @3
+    @0 := ()
+    drop y@2
+    drop x@1
+    @0 := ()
+    return
+}
+
+#[lang_item("eq")]
+pub trait core::cmp::PartialEq<Self, Rhs>
+{
+    fn eq<'_0, '_1> = core::cmp::PartialEq::eq<'_0_0, '_0_1, Self, Rhs>
+}
+
+#[lang_item("Eq")]
+pub trait core::cmp::Eq<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Self>
+}
+
+#[lang_item("sized")]
+pub trait core::marker::Sized<Self>
+
+#[lang_item("Option")]
+pub enum core::option::Option<T>
+  where
+      [@TraitClause0]: core::marker::Sized<T>,
+ =
+|  None()
+|  Some(T)
+
+
+#[lang_item("partial_ord")]
+pub trait core::cmp::PartialOrd<Self, Rhs>
+{
+    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    fn partial_cmp<'_0, '_1> = core::cmp::PartialOrd::partial_cmp<'_0_0, '_0_1, Self, Rhs>
+}
+
+#[lang_item("Ord")]
+pub trait core::cmp::Ord<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::cmp::Eq<Self>
+    parent_clause1 : [@TraitClause1]: core::cmp::PartialOrd<Self, Self>
+    fn cmp<'_0, '_1> = core::cmp::Ord::cmp<'_0_0, '_0_1, Self>
+}
+
+#[lang_item("ord_cmp_method")]
+pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> core::cmp::Ordering
+
+pub fn core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> bool
+
+impl core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30 : core::cmp::PartialEq<i32, i32>
+{
+    fn eq<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30::eq<'_0_0, '_0_1>
+}
+
+impl core::cmp::impls::{impl core::cmp::Eq for i32}#49 : core::cmp::Eq<i32>
+{
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30
+}
+
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+{
+    let @0: core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]; // return
+    let self@1: &'_ (i32); // arg #1
+    let other@2: &'_ (i32); // arg #2
+    let @3: core::cmp::Ordering; // anonymous local
+    let @4: i32; // anonymous local
+    let @5: i32; // anonymous local
+
+    @4 := copy (*(self@1))
+    @5 := copy (*(other@2))
+    @3 := move (@4) cmp move (@5)
+    drop @5
+    drop @4
+    @0 := core::option::Option::Some { 0: move (@3) }
+    drop @3
+    return
+}
+
+impl core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76 : core::cmp::PartialOrd<i32, i32>
+{
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<i32> for i32}#30
+    fn partial_cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76::partial_cmp<'_0_0, '_0_1>
+}
+
+impl core::cmp::impls::{impl core::cmp::Ord for i32}#77 : core::cmp::Ord<i32>
+{
+    parent_clause0 = core::cmp::impls::{impl core::cmp::Eq for i32}#49
+    parent_clause1 = core::cmp::impls::{impl core::cmp::PartialOrd<i32> for i32}#76
+    fn cmp<'_0, '_1> = core::cmp::impls::{impl core::cmp::Ord for i32}#77::cmp<'_0_0, '_0_1>
+}
+
+#[lang_item("cmp_partialeq_eq")]
+pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> bool
+
+#[lang_item("cmp_partialord_cmp")]
+pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(@1: &'_0 (Self), @2: &'_1 (Rhs)) -> core::option::Option<core::cmp::Ordering>[core::marker::Sized<core::cmp::Ordering>]
+
+
+

--- a/charon/tests/ui/simple-cmp.rs
+++ b/charon/tests/ui/simple-cmp.rs
@@ -1,4 +1,3 @@
-//@ charon-args=--include main
 //@ charon-args=--include core::cmp::impls::_::partial_cmp
 
 fn main() {

--- a/charon/tests/ui/simple-cmp.rs
+++ b/charon/tests/ui/simple-cmp.rs
@@ -1,0 +1,8 @@
+//@ charon-args=--include main
+//@ charon-args=--include core::cmp::impls::_::partial_cmp
+
+fn main() {
+    let x: i32 = 11;
+    let y: i32 = 22;
+    let _ = x.cmp(&y);
+}


### PR DESCRIPTION
Add some additional MIR elements to the AST. `BuiltinFunId::PtrFromParts` is desugared from `AggregateKind::RawPtr`, though ideally it will be replaced with `core::ptr::from_raw_parts[_mut]` (or maybe `std::intrinsics::aggregate_raw_ptr`).

@Nadrieril is there a reason why you didn't want RawPtr as an aggregate kind?