### PR TITLE
Monomorphisation hotfix

### DIFF
--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -494,7 +494,12 @@ impl TransformPass for Transform {
                             AnyTransId::Type(typ_id_sub)
                         }
                         AnyTransId::Global(g_id) => {
-                            let glob = ctx.translated.global_decls.get(*g_id).unwrap();
+                            let Some(glob) = ctx.translated.global_decls.get(*g_id) else {
+                                // Something odd happened -- we ignore and move on
+                                *mono = OptionHint::Some(*id);
+                                warn!("Found a global that has no associated declaration");
+                                continue;
+                            };
                             let mut glob_sub = glob.clone().substitute(gargs);
 
                             let init = ctx.translated.fun_decls.get(glob.init).unwrap();


### PR DESCRIPTION
The pass `inline_promoted_consts` currently gets rid of all promoted consts, and tries inlining them, but in some cases (for a reason I don't understand) it sometimes fails to inline; a simple reproducible example is any code that calls `core::fmt::{core::fmt::Arguments<'a>}::new_const`, which will assign a global whose definition has been removed.

This is a hotfix for monomorphisation to not error in these cases, as I don't know how to fix the issue (yet) and just need mono to work again.