### PR TITLE
Substitute const generics in ConstantExpr

### DIFF
--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -42,7 +42,7 @@ use indexmap::IndexMap;
     // Types that we unconditionally explore.
     drive(
         AbortKind, Assert, BinOp, Body, BorrowKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy, Call,
-        CastKind, ClosureInfo, ClosureKind, ConstantExpr, ConstGenericVar, ConstGenericVarId,
+        CastKind, ClosureInfo, ClosureKind, ConstGenericVar, ConstGenericVarId,
         Disambiguator, ExistentialPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
         FnOperand, FunId, FunIdOrTraitMethodRef, FunSig, ImplElem, IntegerTy, Literal, LiteralTy,
         llbc_ast::Block, llbc_ast::ExprBody, llbc_ast::RawStatement, llbc_ast::Switch,
@@ -70,7 +70,7 @@ use indexmap::IndexMap;
         for<T: AstVisitable> RegionBinder<T>,
         for<T: AstVisitable> Binder<T>,
         llbc_statement: llbc_ast::Statement, ullbc_statement: ullbc_ast::Statement,
-        AggregateKind, FnPtr, ItemKind, ItemMeta, Span,
+        AggregateKind, FnPtr, ItemKind, ItemMeta, Span, ConstantExpr,
         FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId,
         FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
     )

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -535,6 +535,11 @@ impl TransformPass for Transform {
                 }
                 *mono = OptionHint::Some(new_mono);
                 data.worklist.push(new_mono);
+
+                let item = ctx.translated.get_item(new_mono).unwrap();
+                ctx.translated
+                    .item_names
+                    .insert(new_mono, item.item_meta().name.clone());
             }
 
             // 3. Substitute all generics with the monomorphized versions

--- a/charon/tests/ui/monomorphization/adt_proj.out
+++ b/charon/tests/ui/monomorphization/adt_proj.out
@@ -16,7 +16,7 @@ pub trait core::marker::Sized<Self>
 fn test_crate::main()
 {
     let @0: (); // return
-    let res@1: @Adt1<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]; // local
+    let res@1: core::result::Result<u32, u32>[core::marker::Sized<u32>, core::marker::Sized<u32>]; // local
     let n@2: u32; // local
 
     storage_live(res@1)

--- a/charon/tests/ui/monomorphization/const_generics.out
+++ b/charon/tests/ui/monomorphization/const_generics.out
@@ -11,22 +11,22 @@ struct test_crate::Foo<T>
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 
-fn test_crate::FooBool() -> @Adt1<bool>[core::marker::Sized<bool>]
+fn test_crate::FooBool() -> test_crate::Foo<bool>[core::marker::Sized<bool>]
 {
-    let @0: @Adt1<bool>[core::marker::Sized<bool>]; // return
+    let @0: test_crate::Foo<bool>[core::marker::Sized<bool>]; // return
 
-    @0 := @Adt1 { value: const (false) }
+    @0 := test_crate::Foo { value: const (false) }
     return
 }
 
-static test_crate::FooBool: @Adt1<bool>[core::marker::Sized<bool>] = test_crate::FooBool()
+static test_crate::FooBool: test_crate::Foo<bool>[core::marker::Sized<bool>] = test_crate::FooBool()
 
 fn test_crate::main()
 {
     let @0: (); // return
     let _b@1: bool; // local
-    let @2: &'_ (@Adt1<bool>[core::marker::Sized<bool>]); // anonymous local
-    let @3: &'_ (@Adt1<bool>[core::marker::Sized<bool>]); // anonymous local
+    let @2: &'_ (test_crate::Foo<bool>[core::marker::Sized<bool>]); // anonymous local
+    let @3: &'_ (test_crate::Foo<bool>[core::marker::Sized<bool>]); // anonymous local
 
     storage_live(@3)
     storage_live(_b@1)
@@ -49,11 +49,11 @@ struct test_crate::Foo<T>
   value: i32,
 }
 
-fn test_crate::FooInt() -> @Adt2<i32>[core::marker::Sized<i32>]
+fn test_crate::FooInt() -> test_crate::Foo<i32>[core::marker::Sized<i32>]
 {
-    let @0: @Adt2<i32>[core::marker::Sized<i32>]; // return
+    let @0: test_crate::Foo<i32>[core::marker::Sized<i32>]; // return
 
-    @0 := @Adt2 { value: const (0 : i32) }
+    @0 := test_crate::Foo { value: const (0 : i32) }
     return
 }
 

--- a/charon/tests/ui/monomorphization/fn_ptr_generics.out
+++ b/charon/tests/ui/monomorphization/fn_ptr_generics.out
@@ -15,17 +15,17 @@ pub trait core::marker::Sized<Self>
 fn test_crate::init_option()
 {
     let @0: (); // return
-    let a@1: Array<@Adt1<u8>[core::marker::Sized<u8>], 6 : usize>; // local
-    let @2: @Adt1<u8>[core::marker::Sized<u8>]; // anonymous local
-    let b@3: @Adt1<u8>[core::marker::Sized<u8>]; // local
+    let a@1: Array<core::option::Option<u8>[core::marker::Sized<u8>], 6 : usize>; // local
+    let @2: core::option::Option<u8>[core::marker::Sized<u8>]; // anonymous local
+    let b@3: core::option::Option<u8>[core::marker::Sized<u8>]; // local
     let @4: usize; // anonymous local
-    let @5: &'_ (Array<@Adt1<u8>[core::marker::Sized<u8>], 6 : usize>); // anonymous local
-    let @6: &'_ (@Adt1<u8>[core::marker::Sized<u8>]); // anonymous local
+    let @5: &'_ (Array<core::option::Option<u8>[core::marker::Sized<u8>], 6 : usize>); // anonymous local
+    let @6: &'_ (core::option::Option<u8>[core::marker::Sized<u8>]); // anonymous local
 
     storage_live(a@1)
     storage_live(@2)
     @2 := core::option::Option::Some { 0: const (4 : u8) }
-    a@1 := @ArrayRepeat<'_, @Adt1<u8>[core::marker::Sized<u8>], 6 : usize>(move (@2))
+    a@1 := @ArrayRepeat<'_, core::option::Option<u8>[core::marker::Sized<u8>], 6 : usize>(move (@2))
     storage_dead(@2)
     storage_live(b@3)
     storage_live(@4)
@@ -33,7 +33,7 @@ fn test_crate::init_option()
     storage_live(@5)
     @5 := &a@1
     storage_live(@6)
-    @6 := @ArrayIndexShared<'_, @Adt1<u8>[core::marker::Sized<u8>], 6 : usize>(move (@5), copy (@4))
+    @6 := @ArrayIndexShared<'_, core::option::Option<u8>[core::marker::Sized<u8>], 6 : usize>(move (@5), copy (@4))
     b@3 := copy (*(@6))
     storage_dead(@4)
     @0 := ()

--- a/charon/tests/ui/monomorphization/trait_impls.out
+++ b/charon/tests/ui/monomorphization/trait_impls.out
@@ -69,7 +69,7 @@ fn test_crate::main()
     let @1: (); // anonymous local
 
     storage_live(@1)
-    @1 := @Fun7<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true))
+    @1 := test_crate::do_test<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true))
     storage_dead(@1)
     @0 := ()
     @0 := ()

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -84,7 +84,7 @@ fn test_crate::main()
 
     bb0: {
         storage_live(@1);
-        @1 := test_crate::do_test<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1;
+        @1 := test_crate::do_test<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1 (unwind: bb2);
     }
 
     bb1: {

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -84,7 +84,7 @@ fn test_crate::main()
 
     bb0: {
         storage_live(@1);
-        @1 := @Fun7<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1 (unwind: bb2);
+        @1 := test_crate::do_test<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1;
     }
 
     bb1: {


### PR DESCRIPTION
Fixes #698

SIdenote, @Nadrieril : `RawConstantExpr` defines `Literal`, `Global` and `Var`, and so does `ConstGeneric`. I understand these don't really mean the same thing, but really they are the same; do you think there's a way of merging the two? Though I do like having RawConstantExpr relatively flat.