### PR TITLE
Fix infinite loops in mono

### DIFF
--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -112,6 +112,11 @@ impl UsageVisitor<'_> {
     }
 }
 impl VisitAst for UsageVisitor<'_> {
+    // we need to skip ItemMeta, as we don't want to collect the types in PathElem::Impl
+    fn visit_item_meta(&mut self, _: &ItemMeta) -> ControlFlow<Infallible> {
+        Continue(())
+    }
+
     fn enter_aggregate_kind(&mut self, kind: &AggregateKind) {
         match kind {
             AggregateKind::Adt(TypeId::Adt(id), _, _, gargs) => self.found_use_ty(id, gargs),

--- a/charon/tests/ui/monomorphization/rec-adt.out
+++ b/charon/tests/ui/monomorphization/rec-adt.out
@@ -1,0 +1,68 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+
+// Full name: core::option::Option
+#[lang_item("Option")]
+pub enum Option<T>
+where
+    [@TraitClause0]: Sized<T>,
+{
+  None,
+  Some(T),
+}
+
+// Full name: core::ptr::non_null::NonNull
+#[lang_item("NonNull")]
+pub opaque type NonNull<T>
+
+// Full name: test_crate::Node
+struct Node<T>
+where
+    [@TraitClause0]: Sized<T>,
+{
+  next: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>],
+  element: T,
+}
+
+// Full name: test_crate::LinkedList
+pub struct LinkedList<T>
+where
+    [@TraitClause0]: Sized<T>,
+{
+  head: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>],
+}
+
+// Full name: test_crate::{LinkedList<T>[@TraitClause0]}::new
+fn new<T>() -> LinkedList<T>[@TraitClause0]
+where
+    [@TraitClause0]: Sized<T>,
+{
+    let @0: LinkedList<T>[@TraitClause0]; // return
+    let @1: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>]; // anonymous local
+
+    storage_live(@1)
+    @1 := Option::None {  }
+    @0 := LinkedList { head: move (@1) }
+    storage_dead(@1)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let @0: (); // return
+    let list@1: LinkedList<u8>[Sized<u8>]; // local
+
+    storage_live(list@1)
+    list@1 := new<u8>[Sized<u8>]()
+    @0 := ()
+    storage_dead(list@1)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/monomorphization/rec-adt.out
+++ b/charon/tests/ui/monomorphization/rec-adt.out
@@ -4,48 +4,18 @@
 #[lang_item("sized")]
 pub trait Sized<Self>
 
-// Full name: core::option::Option
-#[lang_item("Option")]
-pub enum Option<T>
-where
-    [@TraitClause0]: Sized<T>,
-{
-  None,
-  Some(T),
+pub struct test_crate::LinkedList::<u8> {
+  head: core::option::Option::<NonNull<Node<u8>[Sized<u8>]>>,
 }
 
-// Full name: core::ptr::non_null::NonNull
-#[lang_item("NonNull")]
-pub opaque type NonNull<T>
-
-// Full name: test_crate::Node
-struct Node<T>
-where
-    [@TraitClause0]: Sized<T>,
+fn test_crate::{LinkedList<T>[@TraitClause0]}::new::<u8>() -> test_crate::LinkedList::<u8>
 {
-  next: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>],
-  element: T,
-}
-
-// Full name: test_crate::LinkedList
-pub struct LinkedList<T>
-where
-    [@TraitClause0]: Sized<T>,
-{
-  head: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>],
-}
-
-// Full name: test_crate::{LinkedList<T>[@TraitClause0]}::new
-fn new<T>() -> LinkedList<T>[@TraitClause0]
-where
-    [@TraitClause0]: Sized<T>,
-{
-    let @0: LinkedList<T>[@TraitClause0]; // return
-    let @1: Option<NonNull<Node<T>[@TraitClause0]>>[Sized<NonNull<Node<T>[@TraitClause0]>>]; // anonymous local
+    let @0: test_crate::LinkedList::<u8>; // return
+    let @1: core::option::Option::<NonNull<Node<u8>[Sized<u8>]>>; // anonymous local
 
     storage_live(@1)
-    @1 := Option::None {  }
-    @0 := LinkedList { head: move (@1) }
+    @1 := core::option::Option::<NonNull<Node<u8>[Sized<u8>]>>::None {  }
+    @0 := test_crate::LinkedList::<u8> { head: move (@1) }
     storage_dead(@1)
     return
 }
@@ -54,10 +24,10 @@ where
 fn main()
 {
     let @0: (); // return
-    let list@1: LinkedList<u8>[Sized<u8>]; // local
+    let list@1: test_crate::LinkedList::<u8>; // local
 
     storage_live(list@1)
-    list@1 := new<u8>[Sized<u8>]()
+    list@1 := test_crate::{LinkedList<T>[@TraitClause0]}::new::<u8>()
     @0 := ()
     storage_dead(list@1)
     @0 := ()

--- a/charon/tests/ui/monomorphization/rec-adt.rs
+++ b/charon/tests/ui/monomorphization/rec-adt.rs
@@ -1,0 +1,21 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+pub struct LinkedList<T> {
+    head: Option<NonNull<Node<T>>>,
+}
+
+struct Node<T> {
+    next: Option<NonNull<Node<T>>>,
+    element: T,
+}
+
+impl<T> LinkedList<T> {
+    fn new() -> Self {
+        Self { head: None }
+    }
+}
+
+fn main() {
+    let list: LinkedList<u8> = LinkedList::new();
+}

--- a/charon/tests/ui/monomorphization/rec-adt.rs
+++ b/charon/tests/ui/monomorphization/rec-adt.rs
@@ -1,3 +1,4 @@
+//@ charon-args=--monomorphize
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 


### PR DESCRIPTION
Fixes #675 -- was caused by monomorphization detecting types in `PathElem::Impl`s as uses of that type