### PR TITLE
Rework pretty-printing machinery

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "convert_case",
  "crates_io_api",
  "derive_generic_visitor",
+ "either",
  "env_logger",
  "flate2",
  "hax-frontend-exporter",
@@ -489,9 +490,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -49,6 +49,7 @@ colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
 derive_generic_visitor = "0.1.0"
+either = "1.15.0"
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }
 indexmap = { version = "2.7.1", features = ["serde"] }

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -1,6 +1,7 @@
 use crate::ast::*;
-use crate::formatter::{FmtCtx, Formatter, IntoFormatter};
+use crate::formatter::{FmtCtx, IntoFormatter};
 use crate::ids::Vector;
+use crate::pretty::FmtWithCtx;
 use crate::reorder_decls::DeclarationsGroups;
 use derive_generic_visitor::{ControlFlow, Drive, DriveMut};
 use index_vec::Idx;
@@ -281,24 +282,24 @@ impl<'ctx> AnyTransItemMut<'ctx> {
 
 impl fmt::Display for TranslatedCrate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let fmt: FmtCtx = self.into_fmt();
+        let fmt: &FmtCtx = &self.into_fmt();
         match &self.ordered_decls {
             None => {
                 // We do simple: types, globals, traits, functions
                 for d in &self.type_decls {
-                    writeln!(f, "{}\n", fmt.format_object(d))?
+                    writeln!(f, "{}\n", d.with_ctx(fmt))?
                 }
                 for d in &self.global_decls {
-                    writeln!(f, "{}\n", fmt.format_object(d))?
+                    writeln!(f, "{}\n", d.with_ctx(fmt))?
                 }
                 for d in &self.trait_decls {
-                    writeln!(f, "{}\n", fmt.format_object(d))?
+                    writeln!(f, "{}\n", d.with_ctx(fmt))?
                 }
                 for d in &self.trait_impls {
-                    writeln!(f, "{}\n", fmt.format_object(d))?
+                    writeln!(f, "{}\n", d.with_ctx(fmt))?
                 }
                 for d in &self.fun_decls {
-                    writeln!(f, "{}\n", fmt.format_object(d))?
+                    writeln!(f, "{}\n", d.with_ctx(fmt))?
                 }
             }
             Some(ordered_decls) => {

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -404,13 +404,16 @@ impl GenericsSource {
     /// Return a path that represents the target item.
     pub fn item_name(&self, translated: &TranslatedCrate, fmt_ctx: &FmtCtx) -> String {
         match self {
-            GenericsSource::Item(id) => translated.item_name(*id).unwrap().fmt_with_ctx(fmt_ctx),
+            GenericsSource::Item(id) => translated
+                .item_name(*id)
+                .unwrap()
+                .to_string_with_ctx(fmt_ctx),
             GenericsSource::Method(trait_id, method_name) => format!(
                 "{}::{method_name}",
                 translated
                     .item_name(*trait_id)
                     .unwrap()
-                    .fmt_with_ctx(fmt_ctx),
+                    .to_string_with_ctx(fmt_ctx),
             ),
             GenericsSource::Builtin => format!("<built-in>"),
             GenericsSource::Other => format!("<unknown>"),

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -25,6 +25,7 @@ impl TraitClause {
         }
     }
 }
+
 impl GenericParams {
     pub fn empty() -> Self {
         Self::default()
@@ -33,7 +34,12 @@ impl GenericParams {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
+    /// Whether this has any explicit arguments (types, regions or const generics).
+    pub fn has_explicits(&self) -> bool {
+        !self.regions.is_empty() || !self.types.is_empty() || !self.const_generics.is_empty()
+    }
+    /// Whether this has any implicit arguments (trait clauses, outlives relations, associated type
+    /// equality constraints).
     pub fn has_predicates(&self) -> bool {
         !self.trait_clauses.is_empty()
             || !self.types_outlive.is_empty()
@@ -308,6 +314,14 @@ impl GenericArgs {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+    /// Whether this has any explicit arguments (types, regions or const generics).
+    pub fn has_explicits(&self) -> bool {
+        !self.regions.is_empty() || !self.types.is_empty() || !self.const_generics.is_empty()
+    }
+    /// Whether this has any implicit arguments (trait refs).
+    pub fn has_implicits(&self) -> bool {
+        !self.trait_refs.is_empty()
     }
 
     pub fn empty(target: GenericsSource) -> Self {

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -582,7 +582,7 @@ impl BodyTransCtx<'_, '_, '_> {
                         self,
                         span,
                         "Unexpected scrutinee type for ReadDiscriminant: {}",
-                        place.ty().fmt_with_ctx(&self.into_fmt())
+                        place.ty().with_ctx(&self.into_fmt())
                     )
                 }
             }

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -45,8 +45,9 @@ use crate::translate::translate_bodies::BodyTransCtx;
 use super::translate_ctx::*;
 use charon_lib::ast::*;
 use charon_lib::common::*;
-use charon_lib::formatter::{Formatter, IntoFormatter};
+use charon_lib::formatter::IntoFormatter;
 use charon_lib::ids::Vector;
+use charon_lib::pretty::FmtWithCtx;
 use charon_lib::ullbc_ast::*;
 use hax_frontend_exporter as hax;
 use itertools::Itertools;
@@ -264,15 +265,12 @@ impl ItemTransCtx<'_, '_> {
             .try_collect()?;
         let output = self.translate_ty(span, &signature.value.output)?;
 
-        let fmt_ctx = self.into_fmt();
+        let fmt_ctx = &self.into_fmt();
         trace!(
             "# Input variables types:\n{}",
-            pretty_display_list(|x| fmt_ctx.format_object(x), &inputs)
+            pretty_display_list(|x| x.to_string_with_ctx(fmt_ctx), &inputs)
         );
-        trace!(
-            "# Output variable type:\n{}",
-            fmt_ctx.format_object(&output)
-        );
+        trace!("# Output variable type:\n{}", output.with_ctx(fmt_ctx));
 
         let is_unsafe = match signature.value.safety {
             hax::Safety::Unsafe => true,

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -1262,6 +1262,7 @@ impl<'a> IntoFormatter for &'a ItemTransCtx<'_, '_> {
             translated: Some(&self.t_ctx.translated),
             generics: self.binding_levels.map_ref(|bl| Cow::Borrowed(&bl.params)),
             locals: None,
+            indent_level: 0,
         }
     }
 }

--- a/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions_to_ullbc.rs
@@ -10,8 +10,9 @@ use crate::translate::translate_bodies::BodyTransCtx;
 use super::translate_ctx::*;
 use charon_lib::ast::*;
 use charon_lib::common::*;
-use charon_lib::formatter::{Formatter, IntoFormatter};
+use charon_lib::formatter::IntoFormatter;
 use charon_lib::ids::Vector;
+use charon_lib::pretty::FmtWithCtx;
 use charon_lib::ullbc_ast::*;
 use hax_frontend_exporter as hax;
 use itertools::Itertools;
@@ -168,15 +169,12 @@ impl ItemTransCtx<'_, '_> {
             .try_collect()?;
         let output = self.translate_ty(span, &signature.value.output)?;
 
-        let fmt_ctx = self.into_fmt();
+        let fmt_ctx = &self.into_fmt();
         trace!(
             "# Input variables types:\n{}",
-            pretty_display_list(|x| fmt_ctx.format_object(x), &inputs)
+            pretty_display_list(|x| x.to_string_with_ctx(fmt_ctx), &inputs)
         );
-        trace!(
-            "# Output variable type:\n{}",
-            fmt_ctx.format_object(&output)
-        );
+        trace!("# Output variable type:\n{}", output.with_ctx(fmt_ctx));
 
         let is_unsafe = match signature.value.safety {
             hax::Safety::Unsafe => true,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -258,7 +258,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                                     span,
                                     "Found unsupported GAT `{}` when resolving trait `{}`",
                                     item.name,
-                                    trait_decl_ref.fmt_with_ctx(&self.into_fmt())
+                                    trait_decl_ref.with_ctx(&self.into_fmt())
                                 )
                             }
                             trait_id = TraitRefKind::ItemClause(

--- a/charon/src/bin/charon-driver/translate/translate_traits.rs
+++ b/charon/src/bin/charon-driver/translate/translate_traits.rs
@@ -238,9 +238,8 @@ impl ItemTransCtx<'_, '_> {
             let ctx = self.into_fmt();
             let refs = parent_trait_refs
                 .iter()
-                .map(|c| c.fmt_with_ctx(&ctx))
-                .collect::<Vec<String>>()
-                .join("\n");
+                .map(|c| c.with_ctx(&ctx))
+                .format("\n");
             trace!(
                 "Trait impl: {:?}\n- parent_trait_refs:\n{}",
                 def.def_id,

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -27,6 +27,11 @@ pub fn pretty_display_list<T>(
     }
 }
 
+/// Yield `None` then infinitely many `Some(x)`.
+pub fn repeat_except_first<T: Clone>(x: T) -> impl Iterator<Item = Option<T>> {
+    [None].into_iter().chain(std::iter::repeat(Some(x)))
+}
+
 pub mod type_map {
     use std::{
         any::{Any, TypeId},

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -1,6 +1,7 @@
 //! Utilities to generate error reports about the external dependencies.
 use crate::ast::*;
-use crate::formatter::{Formatter, IntoFormatter};
+use crate::formatter::IntoFormatter;
+use crate::pretty::FmtWithCtx;
 pub use annotate_snippets::Level;
 use itertools::Itertools;
 use macros::VariantIndexArity;
@@ -326,7 +327,7 @@ impl ErrorCtx {
         let msg = format!(
             "the error occurred when translating `{}`, \
              which is (transitively) used at the following location(s):",
-            krate.into_fmt().format_object(id)
+            id.with_ctx(&krate.into_fmt())
         );
         let message = level.header(&msg).group(Group::new().elements(snippets));
         let out = Renderer::styled().render(message).to_string();

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -572,9 +572,7 @@ where
         let ctx = &ctx.set_generics(&self.generics);
 
         // Translate the parameters and the trait clauses
-        let (params, preds) = self
-            .generics
-            .fmt_with_ctx_with_trait_clauses(&ctx.half_indent());
+        let (params, preds) = self.generics.fmt_with_ctx_with_trait_clauses(ctx);
         // Type
         let ty = self.ty.with_ctx(ctx);
         // Predicates
@@ -1494,9 +1492,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TypeDecl {
         let intro = self.item_meta.fmt_item_intro(ctx, keyword, self.def_id);
 
         let ctx = &ctx.set_generics(&self.generics);
-        let (params, preds) = self
-            .generics
-            .fmt_with_ctx_with_trait_clauses(&ctx.half_indent());
+        let (params, preds) = self.generics.fmt_with_ctx_with_trait_clauses(ctx);
         // Predicates
         let nl_or_space = if !self.generics.has_predicates() {
             " ".to_string()

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -1,98 +1,31 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::fmt::Display;
 
 use index_vec::Idx;
 
 use crate::ast::*;
 use crate::common::TAB_INCR;
-use crate::gast;
 use crate::ids::Vector;
-use crate::llbc_ast;
 use crate::pretty::FmtWithCtx;
-use crate::ullbc_ast;
-use crate::ullbc_ast as ast;
-
-/// [`Formatter`] is a trait for converting objects to string.
-///
-/// We need it because pretty-printing data structures often requires some
-/// context. For instance, because values use value ids to point to other values,
-/// we need a context to give us the mapping from value ids to values when pretty
-/// printing. As the `EvalContext` data structure handles such a mapping, we
-/// implement the `Formatter<ValueId>` trait for it.
-///
-/// Our way of implementing pretty-printing for data-structures while factorizing
-/// the code is as follows:
-/// - for every data structure which requires formatting, we implement a
-///   function `fn fmt_with_ctx(&self, ctx: T) -> String`, with proper trait
-///   constraints on the context type T. We implement this kind of functions
-///   for values, types, places, operands, rvalues, statements, etc, and
-///   the formatting trait constraints often require the context to implement
-///   `Formatter` for a various set of indices (type variable index, variable
-///   index, type definition index, etc.).
-/// - later on, whenever we have a suitable context type (like `EvalContext`),
-///   we implement the `Formatter` trait for all the index types we need, and
-///   then can easily implement it for all the above data-structures (values,
-///   types, places, etc.) by calling the appropriate `fmt_with_ctx` functions.
-/// The advantage of using auxiliary `fmt_with_ctx` functions is that we can
-/// easily reuse those functions to implement pretty-printing with different
-/// contexts, without duplicating the "non-trivial" code.
-pub trait Formatter<T> {
-    fn format_object(&self, x: T) -> String;
-}
-
-impl<C, T> Formatter<T> for &C
-where
-    C: Formatter<T>,
-{
-    fn format_object(&self, x: T) -> String {
-        (*self).format_object(x)
-    }
-}
 
 pub trait IntoFormatter {
     type C: AstFormatter;
-
     fn into_fmt(self) -> Self::C;
 }
 
-impl<C: AstFormatter> IntoFormatter for C {
-    type C = Self;
-
-    fn into_fmt(self) -> Self::C {
-        self
-    }
-}
-
-pub trait AstFormatter:
-    Formatter<TypeDeclId>
-    + Formatter<FunDeclId>
-    + Formatter<GlobalDeclId>
-    + Formatter<TraitDeclId>
-    + Formatter<TraitImplId>
-    + Formatter<AnyTransId>
-    + Formatter<RegionDbVar>
-    + Formatter<TypeDbVar>
-    + Formatter<ConstGenericDbVar>
-    + Formatter<ClauseDbVar>
-    + Formatter<LocalId>
-    + Formatter<(TypeDeclId, VariantId)>
-    + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
-    + for<'a> Formatter<&'a ImplElem>
-    + for<'a> Formatter<&'a RegionVar>
-    + for<'a> Formatter<&'a llbc_ast::Block>
-{
+/// An [`AstFormatter`] contains the context required to pretty-print the ast. An ast type can then
+/// be pretty-printed using the [`FmtWithCtx`] trait.
+pub trait AstFormatter: Sized {
     type Reborrow<'a>: AstFormatter + 'a
     where
         Self: 'a;
 
     fn get_crate(&self) -> Option<&TranslatedCrate>;
+
     fn set_generics<'a>(&'a self, generics: &'a GenericParams) -> Self::Reborrow<'a>;
     fn set_locals<'a>(&'a self, locals: &'a Locals) -> Self::Reborrow<'a>;
     fn push_binder<'a>(&'a self, new_params: Cow<'a, GenericParams>) -> Self::Reborrow<'a>;
-
-    fn increase_indent<'a>(&'a self) -> Self::Reborrow<'a>;
-    fn indent(&self) -> String;
-
     fn push_bound_regions<'a>(
         &'a self,
         regions: &'a Vector<RegionId, RegionVar>,
@@ -102,7 +35,79 @@ pub trait AstFormatter:
             ..Default::default()
         }))
     }
+
+    fn increase_indent<'a>(&'a self) -> Self::Reborrow<'a>;
+    fn indent(&self) -> String;
+
+    fn format_local_id(&self, f: &mut fmt::Formatter<'_>, id: LocalId) -> fmt::Result;
+    fn format_bound_var<Id: Idx + Display, T>(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        var: DeBruijnVar<Id>,
+        var_prefix: &str,
+        fmt_var: impl Fn(&T) -> Option<String>,
+    ) -> fmt::Result
+    where
+        GenericParams: HasVectorOf<Id, Output = T>;
+
+    fn format_enum_variant(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        type_id: TypeDeclId,
+        variant_id: VariantId,
+    ) -> fmt::Result {
+        let variant = if let Some(translated) = self.get_crate()
+            && let Some(def) = translated.type_decls.get(type_id)
+            && let Some(variants) = def.kind.as_enum()
+        {
+            &variants.get(variant_id).unwrap().name
+        } else {
+            &variant_id.to_pretty_string()
+        };
+        write!(f, "{}::{variant}", type_id.with_ctx(self))
+    }
+
+    fn format_field_name(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        type_id: TypeDeclId,
+        opt_variant_id: Option<VariantId>,
+        field_id: FieldId,
+    ) -> fmt::Result {
+        let field_name = if let Some(translated) = self.get_crate()
+            && let Some(def) = translated.type_decls.get(type_id)
+        {
+            match (&def.kind, opt_variant_id) {
+                (TypeDeclKind::Enum(variants), Some(variant_id)) => {
+                    variants[variant_id].fields[field_id].name.as_ref()
+                }
+                (TypeDeclKind::Struct(fields) | TypeDeclKind::Union(fields), None) => {
+                    fields[field_id].name.as_ref()
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if let Some(field_name) = field_name {
+            write!(f, "{field_name}")
+        } else {
+            write!(f, "{field_id}")
+        }
+    }
 }
+
+/// Context for formatting.
+#[derive(Default)]
+pub struct FmtCtx<'a> {
+    pub translated: Option<&'a TranslatedCrate>,
+    /// Generics form a stack, where each binder introduces a new level. For DeBruijn indices to
+    /// work, we keep the innermost parameters at the start of the vector.
+    pub generics: BindingStack<Cow<'a, GenericParams>>,
+    pub locals: Option<&'a Locals>,
+    pub indent_level: usize,
+}
+
 impl<'c> AstFormatter for FmtCtx<'c> {
     type Reborrow<'a>
         = FmtCtx<'a>
@@ -112,6 +117,7 @@ impl<'c> AstFormatter for FmtCtx<'c> {
     fn get_crate(&self) -> Option<&TranslatedCrate> {
         self.translated
     }
+
     fn set_generics<'a>(&'a self, generics: &'a GenericParams) -> Self::Reborrow<'a> {
         FmtCtx {
             generics: BindingStack::new(Cow::Borrowed(generics)),
@@ -139,41 +145,51 @@ impl<'c> AstFormatter for FmtCtx<'c> {
     fn indent(&self) -> String {
         TAB_INCR.repeat(self.indent_level)
     }
-}
 
-/// For formatting.
-///
-/// Note that we use the ULLBC definitions, even when formatting LLBC
-/// definitions. It doesn't really matter, as all we use is the *name*
-/// of the definitions.
-///
-/// Remark: we take shared borrows to the top-level declarations, but
-/// clone the generics, because we may dive into different contexts and may
-/// need to update those. We can think of a smarter way of doing this, but
-/// for now it is simple and efficient enough.
-#[derive(Default)]
-pub struct FmtCtx<'a> {
-    pub translated: Option<&'a TranslatedCrate>,
-    /// Generics form a stack, where each binder introduces a new level. For DeBruijn indices to
-    /// work, we keep the innermost parameters at the start of the vector.
-    pub generics: BindingStack<Cow<'a, GenericParams>>,
-    pub locals: Option<&'a Locals>,
-    pub indent_level: usize,
+    fn format_local_id(&self, f: &mut fmt::Formatter<'_>, id: LocalId) -> fmt::Result {
+        if let Some(locals) = &self.locals
+            && let Some(v) = locals.locals.get(id)
+        {
+            write!(f, "{v}")
+        } else {
+            write!(f, "{}", id.to_pretty_string())
+        }
+    }
+
+    fn format_bound_var<Id: Idx + Display, T>(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        var: DeBruijnVar<Id>,
+        var_prefix: &str,
+        fmt_var: impl Fn(&T) -> Option<String>,
+    ) -> fmt::Result
+    where
+        GenericParams: HasVectorOf<Id, Output = T>,
+    {
+        if self.generics.is_empty() {
+            return write!(f, "{var_prefix}{var}");
+        }
+        match self.generics.get_var::<_, GenericParams>(var) {
+            None => write!(f, "missing({var_prefix}{var})"),
+            Some(v) => match fmt_var(v) {
+                Some(name) => write!(f, "{name}"),
+                None => {
+                    write!(f, "{var_prefix}")?;
+                    let (dbid, varid) = self.generics.as_bound_var(var);
+                    if dbid == self.generics.depth() {
+                        write!(f, "{varid}")
+                    } else {
+                        write!(f, "{var}")
+                    }
+                }
+            },
+        }
+    }
 }
 
 impl<'a> FmtCtx<'a> {
     pub fn new() -> Self {
         FmtCtx::default()
-    }
-
-    pub fn format_decl_id(&self, id: AnyTransId) -> String {
-        match id {
-            AnyTransId::Type(id) => self.format_decl(id),
-            AnyTransId::Fun(id) => self.format_decl(id),
-            AnyTransId::Global(id) => self.format_decl(id),
-            AnyTransId::TraitDecl(id) => self.format_decl(id),
-            AnyTransId::TraitImpl(id) => self.format_decl(id),
-        }
     }
 
     pub fn get_item(&self, id: AnyTransId) -> Result<AnyTransItem<'_>, Option<&Name>> {
@@ -186,7 +202,7 @@ impl<'a> FmtCtx<'a> {
     }
 
     /// Print the whole definition.
-    fn format_decl(&self, id: impl Into<AnyTransId>) -> String {
+    pub fn format_decl_id(&self, id: impl Into<AnyTransId>) -> String {
         let id = id.into();
         match self.get_item(id) {
             Ok(d) => d.to_string_with_ctx(self),
@@ -206,263 +222,5 @@ impl<'a> FmtCtx<'a> {
             locals: self.locals.as_deref(),
             indent_level: self.indent_level,
         }
-    }
-}
-
-impl<'a> Formatter<TypeDeclId> for FmtCtx<'a> {
-    fn format_object(&self, id: TypeDeclId) -> String {
-        self.format_object(AnyTransId::from(id))
-    }
-}
-
-impl<'a> Formatter<GlobalDeclId> for FmtCtx<'a> {
-    fn format_object(&self, id: GlobalDeclId) -> String {
-        self.format_object(AnyTransId::from(id))
-    }
-}
-
-impl<'a> Formatter<FunDeclId> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::FunDeclId) -> String {
-        self.format_object(AnyTransId::from(id))
-    }
-}
-
-impl<'a> Formatter<TraitDeclId> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitDeclId) -> String {
-        self.format_object(AnyTransId::from(id))
-    }
-}
-
-impl<'a> Formatter<TraitImplId> for FmtCtx<'a> {
-    fn format_object(&self, id: ast::TraitImplId) -> String {
-        self.format_object(AnyTransId::from(id))
-    }
-}
-
-impl<'a> Formatter<AnyTransId> for FmtCtx<'a> {
-    fn format_object(&self, id: AnyTransId) -> String {
-        match self
-            .translated
-            .and_then(|translated| translated.item_short_name(id))
-        {
-            None => id.to_string(),
-            Some(name) => name.to_string_with_ctx(self),
-        }
-    }
-}
-
-impl<'a> FmtCtx<'a> {
-    fn format_bound_var<Id: Idx + Display, T>(
-        &self,
-        var: DeBruijnVar<Id>,
-        var_prefix: &str,
-        f: impl Fn(&T) -> Option<String>,
-    ) -> String
-    where
-        GenericParams: HasVectorOf<Id, Output = T>,
-    {
-        if self.generics.is_empty() {
-            return format!("{var_prefix}{var}");
-        }
-        match self.generics.get_var::<_, GenericParams>(var) {
-            None => format!("missing({var_prefix}{var})"),
-            Some(v) => match f(v) {
-                Some(name) => name,
-                None => {
-                    let (dbid, varid) = self.generics.as_bound_var(var);
-                    if dbid == self.generics.depth() {
-                        format!("{var_prefix}{varid}")
-                    } else {
-                        format!("{var_prefix}{var}")
-                    }
-                }
-            },
-        }
-    }
-}
-
-impl<'a> Formatter<RegionDbVar> for FmtCtx<'a> {
-    fn format_object(&self, var: RegionDbVar) -> String {
-        self.format_bound_var(var, "'_", |v| v.name.as_ref().map(|name| name.to_string()))
-    }
-}
-
-impl<'a> Formatter<&RegionVar> for FmtCtx<'a> {
-    fn format_object(&self, var: &RegionVar) -> String {
-        match &var.name {
-            Some(name) => name.to_string(),
-            None => format!("'_{}", var.index),
-        }
-    }
-}
-
-impl<'a> Formatter<TypeDbVar> for FmtCtx<'a> {
-    fn format_object(&self, var: TypeDbVar) -> String {
-        self.format_bound_var(var, "@Type", |v| Some(v.to_string()))
-    }
-}
-
-impl<'a> Formatter<ConstGenericDbVar> for FmtCtx<'a> {
-    fn format_object(&self, var: ConstGenericDbVar) -> String {
-        self.format_bound_var(var, "@ConstGeneric", |v| Some(v.to_string_with_ctx(self)))
-    }
-}
-
-impl<'a> Formatter<ClauseDbVar> for FmtCtx<'a> {
-    fn format_object(&self, var: ClauseDbVar) -> String {
-        self.format_bound_var(var, "@TraitClause", |_| None)
-    }
-}
-
-impl<'a> Formatter<&ImplElem> for FmtCtx<'a> {
-    fn format_object(&self, elem: &ImplElem) -> String {
-        let inner = match elem {
-            ImplElem::Ty(bound_ty) => {
-                // Just printing the generics (not the predicates)
-                let ctx = self.set_generics(&bound_ty.params);
-                bound_ty.skip_binder.to_string_with_ctx(&ctx)
-            }
-            ImplElem::Trait(impl_id) => {
-                match &self.translated {
-                    None => format!("impl#{impl_id}"),
-                    Some(translated) => match translated.trait_impls.get(*impl_id) {
-                        None => format!("impl#{impl_id}"),
-                        Some(timpl) => {
-                            // We need to put the first type parameter aside: it is
-                            // the type for which we implement the trait.
-                            // This is not very clean because it's hard to move the
-                            // first element out of a vector...
-                            let ctx = &self.set_generics(&timpl.generics);
-                            let TraitDeclRef { trait_id, generics } = &timpl.impl_trait;
-                            let (ty, generics) = generics.pop_first_type_arg();
-                            let tr = TraitDeclRef {
-                                trait_id: *trait_id,
-                                generics: Box::new(generics),
-                            };
-                            format!("impl {} for {}", tr.with_ctx(ctx), ty.with_ctx(ctx))
-                        }
-                    },
-                }
-            }
-        };
-
-        format!("{{{inner}}}")
-    }
-}
-
-/// For enum values: `List::Cons`
-impl<'a> Formatter<(TypeDeclId, VariantId)> for FmtCtx<'a> {
-    fn format_object(&self, id: (TypeDeclId, VariantId)) -> String {
-        let (type_id, variant_id) = id;
-        let name = self.format_object(type_id);
-        let variant = match &self.translated {
-            None => &variant_id.to_pretty_string(),
-            Some(translated) => match translated.type_decls.get(type_id) {
-                Some(def) if let Some(variants) = def.kind.as_enum() => {
-                    &variants.get(variant_id).unwrap().name
-                }
-                _ => &variant_id.to_pretty_string(),
-            },
-        };
-        format!("{name}::{variant}",)
-    }
-}
-
-/// For struct/enum values: retrieve a field name
-impl<'a> Formatter<(TypeDeclId, Option<VariantId>, FieldId)> for FmtCtx<'a> {
-    fn format_object(&self, id: (TypeDeclId, Option<VariantId>, FieldId)) -> String {
-        let (type_id, opt_variant_id, field_id) = id;
-        match self
-            .translated
-            .as_ref()
-            .and_then(|tr| tr.type_decls.get(type_id))
-        {
-            None => field_id.to_string(),
-            Some(def) => match (&def.kind, opt_variant_id) {
-                (TypeDeclKind::Enum(variants), Some(variant_id)) => variants[variant_id].fields
-                    [field_id]
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| field_id.to_string()),
-                (TypeDeclKind::Struct(fields) | TypeDeclKind::Union(fields), None) => fields
-                    [field_id]
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| field_id.to_string()),
-                _ => field_id.to_string(),
-            },
-        }
-    }
-}
-
-impl<'a> Formatter<LocalId> for FmtCtx<'a> {
-    fn format_object(&self, id: LocalId) -> String {
-        match &self.locals {
-            None => id.to_pretty_string(),
-            Some(locals) => match locals.locals.get(id) {
-                None => id.to_pretty_string(),
-                Some(v) => v.to_string(),
-            },
-        }
-    }
-}
-
-impl<'a> Formatter<&llbc_ast::Block> for FmtCtx<'a> {
-    fn format_object(&self, x: &llbc_ast::Block) -> String {
-        x.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&Ty> for FmtCtx<'a> {
-    fn format_object(&self, x: &Ty) -> String {
-        x.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&TypeDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &TypeDecl) -> String {
-        def.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&ullbc_ast::ExprBody> for FmtCtx<'a> {
-    fn format_object(&self, body: &ullbc_ast::ExprBody) -> String {
-        body.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&llbc_ast::ExprBody> for FmtCtx<'a> {
-    fn format_object(&self, body: &llbc_ast::ExprBody) -> String {
-        body.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&gast::FunDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &llbc_ast::FunDecl) -> String {
-        def.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&gast::GlobalDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &llbc_ast::GlobalDecl) -> String {
-        def.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&FunSig> for FmtCtx<'a> {
-    fn format_object(&self, x: &FunSig) -> String {
-        x.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&gast::TraitDecl> for FmtCtx<'a> {
-    fn format_object(&self, def: &gast::TraitDecl) -> String {
-        def.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&gast::TraitImpl> for FmtCtx<'a> {
-    fn format_object(&self, def: &gast::TraitImpl) -> String {
-        def.to_string_with_ctx(self)
     }
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -182,11 +182,10 @@ impl<'a> FmtCtx<'a> {
     fn format_decl(&self, id: impl Into<AnyTransId>) -> String {
         let id = id.into();
         match self.get_item(id) {
-            Ok(d) => d.fmt_with_ctx(self),
+            Ok(d) => d.to_string_with_ctx(self),
             Err(opt_name) => {
                 let opt_name = opt_name
-                    .map(|n| n.fmt_with_ctx(self))
-                    .map(|n| format!(" ({n})"))
+                    .map(|n| format!(" ({})", n.with_ctx(self)))
                     .unwrap_or_default();
                 format!("Missing decl: {id:?}{opt_name}")
             }
@@ -231,7 +230,7 @@ impl<'a> Formatter<AnyTransId> for FmtCtx<'a> {
             .and_then(|translated| translated.item_short_name(id))
         {
             None => id.to_string(),
-            Some(name) => name.fmt_with_ctx(self),
+            Some(name) => name.to_string_with_ctx(self),
         }
     }
 }
@@ -289,7 +288,7 @@ impl<'a> Formatter<TypeDbVar> for FmtCtx<'a> {
 
 impl<'a> Formatter<ConstGenericDbVar> for FmtCtx<'a> {
     fn format_object(&self, var: ConstGenericDbVar) -> String {
-        self.format_bound_var(var, "@ConstGeneric", |v| Some(v.fmt_with_ctx(self)))
+        self.format_bound_var(var, "@ConstGeneric", |v| Some(v.to_string_with_ctx(self)))
     }
 }
 
@@ -305,7 +304,7 @@ impl<'a> Formatter<&ImplElem> for FmtCtx<'a> {
             ImplElem::Ty(bound_ty) => {
                 // Just printing the generics (not the predicates)
                 let ctx = self.set_generics(&bound_ty.params);
-                bound_ty.skip_binder.fmt_with_ctx(&ctx)
+                bound_ty.skip_binder.to_string_with_ctx(&ctx)
             }
             ImplElem::Trait(impl_id) => {
                 match &self.translated {
@@ -324,7 +323,7 @@ impl<'a> Formatter<&ImplElem> for FmtCtx<'a> {
                                 trait_id: *trait_id,
                                 generics: Box::new(generics),
                             };
-                            format!("impl {} for {}", tr.fmt_with_ctx(ctx), ty.fmt_with_ctx(ctx))
+                            format!("impl {} for {}", tr.with_ctx(ctx), ty.with_ctx(ctx))
                         }
                     },
                 }
@@ -394,7 +393,7 @@ impl<'a> Formatter<LocalId> for FmtCtx<'a> {
 
 impl<'a> Formatter<&llbc_ast::Block> for FmtCtx<'a> {
     fn format_object(&self, x: &llbc_ast::Block) -> String {
-        x.fmt_with_ctx(self)
+        x.to_string_with_ctx(self)
     }
 }
 
@@ -406,54 +405,54 @@ impl<'a> Formatter<&Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>> for FmtCtx
 
 impl<'a> Formatter<&Ty> for FmtCtx<'a> {
     fn format_object(&self, x: &Ty) -> String {
-        x.fmt_with_ctx(self)
+        x.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&TypeDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &TypeDecl) -> String {
-        def.fmt_with_ctx(self)
+        def.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&ullbc_ast::ExprBody> for FmtCtx<'a> {
     fn format_object(&self, body: &ullbc_ast::ExprBody) -> String {
-        body.fmt_with_ctx(self)
+        body.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&llbc_ast::ExprBody> for FmtCtx<'a> {
     fn format_object(&self, body: &llbc_ast::ExprBody) -> String {
-        body.fmt_with_ctx(self)
+        body.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&gast::FunDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &llbc_ast::FunDecl) -> String {
-        def.fmt_with_ctx(self)
+        def.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&gast::GlobalDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &llbc_ast::GlobalDecl) -> String {
-        def.fmt_with_ctx(self)
+        def.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&FunSig> for FmtCtx<'a> {
     fn format_object(&self, x: &FunSig) -> String {
-        x.fmt_with_ctx(self)
+        x.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&gast::TraitDecl> for FmtCtx<'a> {
     fn format_object(&self, def: &gast::TraitDecl) -> String {
-        def.fmt_with_ctx(self)
+        def.to_string_with_ctx(self)
     }
 }
 
 impl<'a> Formatter<&gast::TraitImpl> for FmtCtx<'a> {
     fn format_object(&self, def: &gast::TraitImpl) -> String {
-        def.fmt_with_ctx(self)
+        def.to_string_with_ctx(self)
     }
 }

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 use index_vec::Idx;
 
 use crate::ast::*;
+use crate::common::TAB_INCR;
 use crate::gast;
 use crate::ids::Vector;
 use crate::llbc_ast;
@@ -91,7 +92,6 @@ pub trait AstFormatter:
     fn push_binder<'a>(&'a self, new_params: Cow<'a, GenericParams>) -> Self::Reborrow<'a>;
 
     fn increase_indent<'a>(&'a self) -> Self::Reborrow<'a>;
-    fn half_indent<'a>(&'a self) -> Self::Reborrow<'a>;
     fn indent(&self) -> String;
 
     fn push_bound_regions<'a>(
@@ -133,18 +133,12 @@ impl<'c> AstFormatter for FmtCtx<'c> {
 
     fn increase_indent<'a>(&'a self) -> Self::Reborrow<'a> {
         FmtCtx {
-            indent_level: self.indent_level + 2,
-            ..self.reborrow()
-        }
-    }
-    fn half_indent<'a>(&'a self) -> Self::Reborrow<'a> {
-        FmtCtx {
             indent_level: self.indent_level + 1,
             ..self.reborrow()
         }
     }
     fn indent(&self) -> String {
-        "  ".repeat(self.indent_level)
+        TAB_INCR.repeat(self.indent_level)
     }
 }
 

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -8,7 +8,7 @@ use crate::common::TAB_INCR;
 use crate::gast;
 use crate::ids::Vector;
 use crate::llbc_ast;
-use crate::pretty::{fmt_with_ctx, FmtWithCtx};
+use crate::pretty::FmtWithCtx;
 use crate::ullbc_ast;
 use crate::ullbc_ast as ast;
 
@@ -79,7 +79,6 @@ pub trait AstFormatter:
     + Formatter<(TypeDeclId, Option<VariantId>, FieldId)>
     + for<'a> Formatter<&'a ImplElem>
     + for<'a> Formatter<&'a RegionVar>
-    + for<'a> Formatter<&'a Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>>
     + for<'a> Formatter<&'a llbc_ast::Block>
 {
     type Reborrow<'a>: AstFormatter + 'a
@@ -411,12 +410,6 @@ impl<'a> Formatter<LocalId> for FmtCtx<'a> {
 impl<'a> Formatter<&llbc_ast::Block> for FmtCtx<'a> {
     fn format_object(&self, x: &llbc_ast::Block) -> String {
         x.to_string_with_ctx(self)
-    }
-}
-
-impl<'a> Formatter<&Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>> for FmtCtx<'a> {
-    fn format_object(&self, x: &Vector<ullbc_ast::BlockId, ullbc_ast::BlockData>) -> String {
-        fmt_with_ctx::fmt_body_blocks_with_ctx(x, self)
     }
 }
 

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -72,9 +72,9 @@ impl CheckGenericsVisitor<'_> {
         if a.elem_count() == b.elem_count() {
             a.iter().zip(b.iter()).for_each(|(x, y)| check_inner(x, y));
         } else {
-            let a = a.iter().map(|x| x.fmt_with_ctx(a_fmt)).join(", ");
-            let b = b.iter().map(|x| x.fmt_with_ctx(b_fmt)).join(", ");
-            let target = target.fmt_with_ctx(a_fmt);
+            let a = a.iter().map(|x| x.with_ctx(a_fmt)).join(", ");
+            let b = b.iter().map(|x| x.with_ctx(b_fmt)).join(", ");
+            let target = target.with_ctx(a_fmt);
             self.error(format!(
                 "Mismatched {kind}:\
                 \ntarget: {target}\
@@ -94,9 +94,9 @@ impl CheckGenericsVisitor<'_> {
         let ref_trait_id = tref.trait_decl_ref.skip_binder.trait_id;
         if clause_trait_id != ref_trait_id {
             let args_fmt = &self.val_fmt_ctx();
-            let tclause = tclause.fmt_with_ctx(params_fmt);
-            let tref_pred = tref.trait_decl_ref.fmt_with_ctx(args_fmt);
-            let tref = tref.fmt_with_ctx(args_fmt);
+            let tclause = tclause.with_ctx(params_fmt);
+            let tref_pred = tref.trait_decl_ref.with_ctx(args_fmt);
+            let tref = tref.with_ctx(args_fmt);
             self.error(format!(
                 "Mismatched trait clause:\
                 \nexpected: {tclause}\

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -59,7 +59,7 @@ pub trait UllbcPass: Sync {
     ) {
         let fmt_ctx = &ctx.into_fmt();
         let body_str = if let Ok(body) = body {
-            body.fmt_with_ctx(fmt_ctx)
+            body.to_string_with_ctx(fmt_ctx)
         } else {
             "<opaque>".to_owned()
         };
@@ -112,7 +112,7 @@ pub trait LlbcPass: Sync {
     ) {
         let fmt_ctx = &ctx.into_fmt();
         let body_str = if let Ok(body) = body {
-            body.fmt_with_ctx(fmt_ctx)
+            body.to_string_with_ctx(fmt_ctx)
         } else {
             "<opaque>".to_owned()
         };

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -1068,7 +1068,7 @@ impl UpdateItemBody<'_> {
                     self.type_replacements
                         .iter()
                         .flat_map(|x| x.iter())
-                        .map(|(path, ty)| format!("  - {path} = {}", ty.fmt_with_ctx(fmt_ctx)))
+                        .map(|(path, ty)| format!("  - {path} = {}", ty.with_ctx(fmt_ctx)))
                         .join("\n"),
                 );
                 TyKind::Error(format!("Can't compute {path}")).into_ty()

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -65,7 +65,7 @@ impl Transform {
                                     "reading the discriminant of an opaque enum. \
                                     Add `--include {}` to the `charon` arguments \
                                     to translate this enum.",
-                                    name.fmt_with_ctx(&ctx.into_fmt())
+                                    name.with_ctx(&ctx.into_fmt())
                                 );
                             }
                             // Don't double-error

--- a/charon/src/transform/ullbc_to_llbc.rs
+++ b/charon/src/transform/ullbc_to_llbc.rs
@@ -23,9 +23,10 @@
 use crate::ast::*;
 use crate::common::ensure_sufficient_stack;
 use crate::errors::sanity_check;
-use crate::formatter::{Formatter, IntoFormatter};
+use crate::formatter::IntoFormatter;
 use crate::llbc_ast as tgt;
 use crate::meta::{combine_span, Span};
+use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::{self as src};
 use indexmap::IndexMap;
@@ -1769,20 +1770,20 @@ impl TransformPass for Transform {
         });
 
         // Print the functions
-        let fmt_ctx = ctx.into_fmt();
+        let fmt_ctx = &ctx.into_fmt();
         for fun in &ctx.translated.fun_decls {
             trace!(
                 "# Signature:\n{}\n\n# Function definition:\n{}\n",
-                fmt_ctx.format_object(&fun.signature),
-                fmt_ctx.format_object(fun),
+                fun.signature.with_ctx(fmt_ctx),
+                fun.with_ctx(fmt_ctx),
             );
         }
         // Print the global variables
         for global in &ctx.translated.global_decls {
             trace!(
                 "# Type:\n{}\n\n# Global definition:\n{}\n",
-                fmt_ctx.format_object(&global.ty),
-                fmt_ctx.format_object(global)
+                global.ty.with_ctx(fmt_ctx),
+                global.with_ctx(fmt_ctx),
             );
         }
 

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -14,8 +14,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -24,8 +24,8 @@ pub enum Option<T>
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: test_cargo_dependencies::main::silly_incr::closure
 struct closure {}

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -3,8 +3,8 @@
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::{Arguments<'a>}#4::new_const
 pub fn new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> Arguments<'a>

--- a/charon/tests/test-rust-name-matcher.rs
+++ b/charon/tests/test-rust-name-matcher.rs
@@ -50,12 +50,12 @@ fn test_name_matcher() -> anyhow::Result<()> {
                 if passes {
                     panic!(
                         "Pattern `{pat}` passes on `{}` but shouldn't",
-                        name.fmt_with_ctx(fmt_ctx)
+                        name.with_ctx(fmt_ctx)
                     );
                 } else {
                     panic!(
                         "Pattern `{pat}` doesn't pass on `{}` but should",
-                        name.fmt_with_ctx(fmt_ctx)
+                        name.with_ctx(fmt_ctx)
                     );
                 }
             }

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -281,8 +281,8 @@ where
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -294,8 +294,8 @@ pub trait Sealed<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -6,8 +6,8 @@ pub trait Sized<Self>
 
 // Full name: test_crate::V
 struct V<T, const N : usize>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   x: Array<T, const N : usize>,
 }
@@ -23,8 +23,8 @@ where
 }
 
 const test_crate::{V<T, const N : usize>[@TraitClause0]}::LEN<T, const N : usize>: usize
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
  = test_crate::{V<T, const N : usize>[@TraitClause0]}::LEN()
 
 // Full name: test_crate::HasLen

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -33,8 +33,8 @@ where
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -338,10 +338,10 @@ pub trait ToOwned<Self, Self_Owned>
 
 // Full name: test_crate::cow::Cow
 enum Cow<'a, B, Clause0_Owned>
-  where
-      [@TraitClause0]: ToOwned<B, Clause0_Owned>,
-      B : 'a,
-      B : 'a,
+where
+    [@TraitClause0]: ToOwned<B, Clause0_Owned>,
+    B : 'a,
+    B : 'a,
 {
   Borrowed(&'a (B)),
   Owned(Clause0_Owned),

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -6,8 +6,8 @@ pub trait Sized<Self>
 
 // Full name: test_crate::Struct
 struct Struct<A>
-  where
-      [@TraitClause0]: Sized<A>,
+where
+    [@TraitClause0]: Sized<A>,
 {
   A,
 }

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -55,8 +55,8 @@ pub trait Fn<Self, Args, Self_Clause0_Clause0_Output>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -266,8 +266,8 @@ pub fn test_closure_ref_u32<'a>(@1: &'a (u32)) -> &'a (u32)
 }
 
 struct test_crate::test_closure_ref_param::closure<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {}
 
 // Full name: test_crate::test_closure_ref_param
@@ -306,9 +306,9 @@ where
 trait Trait<'a, Self>
 
 struct test_crate::test_closure_ref_early_bound::closure<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Trait<'a, T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Trait<'a, T>,
 {}
 
 // Full name: test_crate::test_closure_ref_early_bound
@@ -715,9 +715,9 @@ pub fn test_closure_capture(@1: u32, @2: u32) -> u32
 }
 
 struct test_crate::test_closure_clone::closure<T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
 {}
 
 // Full name: test_crate::test_closure_clone::{impl Fn<(T), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -12,9 +12,9 @@ pub trait Sized<Self>
 
 // Full name: test_crate::test::closure
 struct closure<T, const K : usize>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Ops<T, const K : usize>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Ops<T, const K : usize>,
 {}
 
 // Full name: core::marker::Tuple

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -248,8 +248,8 @@ pub enum AssertKind {
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -258,8 +258,8 @@ pub enum Option<T>
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: test_crate::foo
 fn foo()

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -90,9 +90,9 @@ pub trait Sized<Self>
 
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   x: T1,
   y: T2,
@@ -159,8 +159,8 @@ pub const test_crate::P3: Pair<u32, u32>[Sized<u32>, Sized<u32>] = test_crate::P
 
 // Full name: test_crate::Wrap
 pub struct Wrap<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   value: T,
 }
@@ -375,8 +375,8 @@ pub static test_crate::S4: Pair<u32, u32>[Sized<u32>, Sized<u32>] = test_crate::
 
 // Full name: test_crate::V
 pub struct V<T, const N : usize>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   x: Array<T, const N : usize>,
 }
@@ -392,8 +392,8 @@ where
 }
 
 pub const test_crate::{V<T, const N : usize>[@TraitClause0]}#1::LEN<T, const N : usize>: usize
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
  = test_crate::{V<T, const N : usize>[@TraitClause0]}#1::LEN()
 
 // Full name: test_crate::use_v

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -152,8 +152,8 @@ pub struct Global {}
 
 // Full name: test_crate::CList
 pub enum CList<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   CCons(T, alloc::boxed::Box<CList<T>[@TraitClause0]>[Sized<Global>]),
   CNil,

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -7,15 +7,15 @@ pub trait Sized<Self>
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -62,9 +62,9 @@ pub trait ZeroablePrimitive<Self>
 // Full name: core::num::nonzero::NonZero
 #[lang_item("NonZero")]
 pub opaque type NonZero<T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: ZeroablePrimitive<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: ZeroablePrimitive<T>,
 
 // Full name: core::clone::impls::{impl Clone for u32}#8::clone
 pub fn {impl Clone for u32}#8::clone<'_0>(@1: &'_0 (u32)) -> u32
@@ -113,8 +113,8 @@ impl ZeroablePrimitive for u32 {
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -152,9 +152,9 @@ pub fn test_new_non_zero_u32(@1: u32) -> NonZero<u32>[Sized<u32>, {impl Zeroable
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]

--- a/charon/tests/ui/find-sized-clause.out
+++ b/charon/tests/ui/find-sized-clause.out
@@ -10,8 +10,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -7,15 +7,15 @@ pub trait Sized<Self>
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -34,16 +34,16 @@ pub trait Debug<Self>
 // Full name: core::slice::iter::Iter
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -52,8 +52,8 @@ pub enum Option<T>
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::rt::Argument
 #[lang_item("format_argument")]
@@ -356,9 +356,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/hide-marker-traits.out
+++ b/charon/tests/ui/hide-marker-traits.out
@@ -5,16 +5,16 @@ trait Idx<Self>
 
 // Full name: test_crate::IndexVec
 pub struct IndexVec<I>
-  where
-      [@TraitClause1]: Idx<I>,
+where
+    [@TraitClause1]: Idx<I>,
 {
   i: I,
 }
 
 // Full name: test_crate::Vector
 pub struct Vector<I>
-  where
-      [@TraitClause1]: Idx<I>,
+where
+    [@TraitClause1]: Idx<I>,
 {
   vector: IndexVec<I>[@TraitClause1],
 }

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -175,17 +175,17 @@ where
 
 // Full name: test_crate::WrapClone
 pub struct WrapClone<T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
 {
   T,
 }
 
 // Full name: test_crate::wrap::closure
 struct closure<U>
-  where
-      [@TraitClause0]: Sized<U>,
+where
+    [@TraitClause0]: Sized<U>,
 {}
 
 // Full name: test_crate::wrap

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -72,8 +72,8 @@ fn use_inlines() -> u32
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -169,8 +169,8 @@ pub struct UsizeNoHighBit {
 
 // Full name: alloc::raw_vec::RawVecInner
 struct RawVecInner<A>
-  where
-      [@TraitClause0]: Sized<A>,
+where
+    [@TraitClause0]: Sized<A>,
 {
   ptr: Unique<u8>,
   cap: UsizeNoHighBit,
@@ -179,9 +179,9 @@ struct RawVecInner<A>
 
 // Full name: alloc::raw_vec::RawVec
 struct RawVec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 {
   inner: RawVecInner<A>[@TraitClause1],
   _marker: PhantomData<T>,
@@ -190,9 +190,9 @@ struct RawVec<T, A>
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub struct Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 {
   buf: RawVec<T, A>[@TraitClause0, @TraitClause1],
   len: usize,

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -87,16 +87,16 @@ pub trait Sized<Self>
 
 // Full name: core::slice::iter::Chunks
 pub opaque type Chunks<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -521,9 +521,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -21,8 +21,8 @@ pub trait Try<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -6,9 +6,9 @@ pub trait Sized<Self>
 
 // Full name: test_crate::S
 pub struct S<'a, K>
-  where
-      [@TraitClause0]: Sized<K>,
-      K : 'a,
+where
+    [@TraitClause0]: Sized<K>,
+    K : 'a,
 {
   x: &'a (K),
 }

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -40,9 +40,9 @@ struct test_crate::Foo {
 
 // Full name: test_crate::Bar
 enum Bar<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
 {
   Variant(&'a (T)),
 }

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -6,8 +6,8 @@ pub trait Sized<Self>
 
 // Full name: core::iter::sources::from_fn::FromFn
 pub opaque type FromFn<F>
-  where
-      [@TraitClause0]: Sized<F>,
+where
+    [@TraitClause0]: Sized<F>,
 
 // Full name: test_crate::sparse_transitions::closure
 struct closure<'a> {}
@@ -40,8 +40,8 @@ pub trait FnMut<Self, Args>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -14,8 +14,8 @@ pub trait Trait<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -23,8 +23,8 @@ pub enum Option<T>
 
 // Full name: test_crate::Alias
 pub type Alias<T>
-  where
-      [@TraitClause0]: Sized<T>, = Option<UNKNOWN(Could not find a clause for `Binder { value: <T as Trait>, bound_vars: [] }` in the current context: `Unimplemented`)::AssocType>[UNKNOWN(Could not find a clause for `Binder { value: <<T as Trait>::AssocType as std::marker::Sized>, bound_vars: [] }` in the current context: `Ambiguity`)]
+where
+    [@TraitClause0]: Sized<T>, = Option<UNKNOWN(Could not find a clause for `Binder { value: <T as Trait>, bound_vars: [] }` in the current context: `Unimplemented`)::AssocType>[UNKNOWN(Could not find a clause for `Binder { value: <<T as Trait>::AssocType as std::marker::Sized>, bound_vars: [] }` in the current context: `Ambiguity`)]
 
 // Full name: test_crate::C
 pub trait C<Self, T>
@@ -43,11 +43,11 @@ pub trait Iterator<Self>
 
 // Full name: test_crate::S
 pub struct S<I, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>,
-      [@TraitClause2]: Iterator<I>,
-      [@TraitClause3]: C<F, @TraitClause2::Item>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>,
+    [@TraitClause2]: Iterator<I>,
+    [@TraitClause3]: C<F, @TraitClause2::Item>,
 {
   I,
   F,
@@ -55,9 +55,9 @@ pub struct S<I, F>
 
 // Full name: test_crate::S2
 pub type S2<I, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>, = S<I, F>[@TraitClause0, @TraitClause1, UNKNOWN(Could not find a clause for `Binder { value: <I as std::iter::Iterator>, bound_vars: [] }` in the current context: `Unimplemented`), UNKNOWN(Could not find a clause for `Binder { value: <F as C<<I as std::iter::Iterator>::Item>>, bound_vars: [] }` in the current context: `Unimplemented`)]
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>, = S<I, F>[@TraitClause0, @TraitClause1, UNKNOWN(Could not find a clause for `Binder { value: <I as std::iter::Iterator>, bound_vars: [] }` in the current context: `Unimplemented`), UNKNOWN(Could not find a clause for `Binder { value: <F as C<<I as std::iter::Iterator>::Item>>, bound_vars: [] }` in the current context: `Unimplemented`)]
 
 // Full name: core::iter::traits::iterator::Iterator::next
 #[lang_item("next")]
@@ -130,9 +130,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -87,8 +87,8 @@ impl Copy for u8 {
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::Error
 pub struct Error {}

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -87,8 +87,8 @@ impl Copy for u8 {
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::Error
 pub struct Error {}

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -115,8 +115,8 @@ pub fn array<const LEN : usize>() -> Array<u8, const LEN : usize>
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -125,8 +125,8 @@ pub struct Range<Idx>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -337,8 +337,8 @@ pub enum AssertKind {
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 #[lang_item("slice_len_fn")]
 pub fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
@@ -566,9 +566,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -30,8 +30,8 @@ trait GenericTrait<Self, T>
 
 // Full name: test_crate::Override
 struct Override<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   T,
 }
@@ -39,8 +39,8 @@ struct Override<T>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -137,8 +137,8 @@ where
 
 // Full name: test_crate::NoOverride
 struct NoOverride<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   T,
 }

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -9,8 +9,8 @@ pub trait Sized<Self>
 
 // Full name: test_crate::AVLTree
 pub struct AVLTree<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   x: T,
 }

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -7,14 +7,14 @@ pub trait Sized<Self>
 // Full name: core::array::iter::IntoIter
 #[lang_item("ArrayIntoIter")]
 pub opaque type IntoIter<T, const N : usize>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -23,24 +23,24 @@ pub enum Option<T>
 // Full name: core::slice::iter::Iter
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::slice::iter::Chunks
 pub opaque type Chunks<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::slice::iter::ChunksExact
 pub opaque type ChunksExact<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::panicking::AssertKind
 pub enum AssertKind {
@@ -52,8 +52,8 @@ pub enum AssertKind {
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::array::iter::{impl IntoIterator for Array<T, const N : usize>}::into_iter
 pub fn {impl IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>(@1: Array<T, const N : usize>) -> IntoIter<T, const N : usize>[@TraitClause0]
@@ -63,9 +63,9 @@ where
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -104,9 +104,9 @@ pub trait ZeroablePrimitive<Self>
 // Full name: core::num::nonzero::NonZero
 #[lang_item("NonZero")]
 pub opaque type NonZero<T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: ZeroablePrimitive<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: ZeroablePrimitive<T>,
 
 // Full name: core::clone::impls::{impl Clone for usize}#5::clone
 pub fn {impl Clone for usize}#5::clone<'_0>(@1: &'_0 (usize)) -> usize
@@ -160,20 +160,20 @@ impl ZeroablePrimitive for usize {
 
 // Full name: core::iter::adapters::step_by::StepBy
 pub opaque type StepBy<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::chain::Chain
 pub opaque type Chain<A, B>
-  where
-      [@TraitClause0]: Sized<A>,
-      [@TraitClause1]: Sized<B>,
+where
+    [@TraitClause0]: Sized<A>,
+    [@TraitClause1]: Sized<B>,
 
 // Full name: core::iter::adapters::zip::Zip
 pub opaque type Zip<A, B>
-  where
-      [@TraitClause0]: Sized<A>,
-      [@TraitClause1]: Sized<B>,
+where
+    [@TraitClause0]: Sized<A>,
+    [@TraitClause1]: Sized<B>,
 
 // Full name: core::marker::Tuple
 #[lang_item("tuple_trait")]
@@ -202,73 +202,73 @@ pub trait FnMut<Self, Args>
 
 // Full name: core::iter::adapters::map::Map
 pub opaque type Map<I, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>,
 
 // Full name: core::iter::adapters::filter::Filter
 pub opaque type Filter<I, P>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<P>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<P>,
 
 // Full name: core::iter::adapters::filter_map::FilterMap
 pub opaque type FilterMap<I, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>,
 
 // Full name: core::iter::adapters::enumerate::Enumerate
 #[lang_item("Enumerate")]
 pub opaque type Enumerate<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::skip_while::SkipWhile
 pub opaque type SkipWhile<I, P>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<P>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<P>,
 
 // Full name: core::iter::adapters::take_while::TakeWhile
 pub opaque type TakeWhile<I, P>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<P>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<P>,
 
 // Full name: core::iter::adapters::map_while::MapWhile
 pub opaque type MapWhile<I, P>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<P>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<P>,
 
 // Full name: core::iter::adapters::skip::Skip
 pub opaque type Skip<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::take::Take
 pub opaque type Take<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::scan::Scan
 pub opaque type Scan<I, St, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<St>,
-      [@TraitClause2]: Sized<F>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<St>,
+    [@TraitClause2]: Sized<F>,
 
 // Full name: core::iter::adapters::fuse::Fuse
 pub opaque type Fuse<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::inspect::Inspect
 pub opaque type Inspect<I, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>,
 
 // Full name: core::ops::try_trait::FromResidual
 #[lang_item("FromResidual")]
@@ -281,9 +281,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),
@@ -376,23 +376,23 @@ pub trait Ord<Self>
 
 // Full name: core::iter::adapters::rev::Rev
 pub opaque type Rev<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 
 // Full name: core::iter::adapters::copied::Copied
 pub opaque type Copied<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::cloned::Cloned
 pub opaque type Cloned<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::adapters::cycle::Cycle
 pub opaque type Cycle<I>
-  where
-      [@TraitClause0]: Sized<I>,
+where
+    [@TraitClause0]: Sized<I>,
 
 // Full name: core::iter::traits::iterator::Iterator
 #[lang_item("iterator")]
@@ -495,46 +495,46 @@ where
 
 // Full name: core::iter::adapters::intersperse::Intersperse
 pub opaque type Intersperse<I>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Iterator<I>,
-      [@TraitClause2]: Clone<@TraitClause1::Item>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Iterator<I>,
+    [@TraitClause2]: Clone<@TraitClause1::Item>,
 
 // Full name: core::iter::adapters::intersperse::IntersperseWith
 pub opaque type IntersperseWith<I, G>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<G>,
-      [@TraitClause2]: Iterator<I>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<G>,
+    [@TraitClause2]: Iterator<I>,
 
 // Full name: core::iter::adapters::peekable::Peekable
 #[lang_item("IterPeekable")]
 pub opaque type Peekable<I>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Iterator<I>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Iterator<I>,
 
 // Full name: core::iter::adapters::flatten::FlatMap
 pub opaque type FlatMap<I, U, F>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<U>,
-      [@TraitClause2]: Sized<F>,
-      [@TraitClause3]: IntoIterator<U>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<U>,
+    [@TraitClause2]: Sized<F>,
+    [@TraitClause3]: IntoIterator<U>,
 
 // Full name: core::iter::adapters::flatten::Flatten
 pub opaque type Flatten<I>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Iterator<I>,
-      [@TraitClause2]: IntoIterator<@TraitClause1::Item>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Iterator<I>,
+    [@TraitClause2]: IntoIterator<@TraitClause1::Item>,
 
 // Full name: core::iter::adapters::map_windows::MapWindows
 pub opaque type MapWindows<I, F, const N : usize>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Sized<F>,
-      [@TraitClause2]: Iterator<I>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Sized<F>,
+    [@TraitClause2]: Iterator<I>,
 
 // Full name: core::iter::traits::collect::FromIterator
 #[lang_item("FromIterator")]
@@ -578,9 +578,9 @@ pub trait ExactSizeIterator<Self>
 
 // Full name: core::iter::adapters::array_chunks::ArrayChunks
 pub opaque type ArrayChunks<I, const N : usize>
-  where
-      [@TraitClause0]: Sized<I>,
-      [@TraitClause1]: Iterator<I>,
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Iterator<I>,
 
 // Full name: core::iter::traits::accum::Sum
 pub trait Sum<Self, A>

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -829,8 +829,8 @@ pub trait Sized<Self>
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -839,8 +839,8 @@ pub struct Range<Idx>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -1427,9 +1427,9 @@ pub fn sum_array<const N : usize>(@1: Array<u32, const N : usize>) -> u32
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
@@ -1578,8 +1578,8 @@ pub fn clear<'_0>(@1: &'_0 mut (Vec<u32, Global>[Sized<u32>, Sized<Global>]))
 
 // Full name: test_crate::List
 pub enum List<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   Cons(T, alloc::boxed::Box<List<T>[@TraitClause0]>[Sized<Global>]),
   Nil,
@@ -1882,9 +1882,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -28,8 +28,8 @@ pub struct Global {}
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -84,8 +84,8 @@ where
 // Full name: core::ops::range::RangeFrom
 #[lang_item("RangeFrom")]
 pub struct RangeFrom<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
 }

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -6,9 +6,9 @@ pub trait Sized<Self>
 
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   x: T1,
   y: T2,
@@ -20,8 +20,8 @@ pub struct Global {}
 
 // Full name: test_crate::List
 pub enum List<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   Cons(T, alloc::boxed::Box<List<T>[@TraitClause0]>[Sized<Global>]),
   Nil,
@@ -29,8 +29,8 @@ pub enum List<T>
 
 // Full name: test_crate::One
 pub enum One<T1>
-  where
-      [@TraitClause0]: Sized<T1>,
+where
+    [@TraitClause0]: Sized<T1>,
 {
   One(T1),
 }
@@ -51,9 +51,9 @@ pub struct EmptyStruct {}
 
 // Full name: test_crate::Sum
 pub enum Sum<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   Left(T1),
   Right(T2),
@@ -61,9 +61,9 @@ pub enum Sum<T1, T2>
 
 // Full name: test_crate::Tuple
 pub struct Tuple<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   T1,
   T2,
@@ -121,8 +121,8 @@ pub fn create_pair(@1: u32, @2: u64) -> Pair<u32, u64>[Sized<u32>, Sized<u64>]
 
 // Full name: test_crate::IdType
 pub struct IdType<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   T,
 }
@@ -468,8 +468,8 @@ pub fn test_char() -> char
 
 // Full name: test_crate::Tree
 pub enum Tree<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   Leaf(T),
   Node(T, NodeElem<T>[@TraitClause0], alloc::boxed::Box<Tree<T>[@TraitClause0]>[Sized<Global>]),
@@ -477,8 +477,8 @@ pub enum Tree<T>
 
 // Full name: test_crate::NodeElem
 pub enum NodeElem<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   Cons(alloc::boxed::Box<Tree<T>[@TraitClause0]>[Sized<Global>], alloc::boxed::Box<NodeElem<T>[@TraitClause0]>[Sized<Global>]),
   Nil,
@@ -596,9 +596,9 @@ pub fn test_even_odd()
 
 // Full name: test_crate::StructWithTuple
 pub struct StructWithTuple<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   p: (T1, T2),
 }
@@ -644,9 +644,9 @@ pub fn new_tuple3() -> StructWithTuple<u64, i64>[Sized<u64>, Sized<i64>]
 
 // Full name: test_crate::StructWithPair
 pub struct StructWithPair<T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
 {
   p: Pair<T1, T2>[@TraitClause0, @TraitClause1],
 }

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/opaque_attribute.out
+++ b/charon/tests/ui/opaque_attribute.out
@@ -28,8 +28,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -11,8 +11,8 @@ fn panic1()
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::{Arguments<'a>}#4::new_const
 pub fn new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> Arguments<'a>

--- a/charon/tests/ui/params.out
+++ b/charon/tests/ui/params.out
@@ -21,11 +21,11 @@ pub trait Sized<Self>
 
 // Full name: test_crate::E0
 enum E0<'a, 'b, T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      T1 : 'a,
-      T2 : 'b,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    T1 : 'a,
+    T2 : 'b,
 {
   V1(&'a mut (T1), &'b mut (T2)),
 }
@@ -36,13 +36,13 @@ pub struct Global {}
 
 // Full name: test_crate::E1
 enum E1<'a, 'b, T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      T1 : 'a,
-      T2 : 'b,
-      T2 : 'a,
-      T1 : 'b,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    T1 : 'a,
+    T2 : 'b,
+    T2 : 'a,
+    T1 : 'b,
 {
   V1(&'a mut (T1), &'b mut (T2)),
   V2(alloc::boxed::Box<E1<'a, 'b, T2, T1>[@TraitClause1, @TraitClause0]>[Sized<Global>]),
@@ -50,13 +50,13 @@ enum E1<'a, 'b, T1, T2>
 
 // Full name: test_crate::E2
 enum E2<'a, 'b, T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      T1 : 'a,
-      T2 : 'b,
-      T1 : 'b,
-      T2 : 'a,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    T1 : 'a,
+    T2 : 'b,
+    T1 : 'b,
+    T2 : 'a,
 {
   V1(&'a mut (T1), &'b mut (T2)),
   V3(alloc::boxed::Box<E2<'b, 'a, T1, T2>[@TraitClause0, @TraitClause1]>[Sized<Global>]),
@@ -64,17 +64,17 @@ enum E2<'a, 'b, T1, T2>
 
 // Full name: test_crate::E3
 enum E3<'a, 'b, 'c, T1, T2>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      T1 : 'a,
-      T2 : 'b,
-      T2 : 'a,
-      T1 : 'b,
-      T2 : 'c,
-      T1 : 'c,
-      'a : 'c,
-      'b : 'c,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    T1 : 'a,
+    T2 : 'b,
+    T2 : 'a,
+    T1 : 'b,
+    T2 : 'c,
+    T1 : 'c,
+    'a : 'c,
+    'b : 'c,
 {
   V1(&'a mut (T1), &'b mut (T2)),
   V2(alloc::boxed::Box<E3<'a, 'b, 'c, T2, T1>[@TraitClause1, @TraitClause0]>[Sized<Global>]),
@@ -84,19 +84,19 @@ enum E3<'a, 'b, 'c, T1, T2>
 
 // Full name: test_crate::E4
 enum E4<'a, 'b, 'c, T1, T2, T3>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      [@TraitClause2]: Sized<T3>,
-      T1 : 'a,
-      T2 : 'b,
-      T2 : 'a,
-      T1 : 'b,
-      T3 : 'c,
-      T3 : 'a,
-      T3 : 'b,
-      'a : 'c,
-      'b : 'c,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    [@TraitClause2]: Sized<T3>,
+    T1 : 'a,
+    T2 : 'b,
+    T2 : 'a,
+    T1 : 'b,
+    T3 : 'c,
+    T3 : 'a,
+    T3 : 'b,
+    'a : 'c,
+    'b : 'c,
 {
   V1(&'a mut (T1), &'b mut (T2)),
   V2(alloc::boxed::Box<E4<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]>[Sized<Global>]),
@@ -106,19 +106,19 @@ enum E4<'a, 'b, 'c, T1, T2, T3>
 
 // Full name: test_crate::E5
 enum E5<'a, 'b, 'c, T1, T2, T3>
-  where
-      [@TraitClause0]: Sized<T1>,
-      [@TraitClause1]: Sized<T2>,
-      [@TraitClause2]: Sized<T3>,
-      T1 : 'a,
-      T2 : 'b,
-      T2 : 'a,
-      T1 : 'b,
-      T3 : 'a,
-      T3 : 'c,
-      T3 : 'b,
-      'c : 'a,
-      'c : 'b,
+where
+    [@TraitClause0]: Sized<T1>,
+    [@TraitClause1]: Sized<T2>,
+    [@TraitClause2]: Sized<T3>,
+    T1 : 'a,
+    T2 : 'b,
+    T2 : 'a,
+    T1 : 'b,
+    T3 : 'a,
+    T3 : 'c,
+    T3 : 'b,
+    'c : 'a,
+    'c : 'b,
 {
   V1(&'a mut (T1), &'b mut (T2)),
   V2(alloc::boxed::Box<E5<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]>[Sized<Global>]),
@@ -128,11 +128,11 @@ enum E5<'a, 'b, 'c, T1, T2, T3>
 
 // Full name: test_crate::S1
 struct S1<'a, 'b, 'c, 'd>
-  where
-      'c : 'a,
-      'd : 'b,
-      'd : 'a,
-      'c : 'b,
+where
+    'c : 'a,
+    'd : 'b,
+    'd : 'a,
+    'c : 'b,
 {
   x: E1<'a, 'b, &'c mut (u32), &'d (u32)>[Sized<&'_ mut (u32)>, Sized<&'_ (u32)>],
 }

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -3,8 +3,8 @@
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::{Arguments<'a>}#4::new_const
 pub fn new_const<'a, const N : usize>(@1: &'a (Array<&'static (Str), const N : usize>)) -> Arguments<'a>

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -7,10 +7,10 @@ pub trait Sized<Self>
 // Full name: std::collections::hash::map::HashMap
 #[lang_item("HashMap")]
 pub opaque type HashMap<K, V, S>
-  where
-      [@TraitClause0]: Sized<K>,
-      [@TraitClause1]: Sized<V>,
-      [@TraitClause2]: Sized<S>,
+where
+    [@TraitClause0]: Sized<K>,
+    [@TraitClause1]: Sized<V>,
+    [@TraitClause2]: Sized<S>,
 
 // Full name: std::hash::random::RandomState
 pub opaque type RandomState
@@ -18,8 +18,8 @@ pub opaque type RandomState
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -59,9 +59,9 @@ pub opaque type RefCell<T>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -70,8 +70,8 @@ pub enum Result<T, E>
 // Full name: core::cell::Ref
 #[lang_item("RefCellRef")]
 pub opaque type Ref<'b, T>
-  where
-      T : 'b,
+where
+    T : 'b,
 
 // Full name: core::cell::BorrowError
 pub struct BorrowError {}

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -62,8 +62,8 @@ where
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -85,9 +85,9 @@ pub trait Trait<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -178,9 +178,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),

--- a/charon/tests/ui/regressions/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/regressions/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -12,17 +12,17 @@ pub trait PrimeField<Self, Self_Repr>
 
 // Full name: test_crate::SqrtTables
 pub struct SqrtTables<F>
-  where
-      [@TraitClause0]: Sized<F>,
+where
+    [@TraitClause0]: Sized<F>,
 {
   F,
 }
 
 // Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::closure
 struct closure<F, Clause1_Repr>
-  where
-      [@TraitClause0]: Sized<F>,
-      [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+where
+    [@TraitClause0]: Sized<F>,
+    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
 {}
 
 // Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -25,8 +25,8 @@ pub struct FormattingOptions {
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub struct Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 {
   options: FormattingOptions,
   buf: &'a mut (dyn (exists(TODO))),

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -28,8 +28,8 @@ pub struct Global {}
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -305,8 +305,8 @@ where
 
 // Full name: test_crate::nullary_ops::Struct
 struct Struct<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   a: u8,
   b: T,

--- a/charon/tests/ui/simple-cmp.out
+++ b/charon/tests/ui/simple-cmp.out
@@ -66,8 +66,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
+++ b/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
@@ -28,8 +28,8 @@ impl HasOutput2<()> for () {
 
 // Full name: test_crate::Wrapper
 struct Wrapper<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   T,
 }

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -17,8 +17,8 @@ impl Trait<()> for () {
 
 // Full name: test_crate::HashMap
 pub struct HashMap<S>
-  where
-      [@TraitClause0]: Sized<S>,
+where
+    [@TraitClause0]: Sized<S>,
 {
   S,
 }

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -6,17 +6,17 @@ pub trait Sized<Self>
 
 // Full name: test_crate::Foo
 pub struct Foo<F>
-  where
-      [@TraitClause0]: Sized<F>,
+where
+    [@TraitClause0]: Sized<F>,
 {
   F,
 }
 
 // Full name: test_crate::{Foo<F>[@TraitClause0]}::method::closure
 struct closure<F, T>
-  where
-      [@TraitClause0]: Sized<F>,
-      [@TraitClause1]: Sized<T>,
+where
+    [@TraitClause0]: Sized<F>,
+    [@TraitClause1]: Sized<T>,
 {}
 
 // Full name: test_crate::{Foo<F>[@TraitClause0]}::method

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
@@ -19,8 +19,8 @@ trait HasMethod<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
@@ -13,8 +13,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/simple/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/simple/mem-discriminant-from-derive.out
@@ -172,15 +172,15 @@ pub trait Copy<Self>
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -6,9 +6,9 @@ pub trait Sized<Self>
 
 // Full name: test_crate::Foo
 struct Foo<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
 {
   &'a (T),
 }
@@ -22,25 +22,25 @@ pub trait Clone<Self>
 }
 
 struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
 {
   &'_1 (T),
 }
 
 struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
 {
   &'_1 (T),
 }
 
 struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
 {
   &'_1 (T),
 }

--- a/charon/tests/ui/simple/pointee_metadata.out
+++ b/charon/tests/ui/simple/pointee_metadata.out
@@ -7,15 +7,15 @@ pub trait Sized<Self>
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -71,8 +71,8 @@ pub trait Eq<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::ops::range::RangeInclusive
 #[lang_item("RangeInclusive")]
 pub struct RangeInclusive<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -35,8 +35,8 @@ pub trait Sealed<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -355,8 +355,8 @@ pub struct FormattingOptions {
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub struct Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 {
   options: FormattingOptions,
   buf: &'a mut (dyn (exists(TODO))),
@@ -365,9 +365,9 @@ pub struct Formatter<'a>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -395,8 +395,8 @@ pub struct Argument<'a> {
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub struct Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 {
   pieces: &'a (Slice<&'static (Str)>),
   fmt: Option<&'a (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>],
@@ -687,8 +687,8 @@ where
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -6,16 +6,16 @@ pub trait Sized<Self>
 
 // Full name: alloc::raw_vec::RawVec
 opaque type RawVec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub struct Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 {
   buf: RawVec<T, A>[@TraitClause0, @TraitClause1],
   len: usize,
@@ -27,8 +27,8 @@ pub struct Global {}
 
 // Full name: alloc::raw_vec::RawVecInner
 opaque type RawVecInner<A>
-  where
-      [@TraitClause0]: Sized<A>,
+where
+    [@TraitClause0]: Sized<A>,
 
 // Full name: core::num::niche_types::UsizeNoHighBit
 pub opaque type UsizeNoHighBit

--- a/charon/tests/ui/simple/vec-with-capacity.out
+++ b/charon/tests/ui/simple/vec-with-capacity.out
@@ -6,16 +6,16 @@ pub trait Sized<Self>
 
 // Full name: alloc::raw_vec::RawVec
 opaque type RawVec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub struct Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 {
   buf: RawVec<T, A>[@TraitClause0, @TraitClause1],
   len: usize,
@@ -27,8 +27,8 @@ pub struct Global {}
 
 // Full name: alloc::raw_vec::RawVecInner
 opaque type RawVecInner<A>
-  where
-      [@TraitClause0]: Sized<A>,
+where
+    [@TraitClause0]: Sized<A>,
 
 // Full name: core::alloc::layout::Layout
 #[lang_item("alloc_layout")]

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -35,8 +35,8 @@ pub trait Sealed<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),

--- a/charon/tests/ui/start_from.out
+++ b/charon/tests/ui/start_from.out
@@ -25,8 +25,8 @@ pub trait Sized<Self>
 // Full name: core::iter::sources::once::Once
 #[lang_item("IterOnce")]
 pub opaque type Once<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 
 // Full name: core::iter::sources::once::once
 pub fn once<T>(@1: T) -> Once<T>[@TraitClause0]
@@ -48,10 +48,10 @@ pub fn clone_from<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Self))
 // Full name: core::slice::iter::Iter
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::slice::iter::{Iter<'a, T>[@TraitClause0]}#6::as_slice
 pub fn as_slice<'a, '_1, T>(@1: &'_1 (Iter<'a, T>[@TraitClause0])) -> &'a (Slice<T>)

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -41,8 +41,8 @@ pub opaque type String
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
@@ -51,9 +51,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -68,8 +68,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -280,8 +280,8 @@ pub fn h0(@1: u64) -> u64
 
 // Full name: test_crate::Wrapper
 pub struct Wrapper<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   x: T,
 }
@@ -439,8 +439,8 @@ where
 
 // Full name: test_crate::TestType
 pub struct TestType<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   T,
 }
@@ -929,8 +929,8 @@ where
 
 // Full name: test_crate::{impl Trait for Array<T, const N : usize>}#14::LEN
 pub const {impl Trait for Array<T, const N : usize>}#14::LEN<T, const N : usize>: usize
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
  = {impl Trait for Array<T, const N : usize>}#14::LEN()
 
 // Full name: test_crate::{impl Trait for Array<T, const N : usize>}#14
@@ -955,9 +955,9 @@ where
 
 // Full name: test_crate::{impl Trait for Wrapper<T>[@TraitClause0]}#15::LEN
 pub const {impl Trait for Wrapper<T>[@TraitClause0]}#15::LEN<T>: usize
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Trait<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Trait<T>,
  = {impl Trait for Wrapper<T>[@TraitClause0]}#15::LEN()
 
 // Full name: test_crate::{impl Trait for Wrapper<T>[@TraitClause0]}#15
@@ -983,9 +983,9 @@ where
 
 // Full name: test_crate::Foo
 pub struct Foo<T, U>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<U>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<U>,
 {
   x: T,
   y: U,
@@ -994,9 +994,9 @@ pub struct Foo<T, U>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -1015,10 +1015,10 @@ where
 }
 
 pub const test_crate::{Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO<T, U>: Result<T, i32>[@TraitClause0, Sized<i32>]
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<U>,
-      [@TraitClause2]: Trait<T>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<U>,
+    [@TraitClause2]: Trait<T>,
  = test_crate::{Foo<T, U>[@TraitClause0, @TraitClause1]}#16::FOO()
 
 // Full name: test_crate::use_foo1

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -7,9 +7,9 @@ pub trait Sized<Self>
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -32,10 +32,10 @@ pub trait ToOwned<Self>
 // Full name: alloc::borrow::Cow
 #[lang_item("Cow")]
 pub enum Cow<'a, B>
-  where
-      [@TraitClause0]: ToOwned<B>,
-      B : 'a,
-      B : 'a,
+where
+    [@TraitClause0]: ToOwned<B>,
+    B : 'a,
+    B : 'a,
 {
   Borrowed(&'a (B)),
   Owned(@TraitClause0::Owned),
@@ -44,9 +44,9 @@ pub enum Cow<'a, B>
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T, A>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<A>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<A>,
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
@@ -87,10 +87,10 @@ where
 
 // Full name: test_crate::Generic2
 struct Generic2<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Clone<T>,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+    T : 'a,
 {
   Cow<'a, Slice<T>>[{impl ToOwned for Slice<T>}#9<T>[@TraitClause0, @TraitClause1]],
 }

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -34,15 +34,15 @@ pub trait Default<Self>
 // Full name: core::fmt::Formatter
 #[lang_item("Formatter")]
 pub opaque type Formatter<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
-  where
-      [@TraitClause0]: Sized<T>,
-      [@TraitClause1]: Sized<E>,
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
 {
   Ok(T),
   Err(E),
@@ -61,8 +61,8 @@ pub trait Debug<Self>
 // Full name: core::fmt::Arguments
 #[lang_item("format_arguments")]
 pub opaque type Arguments<'a>
-  where
-      'a : 'a,
+where
+    'a : 'a,
 
 // Full name: core::fmt::rt::Argument
 #[lang_item("format_argument")]

--- a/charon/tests/ui/ullbc-control-flow.out
+++ b/charon/tests/ui/ullbc-control-flow.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
-  where
-      [@TraitClause0]: Sized<Idx>,
+where
+    [@TraitClause0]: Sized<Idx>,
 {
   start: Idx,
   end: Idx,
@@ -17,8 +17,8 @@ pub struct Range<Idx>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -531,9 +531,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -11,8 +11,8 @@ pub struct Global {}
 // Full name: alloc::rc::Rc
 #[lang_item("Rc")]
 pub opaque type Rc<T, A>
-  where
-      [@TraitClause0]: Sized<A>,
+where
+    [@TraitClause0]: Sized<A>,
 
 // Full name: alloc::string::String
 #[lang_item("String")]

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -7,8 +7,8 @@ pub trait Sized<Self>
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
-  where
-      [@TraitClause0]: Sized<T>,
+where
+    [@TraitClause0]: Sized<T>,
 {
   None,
   Some(T),
@@ -17,10 +17,10 @@ pub enum Option<T>
 // Full name: core::slice::iter::Iter
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
-  where
-      [@TraitClause0]: Sized<T>,
-      T : 'a,
-      T : 'a,
+where
+    [@TraitClause0]: Sized<T>,
+    T : 'a,
+    T : 'a,
 
 // Full name: core::slice::{Slice<T>}::iter
 #[lang_item("slice_iter")]
@@ -164,9 +164,9 @@ pub trait FromResidual<Self, R>
 // Full name: core::ops::control_flow::ControlFlow
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
-  where
-      [@TraitClause0]: Sized<B>,
-      [@TraitClause1]: Sized<C>,
+where
+    [@TraitClause0]: Sized<B>,
+    [@TraitClause1]: Sized<C>,
 {
   Continue(C),
   Break(B),


### PR DESCRIPTION
This reworks the `FmtWithCtx` machinery by removing `Formatter` entirely and making `FmtWithCtx` work by appending into a buffer instead of allocating a fresh string, as is standard for string formatting in Rust. I took the opportunity to considerably simplify that code.