### PR TITLE
Use latest annotate-snippets

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -28,9 +28,8 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+version = "0.11.5"
+source = "git+https://github.com/rust-lang/annotate-snippets-rs#a78e165de1e2bc65bf261f5770bdcfa172a9654a"
 dependencies = [
  "anstyle",
  "unicode-width",
@@ -2392,9 +2391,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -37,7 +37,7 @@ path = "tests/cargo.rs"
 harness = false
 
 [dependencies]
-annotate-snippets = "0.11.4"
+annotate-snippets = { git = "https://github.com/rust-lang/annotate-snippets-rs", version = "0.11.5" }
 anstream = "0.6.18"
 anyhow = "1.0.81"
 assert_cmd = "2.0"

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -42,7 +42,7 @@ impl CheckGenericsVisitor<'_> {
                 .join("\n  "),
         );
         // This is a fatal error: the output llbc is inconsistent and should not be used.
-        self.ctx.span_err(self.span, &msg, Level::Error);
+        self.ctx.span_err(self.span, &msg, Level::ERROR);
     }
 
     /// For pretty error printing. This can print values that we encounter because we track binders

--- a/charon/tests/cargo/error-dependencies.out
+++ b/charon/tests/cargo/error-dependencies.out
@@ -13,7 +13,6 @@ note: the error occurred when translating `core::ptr::metadata::Thin`, which is 
    |             -----------------------
  7 |     let _ = crate::opaque::custom_null::<u8>();
    |             ----------------------------------
-   |
 error: Item `core::ptr::metadata::Thin` caused errors; ignoring.
  --> /rustc/library/core/src/ptr/metadata.rs:84:1
 

--- a/charon/tests/ui/error-dependencies.out
+++ b/charon/tests/ui/error-dependencies.out
@@ -6,15 +6,12 @@ note: the error occurred when translating `core::ptr::metadata::Thin`, which is 
    |
  9 |     let _ = core::ptr::null::<u8>();
    |             -----------------------
-10 |     let _ = opaque::other_error();
 ...
-15 |     pub fn other_error() {
 16 |         let _ = custom_null::<u8>();
    |                 -------------------
 17 |     }
 18 |     fn custom_null<T: core::ptr::Thin>() {}
    |                       ---------------
-   |
 error: Item `core::ptr::metadata::Thin` caused errors; ignoring.
  --> /rustc/library/core/src/ptr/metadata.rs:84:1
 

--- a/charon/tests/ui/gat-causes-unhandled-ty-clause.out
+++ b/charon/tests/ui/gat-causes-unhandled-ty-clause.out
@@ -3,35 +3,31 @@ error: Generic associated types are not supported
   |
 4 |     type GAT<T>;
   |     ^^^^^^^^^^^
-  |
 
 error: Item `test_crate::HasGAT` caused errors; ignoring.
  --> tests/ui/gat-causes-unhandled-ty-clause.rs:3:1
   |
 3 | trait HasGAT {
   | ^^^^^^^^^^^^
-  |
 
 error: Found unhandled item clause; this is a bug unless the clause is coming from a GAT.
   --> tests/ui/gat-causes-unhandled-ty-clause.rs:12:1
    |
 12 | / fn floatify<C>() -> <C::Friend as HasAssoc>::Assoc
 13 | | where
+14 | |     C: HasGAT,
 ...  |
-16 | |     todo!()
 17 | | }
    | |_^
-   |
 
 error: Found unhandled item clause; this is a bug unless the clause is coming from a GAT.
   --> tests/ui/gat-causes-unhandled-ty-clause.rs:12:1
    |
 12 | / fn floatify<C>() -> <C::Friend as HasAssoc>::Assoc
 13 | | where
+14 | |     C: HasGAT,
 ...  |
-16 | |     todo!()
 17 | | }
    | |_^
-   |
 
 ERROR Charon failed to translate this code (4 errors)

--- a/charon/tests/ui/generic-associated-types.out
+++ b/charon/tests/ui/generic-associated-types.out
@@ -3,69 +3,59 @@ error: Generic associated types are not supported
   |
 5 |     type Item<'a>
   |     ^^^^^^^^^^^^^
-  |
 
 error: Item `test_crate::LendingIterator` caused errors; ignoring.
  --> tests/ui/generic-associated-types.rs:4:1
   |
 4 | pub trait LendingIterator {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Found unsupported GAT `Item` when resolving trait `core::marker::Sized<Self::Item>`
  --> tests/ui/generic-associated-types.rs:9:5
   |
 9 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Error during trait resolution: Found unsupported GAT `Item` when resolving trait `core::marker::Sized<Self::Item>`
  --> tests/ui/generic-associated-types.rs:9:5
   |
 9 |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Found unsupported GAT `Item` when resolving trait `core::marker::Sized<@TraitClause2::Item>`
   --> tests/ui/generic-associated-types.rs:29:28
    |
 29 |     while let Some(item) = iter.next() {
    |                            ^^^^^^^^^^^
-   |
 
 error: Error during trait resolution: Found unsupported GAT `Item` when resolving trait `core::marker::Sized<@TraitClause2::Item>`
   --> tests/ui/generic-associated-types.rs:29:28
    |
 29 |     while let Some(item) = iter.next() {
    |                            ^^^^^^^^^^^
-   |
 
 error: Generic associated types are not supported
   --> tests/ui/generic-associated-types.rs:48:9
    |
 48 |         type Type<'b>: for<'c> Foo<&'a &'b &'c ()>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: Item `test_crate::lifetimes::Bar` caused errors; ignoring.
   --> tests/ui/generic-associated-types.rs:47:5
    |
 47 |     pub trait Bar<'a> {
    |     ^^^^^^^^^^^^^^^^^
-   |
 
 error: Found unsupported GAT `Type` when resolving trait `test_crate::lifetimes::Foo<@TraitClause1::Type, &'_ (&'_ (&'_ (())))>`
   --> tests/ui/generic-associated-types.rs:55:9
    |
 55 |         x.foo()
    |         ^^^^^^^
-   |
 
 error: Error during trait resolution: Found unsupported GAT `Type` when resolving trait `test_crate::lifetimes::Foo<@TraitClause1::Type, &'_ (&'_ (&'_ (())))>`
   --> tests/ui/generic-associated-types.rs:55:9
    |
 55 |         x.foo()
    |         ^^^^^^^
-   |
 
 ERROR Charon failed to translate this code (10 errors)

--- a/charon/tests/ui/issue-393-shallowinitbox.out
+++ b/charon/tests/ui/issue-393-shallowinitbox.out
@@ -6,6 +6,5 @@ error: Could not reconstruct `Box` initialization; branching during `Box` initia
 4 | |     Some(vec)
 5 | | }
   | |_^
-  |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/match_on_opaque_enum.out
+++ b/charon/tests/ui/match_on_opaque_enum.out
@@ -1,13 +1,11 @@
 error: reading the discriminant of an opaque enum. Add `--include test_crate::Enum` to the `charon` arguments to translate this enum.
   --> tests/ui/match_on_opaque_enum.rs:9:5
    |
- 9 |       match x {
-   |  _____^
+ 9 | /     match x {
 10 | |         Enum::A => true,
 11 | |         Enum::B => false,
 12 | |     }
 13 | | }
    | |_^
-   |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/non-lifetime-gats.out
+++ b/charon/tests/ui/non-lifetime-gats.out
@@ -3,27 +3,23 @@ error: Generic associated types are not supported
   |
 5 |     type Pointer<T>: Deref<Target = T>;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Item `test_crate::PointerFamily` caused errors; ignoring.
  --> tests/ui/non-lifetime-gats.rs:4:1
   |
 4 | pub trait PointerFamily {
   | ^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Generic associated types are not supported
   --> tests/ui/non-lifetime-gats.rs:34:9
    |
 34 |         type Type<U>: Link<T>;
    |         ^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: Item `test_crate::moar_variables::Trait` caused errors; ignoring.
   --> tests/ui/non-lifetime-gats.rs:33:5
    |
 33 |     pub trait Trait<T> {
    |     ^^^^^^^^^^^^^^^^^^
-   |
 
 ERROR Charon failed to translate this code (4 errors)

--- a/charon/tests/ui/pointers-in-consts.out
+++ b/charon/tests/ui/pointers-in-consts.out
@@ -3,6 +3,5 @@ error: Unsupported constant: `ConstantExprKind::Cast {..}`
   |
 6 |         DISGUISED_INT => {}
   |         ^^^^^^^^^^^^^
-  |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/rename_attribute_failure.out
+++ b/charon/tests/ui/rename_attribute_failure.out
@@ -3,41 +3,35 @@ error: Error parsing attribute: attribute `rename` should not be empty
   |
 6 | #[charon::rename("")]
   | ^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Error parsing attribute: attribute `rename` should contain a valid identifier
  --> tests/ui/rename_attribute_failure.rs:9:1
   |
 9 | #[charon::rename("Test!976?")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Error parsing attribute: attribute `rename` should contain a valid identifier
   --> tests/ui/rename_attribute_failure.rs:12:1
    |
 12 | #[charon::rename("75Test")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: Error parsing attribute: the new name should be between quotes: `rename("aaaa")`.
   --> tests/ui/rename_attribute_failure.rs:15:1
    |
 15 | #[charon::rename(aaaa)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: There should be at most one `charon::rename("...")` or `aeneas::rename("...")` attribute per declaration
   --> tests/ui/rename_attribute_failure.rs:20:1
    |
 20 | pub type TestMultiple = ();
    | ^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: Error parsing attribute: Unrecognized attribute: `charon::something_else("_Type36")`
   --> tests/ui/rename_attribute_failure.rs:22:1
    |
 22 | #[charon::something_else("_Type36")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 ERROR Charon failed to translate this code (6 errors)

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.out
@@ -5,6 +5,5 @@ error: Could not compute the value of Self::Clause1::Clause0::Clause0::Output ne
   |
 9 |     fn call(&self) -> <Self::Foo as FnOnce<()>>::Output;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
@@ -5,6 +5,5 @@ error: Mismatched method generics:
    |
 14 |     <() as Trait>::method()
    |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -7,21 +7,18 @@ error: Hax panicked when translating `test_crate::{impl#0}`.
   |
 9 | impl Collection for () {}
   | ^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Generic associated types are not supported
  --> tests/ui/simple/gat-default.rs:6:5
   |
 6 |     type Sibling<U> = Vec<U>;
   |     ^^^^^^^^^^^^^^^
-  |
 
 error: Item `test_crate::Collection` caused errors; ignoring.
  --> tests/ui/simple/gat-default.rs:5:1
   |
 5 | trait Collection {
   | ^^^^^^^^^^^^^^^^
-  |
 
 
 thread 'rustc' panicked at /rustc/920d95eaf23d7eb6b415d09868e4f793024fa604/compiler/rustc_type_ir/src/binder.rs:737:9:
@@ -31,13 +28,11 @@ error: Hax panicked when translating `test_crate::{impl#0}`.
   |
 9 | impl Collection for () {}
   | ^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Item `test_crate::{impl#0}` caused errors; ignoring.
  --> tests/ui/simple/gat-default.rs:9:1
   |
 9 | impl Collection for () {}
   | ^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 ERROR Charon failed to translate this code (5 errors)

--- a/charon/tests/ui/simple/match-on-char.out
+++ b/charon/tests/ui/simple/match-on-char.out
@@ -3,6 +3,5 @@ error: Can't match on type char
   |
 3 |     match 'x' {
   |     ^^^^^^^^^
-  |
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -23,7 +23,6 @@ error: Hax panicked when translating `Body { basic_blocks: BasicBlocks { basic_b
 4 | |     &|x: u32| x
 5 | | }
   | |_^
-  |
 
 error: aborting due to 1 previous error
 

--- a/charon/tests/ui/simple/promoted-in-generic-fn.out
+++ b/charon/tests/ui/simple/promoted-in-generic-fn.out
@@ -36,7 +36,6 @@ error: Hax panicked when translating `Body { basic_blocks: BasicBlocks { basic_b
 5 | |     let _ = &size_of::<T>();
 6 | | }
   | |_^
-  |
 
 error: aborting due to 1 previous error
 

--- a/charon/tests/ui/unsupported/advanced-const-generics.out
+++ b/charon/tests/ui/unsupported/advanced-const-generics.out
@@ -3,14 +3,12 @@ error: Constant parameters of non-literal type are not supported
    |
 14 | fn foo<const X: Foo>() -> Foo {
    |        ^^^^^^^^^^^^
-   |
 
 error: Item `test_crate::foo` caused errors; ignoring.
   --> tests/ui/unsupported/advanced-const-generics.rs:14:1
    |
 14 | fn foo<const X: Foo>() -> Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 disabled backtrace
 error[E9999]: Supposely unreachable place in the Rust AST. The label is "TranslateUneval".
@@ -41,7 +39,6 @@ error: Hax panicked when translating `test_crate::bar`.
 19 | | where
 20 | |     [(); N + 1]:,
    | |_________________^
-   |
 
 error: Item `test_crate::bar` caused errors; ignoring.
   --> tests/ui/unsupported/advanced-const-generics.rs:18:1
@@ -50,7 +47,6 @@ error: Item `test_crate::bar` caused errors; ignoring.
 19 | | where
 20 | |     [(); N + 1]:,
    | |_________________^
-   |
 
 error: aborting due to 1 previous error
 

--- a/charon/tests/ui/unsupported/unbound-lifetime.out
+++ b/charon/tests/ui/unsupported/unbound-lifetime.out
@@ -11,14 +11,12 @@ error: Unexpected region kind: Region { kind: ReError(ErrorGuaranteed { todo: "E
   |
 5 | fn get(_x: &'a u32) {}
   | ^^^^^^^^^^^^^^^^^^^^^^
-  |
 
 error: Item `test_crate::get` caused errors; ignoring.
  --> tests/ui/unsupported/unbound-lifetime.rs:5:1
   |
 5 | fn get(_x: &'a u32) {}
   | ^^^^^^^^^^^^^^^^^^^
-  |
 
 error: aborting due to 1 previous error
 

--- a/charon/tests/ui/unsupported/well-formedness-bound.out
+++ b/charon/tests/ui/unsupported/well-formedness-bound.out
@@ -3,7 +3,6 @@ error: Well-formedness clauses are unsupported
   |
 4 |     &'a ():,
   |     ^^^^^^
-  |
 
 error: Item `test_crate::get` caused errors; ignoring.
  --> tests/ui/unsupported/well-formedness-bound.rs:2:1
@@ -12,6 +11,5 @@ error: Item `test_crate::get` caused errors; ignoring.
 3 | | where
 4 | |     &'a ():,
   | |____________^
-  |
 
 ERROR Charon failed to translate this code (2 errors)


### PR DESCRIPTION
Now that https://github.com/rust-lang/annotate-snippets-rs/issues/160 is fixed, we can remove some workarounds in Charon.