### PR TITLE
Remove the version pin in charon-ml/.ocamlformat

### DIFF
--- a/charon-ml/.ocamlformat
+++ b/charon-ml/.ocamlformat
@@ -1,5 +1,4 @@
 profile = default
-version = 0.26.2
 margin = 80
 
 break-cases = fit-or-vertical


### PR DESCRIPTION
The default version of ocamlformat is not 0.26.2 anymore. Instead of regularly updating the pinned version I suggest removing the pin altogether: if it leads to issues in the future (in particular, changes in the formatting depending on the version) I will put it back.