### PR TITLE
Add more Discriminant layout information

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.96"
+let supported_charon_version = "0.1.97"

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1317,10 +1317,11 @@ and discriminant_layout_of_json (ctx : of_json_ctx) (js : json) :
     (discriminant_layout, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("offset", offset); ("repr", repr) ] ->
+    | `Assoc [ ("Direct", `Assoc [ ("offset", offset); ("repr", repr) ]) ] ->
         let* offset = int_of_json ctx offset in
-        let* repr = option_of_json integer_type_of_json ctx repr in
-        Ok ({ offset; repr } : discriminant_layout)
+        let* repr = integer_type_of_json ctx repr in
+        Ok (Direct (offset, repr))
+    | `String "Niche" -> Ok Niche
     | _ -> Error "")
 
 and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1313,6 +1313,16 @@ and variant_layout_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ field_offsets } : variant_layout)
     | _ -> Error "")
 
+and discriminant_layout_of_json (ctx : of_json_ctx) (js : json) :
+    (discriminant_layout, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("offset", offset); ("size", size) ] ->
+        let* offset = int_of_json ctx offset in
+        let* size = int_of_json ctx size in
+        Ok ({ offset; size } : discriminant_layout)
+    | _ -> Error "")
+
 and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1320,14 +1330,14 @@ and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =
         [
           ("size", size);
           ("align", align);
-          ("discriminant_offset", discriminant_offset);
+          ("discriminant_layout", discriminant_layout);
           ("uninhabited", uninhabited);
           ("variant_layouts", variant_layouts);
         ] ->
         let* size = option_of_json int_of_json ctx size in
         let* align = option_of_json int_of_json ctx align in
-        let* discriminant_offset =
-          option_of_json int_of_json ctx discriminant_offset
+        let* discriminant_layout =
+          option_of_json discriminant_layout_of_json ctx discriminant_layout
         in
         let* uninhabited = bool_of_json ctx uninhabited in
         let* variant_layouts =
@@ -1335,7 +1345,7 @@ and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =
             variant_layouts
         in
         Ok
-          ({ size; align; discriminant_offset; uninhabited; variant_layouts }
+          ({ size; align; discriminant_layout; uninhabited; variant_layouts }
             : layout)
     | _ -> Error "")
 

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1317,10 +1317,10 @@ and discriminant_layout_of_json (ctx : of_json_ctx) (js : json) :
     (discriminant_layout, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("offset", offset); ("size", size) ] ->
+    | `Assoc [ ("offset", offset); ("repr", repr) ] ->
         let* offset = int_of_json ctx offset in
-        let* size = int_of_json ctx size in
-        Ok ({ offset; size } : discriminant_layout)
+        let* repr = option_of_json integer_type_of_json ctx repr in
+        Ok ({ offset; repr } : discriminant_layout)
     | _ -> Error "")
 
 and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -654,11 +654,18 @@ and variant_layout = {
   field_offsets : int list;  (** The offset of each field. *)
 }
 
-(** Layout of the discriminant with its size and offset.
+(** Layout of the discriminant with its offset and representation type.
 
-    Does not include information about the value range or encoding.
+    Does not include information about the value range.
  *)
-and discriminant_layout = { offset : int; size : int }
+and discriminant_layout = {
+  offset : int;  (** The offset of the discriminant in bytes. *)
+  repr : integer_type option;
+      (** The representation type of the discriminant.
+        If the discriminant is in a niche of a non-scalar type,
+        this is [None].
+     *)
+}
 
 (** Simplified type layout information.
 

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -651,23 +651,26 @@ and generic_params = {
     Maps fields to their offset within the layout.
  *)
 and variant_layout = {
-  field_offsets : int list;
-      (** The offset of each field. [None] if it is not knowable at this point, either because of
-        generics or dynamically-sized types.
-     *)
+  field_offsets : int list;  (** The offset of each field. *)
 }
+
+(** Layout of the discriminant with its size and offset.
+
+    Does not include information about the value range or encoding.
+ *)
+and discriminant_layout = { offset : int; size : int }
 
 (** Simplified type layout information.
 
     Does not include information about niches.
-    If the type does not have fully known layout (e.g. it is ?Sized)
+    If the type does not have a fully known layout (e.g. it is ?Sized)
     some of the layout parts are not available.
  *)
 and layout = {
   size : int option;  (** The size of the type in bytes. *)
   align : int option;  (** The alignment, in bytes. *)
-  discriminant_offset : int option;
-      (** The discriminant's offset, if any. Only relevant for types with multiple variants. *)
+  discriminant_layout : discriminant_layout option;
+      (** The discriminant's layout, if any. Only relevant for types with multiple variants. *)
   uninhabited : bool;
       (** Whether the type is uninhabited, i.e. has any valid value at all.
         Note that uninhabited types can have arbitrary layouts: [(u32, !)] has space for the [u32]

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -658,14 +658,14 @@ and variant_layout = {
 
     Does not include information about the value range.
  *)
-and discriminant_layout = {
-  offset : int;  (** The offset of the discriminant in bytes. *)
-  repr : integer_type option;
-      (** The representation type of the discriminant.
-        If the discriminant is in a niche of a non-scalar type,
-        this is [None].
-     *)
-}
+and discriminant_layout =
+  | Direct of int * integer_type
+      (** 
+          Fields:
+          - [offset]:  The offset of the discriminant in bytes.
+          - [repr]:  The representation type of the discriminant.
+       *)
+  | Niche
 
 (** Simplified type layout information.
 
@@ -677,7 +677,8 @@ and layout = {
   size : int option;  (** The size of the type in bytes. *)
   align : int option;  (** The alignment, in bytes. *)
   discriminant_layout : discriminant_layout option;
-      (** The discriminant's layout, if any. Only relevant for types with multiple variants. *)
+      (** The discriminant's layout, if any. Only relevant for types with multiple variants.
+     *)
   uninhabited : bool;
       (** Whether the type is uninhabited, i.e. has any valid value at all.
         Note that uninhabited types can have arbitrary layouts: [(u32, !)] has space for the [u32]

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.96"
+version = "0.1.97"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -353,16 +353,24 @@ type ByteCount = u64;
 /// Maps fields to their offset within the layout.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct VariantLayout {
-    /// The offset of each field. `None` if it is not knowable at this point, either because of
-    /// generics or dynamically-sized types.
+    /// The offset of each field.
     #[drive(skip)]
     pub field_offsets: Vector<FieldId, ByteCount>,
+}
+
+/// Layout of the discriminant with its size and offset.
+///
+/// Does not include information about the value range or encoding.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscriminantLayout {
+    pub offset: ByteCount,
+    pub size: ByteCount,
 }
 
 /// Simplified type layout information.
 ///
 /// Does not include information about niches.
-/// If the type does not have fully known layout (e.g. it is ?Sized)
+/// If the type does not have a fully known layout (e.g. it is ?Sized)
 /// some of the layout parts are not available.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
 pub struct Layout {
@@ -372,9 +380,9 @@ pub struct Layout {
     /// The alignment, in bytes.
     #[drive(skip)]
     pub align: Option<ByteCount>,
-    /// The discriminant's offset, if any. Only relevant for types with multiple variants.
+    /// The discriminant's layout, if any. Only relevant for types with multiple variants.
     #[drive(skip)]
-    pub discriminant_offset: Option<ByteCount>,
+    pub discriminant_layout: Option<DiscriminantLayout>,
     /// Whether the type is uninhabited, i.e. has any valid value at all.
     /// Note that uninhabited types can have arbitrary layouts: `(u32, !)` has space for the `u32`
     /// and `enum E2 { A, B(!), C(i32, !) }` may have space for a discriminant.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -358,13 +358,17 @@ pub struct VariantLayout {
     pub field_offsets: Vector<FieldId, ByteCount>,
 }
 
-/// Layout of the discriminant with its size and offset.
+/// Layout of the discriminant with its offset and representation type.
 ///
-/// Does not include information about the value range or encoding.
+/// Does not include information about the value range.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscriminantLayout {
+    /// The offset of the discriminant in bytes.
     pub offset: ByteCount,
-    pub size: ByteCount,
+    /// The representation type of the discriminant.
+    /// If the discriminant is in a niche of a non-scalar type,
+    /// this is `None`.
+    pub repr: Option<IntegerTy>,
 }
 
 /// Simplified type layout information.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -369,7 +369,7 @@ pub enum DiscriminantLayout {
         /// The representation type of the discriminant.
         repr: IntegerTy,
     },
-    Niche // TODO: Add more useful information about niches here in the future.
+    Niche, // TODO: Add more useful information about niches here in the future.
 }
 
 /// Simplified type layout information.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -361,14 +361,15 @@ pub struct VariantLayout {
 /// Layout of the discriminant with its offset and representation type.
 ///
 /// Does not include information about the value range.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DiscriminantLayout {
-    /// The offset of the discriminant in bytes.
-    pub offset: ByteCount,
-    /// The representation type of the discriminant.
-    /// If the discriminant is in a niche of a non-scalar type,
-    /// this is `None`.
-    pub repr: Option<IntegerTy>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiscriminantLayout {
+    Direct {
+        /// The offset of the discriminant in bytes.
+        offset: ByteCount,
+        /// The representation type of the discriminant.
+        repr: IntegerTy,
+    },
+    Niche // TODO: Add more useful information about niches here in the future.
 }
 
 /// Simplified type layout information.
@@ -385,6 +386,7 @@ pub struct Layout {
     #[drive(skip)]
     pub align: Option<ByteCount>,
     /// The discriminant's layout, if any. Only relevant for types with multiple variants.
+    ///
     #[drive(skip)]
     pub discriminant_layout: Option<DiscriminantLayout>,
     /// Whether the type is uninhabited, i.e. has any valid value at all.

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -2,7 +2,7 @@
   "test_crate::SimpleStruct": {
     "size": 12,
     "align": 4,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -18,7 +18,7 @@
   "test_crate::UnsizedStruct": {
     "size": null,
     "align": null,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -32,7 +32,10 @@
   "test_crate::SimpleEnum": {
     "size": 1,
     "align": 1,
-    "discriminant_offset": 0,
+    "discriminant_layout": {
+      "offset": 0,
+      "size": 1
+    },
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -46,7 +49,10 @@
   "test_crate::SimpleAdt": {
     "size": 24,
     "align": 8,
-    "discriminant_offset": 0,
+    "discriminant_layout": {
+      "offset": 0,
+      "size": 4
+    },
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -69,7 +75,10 @@
   "test_crate::NicheAdt": {
     "size": 4,
     "align": 4,
-    "discriminant_offset": 0,
+    "discriminant_layout": {
+      "offset": 0,
+      "size": 4
+    },
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -85,7 +94,7 @@
   "test_crate::IsAZST": {
     "size": 0,
     "align": 1,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -96,7 +105,7 @@
   "test_crate::UnsizedStruct2": {
     "size": null,
     "align": null,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -110,7 +119,7 @@
   "test_crate::GenericWithKnownLayout": {
     "size": 16,
     "align": 8,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -124,7 +133,7 @@
   "test_crate::Reordered": {
     "size": 8,
     "align": 4,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -139,7 +148,7 @@
   "test_crate::NotReordered": {
     "size": 12,
     "align": 4,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -154,7 +163,7 @@
   "test_crate::Packed": {
     "size": 6,
     "align": 1,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -169,7 +178,10 @@
   "test_crate::UninhabitedVariant": {
     "size": 8,
     "align": 4,
-    "discriminant_offset": 0,
+    "discriminant_layout": {
+      "offset": 0,
+      "size": 4
+    },
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -188,7 +200,7 @@
   "test_crate::Uninhabited": {
     "size": 0,
     "align": 1,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": true,
     "variant_layouts": [
       {
@@ -201,7 +213,10 @@
   "test_crate::DiscriminantInNicheOfField": {
     "size": 16,
     "align": 8,
-    "discriminant_offset": 8,
+    "discriminant_layout": {
+      "offset": 8,
+      "size": 8
+    },
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -217,7 +232,7 @@
   "test_crate::PackIntsUnion": {
     "size": 8,
     "align": 8,
-    "discriminant_offset": null,
+    "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": []
   }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -34,7 +34,7 @@
     "align": 1,
     "discriminant_layout": {
       "offset": 0,
-      "size": 1
+      "repr": "U8"
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -51,7 +51,7 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 0,
-      "size": 4
+      "repr": "U32"
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -77,7 +77,7 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "size": 4
+      "repr": "U32"
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -180,7 +180,7 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "size": 4
+      "repr": "U32"
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -215,7 +215,7 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 8,
-      "size": 8
+      "repr": null
     },
     "uninhabited": false,
     "variant_layouts": [

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -33,8 +33,10 @@
     "size": 1,
     "align": 1,
     "discriminant_layout": {
-      "offset": 0,
-      "repr": "U8"
+      "Direct": {
+        "offset": 0,
+        "repr": "U8"
+      }
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -50,8 +52,10 @@
     "size": 24,
     "align": 8,
     "discriminant_layout": {
-      "offset": 0,
-      "repr": "U32"
+      "Direct": {
+        "offset": 0,
+        "repr": "U32"
+      }
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -75,10 +79,7 @@
   "test_crate::NicheAdt": {
     "size": 4,
     "align": 4,
-    "discriminant_layout": {
-      "offset": 0,
-      "repr": "U32"
-    },
+    "discriminant_layout": "Niche",
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -179,8 +180,10 @@
     "size": 8,
     "align": 4,
     "discriminant_layout": {
-      "offset": 0,
-      "repr": "U32"
+      "Direct": {
+        "offset": 0,
+        "repr": "U32"
+      }
     },
     "uninhabited": false,
     "variant_layouts": [
@@ -213,10 +216,7 @@
   "test_crate::DiscriminantInNicheOfField": {
     "size": 16,
     "align": 8,
-    "discriminant_layout": {
-      "offset": 8,
-      "repr": null
-    },
+    "discriminant_layout": "Niche",
     "uninhabited": false,
     "variant_layouts": [
       {
@@ -235,5 +235,50 @@
     "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": []
+  },
+  "test_crate::NonZeroNiche": {
+    "size": 4,
+    "align": 4,
+    "discriminant_layout": "Niche",
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0
+        ]
+      },
+      {
+        "field_offsets": []
+      },
+      {
+        "field_offsets": []
+      }
+    ]
+  },
+  "test_crate::ArbitraryDiscriminants": {
+    "size": 32,
+    "align": 8,
+    "discriminant_layout": {
+      "Direct": {
+        "offset": 0,
+        "repr": "I32"
+      }
+    },
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          8
+        ]
+      },
+      {
+        "field_offsets": [
+          4
+        ]
+      },
+      {
+        "field_offsets": []
+      }
+    ]
   }
 }

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -98,6 +98,19 @@ fn type_layout() -> anyhow::Result<()> {
             x: (u32, u32),
             y: u64,
         }
+
+        enum NonZeroNiche {
+            A(char),
+            B,
+            C,
+        }
+
+        #[repr(i32)]
+        enum ArbitraryDiscriminants {
+            A(String) = 12,
+            B(u32) = 43,
+            C = 123456,
+        }
         "#,
     )?;
     let layouts: IndexMap<String, Option<Layout>> = crate_data


### PR DESCRIPTION
While working with the new layout information, I found that we currently don't have enough information about the discriminant of enums. Specifically, we don't know their size (and how they are represented in memory)[^1]. To fix this, I add the representation type in memory, which implicitly also encodes the size of the field. Currently, this does not support niches with non-integer types (i.e. float/reference according to `rustc_abi::Scalar`), since Charon has no good way to handle these uniformly.


[^1]: The `TypeDeclKind` has the discriminants of all variants as `ScalarValue`, but these are not equivalent to the representation in memory and have potentially different sizes.