### PR TITLE
Calls can now unwind - attempt 2

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.90"
+let supported_charon_version = "0.1.91"

--- a/charon-ml/src/PrintLlbcAst.ml
+++ b/charon-ml/src/PrintLlbcAst.ml
@@ -41,6 +41,7 @@ module Ast = struct
     | Call call -> call_to_string env indent call
     | Abort (Panic _) -> indent ^ "panic"
     | Abort UndefinedBehavior -> indent ^ "undefined_behavior"
+    | Abort UnwindTerminate -> indent ^ "unwind_terminate"
     | Return -> indent ^ "return"
     | Break i -> indent ^ "break " ^ string_of_int i
     | Continue i -> indent ^ "continue " ^ string_of_int i

--- a/charon-ml/src/PrintUllbcAst.ml
+++ b/charon-ml/src/PrintUllbcAst.ml
@@ -69,10 +69,13 @@ module Ast = struct
     | Switch (op, tgts) ->
         indent ^ "switch " ^ operand_to_string env op
         ^ switch_to_string indent tgts
-    | Call (call, tgt) ->
-        call_to_string env indent call ^ " -> " ^ block_id_to_string tgt
+    | Call (call, tgt, unwind) ->
+        call_to_string env indent call
+        ^ " -> " ^ block_id_to_string tgt ^ "(unwind:"
+        ^ block_id_to_string unwind ^ ")"
     | Abort _ -> indent ^ "panic"
     | Return -> indent ^ "return"
+    | UnwindResume -> indent ^ "unwind_continue"
 
   let block_to_string (env : fmt_env) (indent : string) (indent_incr : string)
       (id : BlockId.id) (block : block) : string =

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -663,6 +663,7 @@ and abort_kind_of_json (ctx : of_json_ctx) (js : json) :
         let* panic = option_of_json name_of_json ctx panic in
         Ok (Panic panic)
     | `String "UndefinedBehavior" -> Ok UndefinedBehavior
+    | `String "UnwindTerminate" -> Ok UnwindTerminate
     | _ -> Error "")
 
 and assertion_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -503,6 +503,8 @@ class ['self] map_type_decl_base =
 type abort_kind =
   | Panic of name option  (** A built-in panicking function. *)
   | UndefinedBehavior  (** Undefined behavior in the rust abstract machine. *)
+  | UnwindTerminate
+      (** Unwind had to stop for Abi reasons or because cleanup code panicked again. *)
 
 (** Meta information about an item (function, trait decl, trait impl, type decl, global). *)
 and item_meta = {

--- a/charon-ml/src/generated/Generated_UllbcAst.ml
+++ b/charon-ml/src/generated/Generated_UllbcAst.ml
@@ -84,14 +84,16 @@ and raw_terminator =
           - [discr]
           - [targets]
        *)
-  | Call of call * block_id
+  | Call of call * block_id * block_id
       (** 
           Fields:
           - [call]
           - [target]
+          - [on_unwind]
        *)
   | Abort of abort_kind  (** Handles panics and impossible cases. *)
   | Return
+  | UnwindResume
 
 and terminator = {
   span : span;

--- a/charon-ml/src/generated/Generated_UllbcOfJson.ml
+++ b/charon-ml/src/generated/Generated_UllbcOfJson.ml
@@ -102,14 +102,22 @@ and raw_terminator_of_json (ctx : of_json_ctx) (js : json) :
         let* discr = operand_of_json ctx discr in
         let* targets = switch_of_json ctx targets in
         Ok (Switch (discr, targets))
-    | `Assoc [ ("Call", `Assoc [ ("call", call); ("target", target) ]) ] ->
+    | `Assoc
+        [
+          ( "Call",
+            `Assoc
+              [ ("call", call); ("target", target); ("on_unwind", on_unwind) ]
+          );
+        ] ->
         let* call = call_of_json ctx call in
         let* target = block_id_of_json ctx target in
-        Ok (Call (call, target))
+        let* on_unwind = block_id_of_json ctx on_unwind in
+        Ok (Call (call, target, on_unwind))
     | `Assoc [ ("Abort", abort) ] ->
         let* abort = abort_kind_of_json ctx abort in
         Ok (Abort abort)
     | `String "Return" -> Ok Return
+    | `String "UnwindResume" -> Ok UnwindResume
     | _ -> Error "")
 
 and terminator_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "charon"
-version = "0.1.90"
-authors = ["Son Ho <hosonmarc@gmail.com>", "Guillaume Boisseau <nadrieril+git@gmail.com>"]
+version = "0.1.91"
+authors = [
+    "Son Ho <hosonmarc@gmail.com>",
+    "Guillaume Boisseau <nadrieril+git@gmail.com>",
+]
 edition = "2021"
 license = "Apache-2.0"
 
@@ -56,8 +59,8 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 nom = "7.1.3"
 nom-supreme = "0.8.0"
-num-bigint="0.4.6"
-num-rational="0.4"
+num-bigint = "0.4.6"
+num-rational = "0.4"
 petgraph = "0.6.2"
 reqwest = { version = "0.12.8", optional = true }
 rustc_version = "0.4"
@@ -70,9 +73,15 @@ strip-ansi-escapes = "0.2.1"
 take_mut = "0.2.2"
 tar = { version = "0.4.42", optional = true }
 toml = { version = "0.8", features = ["parse"] }
-tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "fmt" ] }
-tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [ "time" ] } # Fork with improved formating and timing info.
-tracing = { version = "0.1", features = [ "max_level_trace" ] }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "std",
+    "fmt",
+] }
+tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [
+    "time",
+] } # Fork with improved formating and timing info.
+tracing = { version = "0.1", features = ["max_level_trace"] }
 wait-timeout = { version = "0.2.0", optional = true }
 which = "7.0"
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -353,6 +353,8 @@ pub enum AbortKind {
     Panic(Option<Name>),
     /// Undefined behavior in the rust abstract machine.
     UndefinedBehavior,
+    /// Unwind had to stop for Abi reasons or because cleanup code panicked again.
+    UnwindTerminate,
 }
 
 /// Check the value of an operand and abort if the value is not expected. This is introduced to

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -92,10 +92,12 @@ pub enum RawTerminator {
     Call {
         call: Call,
         target: BlockId,
+        on_unwind: BlockId,
     },
     /// Handles panics and impossible cases.
     Abort(AbortKind),
     Return,
+    UnwindResume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]

--- a/charon/src/ast/ullbc_ast_utils.rs
+++ b/charon/src/ast/ullbc_ast_utils.rs
@@ -66,8 +66,12 @@ impl BlockData {
                 vec![*target]
             }
             RawTerminator::Switch { targets, .. } => targets.get_targets(),
-            RawTerminator::Call { call: _, target } => vec![*target],
-            RawTerminator::Abort(..) | RawTerminator::Return => {
+            RawTerminator::Call {
+                call: _,
+                target,
+                on_unwind,
+            } => vec![*target, *on_unwind],
+            RawTerminator::Abort(..) | RawTerminator::Return | RawTerminator::UnwindResume => {
                 vec![]
             }
         }

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -18,6 +18,7 @@ use charon_lib::ids::Vector;
 use charon_lib::pretty::FmtWithCtx;
 use charon_lib::ullbc_ast::*;
 use hax_frontend_exporter as hax;
+use hax_frontend_exporter::UnwindAction;
 use itertools::Itertools;
 use rustc_middle::mir;
 
@@ -838,13 +839,9 @@ impl BodyTransCtx<'_, '_, '_> {
 
                 RawTerminator::Switch { discr, targets }
             }
-            TerminatorKind::UnwindResume => {
-                // This is used to correctly unwind. We shouldn't get there: if
-                // we panic, the state gets stuck.
-                raise_error!(self, span, "Unexpected terminator: UnwindResume");
-            }
+            TerminatorKind::UnwindResume => RawTerminator::UnwindResume,
             TerminatorKind::UnwindTerminate { .. } => {
-                raise_error!(self, span, "Unexpected terminator: UnwindTerminate")
+                RawTerminator::Abort(AbortKind::UnwindTerminate)
             }
             TerminatorKind::Return => RawTerminator::Return,
             // A MIR `Unreachable` terminator indicates undefined behavior of the rust abstract
@@ -866,10 +863,10 @@ impl BodyTransCtx<'_, '_, '_> {
                 args,
                 destination,
                 target,
-                unwind: _, // We model unwinding as an effet, we don't represent it in control flow
+                unwind,
                 fn_span: _,
                 ..
-            } => self.translate_function_call(span, fun, args, destination, target)?,
+            } => self.translate_function_call(span, fun, args, destination, target, unwind)?,
             TerminatorKind::Assert {
                 cond,
                 expected,
@@ -975,6 +972,7 @@ impl BodyTransCtx<'_, '_, '_> {
         args: &Vec<hax::Spanned<hax::Operand>>,
         destination: &hax::Place,
         target: &Option<hax::BasicBlock>,
+        unwind: &UnwindAction,
     ) -> Result<RawTerminator, Error> {
         trace!();
         // There are two cases, depending on whether this is a "regular"
@@ -1040,7 +1038,27 @@ impl BodyTransCtx<'_, '_, '_> {
                 self.blocks.push(abort.into_block())
             }
         };
-        Ok(RawTerminator::Call { call, target })
+        let on_unwind = match unwind {
+            UnwindAction::Continue => {
+                let unwind_continue = Terminator::new(span, RawTerminator::UnwindResume);
+                self.blocks.push(unwind_continue.into_block())
+            }
+            UnwindAction::Unreachable => {
+                let abort =
+                    Terminator::new(span, RawTerminator::Abort(AbortKind::UndefinedBehavior));
+                self.blocks.push(abort.into_block())
+            }
+            UnwindAction::Terminate(..) => {
+                let abort = Terminator::new(span, RawTerminator::Abort(AbortKind::UnwindTerminate));
+                self.blocks.push(abort.into_block())
+            }
+            UnwindAction::Cleanup(bb) => self.translate_basic_block_id(*bb),
+        };
+        Ok(RawTerminator::Call {
+            call,
+            target,
+            on_unwind,
+        })
     }
 
     /// Evaluate function arguments in a context, and return the list of computed

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -61,6 +61,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for AbortKind {
                 format!("{tab}panic{name}")
             }
             AbortKind::UndefinedBehavior => format!("{tab}undefined_behavior"),
+            AbortKind::UnwindTerminate => format!("{tab}unwind_terminate"),
         }
     }
 }
@@ -1260,16 +1261,21 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
                     )
                 }
             },
-            RawTerminator::Call { call, target } => {
+            RawTerminator::Call {
+                call,
+                target,
+                on_unwind,
+            } => {
                 let (call_s, _) = fmt_call(ctx, call);
                 write!(
                     &mut out,
-                    "{tab}{} := {call_s} -> bb{target}",
+                    "{tab}{} := {call_s} -> bb{target} (unwind: bb{on_unwind})",
                     call.dest.fmt_with_ctx(ctx)
                 )
             }
             RawTerminator::Abort(kind) => write!(&mut out, "{tab}{}", kind.fmt_with_ctx(ctx)),
             RawTerminator::Return => write!(&mut out, "{tab}return"),
+            RawTerminator::UnwindResume => write!(&mut out, "{tab}unwind_continue"),
         };
         out
     }

--- a/charon/src/transform/filter_unreachable_blocks.rs
+++ b/charon/src/transform/filter_unreachable_blocks.rs
@@ -20,7 +20,7 @@ impl UllbcPass for Transform {
                 continue;
             }
             explored.insert(bid);
-            to_explore.append(&mut b.body[bid].targets())
+            to_explore.append(&mut b.body[bid].targets());
         }
 
         // Renumerotate

--- a/charon/src/transform/inline_local_panic_functions.rs
+++ b/charon/src/transform/inline_local_panic_functions.rs
@@ -47,14 +47,18 @@ impl UllbcPass for Transform {
                     let Some(block) = body.body.get_mut(block_id) else {
                         continue;
                     };
-                    if let RawTerminator::Call{call: Call {
-                        func:
-                            FnOperand::Regular(FnPtr {
-                                func: box FunIdOrTraitMethodRef::Fun(FunId::Regular(fun_id)),
+                    if let RawTerminator::Call {
+                        call:
+                            Call {
+                                func:
+                                    FnOperand::Regular(FnPtr {
+                                        func: box FunIdOrTraitMethodRef::Fun(FunId::Regular(fun_id)),
+                                        ..
+                                    }),
                                 ..
-                            }),
+                            },
                         ..
-                    }, target: _} = &block.terminator.content
+                    } = &block.terminator.content
                         && panic_fns.contains(fun_id)
                     {
                         block.terminator.content = panic_terminator.clone();

--- a/charon/src/transform/reconstruct_boxes.rs
+++ b/charon/src/transform/reconstruct_boxes.rs
@@ -53,6 +53,7 @@ impl UllbcPass for Transform {
             let value_to_write;
             let old_assign_idx;
             let assign_span;
+            let unwind_target;
 
             if let Some(candidate_block) = b.body.get(candidate_block_idx)
                 // If the terminator is a call
@@ -64,6 +65,7 @@ impl UllbcPass for Transform {
                             func: _, // TODO: once we have a system to recognize intrinsics, check the call is to exchange_malloc.
                             dest: malloc_dest,
                         },
+                        on_unwind,
                 } = &candidate_block.terminator.content
                 // The call has two move arguments
                 && let [Operand::Move(arg0), Operand::Move(arg1)] = malloc_args.as_slice()
@@ -110,6 +112,7 @@ impl UllbcPass for Transform {
                 box_generics = generics.clone();
                 second_block = *target_block_idx;
                 assign_span = *span;
+                unwind_target = *on_unwind;
             } else {
                 continue;
             }
@@ -159,6 +162,7 @@ impl UllbcPass for Transform {
                     dest: at_5,
                 },
                 target: second_block,
+                on_unwind: unwind_target,
             };
 
             // We now update the statements in the second block.

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -20,14 +20,20 @@ where
         @5 := &expected@2;
         storage_live(@6);
         @6 := &init@1;
-        @4 := core::cmp::impls::{impl core::cmp::Eq for bool}#38::parent_clause0::eq<'_, '_, bool, bool>(move (@5), move (@6)) -> bb1;
+        @4 := core::cmp::impls::{impl core::cmp::Eq for bool}#38::parent_clause0::eq<'_, '_, bool, bool>(move (@5), move (@6)) -> bb1 (unwind: bb2);
     }
 
     bb1: {
-        if move (@4) -> bb2 else -> bb3;
+        if move (@4) -> bb3 else -> bb4;
     }
 
     bb2: {
+        drop expected@2;
+        drop init@1;
+        unwind_continue;
+    }
+
+    bb3: {
         storage_dead(@6);
         storage_dead(@5);
         storage_dead(@4);
@@ -39,7 +45,7 @@ where
         return;
     }
 
-    bb3: {
+    bb4: {
         storage_dead(@6);
         storage_dead(@5);
         panic(core::panicking::panic);
@@ -78,7 +84,7 @@ fn test_crate::main()
 
     bb0: {
         storage_live(@1);
-        @1 := @Fun7<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1;
+        @1 := @Fun7<bool>[core::marker::Sized<bool>, core::cmp::impls::{impl core::cmp::Eq for bool}#38](const (true), const (true)) -> bb1 (unwind: bb2);
     }
 
     bb1: {
@@ -86,6 +92,10 @@ fn test_crate::main()
         @0 := ();
         @0 := ();
         return;
+    }
+
+    bb2: {
+        unwind_continue;
     }
 }
 

--- a/charon/tests/ui/ullbc-control-flow.out
+++ b/charon/tests/ui/ullbc-control-flow.out
@@ -213,33 +213,37 @@ pub fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
         storage_live(@5);
         storage_live(@6);
         @6 := core::ops::range::Range { start: const (0 : i32), end: const (128 : i32) };
-        @5 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<i32>[core::marker::Sized<i32>]>[core::marker::Sized<core::ops::range::Range<i32>[core::marker::Sized<i32>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<i32>[core::marker::Sized<i32>, core::iter::range::{impl core::iter::range::Step for i32}#40]](move (@6)) -> bb1;
+        @5 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<i32>[core::marker::Sized<i32>]>[core::marker::Sized<core::ops::range::Range<i32>[core::marker::Sized<i32>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<i32>[core::marker::Sized<i32>, core::iter::range::{impl core::iter::range::Step for i32}#40]](move (@6)) -> bb1 (unwind: bb2);
     }
 
     bb1: {
         storage_dead(@6);
         storage_live(iter@7);
         iter@7 := move (@5);
-        goto bb2;
+        goto bb3;
     }
 
     bb2: {
+        unwind_continue;
+    }
+
+    bb3: {
         storage_live(@8);
         storage_live(@9);
         storage_live(@10);
         storage_live(@11);
         @11 := &mut iter@7;
         @10 := &two-phase-mut *(@11);
-        @9 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, i32>[core::marker::Sized<i32>, core::iter::range::{impl core::iter::range::Step for i32}#40](move (@10)) -> bb3;
-    }
-
-    bb3: {
-        storage_dead(@10);
-        @12 := @discriminant(@9);
-        switch move (@12) -> 0 : isize: bb4, 1 : isize: bb5, otherwise: bb6;
+        @9 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, i32>[core::marker::Sized<i32>, core::iter::range::{impl core::iter::range::Step for i32}#40](move (@10)) -> bb4 (unwind: bb2);
     }
 
     bb4: {
+        storage_dead(@10);
+        @12 := @discriminant(@9);
+        switch move (@12) -> 0 : isize: bb5, 1 : isize: bb6, otherwise: bb7;
+    }
+
+    bb5: {
         storage_dead(@11);
         storage_dead(@9);
         storage_dead(@8);
@@ -253,45 +257,45 @@ pub fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
         @16 := copy (step_out@1);
         @15 := core::ops::range::Range { start: const (0 : usize), end: move (@16) };
         storage_dead(@16);
-        @14 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43]](move (@15)) -> bb7;
+        @14 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43]](move (@15)) -> bb8 (unwind: bb2);
     }
 
-    bb5: {
+    bb6: {
         s@3 := copy (s@3) + const (1 : usize);
         storage_dead(@11);
         storage_dead(@9);
         storage_dead(@8);
-        goto bb2;
-    }
-
-    bb6: {
-        undefined_behavior;
+        goto bb3;
     }
 
     bb7: {
-        storage_dead(@15);
-        storage_live(iter@17);
-        iter@17 := move (@14);
-        goto bb8;
+        undefined_behavior;
     }
 
     bb8: {
+        storage_dead(@15);
+        storage_live(iter@17);
+        iter@17 := move (@14);
+        goto bb9;
+    }
+
+    bb9: {
         storage_live(@18);
         storage_live(@19);
         storage_live(@20);
         storage_live(@21);
         @21 := &mut iter@17;
         @20 := &two-phase-mut *(@21);
-        @19 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43](move (@20)) -> bb9;
-    }
-
-    bb9: {
-        storage_dead(@20);
-        @22 := @discriminant(@19);
-        switch move (@22) -> 0 : isize: bb10, 1 : isize: bb11, otherwise: bb12;
+        @19 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43](move (@20)) -> bb10 (unwind: bb2);
     }
 
     bb10: {
+        storage_dead(@20);
+        @22 := @discriminant(@19);
+        switch move (@22) -> 0 : isize: bb11, 1 : isize: bb12, otherwise: bb13;
+    }
+
+    bb11: {
         // Test comment
         storage_dead(@21);
         storage_dead(@19);
@@ -304,44 +308,44 @@ pub fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
         return;
     }
 
-    bb11: {
+    bb12: {
         storage_live(@23);
         storage_live(@24);
         storage_live(@25);
         @25 := copy (step_in@2);
         @24 := core::ops::range::Range { start: const (0 : usize), end: move (@25) };
         storage_dead(@25);
-        @23 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43]](move (@24)) -> bb13;
-    }
-
-    bb12: {
-        undefined_behavior;
+        @23 := core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[core::marker::Sized<usize>]>[core::marker::Sized<core::ops::range::Range<usize>[core::marker::Sized<usize>]>, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6<usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43]](move (@24)) -> bb14 (unwind: bb2);
     }
 
     bb13: {
-        storage_dead(@24);
-        storage_live(iter@26);
-        iter@26 := move (@23);
-        goto bb14;
+        undefined_behavior;
     }
 
     bb14: {
+        storage_dead(@24);
+        storage_live(iter@26);
+        iter@26 := move (@23);
+        goto bb15;
+    }
+
+    bb15: {
         storage_live(@27);
         storage_live(@28);
         storage_live(@29);
         storage_live(@30);
         @30 := &mut iter@26;
         @29 := &two-phase-mut *(@30);
-        @28 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43](move (@29)) -> bb15;
-    }
-
-    bb15: {
-        storage_dead(@29);
-        @31 := @discriminant(@28);
-        switch move (@31) -> 0 : isize: bb16, 1 : isize: bb17, otherwise: bb18;
+        @28 := core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}#6::next<'_, usize>[core::marker::Sized<usize>, core::iter::range::{impl core::iter::range::Step for usize}#43](move (@29)) -> bb16 (unwind: bb2);
     }
 
     bb16: {
+        storage_dead(@29);
+        @31 := @discriminant(@28);
+        switch move (@31) -> 0 : isize: bb17, 1 : isize: bb18, otherwise: bb19;
+    }
+
+    bb17: {
         storage_dead(@30);
         storage_dead(@28);
         storage_dead(@27);
@@ -350,34 +354,34 @@ pub fn test_crate::nested_loops_enum(@1: usize, @2: usize) -> usize
         storage_dead(@21);
         storage_dead(@19);
         storage_dead(@18);
-        goto bb8;
+        goto bb9;
     }
 
-    bb17: {
+    bb18: {
         s@3 := copy (s@3) + const (1 : usize);
         storage_live(@32);
         storage_live(@33);
         storage_live(@34);
         @34 := copy (s@3);
         @33 := move (@34) >= const (1 : usize);
-        if move (@33) -> bb19 else -> bb20;
-    }
-
-    bb18: {
-        undefined_behavior;
+        if move (@33) -> bb20 else -> bb21;
     }
 
     bb19: {
+        undefined_behavior;
+    }
+
+    bb20: {
         storage_dead(@34);
         storage_dead(@33);
         storage_dead(@32);
         storage_dead(@30);
         storage_dead(@28);
         storage_dead(@27);
-        goto bb14;
+        goto bb15;
     }
 
-    bb20: {
+    bb21: {
         storage_dead(@34);
         panic(core::panicking::panic);
     }


### PR DESCRIPTION
This is still broken, somehow I have this error in tests now:

```
[Error] Pattern test_crate::funs_with_disambiguator::f failed to match function test_crate::funs_with_disambiguator::f#1

[Error] Pattern test_crate::funs_with_disambiguator::f failed to match function test_crate::funs_with_disambiguator::f#1

[Error] Pattern test_crate::funs_with_disambiguator::f#1 matches function test_crate::funs_with_disambiguator but shouldn't

[Error] Pattern test_crate::funs_with_disambiguator::f#1 failed to match function test_crate::funs_with_disambiguator::f

[Error] Pattern test_crate::funs_with_disambiguator::f matches function test_crate::funs_with_disambiguator but shouldn't

[Error] Pattern test_crate::funs_with_disambiguator::f matches function test_crate::funs_with_disambiguator but shouldn't
````

I don't even understand how I could have broken name_matcher_parser