### PR TITLE
Fix OCaml chars

### DIFF
--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -435,7 +435,7 @@ let match_literal (pl : literal) (l : Values.literal) : bool =
   match (pl, l) with
   | LInt pv, VScalar v -> pv = v.value
   | LBool pv, VBool v -> pv = v
-  | LChar pv, VChar v -> pv = v
+  | LChar pv, VChar v -> Uchar.of_char pv = v
   | _ -> false
 
 let rec match_name_with_generics (ctx : 'fun_body ctx) (c : match_config)
@@ -910,7 +910,9 @@ let literal_to_pattern (_c : to_pat_config) (lit : Values.literal) : literal =
   match lit with
   | VScalar sv -> LInt sv.value
   | VBool v -> LBool v
-  | VChar v -> LChar v
+  | VChar v when Uchar.is_char v -> LChar (Uchar.to_char v)
+  | VChar _ ->
+      raise (Failure "Can't convert non-ASCII character literal to pattern")
   | VFloat _ | VStr _ | VByteStr _ ->
       raise
         (Failure "Float, string and byte string literals are not valid in names")

--- a/charon-ml/src/OfJsonBasic.ml
+++ b/charon-ml/src/OfJsonBasic.ml
@@ -1,5 +1,5 @@
 (** This module defines various basic utilities for json deserialization.
-   
+
  *)
 
 open Yojson.Basic
@@ -27,11 +27,16 @@ let int_of_json (ctx : 'ctx) (js : json) : (int, string) result =
   | `Int i -> Ok i
   | _ -> Error ("int_of_json: not an int: " ^ show js)
 
-let char_of_json (ctx : 'ctx) (js : json) : (char, string) result =
+let char_of_json (ctx : 'ctx) (js : json) : (Uchar.t, string) result =
   match js with
   | `String c ->
-      if String.length c = 1 then Ok c.[0]
-      else Error ("char_of_json: stricly more than one character in: " ^ show js)
+      if String.length c > 4 then
+        Error ("char_of_json: stricly more than four bytes in: " ^ show js)
+      else
+        let uchar = String.get_utf_8_uchar c 0 in
+        if Uchar.utf_decode_is_valid uchar then
+          Ok (Uchar.utf_decode_uchar uchar)
+        else Error ("char_of_json: invalid UTF-8 character: " ^ show js)
   | _ -> Error ("char_of_json: not a char: " ^ show js)
 
 let rec of_json_list (a_of_json : 'ctx -> json -> ('a, string) result)

--- a/charon-ml/src/PrintValues.ml
+++ b/charon-ml/src/PrintValues.ml
@@ -43,6 +43,6 @@ let literal_to_string (lit : literal) : string =
   | VScalar sv -> scalar_value_to_string sv
   | VFloat fv -> float_value_to_string fv
   | VBool b -> Bool.to_string b
-  | VChar c -> String.make 1 c
+  | VChar c -> Uchar.to_string c
   | VStr s -> "\"" ^ s ^ "\""
   | VByteStr bs -> "[" ^ String.concat ", " (List.map string_of_int bs) ^ "]"

--- a/charon-ml/src/Uchar.ml
+++ b/charon-ml/src/Uchar.ml
@@ -1,0 +1,7 @@
+include Stdlib.Uchar
+
+let pp fmt u =
+  if is_char u then Format.fprintf fmt "'%c'" (to_char u)
+  else Format.fprintf fmt "'\\x%x'" (to_int u)
+
+let to_string u = Format.asprintf "%a" pp u

--- a/charon-ml/src/generated/Generated_Values.ml
+++ b/charon-ml/src/generated/Generated_Values.ml
@@ -1,6 +1,8 @@
 (** The primitive values. *)
 include BigInt
 
+include Uchar
+
 type integer_type =
   | Isize
   | I8
@@ -32,7 +34,7 @@ and literal =
   | VScalar of scalar_value
   | VFloat of float_value
   | VBool of bool
-  | VChar of char
+  | VChar of (Uchar.t[@visitors.opaque])
   | VByteStr of int list
   | VStr of string
 

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -216,7 +216,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
 fn type_to_ocaml_name(ctx: &GenerateCtx, ty: &Ty) -> String {
     match ty.kind() {
         TyKind::Literal(LiteralTy::Bool) => "bool".to_string(),
-        TyKind::Literal(LiteralTy::Char) => "char".to_string(),
+        TyKind::Literal(LiteralTy::Char) => "(Uchar.t [@visitors.opaque])".to_string(),
         TyKind::Literal(LiteralTy::Integer(_)) => "int".to_string(),
         TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
         TyKind::Adt(adt_kind, generics) => {

--- a/charon/src/bin/generate-ml/templates/Values.ml
+++ b/charon/src/bin/generate-ml/templates/Values.ml
@@ -1,4 +1,5 @@
 (** The primitive values. *)
 include BigInt
+include Uchar
 
 (* __REPLACE0__ *)

--- a/charon/tests/ui/max_char.out
+++ b/charon/tests/ui/max_char.out
@@ -1,0 +1,43 @@
+# Final LLBC before serialization:
+
+pub fn core::char::methods::{char}::MAX() -> char
+{
+    let @0: char; // return
+
+    @0 := const (􏿿)
+    return
+}
+
+pub global core::char::methods::{char}::MAX: char = core::char::methods::{char}::MAX()
+
+pub fn core::char::MAX() -> char
+{
+    let @0: char; // return
+    let @1: char; // anonymous local
+
+    storage_live(@1)
+    @1 := core::char::methods::{char}::MAX
+    @0 := move (@1)
+    return
+}
+
+pub global core::char::MAX: char = core::char::MAX()
+
+fn test_crate::main()
+{
+    let @0: (); // return
+    let _max_char@1: char; // local
+    let @2: char; // anonymous local
+
+    storage_live(@2)
+    storage_live(_max_char@1)
+    @2 := core::char::MAX
+    _max_char@1 := move (@2)
+    @0 := ()
+    storage_dead(_max_char@1)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/max_char.rs
+++ b/charon/tests/ui/max_char.rs
@@ -1,0 +1,7 @@
+//@ charon-args=--include std::char::MAX
+//@ charon-args=--include core::char::MAX
+//@ charon-args=--include core::char::methods::_::MAX
+
+fn main() {
+    let _max_char = std::char::MAX;
+}


### PR DESCRIPTION
OCaml `char`s are ASCII characters, spanning one byte, whereas Rust `char`s are UTF-8 characters, spanning four bytes. This means that the parsing of certain characters in the OCaml library (e.g. `std::char::MAX`) would fail at the parsing stage. 

This PR addresses this, by using [`Uchar.t`](https://ocaml.org/manual/5.1/api/Uchar.html) instead of `char` in OCaml, which sports the same guarantees as Rust's char. Unfortunately, a few utility functions we would like having were only added in OCaml 4.14.0 (notably [`String.get_utf8_uchar`](https://ocaml.org/manual/5.3/api/String.html#utf_8)), and Charon is currently on OCaml 4.13.1, so I included a few methods from OCaml's stdlib in our version of it, as a temporary measure.

Another option would be storing the value as a `int` -- this works too, and may be simpler, but comes with the drawback of not validating the value for UTF-8, and doesn't make converting to/from a string much easier.

ci: use https://github.com/AeneasVerif/aeneas/pull/506