### PR TITLE
Add rust-src to the toolchain file

### DIFF
--- a/charon/rust-toolchain
+++ b/charon/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-03-29"
-components = [ "rustc-dev", "llvm-tools-preview" ]
+components = [ "rust-src", "rustc-dev", "llvm-tools-preview" ]


### PR DESCRIPTION
So that IDEs can find it