### PR TITLE
Update ML lib with non-opaque index/slice places

### DIFF
--- a/charon-ml/src/ExpressionsUtils.ml
+++ b/charon-ml/src/ExpressionsUtils.ml
@@ -2,7 +2,7 @@ open Expressions
 
 let unop_can_fail (unop : unop) : bool =
   match unop with
-  | Neg | Cast _ | PtrMetadata -> true
+  | Neg | Cast _ | PtrMetadata | ArrayToSlice _ -> true
   | Not -> false
 
 let binop_can_fail (binop : binop) : bool =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -786,8 +786,8 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hax-adt-into"
-version = "0.2.0"
-source = "git+https://github.com/cryspen/hax?branch=main#0275a2b0cda11871b3761b09c2a07d467a5baf1f"
+version = "0.3.0"
+source = "git+https://github.com/cryspen/hax?branch=main#27ba29ff727fb4c4fffecad5e736181087ce2537"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -797,8 +797,8 @@ dependencies = [
 
 [[package]]
 name = "hax-frontend-exporter"
-version = "0.2.0"
-source = "git+https://github.com/cryspen/hax?branch=main#0275a2b0cda11871b3761b09c2a07d467a5baf1f"
+version = "0.3.0"
+source = "git+https://github.com/cryspen/hax?branch=main#27ba29ff727fb4c4fffecad5e736181087ce2537"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -814,8 +814,8 @@ dependencies = [
 
 [[package]]
 name = "hax-frontend-exporter-options"
-version = "0.2.0"
-source = "git+https://github.com/cryspen/hax?branch=main#0275a2b0cda11871b3761b09c2a07d467a5baf1f"
+version = "0.3.0"
+source = "git+https://github.com/cryspen/hax?branch=main#27ba29ff727fb4c4fffecad5e736181087ce2537"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -48,6 +48,7 @@ fn make_ocaml_ident(name: &str) -> String {
             | "float"
             | "end"
             | "include"
+            | "to"
     ) {
         name += "_";
     }


### PR DESCRIPTION
PR #682 made `ops_to_function_calls` a LLBC-only pass, meaning when compiling as ULLBC, `Index`/`Slice` places and `ArrayToSlice` unops can appear in the output, but the ML library hasn't been updated to reflect this.

The next step to this PR is #686

ci: use https://github.com/AeneasVerif/aeneas/pull/519