### PR TITLE
Use `XxxDeclRef` consistently; remove `GenericsSource`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.102"
+let supported_charon_version = "0.1.103"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -525,12 +525,13 @@ and match_primitive_adt (pid : primitive_adt) (id : T.type_id) : bool =
 and match_expr_with_ty (ctx : 'fun_body ctx) (c : match_config) (m : maps)
     (pty : expr) (ty : T.ty) : bool =
   match (pty, ty) with
-  | EComp pid, TAdt (id, generics) ->
-      match_pattern_with_type_id ctx c m pid id generics
+  | EComp pid, TAdt tref ->
+      match_pattern_with_type_id ctx c m pid tref.type_decl_id
+        tref.type_decl_generics
   | EComp pid, TLiteral lit -> match_pattern_with_literal_type pid lit
-  | EPrimAdt (pid, pgenerics), TAdt (id, generics) ->
-      match_primitive_adt pid id
-      && match_generic_args ctx c m pgenerics generics
+  | EPrimAdt (pid, pgenerics), TAdt tref ->
+      match_primitive_adt pid tref.type_decl_id
+      && match_generic_args ctx c m pgenerics tref.type_decl_generics
   | ERef (pr, pty, prk), TRef (r, ty, rk) ->
       match_region c m pr r
       && match_expr_with_ty ctx c m pty ty
@@ -962,9 +963,9 @@ and trait_decl_ref_to_pattern (ctx : 'fun_body ctx) (c : to_pat_config)
 and ty_to_pattern_aux (ctx : 'fun_body ctx) (c : to_pat_config)
     (m : constraints) (ty : T.ty) : expr =
   match ty with
-  | TAdt (id, generics) -> (
-      let generics = generic_args_to_pattern ctx c m generics in
-      match id with
+  | TAdt tref -> (
+      let generics = generic_args_to_pattern ctx c m tref.type_decl_generics in
+      match tref.type_decl_id with
       | TAdtId id ->
           (* Lookup the declaration *)
           let d = T.TypeDeclId.Map.find id ctx.crate.type_decls in

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -206,16 +206,14 @@ and rvalue_to_string (env : 'a fmt_env) (rv : rvalue) : string =
           :: List.map (const_generic_to_string env) const_generics)
       ^ ">(" ^ place_to_string env place ^ ")"
   | Global global_ref ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
+      let generics = generic_args_to_string env global_ref.generics in
+      "global " ^ global_decl_id_to_string env global_ref.id ^ generics
   | GlobalRef (global_ref, RShared) ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "&global " ^ global_decl_id_to_string env global_ref.global_id ^ generics
+      let generics = generic_args_to_string env global_ref.generics in
+      "&global " ^ global_decl_id_to_string env global_ref.id ^ generics
   | GlobalRef (global_ref, RMut) ->
-      let generics = generic_args_to_string env global_ref.global_generics in
-      "&raw mut global "
-      ^ global_decl_id_to_string env global_ref.global_id
-      ^ generics
+      let generics = generic_args_to_string env global_ref.generics in
+      "&raw mut global " ^ global_decl_id_to_string env global_ref.id ^ generics
   | Repeat (v, _, len) ->
       "[" ^ operand_to_string env v ^ ";"
       ^ const_generic_to_string env len
@@ -226,7 +224,7 @@ and rvalue_to_string (env : 'a fmt_env) (rv : rvalue) : string =
       let ops = List.map (operand_to_string env) ops in
       match akind with
       | AggregatedAdt (tref, opt_variant_id, opt_field_id) -> (
-          match tref.type_decl_id with
+          match tref.id with
           | TTuple -> "(" ^ String.concat ", " ops ^ ")"
           | TAdtId def_id ->
               let adt_name = type_decl_id_to_string env def_id in

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -225,8 +225,8 @@ and rvalue_to_string (env : 'a fmt_env) (rv : rvalue) : string =
   | Aggregate (akind, ops) -> begin
       let ops = List.map (operand_to_string env) ops in
       match akind with
-      | AggregatedAdt (type_id, opt_variant_id, opt_field_id, _generics) -> (
-          match type_id with
+      | AggregatedAdt (tref, opt_variant_id, opt_field_id) -> (
+          match tref.type_decl_id with
           | TTuple -> "(" ^ String.concat ", " ops ^ ")"
           | TAdtId def_id ->
               let adt_name = type_decl_id_to_string env def_id in

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -178,9 +178,9 @@ let trait_decl_to_string (env : 'a fmt_env) (indent : string)
     in
     let methods =
       List.map
-        (fun (name, f) ->
+        (fun ((name, f) : _ * fun_decl_ref binder) ->
           indent1 ^ "fn " ^ name ^ " : "
-          ^ fun_decl_id_to_string env f.binder_value.fun_id
+          ^ fun_decl_id_to_string env f.binder_value.id
           ^ "\n")
         def.methods
     in
@@ -233,9 +233,9 @@ let trait_impl_to_string (env : 'a fmt_env) (indent : string)
           indent1 ^ "type " ^ name ^ " = " ^ ty_to_string ty ^ "\n")
         def.types
     in
-    let env_method (name, f) =
+    let env_method ((name, f) : _ * fun_decl_ref binder) =
       indent1 ^ "fn " ^ name ^ " : "
-      ^ fun_decl_id_to_string env f.binder_value.fun_id
+      ^ fun_decl_id_to_string env f.binder_value.id
       ^ "\n"
     in
     let methods = List.map env_method def.methods in

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -182,15 +182,13 @@ and type_decl_id_to_string env def_id =
   | Some def -> name_to_string env def.item_meta.name
 
 and type_decl_ref_to_string (env : 'a fmt_env) (tref : type_decl_ref) : string =
-  match tref.type_decl_id with
+  match tref.id with
   | TTuple ->
-      let params, trait_refs =
-        generic_args_to_strings env tref.type_decl_generics
-      in
+      let params, trait_refs = generic_args_to_strings env tref.generics in
       "(" ^ String.concat ", " params ^ ")"
   | id ->
       let id = type_id_to_string env id in
-      let generics = generic_args_to_string env tref.type_decl_generics in
+      let generics = generic_args_to_string env tref.generics in
       id ^ generics
 
 and fun_decl_id_to_string (env : 'a fmt_env) (id : FunDeclId.id) : string =
@@ -205,8 +203,8 @@ and global_decl_id_to_string env def_id =
 
 and global_decl_ref_to_string (env : 'a fmt_env) (gr : global_decl_ref) : string
     =
-  let global_id = global_decl_id_to_string env gr.global_id in
-  let generics = generic_args_to_string env gr.global_generics in
+  let global_id = global_decl_id_to_string env gr.id in
+  let generics = generic_args_to_string env gr.generics in
   global_id ^ generics
 
 and trait_decl_id_to_string env id =
@@ -221,8 +219,8 @@ and trait_impl_id_to_string env id =
 
 and trait_impl_ref_to_string (env : 'a fmt_env) (iref : trait_impl_ref) : string
     =
-  let impl = trait_impl_id_to_string env iref.trait_impl_id in
-  let generics = generic_args_to_string env iref.impl_generics in
+  let impl = trait_impl_id_to_string env iref.id in
+  let generics = generic_args_to_string env iref.generics in
   impl ^ generics
 
 and const_generic_to_string (env : 'a fmt_env) (cg : const_generic) : string =
@@ -288,8 +286,8 @@ and trait_ref_to_string (env : 'a fmt_env) (tr : trait_ref) : string =
   trait_instance_id_to_string env tr.trait_id
 
 and trait_decl_ref_to_string (env : 'a fmt_env) (tr : trait_decl_ref) : string =
-  let trait_id = trait_decl_id_to_string env tr.trait_decl_id in
-  let generics = generic_args_to_string env tr.decl_generics in
+  let trait_id = trait_decl_id_to_string env tr.id in
+  let generics = generic_args_to_string env tr.generics in
   trait_id ^ generics
 
 and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
@@ -323,10 +321,10 @@ and impl_elem_to_string (env : 'a fmt_env) (elem : impl_elem) : string =
           let env = fmt_env_update_generics_and_preds env impl.generics in
           (* Put the first type argument aside (it gives the type for which we
              implement the trait) *)
-          let { trait_decl_id; decl_generics } = impl.impl_trait in
-          let ty, types = Collections.List.pop decl_generics.types in
-          let decl_generics = { decl_generics with types } in
-          let tr = { trait_decl_id; decl_generics } in
+          let { id; generics } : trait_decl_ref = impl.impl_trait in
+          let ty, types = Collections.List.pop generics.types in
+          let generics = { generics with types } in
+          let tr : trait_decl_ref = { id; generics } in
           let ty = ty_to_string env ty in
           let tr = trait_decl_ref_to_string env tr in
           tr ^ " for " ^ ty

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -219,6 +219,12 @@ and trait_impl_id_to_string env id =
   | None -> trait_impl_id_to_pretty_string id
   | Some def -> name_to_string env def.item_meta.name
 
+and trait_impl_ref_to_string (env : 'a fmt_env) (iref : trait_impl_ref) : string
+    =
+  let impl = trait_impl_id_to_string env iref.trait_impl_id in
+  let generics = generic_args_to_string env iref.impl_generics in
+  impl ^ generics
+
 and const_generic_to_string (env : 'a fmt_env) (cg : const_generic) : string =
   match cg with
   | CgGlobal id -> global_decl_id_to_string env id
@@ -290,10 +296,7 @@ and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
     string =
   match id with
   | Self -> "Self"
-  | TraitImpl (id, generics) ->
-      let impl = trait_impl_id_to_string env id in
-      let generics = generic_args_to_string env generics in
-      impl ^ generics
+  | TraitImpl impl_ref -> trait_impl_ref_to_string env impl_ref
   | BuiltinOrAuto (trait, _, _) ->
       region_binder_to_string trait_decl_ref_to_string env trait
   | Clause id -> trait_db_var_to_string env id

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -564,7 +564,7 @@ let instantiate_method (trait_self : trait_instance_id)
 
 (** Helper *)
 let instantiate_trait_method (trait_ref : trait_ref) =
-  let trait_generics = trait_ref.trait_decl_ref.binder_value.decl_generics in
+  let trait_generics = trait_ref.trait_decl_ref.binder_value.generics in
   let trait_self = trait_ref.trait_id in
   instantiate_method trait_self trait_generics
 
@@ -600,7 +600,7 @@ let lookup_method_sig (crate : 'a gcrate) (trait_id : trait_decl_id)
        } =
     lookup_trait_decl_method tdecl name
   in
-  let method_decl_id = bound_method.binder_value.fun_id in
+  let method_decl_id = bound_method.binder_value.id in
   let* method_decl =
     LlbcAst.FunDeclId.Map.find_opt method_decl_id crate.fun_decls
   in
@@ -608,7 +608,7 @@ let lookup_method_sig (crate : 'a gcrate) (trait_id : trait_decl_id)
   let signature =
     st_substitute_visitor#visit_fun_sig
       (make_subst_from_generics method_decl.signature.generics
-         bound_method.binder_value.fun_generics)
+         bound_method.binder_value.generics)
       method_decl.signature
   in
   (* Rebind everything *)

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -64,15 +64,15 @@ let ty_is_unit (ty : ty) : bool =
   match ty with
   | TAdt
       {
-        type_decl_id = TTuple;
-        type_decl_generics =
+        id = TTuple;
+        generics =
           { regions = []; types = []; const_generics = []; trait_refs = _ };
       } -> true
   | _ -> false
 
 let ty_as_opt_adt (ty : ty) : (type_id * generic_args) option =
   match ty with
-  | TAdt tref -> Some (tref.type_decl_id, tref.type_decl_generics)
+  | TAdt tref -> Some (tref.id, tref.generics)
   | _ -> None
 
 let ty_is_adt (ty : ty) : bool = Option.is_some (ty_as_opt_adt ty)
@@ -84,8 +84,7 @@ let ty_as_adt (ty : ty) : type_id * generic_args =
 
 let ty_as_builtin_adt_opt (ty : ty) : (builtin_ty * generic_args) option =
   match ty with
-  | TAdt { type_decl_id = TBuiltin id; type_decl_generics } ->
-      Some (id, type_decl_generics)
+  | TAdt { id = TBuiltin id; generics } -> Some (id, generics)
   | _ -> None
 
 let ty_is_builtin_adt (ty : ty) : bool =
@@ -141,13 +140,12 @@ let ty_as_ref (ty : ty) : region * ty * ref_kind =
 
 let ty_is_custom_adt (ty : ty) : bool =
   match ty with
-  | TAdt { type_decl_id = TAdtId _; _ } -> true
+  | TAdt { id = TAdtId _; _ } -> true
   | _ -> false
 
 let ty_as_custom_adt (ty : ty) : TypeDeclId.id * generic_args =
   match ty with
-  | TAdt { type_decl_id = TAdtId id; type_decl_generics } ->
-      (id, type_decl_generics)
+  | TAdt { id = TAdtId id; generics } -> (id, generics)
   | _ -> raise (Failure "Unreachable")
 
 let ty_as_literal (ty : ty) : literal_type =
@@ -168,7 +166,7 @@ let const_generic_as_literal (cg : const_generic) : Values.literal =
 let trait_instance_id_as_trait_impl (id : trait_instance_id) :
     trait_impl_id * generic_args =
   match id with
-  | TraitImpl impl_ref -> (impl_ref.trait_impl_id, impl_ref.impl_generics)
+  | TraitImpl impl_ref -> (impl_ref.id, impl_ref.generics)
   | _ -> raise (Failure "Unreachable")
 
 (* Make a debruijn variable of index 0 *)
@@ -230,19 +228,15 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
   { regions; types; const_generics; trait_refs }
 
 (** The unit type *)
-let mk_unit_ty : ty =
-  TAdt { type_decl_id = TTuple; type_decl_generics = empty_generic_args }
+let mk_unit_ty : ty = TAdt { id = TTuple; generics = empty_generic_args }
 
 (** The usize type *)
 let mk_usize_ty : ty = TLiteral (TInteger Usize)
 
 let ty_as_opt_box (box_ty : ty) : ty option =
   match box_ty with
-  | TAdt
-      {
-        type_decl_id = TBuiltin TBox;
-        type_decl_generics = { types = [ boxed_ty ]; _ };
-      } -> Some boxed_ty
+  | TAdt { id = TBuiltin TBox; generics = { types = [ boxed_ty ]; _ } } ->
+      Some boxed_ty
   | _ -> None
 
 let ty_is_box (box_ty : ty) : bool = Option.is_some (ty_as_opt_box box_ty)
@@ -265,11 +259,7 @@ let mk_ref_ty (r : region) (ty : ty) (ref_kind : ref_kind) : ty =
 
 (** Make a box type *)
 let mk_box_ty (ty : ty) : ty =
-  TAdt
-    {
-      type_decl_id = TBuiltin TBox;
-      type_decl_generics = mk_generic_args_from_types [ ty ];
-    }
+  TAdt { id = TBuiltin TBox; generics = mk_generic_args_from_types [ ty ] }
 
 (* TODO: move region set manipulation to aeneas *)
 

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -168,7 +168,7 @@ let const_generic_as_literal (cg : const_generic) : Values.literal =
 let trait_instance_id_as_trait_impl (id : trait_instance_id) :
     trait_impl_id * generic_args =
   match id with
-  | TraitImpl (impl_id, args) -> (impl_id, args)
+  | TraitImpl impl_ref -> (impl_ref.trait_impl_id, impl_ref.impl_generics)
   | _ -> raise (Failure "Unreachable")
 
 (* Make a debruijn variable of index 0 *)

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -36,8 +36,7 @@ module FunDeclId = Types.FunDeclId
     expanded to [Cons (⊥, ⊥)] upon the first assignment, at which point we can
     initialize the field 0, etc.). *)
 type aggregate_kind =
-  | AggregatedAdt of
-      type_id * variant_id option * field_id option * generic_args
+  | AggregatedAdt of type_decl_ref * variant_id option * field_id option
       (** A struct, enum or union aggregate. The [VariantId], if present,
           indicates this is an enum and the aggregate uses that variant. The
           [FieldId], if present, indicates this is a union and the aggregate

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -682,9 +682,9 @@ and fun_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* fun_id = fun_decl_id_of_json ctx id in
-        let* fun_generics = box_of_json generic_args_of_json ctx generics in
-        Ok ({ fun_id; fun_generics } : fun_decl_ref)
+        let* id = fun_decl_id_of_json ctx id in
+        let* generics = box_of_json generic_args_of_json ctx generics in
+        Ok ({ id; generics } : fun_decl_ref)
     | _ -> Error "")
 
 and fun_id_of_json (ctx : of_json_ctx) (js : json) : (fun_id, string) result =
@@ -886,9 +886,9 @@ and global_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* global_id = global_decl_id_of_json ctx id in
-        let* global_generics = box_of_json generic_args_of_json ctx generics in
-        Ok ({ global_id; global_generics } : global_decl_ref)
+        let* id = global_decl_id_of_json ctx id in
+        let* generics = box_of_json generic_args_of_json ctx generics in
+        Ok ({ id; generics } : global_decl_ref)
     | _ -> Error "")
 
 and global_kind_of_json (ctx : of_json_ctx) (js : json) :
@@ -1520,10 +1520,10 @@ and trait_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
     (trait_decl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("trait_id", trait_id); ("generics", generics) ] ->
-        let* trait_decl_id = trait_decl_id_of_json ctx trait_id in
-        let* decl_generics = box_of_json generic_args_of_json ctx generics in
-        Ok ({ trait_decl_id; decl_generics } : trait_decl_ref)
+    | `Assoc [ ("id", id); ("generics", generics) ] ->
+        let* id = trait_decl_id_of_json ctx id in
+        let* generics = box_of_json generic_args_of_json ctx generics in
+        Ok ({ id; generics } : trait_decl_ref)
     | _ -> Error "")
 
 and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
@@ -1592,9 +1592,9 @@ and trait_impl_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* trait_impl_id = trait_impl_id_of_json ctx id in
-        let* impl_generics = box_of_json generic_args_of_json ctx generics in
-        Ok ({ trait_impl_id; impl_generics } : trait_impl_ref)
+        let* id = trait_impl_id_of_json ctx id in
+        let* generics = box_of_json generic_args_of_json ctx generics in
+        Ok ({ id; generics } : trait_impl_ref)
     | _ -> Error "")
 
 and trait_item_name_of_json (ctx : of_json_ctx) (js : json) :
@@ -1791,11 +1791,9 @@ and type_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* type_decl_id = type_id_of_json ctx id in
-        let* type_decl_generics =
-          box_of_json generic_args_of_json ctx generics
-        in
-        Ok ({ type_decl_id; type_decl_generics } : type_decl_ref)
+        let* id = type_id_of_json ctx id in
+        let* generics = box_of_json generic_args_of_json ctx generics in
+        Ok ({ id; generics } : type_decl_ref)
     | _ -> Error "")
 
 and type_id_of_json (ctx : of_json_ctx) (js : json) : (type_id, string) result =

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -774,7 +774,6 @@ and generic_args_of_json (ctx : of_json_ctx) (js : json) :
           ("types", types);
           ("const_generics", const_generics);
           ("trait_refs", trait_refs);
-          ("target", _);
         ] ->
         let* regions =
           vector_of_json region_id_of_json region_of_json ctx regions
@@ -847,20 +846,6 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
              trait_type_constraints;
            }
             : generic_params)
-    | _ -> Error "")
-
-and generics_source_of_json (ctx : of_json_ctx) (js : json) :
-    (generics_source, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Item", item) ] ->
-        let* item = any_decl_id_of_json ctx item in
-        Ok (GSItem item)
-    | `Assoc [ ("Method", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_decl_id_of_json ctx x_0 in
-        let* x_1 = trait_item_name_of_json ctx x_1 in
-        Ok (GSMethod (x_0, x_1))
-    | `String "Builtin" -> Ok GSBuiltin
     | _ -> Error "")
 
 and global_decl_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1606,8 +1606,8 @@ and trait_impl_ref_of_json (ctx : of_json_ctx) (js : json) :
     (trait_impl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("impl_id", impl_id); ("generics", generics) ] ->
-        let* trait_impl_id = trait_impl_id_of_json ctx impl_id in
+    | `Assoc [ ("id", id); ("generics", generics) ] ->
+        let* trait_impl_id = trait_impl_id_of_json ctx id in
         let* impl_generics = box_of_json generic_args_of_json ctx generics in
         Ok ({ trait_impl_id; impl_generics } : trait_impl_ref)
     | _ -> Error "")
@@ -1635,10 +1635,9 @@ and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
     (trait_instance_id, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("TraitImpl", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = trait_impl_id_of_json ctx x_0 in
-        let* x_1 = box_of_json generic_args_of_json ctx x_1 in
-        Ok (TraitImpl (x_0, x_1))
+    | `Assoc [ ("TraitImpl", trait_impl) ] ->
+        let* trait_impl = trait_impl_ref_of_json ctx trait_impl in
+        Ok (TraitImpl trait_impl)
     | `Assoc [ ("Clause", clause) ] ->
         let* clause =
           de_bruijn_var_of_json trait_clause_id_of_json ctx clause

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -359,7 +359,7 @@ and trait_instance_id =
   | UnknownTrait of string  (** For error reporting. *)
 
 and ty =
-  | TAdt of type_id * generic_args
+  | TAdt of type_decl_ref
       (** An ADT. Note that here ADTs are very general. They can be:
           - user-defined ADTs
           - tuples (including [unit], which is a 0-tuple)
@@ -413,6 +413,12 @@ and ty =
           limited generics: it only supports lifetime generics, not other kinds
           of generics. *)
   | TError of string  (** A type that could not be computed or was incorrect. *)
+
+(** Reference to a type declaration or builtin type. *)
+and type_decl_ref = {
+  type_decl_id : type_id;
+  type_decl_generics : generic_args;
+}
 
 (** Type identifier.
 

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -224,13 +224,6 @@ and generic_args = {
   trait_refs : trait_ref list;
 }
 
-(** Each [GenericArgs] is meant for a corresponding [GenericParams]; this
-    describes which one. *)
-and generics_source =
-  | GSItem of any_decl_id  (** A top-level item. *)
-  | GSMethod of trait_decl_id * trait_item_name  (** A trait method. *)
-  | GSBuiltin  (** A builtin item like [Box]. *)
-
 (** Reference to a global declaration. *)
 and global_decl_ref = {
   global_id : global_decl_id;

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -212,8 +212,8 @@ and existential_predicate = unit
 
 (** Reference to a function declaration. *)
 and fun_decl_ref = {
-  fun_id : fun_decl_id;
-  fun_generics : generic_args;  (** Generic arguments passed to the function. *)
+  id : fun_decl_id;
+  generics : generic_args;  (** Generic arguments passed to the function. *)
 }
 
 (** A set of generic arguments. *)
@@ -225,10 +225,7 @@ and generic_args = {
 }
 
 (** Reference to a global declaration. *)
-and global_decl_ref = {
-  global_id : global_decl_id;
-  global_generics : generic_args;
-}
+and global_decl_ref = { id : global_decl_id; generics : generic_args }
 
 and ref_kind = RMut | RShared
 
@@ -261,16 +258,10 @@ and region_var = (region_id, string option) indexed_var
     ]}
 
     The substitution is: [[String, bool]]. *)
-and trait_decl_ref = {
-  trait_decl_id : trait_decl_id;
-  decl_generics : generic_args;
-}
+and trait_decl_ref = { id : trait_decl_id; generics : generic_args }
 
 (** A reference to a tait impl, using the provided arguments. *)
-and trait_impl_ref = {
-  trait_impl_id : trait_impl_id;
-  impl_generics : generic_args;
-}
+and trait_impl_ref = { id : trait_impl_id; generics : generic_args }
 
 and trait_item_name = string
 
@@ -408,10 +399,7 @@ and ty =
   | TError of string  (** A type that could not be computed or was incorrect. *)
 
 (** Reference to a type declaration or builtin type. *)
-and type_decl_ref = {
-  type_decl_id : type_id;
-  type_decl_generics : generic_args;
-}
+and type_decl_ref = { id : type_id; generics : generic_args }
 
 (** Type identifier.
 

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -295,7 +295,7 @@ and trait_ref = {
     *trait instance*, which is why the [[TraitRefKind::Clause]] variant may seem
     redundant with some of the other variants. *)
 and trait_instance_id =
-  | TraitImpl of trait_impl_id * generic_args
+  | TraitImpl of trait_impl_ref
       (** A specific top-level implementation item. *)
   | Clause of trait_clause_id de_bruijn_var
       (** One of the local clauses.

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.102"
+version = "0.1.103"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -634,7 +634,7 @@ pub enum AggregateKind {
     /// A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum
     /// and the aggregate uses that variant. The `FieldId`, if present, indicates this is a union
     /// and the aggregate writes into that field. Otherwise this is a struct.
-    Adt(TypeId, Option<VariantId>, Option<FieldId>, BoxedArgs),
+    Adt(TypeDeclRef, Option<VariantId>, Option<FieldId>),
     /// We don't put this with the ADT cas because this is the only built-in type
     /// with aggregates, and it is a primitive type. In particular, it makes
     /// sense to treat it differently because it has a variable number of fields.

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -90,7 +90,7 @@ impl Rvalue {
             AggregateKind::Adt(
                 TypeDeclRef {
                     id: TypeId::Tuple,
-                    generics: Box::new(GenericArgs::empty(GenericsSource::Builtin)),
+                    generics: Box::new(GenericArgs::empty()),
                 },
                 None,
                 None,

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -62,7 +62,9 @@ impl Place {
         use TyKind::*;
         let proj_ty = match self.ty.kind() {
             Ref(_, ty, _) | RawPtr(ty, _) => ty.clone(),
-            Adt(TypeId::Builtin(BuiltinTy::Box), args) => args.types[0].clone(),
+            Adt(tref) if matches!(tref.id, TypeId::Builtin(BuiltinTy::Box)) => {
+                tref.generics.types[0].clone()
+            }
             Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(_) | Arrow(..)
             | Error(..) => panic!("internal type error"),
         };
@@ -86,10 +88,12 @@ impl Rvalue {
     pub fn unit_value() -> Self {
         Rvalue::Aggregate(
             AggregateKind::Adt(
-                TypeId::Tuple,
+                TypeDeclRef {
+                    id: TypeId::Tuple,
+                    generics: Box::new(GenericArgs::empty(GenericsSource::Builtin)),
+                },
                 None,
                 None,
-                Box::new(GenericArgs::empty(GenericsSource::Builtin)),
             ),
             Vec::new(),
         )
@@ -119,8 +123,8 @@ impl ProjectionElem {
                 use TyKind::*;
                 match ty.kind() {
                     Ref(_, ty, _) | RawPtr(ty, _) => ty.clone(),
-                    Adt(TypeId::Builtin(BuiltinTy::Box), args) => {
-                        args.types.get(TypeVarId::new(0)).unwrap().clone()
+                    Adt(tref) if matches!(tref.id, TypeId::Builtin(BuiltinTy::Box)) => {
+                        tref.generics.types[0].clone()
                     }
                     Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(_)
                     | Arrow(..) | Error(..) => {
@@ -136,8 +140,8 @@ impl ProjectionElem {
                     Adt(type_decl_id, variant_id) => {
                         // Can fail if the type declaration was not translated.
                         let type_decl = type_decls.get(*type_decl_id).ok_or(())?;
-                        let (type_id, generics) = ty.as_adt().ok_or(())?;
-                        assert!(TypeId::Adt(*type_decl_id) == type_id);
+                        let tref = ty.as_adt().ok_or(())?;
+                        assert!(TypeId::Adt(*type_decl_id) == tref.id);
                         use TypeDeclKind::*;
                         match &type_decl.kind {
                             Struct(fields) | Union(fields) => {
@@ -149,7 +153,7 @@ impl ProjectionElem {
                                     .ok_or(())?
                                     .ty
                                     .clone()
-                                    .substitute(generics)
+                                    .substitute(&tref.generics)
                             }
                             Enum(variants) => {
                                 let variant_id = variant_id.ok_or(())?;
@@ -160,7 +164,7 @@ impl ProjectionElem {
                                     .ok_or(())?
                                     .ty
                                     .clone()
-                                    .substitute(generics)
+                                    .substitute(&tref.generics)
                             }
                             Opaque | Alias(_) | Error(_) => return Err(()),
                         }

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -153,10 +153,8 @@ pub struct FunDecl {
 /// Reference to a function declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct FunDeclRef {
-    #[charon::rename("fun_id")]
     pub id: FunDeclId,
     /// Generic arguments passed to the function.
-    #[charon::rename("fun_generics")]
     pub generics: BoxedArgs,
 }
 
@@ -196,9 +194,7 @@ pub struct GlobalDecl {
 /// Reference to a global declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct GlobalDeclRef {
-    #[charon::rename("global_id")]
     pub id: GlobalDeclId,
-    #[charon::rename("global_generics")]
     pub generics: BoxedArgs,
 }
 

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -239,8 +239,7 @@ impl<'ctx> AnyTransItem<'ctx> {
 
     /// See [`GenericParams::identity_args`].
     pub fn identity_args(&self) -> GenericArgs {
-        self.generic_params()
-            .identity_args(GenericsSource::Item(self.id()))
+        self.generic_params().identity_args()
     }
 
     /// We can't implement `AstVisitable` because of the `'static` constraint, but it's ok because

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -15,7 +15,7 @@ pub enum PathElem {
     Ident(#[drive(skip)] String, Disambiguator),
     Impl(ImplElem, Disambiguator),
     /// This item was obtained by monomorphizing its parent with the given args.
-    Monomorphized(Box<GenericArgs>),
+    Monomorphized(BoxedArgs),
 }
 
 /// There are two kinds of `impl` blocks:

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -162,7 +162,7 @@ pub struct TraitRef {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitDeclRef {
     #[charon::rename("trait_decl_id")]
-    pub trait_id: TraitDeclId,
+    pub id: TraitDeclId,
     #[charon::rename("decl_generics")]
     pub generics: BoxedArgs,
 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -621,7 +621,7 @@ pub enum TypeId {
 }
 
 /// Reference to a type declaration or builtin type.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct TypeDeclRef {
     #[charon::rename("type_decl_id")]
     pub id: TypeId,
@@ -748,7 +748,7 @@ pub enum TyKind {
     ///
     /// Note: this is incorrectly named: this can refer to any valid `TypeDecl` including extern
     /// types.
-    Adt(TypeId, GenericArgs),
+    Adt(TypeDeclRef),
     #[charon::rename("TVar")]
     TypeVar(TypeDbVar),
     Literal(LiteralTy),

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -161,9 +161,7 @@ pub struct TraitRef {
 /// The substitution is: `[String, bool]`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitDeclRef {
-    #[charon::rename("trait_decl_id")]
     pub id: TraitDeclId,
-    #[charon::rename("decl_generics")]
     pub generics: BoxedArgs,
 }
 
@@ -173,9 +171,7 @@ pub type PolyTraitDeclRef = RegionBinder<TraitDeclRef>;
 /// A reference to a tait impl, using the provided arguments.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitImplRef {
-    #[charon::rename("trait_impl_id")]
     pub id: TraitImplId,
-    #[charon::rename("impl_generics")]
     pub generics: BoxedArgs,
 }
 
@@ -604,9 +600,7 @@ pub enum TypeId {
 /// Reference to a type declaration or builtin type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct TypeDeclRef {
-    #[charon::rename("type_decl_id")]
     pub id: TypeId,
-    #[charon::rename("type_decl_generics")]
     pub generics: BoxedArgs,
 }
 

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -201,7 +201,7 @@ pub struct TraitTypeConstraint {
 }
 
 /// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, EnumIsA, Deserialize, Drive, DriveMut)]
 #[charon::variants_prefix("GS")]
 pub enum GenericsSource {
     /// A top-level item.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -200,21 +200,6 @@ pub struct TraitTypeConstraint {
     pub ty: Ty,
 }
 
-/// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, EnumIsA, Deserialize, Drive, DriveMut)]
-#[charon::variants_prefix("GS")]
-pub enum GenericsSource {
-    /// A top-level item.
-    Item(AnyTransId),
-    /// A trait method.
-    Method(TraitDeclId, TraitItemName),
-    /// A builtin item like `Box`.
-    Builtin,
-    /// Some other use of generics outside the main Charon ast.
-    #[charon::opaque]
-    Other,
-}
-
 /// A set of generic arguments.
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Drive, DriveMut)]
 pub struct GenericArgs {
@@ -223,10 +208,6 @@ pub struct GenericArgs {
     pub const_generics: Vector<ConstGenericVarId, ConstGeneric>,
     // TODO: rename to match [GenericParams]?
     pub trait_refs: Vector<TraitClauseId, TraitRef>,
-    #[charon::opaque]
-    #[drive(skip)]
-    /// Each `GenericArgs` is meant for a corresponding `GenericParams`; this records which one.
-    pub target: GenericsSource,
 }
 
 pub type BoxedArgs = Box<GenericArgs>;

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -44,7 +44,7 @@ pub enum Region {
 #[charon::rename("TraitInstanceId")]
 pub enum TraitRefKind {
     /// A specific top-level implementation item.
-    TraitImpl(TraitImplId, BoxedArgs),
+    TraitImpl(TraitImplRef),
 
     /// One of the local clauses.
     ///
@@ -174,7 +174,7 @@ pub type PolyTraitDeclRef = RegionBinder<TraitDeclRef>;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitImplRef {
     #[charon::rename("trait_impl_id")]
-    pub impl_id: TraitImplId,
+    pub id: TraitImplId,
     #[charon::rename("impl_generics")]
     pub generics: BoxedArgs,
 }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1,8 +1,6 @@
 //! This file groups everything which is linked to implementations about [crate::types]
 use crate::ast::*;
-use crate::formatter::FmtCtx;
 use crate::ids::Vector;
-use crate::pretty::FmtWithCtx;
 use derive_generic_visitor::*;
 use std::collections::HashSet;
 use std::convert::Infallible;
@@ -95,12 +93,12 @@ impl GenericParams {
     /// Construct a set of generic arguments in the scope of `self` that matches `self` and feeds
     /// each required parameter with itself. E.g. given parameters for `<T, U> where U:
     /// PartialEq<T>`, the arguments would be `<T, U>[@TraitClause0]`.
-    pub fn identity_args(&self, target: GenericsSource) -> GenericArgs {
-        self.identity_args_at_depth(target, DeBruijnId::zero())
+    pub fn identity_args(&self) -> GenericArgs {
+        self.identity_args_at_depth(DeBruijnId::zero())
     }
 
     /// Like `identity_args` but uses variables bound at the given depth.
-    pub fn identity_args_at_depth(&self, target: GenericsSource, depth: DeBruijnId) -> GenericArgs {
+    pub fn identity_args_at_depth(&self, depth: DeBruijnId) -> GenericArgs {
         GenericArgs {
             regions: self
                 .regions
@@ -114,7 +112,6 @@ impl GenericParams {
             trait_refs: self
                 .trait_clauses
                 .map_ref(|clause| clause.identity_tref_at_depth(depth)),
-            target,
         }
     }
 }
@@ -298,7 +295,7 @@ impl<T> RegionBinder<T> {
     {
         let args = GenericArgs {
             regions: self.regions.map_ref_indexed(|_, _| Region::Erased),
-            ..GenericArgs::empty(GenericsSource::Other)
+            ..GenericArgs::empty()
         };
         self.skip_binder.substitute(&args)
     }
@@ -311,7 +308,6 @@ impl GenericArgs {
             types,
             const_generics,
             trait_refs,
-            target: _,
         } = self;
         regions.elem_count()
             + types.elem_count()
@@ -331,20 +327,19 @@ impl GenericArgs {
         !self.trait_refs.is_empty()
     }
 
-    pub fn empty(target: GenericsSource) -> Self {
+    pub fn empty() -> Self {
         GenericArgs {
             regions: Default::default(),
             types: Default::default(),
             const_generics: Default::default(),
             trait_refs: Default::default(),
-            target,
         }
     }
 
     pub fn new_for_builtin(types: Vector<TypeVarId, Ty>) -> Self {
         GenericArgs {
             types,
-            ..Self::empty(GenericsSource::Builtin)
+            ..Self::empty()
         }
     }
 
@@ -353,28 +348,20 @@ impl GenericArgs {
         types: Vector<TypeVarId, Ty>,
         const_generics: Vector<ConstGenericVarId, ConstGeneric>,
         trait_refs: Vector<TraitClauseId, TraitRef>,
-        target: GenericsSource,
     ) -> Self {
         Self {
             regions,
             types,
             const_generics,
             trait_refs,
-            target,
         }
     }
 
-    pub fn new_types(types: Vector<TypeVarId, Ty>, target: GenericsSource) -> Self {
+    pub fn new_types(types: Vector<TypeVarId, Ty>) -> Self {
         Self {
             types,
-            ..Self::empty(target)
+            ..Self::empty()
         }
-    }
-
-    /// Changes the target.
-    pub fn with_target(mut self, target: GenericsSource) -> Self {
-        self.target = target;
-        self
     }
 
     /// Check whether this matches the given `GenericParams`.
@@ -400,45 +387,18 @@ impl GenericArgs {
 
     /// Concatenate this set of arguments with another one. Use with care, you must manage the
     /// order of arguments correctly.
-    pub fn concat(mut self, target: GenericsSource, other: &Self) -> Self {
+    pub fn concat(mut self, other: &Self) -> Self {
         let Self {
             regions,
             types,
             const_generics,
             trait_refs,
-            target: _,
         } = other;
         self.regions.extend_from_slice(regions);
         self.types.extend_from_slice(types);
         self.const_generics.extend_from_slice(const_generics);
         self.trait_refs.extend_from_slice(trait_refs);
-        self.target = target;
         self
-    }
-}
-
-impl GenericsSource {
-    pub fn item<I: Into<AnyTransId>>(id: I) -> Self {
-        Self::Item(id.into())
-    }
-
-    /// Return a path that represents the target item.
-    pub fn item_name(&self, translated: &TranslatedCrate, fmt_ctx: &FmtCtx) -> String {
-        match self {
-            GenericsSource::Item(id) => translated
-                .item_name(*id)
-                .unwrap()
-                .to_string_with_ctx(fmt_ctx),
-            GenericsSource::Method(trait_id, method_name) => format!(
-                "{}::{method_name}",
-                translated
-                    .item_name(*trait_id)
-                    .unwrap()
-                    .to_string_with_ctx(fmt_ctx),
-            ),
-            GenericsSource::Builtin => format!("<built-in>"),
-            GenericsSource::Other => format!("<unknown>"),
-        }
     }
 }
 
@@ -538,16 +498,7 @@ where
         ItemId: Into<AnyTransId>,
         T: TyVisitable,
     {
-        args.map_bound(|args| {
-            assert_eq!(
-                args.target,
-                GenericsSource::item(self.item_id),
-                "These `GenericArgs` are meant for {:?} but were used on {:?}",
-                args.target,
-                self.item_id
-            );
-            self.val.substitute(args)
-        })
+        args.map_bound(|args| self.val.substitute(args))
     }
 }
 
@@ -675,40 +626,11 @@ impl std::ops::Deref for Ty {
 /// For deref patterns.
 unsafe impl std::ops::DerefPure for Ty {}
 
-impl TypeId {
-    pub fn generics_target(&self) -> GenericsSource {
-        match *self {
-            TypeId::Adt(decl_id) => GenericsSource::item(decl_id),
-            TypeId::Tuple | TypeId::Builtin(..) => GenericsSource::Builtin,
-        }
-    }
-}
-
 impl TypeDeclRef {
     pub fn new(id: TypeId, generics: GenericArgs) -> Self {
         Self {
             id,
             generics: Box::new(generics),
-        }
-    }
-}
-
-impl FunId {
-    pub fn generics_target(&self) -> GenericsSource {
-        match *self {
-            FunId::Regular(fun_id) => GenericsSource::item(fun_id),
-            FunId::Builtin(..) => GenericsSource::Builtin,
-        }
-    }
-}
-
-impl FunIdOrTraitMethodRef {
-    pub fn generics_target(&self) -> GenericsSource {
-        match self {
-            FunIdOrTraitMethodRef::Fun(fun_id) => fun_id.generics_target(),
-            FunIdOrTraitMethodRef::Trait(trait_ref, name, _) => {
-                GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.trait_id, name.clone())
-            }
         }
     }
 }
@@ -858,7 +780,7 @@ impl VisitAstMut for SubstVisitor<'_> {
                     ce.value = match new_ce {
                         ConstGeneric::Global(id) => RawConstantExpr::Global(GlobalDeclRef {
                             id,
-                            generics: Box::new(GenericArgs::empty(GenericsSource::item(id))),
+                            generics: Box::new(GenericArgs::empty()),
                         }),
                         ConstGeneric::Var(var) => RawConstantExpr::Var(var),
                         ConstGeneric::Value(lit) => RawConstantExpr::Literal(lit),

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -64,7 +64,7 @@ use indexmap::IndexMap;
     // type but can be overridden.
     override(
         DeBruijnId, Ty, TyKind, Region, ConstGeneric, TraitRef, TraitRefKind,
-        FunDeclRef, MaybeBuiltinFunDeclRef, TraitMethodRef, GlobalDeclRef, TraitDeclRef, TraitImplRef,
+        TypeDeclRef, FunDeclRef, MaybeBuiltinFunDeclRef, TraitMethodRef, GlobalDeclRef, TraitDeclRef, TraitImplRef,
         GenericArgs, GenericParams, TraitClause, TraitClauseId, TraitTypeConstraint, Place, Rvalue,
         for<T: AstVisitable + Idx> DeBruijnVar<T>,
         for<T: AstVisitable> RegionBinder<T>,
@@ -141,7 +141,7 @@ impl<K: Any, T: AstVisitable> AstVisitable for IndexMap<K, T> {
     // Types that are ignored when encountered.
     skip(
         AbortKind, BinOp, BorrowKind, ConstantExpr, ConstGeneric, FieldId, FieldProjKind,
-        FunDeclId, FunIdOrTraitMethodRef, GenericArgs, GlobalDeclRef, IntegerTy,
+        TypeDeclRef, FunDeclId, FunIdOrTraitMethodRef, GenericArgs, GlobalDeclRef, IntegerTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId, LocalId,
     ),
     // Types that we unconditionally explore.

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -583,10 +583,7 @@ impl BodyTransCtx<'_, '_, '_> {
                         ))
                     }
                     hax::AggregateKind::Tuple => {
-                        let tref = TypeDeclRef::new(
-                            TypeId::Tuple,
-                            GenericArgs::empty(GenericsSource::Builtin),
-                        );
+                        let tref = TypeDeclRef::new(TypeId::Tuple, GenericArgs::empty());
                         Ok(Rvalue::Aggregate(
                             AggregateKind::Adt(tref, None, None),
                             operands_t,

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -217,44 +217,15 @@ impl BodyTransCtx<'_, '_, '_> {
                 // to disambiguate
                 let subplace = self.translate_place(span, hax_subplace)?;
                 let place = match kind {
-                    hax::ProjectionElem::Deref => {
-                        // We use the type to disambiguate
-                        match subplace.ty().kind() {
-                            TyKind::Ref(_, _, _) | TyKind::RawPtr(_, _) => {}
-                            TyKind::Adt(TypeId::Builtin(BuiltinTy::Box), generics) => {
-                                assert!(generics.regions.is_empty());
-                                assert!(generics.types.elem_count() == 1);
-                                assert!(generics.const_generics.is_empty());
-                            }
-                            TyKind::Adt(TypeId::Adt(_), generics) => {
-                                let hax_id = match hax_subplace.ty.kind() {
-                                    hax::TyKind::Adt { def_id, .. } => def_id,
-                                    _ => unreachable!(),
-                                };
-                                assert!(
-                                    self.get_lang_item(rustc_hir::LangItem::OwnedBox) == *hax_id
-                                );
-                                assert!(generics.regions.is_empty());
-                                assert!(generics.types.elem_count() == 2); // Box<T, A>
-                                assert!(generics.const_generics.is_empty());
-                            }
-                            _ => {
-                                unreachable!(
-                                    "\n- place.kind: {:?}\n- subplace.ty(): {:?}",
-                                    kind,
-                                    subplace.ty()
-                                )
-                            }
-                        }
-                        subplace.project(ProjectionElem::Deref, ty)
-                    }
+                    hax::ProjectionElem::Deref => subplace.project(ProjectionElem::Deref, ty),
                     hax::ProjectionElem::Field(field_kind) => {
                         use hax::ProjectionElemFieldKind::*;
                         let proj_elem = match field_kind {
                             Tuple(id) => {
-                                let (_, generics) = subplace.ty().kind().as_adt().unwrap();
+                                let tref = subplace.ty().kind().as_adt().unwrap();
                                 let field_id = translate_field_id(*id);
-                                let proj_kind = FieldProjKind::Tuple(generics.types.elem_count());
+                                let proj_kind =
+                                    FieldProjKind::Tuple(tref.generics.types.elem_count());
                                 ProjectionElem::Field(proj_kind, field_id)
                             }
                             Adt {
@@ -264,47 +235,44 @@ impl BodyTransCtx<'_, '_, '_> {
                             } => {
                                 let field_id = translate_field_id(*index);
                                 let variant_id = variant.map(translate_variant_id);
-                                match subplace.ty().kind() {
-                                    TyKind::Adt(TypeId::Adt(type_id), ..) => {
-                                        let proj_kind = FieldProjKind::Adt(*type_id, variant_id);
+                                let tref = subplace.ty().kind().as_adt().unwrap();
+                                let generics = &tref.generics;
+                                match tref.id {
+                                    TypeId::Adt(type_id) => {
+                                        let proj_kind = FieldProjKind::Adt(type_id, variant_id);
                                         ProjectionElem::Field(proj_kind, field_id)
                                     }
-                                    TyKind::Adt(TypeId::Tuple, generics) => {
+                                    TypeId::Tuple => {
                                         assert!(generics.regions.is_empty());
                                         assert!(variant.is_none());
                                         assert!(generics.const_generics.is_empty());
                                         let proj_kind =
                                             FieldProjKind::Tuple(generics.types.elem_count());
-
                                         ProjectionElem::Field(proj_kind, field_id)
                                     }
-                                    TyKind::Adt(TypeId::Builtin(BuiltinTy::Box), generics) => {
+                                    TypeId::Builtin(BuiltinTy::Box) => {
                                         // Some more sanity checks
                                         assert!(generics.regions.is_empty());
                                         assert!(generics.types.elem_count() == 1);
                                         assert!(generics.const_generics.is_empty());
                                         assert!(variant_id.is_none());
                                         assert!(field_id == FieldId::ZERO);
-
                                         ProjectionElem::Deref
                                     }
-                                    _ => {
-                                        raise_error!(self, span, "Unexpected field projection");
-                                    }
+                                    _ => raise_error!(self, span, "Unexpected field projection"),
                                 }
                             }
                             ClosureState(index) => {
                                 let field_id = translate_field_id(*index);
-                                let TyKind::Adt(TypeId::Adt(adt_id), _) = subplace.ty.kind() else {
-                                    unreachable!(
-                                        "Subplace of ClosureState must be a closure, got {:?}",
-                                        subplace.ty
-                                    )
-                                };
-                                ProjectionElem::Field(
-                                    FieldProjKind::Adt(adt_id.clone(), None),
-                                    field_id,
-                                )
+                                let type_id = *subplace
+                                    .ty
+                                    .kind()
+                                    .as_adt()
+                                    .expect("ClosureState projection should apply to an Adt type")
+                                    .id
+                                    .as_adt()
+                                    .unwrap();
+                                ProjectionElem::Field(FieldProjKind::Adt(type_id, None), field_id)
                             }
                         };
                         subplace.project(proj_elem, ty)
@@ -448,17 +416,12 @@ impl BodyTransCtx<'_, '_, '_> {
             hax::Rvalue::Len(place) => {
                 let place = self.translate_place(span, place)?;
                 let ty = place.ty().clone();
-                let cg = match ty.kind() {
-                    TyKind::Adt(
-                        TypeId::Builtin(aty @ (BuiltinTy::Array | BuiltinTy::Slice)),
-                        generics,
-                    ) => {
-                        if aty.is_array() {
-                            Some(generics.const_generics[0].clone())
-                        } else {
-                            None
-                        }
+                let tref = ty.as_adt().unwrap();
+                let cg = match tref.id {
+                    TypeId::Builtin(BuiltinTy::Array) => {
+                        Some(tref.generics.const_generics[0].clone())
                     }
+                    TypeId::Builtin(BuiltinTy::Slice) => None,
                     _ => unreachable!(),
                 };
                 Ok(Rvalue::Len(place, ty, cg))
@@ -508,32 +471,26 @@ impl BodyTransCtx<'_, '_, '_> {
                     )),
                     hax::CastKind::PointerCoercion(hax::PointerCoercion::Unsize, ..) => {
                         let unop = if let (
-                            TyKind::Ref(
-                                _,
-                                deref!(TyKind::Adt(TypeId::Builtin(BuiltinTy::Array), generics)),
-                                kind1,
-                            ),
-                            TyKind::Ref(
-                                _,
-                                deref!(TyKind::Adt(TypeId::Builtin(BuiltinTy::Slice), generics1)),
-                                kind2,
-                            ),
+                            TyKind::Ref(_, deref!(TyKind::Adt(tref1)), kind1),
+                            TyKind::Ref(_, deref!(TyKind::Adt(tref2)), kind2),
                         ) = (src_ty.kind(), tgt_ty.kind())
+                            && matches!(tref1.id, TypeId::Builtin(BuiltinTy::Array))
+                            && matches!(tref2.id, TypeId::Builtin(BuiltinTy::Slice))
                         {
                             // In MIR terminology, we go from &[T; l] to &[T] which means we
                             // effectively "unsize" the type, as `l` no longer appears in the
                             // destination type. At runtime, the converse happens: the length
                             // materializes into the fat pointer.
                             assert!(
-                                generics.types.elem_count() == 1
-                                    && generics.const_generics.elem_count() == 1
+                                tref1.generics.types.elem_count() == 1
+                                    && tref1.generics.const_generics.elem_count() == 1
                             );
-                            assert!(generics.types[0] == generics1.types[0]);
+                            assert!(tref1.generics.types[0] == tref2.generics.types[0]);
                             assert!(kind1 == kind2);
                             UnOp::ArrayToSlice(
                                 *kind1,
-                                generics.types[0].clone(),
-                                generics.const_generics[0].clone(),
+                                tref1.generics.types[0].clone(),
+                                tref1.generics.const_generics[0].clone(),
                             )
                         } else {
                             UnOp::Cast(CastKind::Unsize(src_ty.clone(), tgt_ty.clone()))
@@ -580,7 +537,9 @@ impl BodyTransCtx<'_, '_, '_> {
             }
             hax::Rvalue::Discriminant(place) => {
                 let place = self.translate_place(span, place)?;
-                if let TyKind::Adt(TypeId::Adt(adt_id), _) = *place.ty().kind() {
+                if let TyKind::Adt(tref) = place.ty().kind()
+                    && let TypeId::Adt(adt_id) = tref.id
+                {
                     Ok(Rvalue::Discriminant(place, adt_id))
                 } else {
                     raise_error!(
@@ -623,15 +582,16 @@ impl BodyTransCtx<'_, '_, '_> {
                             operands_t,
                         ))
                     }
-                    hax::AggregateKind::Tuple => Ok(Rvalue::Aggregate(
-                        AggregateKind::Adt(
+                    hax::AggregateKind::Tuple => {
+                        let tref = TypeDeclRef::new(
                             TypeId::Tuple,
-                            None,
-                            None,
-                            Box::new(GenericArgs::empty(GenericsSource::Builtin)),
-                        ),
-                        operands_t,
-                    )),
+                            GenericArgs::empty(GenericsSource::Builtin),
+                        );
+                        Ok(Rvalue::Aggregate(
+                            AggregateKind::Adt(tref, None, None),
+                            operands_t,
+                        ))
+                    }
                     hax::AggregateKind::Adt(
                         adt_id,
                         variant_idx,
@@ -655,8 +615,7 @@ impl BodyTransCtx<'_, '_, '_> {
                             AdtKind::Union => Some(translate_field_id(field_index.unwrap())),
                         };
 
-                        let akind =
-                            AggregateKind::Adt(tref.id, variant_id, field_id, tref.generics);
+                        let akind = AggregateKind::Adt(tref, variant_id, field_id);
                         Ok(Rvalue::Aggregate(akind, operands_t))
                     }
                     hax::AggregateKind::Closure(def_id, closure_args) => {
@@ -667,7 +626,7 @@ impl BodyTransCtx<'_, '_, '_> {
                         );
 
                         let tref = self.translate_closure_type_ref(span, def_id, closure_args)?;
-                        let akind = AggregateKind::Adt(tref.id, None, None, tref.generics);
+                        let akind = AggregateKind::Adt(tref, None, None);
                         Ok(Rvalue::Aggregate(akind, operands_t))
                     }
                     hax::AggregateKind::RawPtr(ty, is_mut) => {

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -174,7 +174,7 @@ impl ItemTransCtx<'_, '_> {
         let input_tuple = Ty::mk_tuple(inputs);
 
         Ok(TraitDeclRef {
-            trait_id,
+            id: trait_id,
             generics: Box::new(GenericArgs::new_types([state_ty, input_tuple].into())),
         })
     }
@@ -553,7 +553,7 @@ impl ItemTransCtx<'_, '_> {
 
         let implemented_trait =
             self.translate_closure_trait_ref(span, def.def_id(), args, target_kind)?;
-        let fn_trait = implemented_trait.trait_id;
+        let fn_trait = implemented_trait.id;
 
         // The input tuple type and output type of the signature.
         let (inputs, output) = self.translate_closure_info(span, args)?.signature.erase();
@@ -563,7 +563,10 @@ impl ItemTransCtx<'_, '_> {
             // Makes a built-in trait ref for `ty: trait`.
             let builtin_tref = |trait_id, ty| {
                 let generics = Box::new(GenericArgs::new_types([ty].into()));
-                let trait_decl_ref = TraitDeclRef { trait_id, generics };
+                let trait_decl_ref = TraitDeclRef {
+                    id: trait_id,
+                    generics,
+                };
                 let trait_decl_ref = RegionBinder::empty(trait_decl_ref);
                 TraitRef {
                     kind: TraitRefKind::BuiltinOrAuto {

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -147,7 +147,7 @@ impl ItemTransCtx<'_, '_> {
         }
 
         Ok(TraitImplRef {
-            impl_id,
+            id: impl_id,
             generics: Box::new(args),
         })
     }
@@ -602,10 +602,7 @@ impl ItemTransCtx<'_, '_> {
                     let parent_predicate =
                         self.translate_closure_trait_ref(span, def.def_id(), args, parent_kind)?;
                     let parent_trait_ref = TraitRef {
-                        kind: TraitRefKind::TraitImpl(
-                            parent_impl_ref.impl_id,
-                            parent_impl_ref.generics,
-                        ),
+                        kind: TraitRefKind::TraitImpl(parent_impl_ref),
                         trait_decl_ref: RegionBinder::empty(parent_predicate),
                     };
                     [

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -188,8 +188,8 @@ impl ItemTransCtx<'_, '_> {
         def_id: &hax::DefId,
         args: &hax::ClosureArgs,
     ) -> Result<Ty, Error> {
-        let ty_ref = self.translate_closure_type_ref(span, def_id, args)?;
-        Ok(TyKind::Adt(ty_ref.id, *ty_ref.generics).into_ty())
+        let tref = self.translate_closure_type_ref(span, def_id, args)?;
+        Ok(TyKind::Adt(tref).into_ty())
     }
 
     pub fn translate_closure_adt(

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -469,7 +469,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let id = self.register_trait_decl_id(span, def_id);
         let generics = self.translate_generic_args(span, substs, trait_refs)?;
         Ok(TraitDeclRef {
-            trait_id: id,
+            id,
             generics: Box::new(generics),
         })
     }

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -348,8 +348,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         trait_refs: &[hax::ImplExpr],
     ) -> Result<TypeDeclRef, Error> {
         let id = self.translate_type_id(span, def_id)?;
-        let generics =
-            self.translate_generic_args(span, substs, trait_refs, id.generics_target())?;
+        let generics = self.translate_generic_args(span, substs, trait_refs)?;
         Ok(TypeDeclRef {
             id,
             generics: Box::new(generics),
@@ -399,13 +398,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
             _ => None,
         };
-        let bound_generics = self.translate_generic_args_with_late_bound(
-            span,
-            substs,
-            trait_refs,
-            late_bound,
-            fun_id.generics_target(),
-        )?;
+        let bound_generics =
+            self.translate_generic_args_with_late_bound(span, substs, trait_refs, late_bound)?;
         Ok(bound_generics.map(|generics| MaybeBuiltinFunDeclRef {
             id: fun_id,
             generics: Box::new(generics),
@@ -430,13 +424,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
             _ => None,
         };
-        let bound_generics = self.translate_generic_args_with_late_bound(
-            span,
-            substs,
-            trait_refs,
-            late_bound,
-            GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.trait_id, name.clone()),
-        )?;
+        let bound_generics =
+            self.translate_generic_args_with_late_bound(span, substs, trait_refs, late_bound)?;
         Ok(bound_generics.map(|generics| TraitMethodRef {
             trait_ref: trait_ref.move_under_binder(),
             name,
@@ -458,8 +447,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         trait_refs: &[hax::ImplExpr],
     ) -> Result<GlobalDeclRef, Error> {
         let id = self.register_global_decl_id(span, def_id);
-        let generics =
-            self.translate_generic_args(span, substs, trait_refs, GenericsSource::item(id))?;
+        let generics = self.translate_generic_args(span, substs, trait_refs)?;
         Ok(GlobalDeclRef {
             id,
             generics: Box::new(generics),
@@ -479,8 +467,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         trait_refs: &[hax::ImplExpr],
     ) -> Result<TraitDeclRef, Error> {
         let id = self.register_trait_decl_id(span, def_id);
-        let generics =
-            self.translate_generic_args(span, substs, trait_refs, GenericsSource::item(id))?;
+        let generics = self.translate_generic_args(span, substs, trait_refs)?;
         Ok(TraitDeclRef {
             trait_id: id,
             generics: Box::new(generics),
@@ -500,8 +487,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         trait_refs: &[hax::ImplExpr],
     ) -> Result<TraitImplRef, Error> {
         let id = self.register_trait_impl_id(span, def_id);
-        let generics =
-            self.translate_generic_args(span, substs, trait_refs, GenericsSource::item(id))?;
+        let generics = self.translate_generic_args(span, substs, trait_refs)?;
         Ok(TraitImplRef {
             id,
             generics: Box::new(generics),

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -503,7 +503,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let generics =
             self.translate_generic_args(span, substs, trait_refs, GenericsSource::item(id))?;
         Ok(TraitImplRef {
-            impl_id: id,
+            id,
             generics: Box::new(generics),
         })
     }

--- a/charon/src/bin/charon-driver/translate/translate_functions.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions.rs
@@ -127,21 +127,15 @@ impl ItemTransCtx<'_, '_> {
             hax::CtorOf::Struct => None,
             hax::CtorOf::Variant => Some(VariantId::from(variant_id)),
         };
+        let tref = TypeDeclRef::new(
+            TypeId::Adt(adt_decl_id),
+            signature
+                .generics
+                .identity_args(GenericsSource::item(adt_decl_id)),
+        );
         let st_kind = RawStatement::Assign(
             locals.return_place(),
-            Rvalue::Aggregate(
-                AggregateKind::Adt(
-                    TypeId::Adt(adt_decl_id),
-                    variant,
-                    None,
-                    Box::new(
-                        signature
-                            .generics
-                            .identity_args(GenericsSource::item(adt_decl_id)),
-                    ),
-                ),
-                args,
-            ),
+            Rvalue::Aggregate(AggregateKind::Adt(tref, variant, None), args),
         );
         let statement = Statement::new(span, st_kind);
         let block = BlockData {

--- a/charon/src/bin/charon-driver/translate/translate_functions.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions.rs
@@ -127,12 +127,7 @@ impl ItemTransCtx<'_, '_> {
             hax::CtorOf::Struct => None,
             hax::CtorOf::Variant => Some(VariantId::from(variant_id)),
         };
-        let tref = TypeDeclRef::new(
-            TypeId::Adt(adt_decl_id),
-            signature
-                .generics
-                .identity_args(GenericsSource::item(adt_decl_id)),
-        );
+        let tref = TypeDeclRef::new(TypeId::Adt(adt_decl_id), signature.generics.identity_args());
         let st_kind = RawStatement::Assign(
             locals.return_place(),
             Rvalue::Aggregate(AggregateKind::Adt(tref, variant, None), args),

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -605,7 +605,7 @@ impl ItemTransCtx<'_, '_> {
             // Do the inverse operation: the trait considers the clauses as implied.
             let parent_trait_refs = mem::take(&mut generics.trait_refs);
             let implemented_trait = TraitDeclRef {
-                trait_id,
+                id: trait_id,
                 generics: Box::new(generics),
             };
             let mut timpl = TraitImpl {
@@ -688,7 +688,7 @@ impl ItemTransCtx<'_, '_> {
 
         // Retrieve the information about the implemented trait.
         let implemented_trait = self.translate_trait_ref(span, &trait_pred.trait_ref)?;
-        let trait_id = implemented_trait.trait_id;
+        let trait_id = implemented_trait.id;
         // A `TraitRef` that points to this impl with the correct generics.
         let self_predicate = TraitRef {
             kind: TraitRefKind::TraitImpl(TraitImplRef {

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -698,14 +698,14 @@ impl ItemTransCtx<'_, '_> {
         let trait_id = implemented_trait.trait_id;
         // A `TraitRef` that points to this impl with the correct generics.
         let self_predicate = TraitRef {
-            kind: TraitRefKind::TraitImpl(
-                def_id,
-                Box::new(
+            kind: TraitRefKind::TraitImpl(TraitImplRef {
+                id: def_id,
+                generics: Box::new(
                     self.the_only_binder()
                         .params
                         .identity_args(GenericsSource::item(def_id)),
                 ),
-            ),
+            }),
             trait_decl_ref: RegionBinder::empty(implemented_trait.clone()),
         };
 

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -201,7 +201,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 let impl_ref =
                     self.translate_trait_impl_ref(span, impl_def_id, generics, impl_exprs)?;
                 TraitRef {
-                    kind: TraitRefKind::TraitImpl(impl_ref.impl_id, impl_ref.generics),
+                    kind: TraitRefKind::TraitImpl(impl_ref),
                     trait_decl_ref,
                 }
             }
@@ -329,8 +329,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                                 closure_kind,
                             )
                         })?;
-                    let TraitImplRef { impl_id, generics } = binder.erase();
-                    TraitRefKind::TraitImpl(impl_id, generics)
+                    TraitRefKind::TraitImpl(binder.erase())
                 } else if let hax::FullDefKind::TraitAlias { .. } = trait_def.kind() {
                     // We reuse the same `def_id` to generate a blanket impl for the trait.
                     let impl_id = self.register_trait_impl_id(span, trait_def_id);
@@ -344,7 +343,10 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                         "found trait alias with non-empty required predicates"
                     );
                     generics.trait_refs = self.translate_trait_impl_exprs(span, &impl_exprs)?;
-                    TraitRefKind::TraitImpl(impl_id, Box::new(generics))
+                    TraitRefKind::TraitImpl(TraitImplRef {
+                        id: impl_id,
+                        generics: Box::new(generics),
+                    })
                 } else {
                     let parent_trait_refs = self.translate_trait_impl_exprs(span, &impl_exprs)?;
                     let types = types

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -333,11 +333,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 } else if let hax::FullDefKind::TraitAlias { .. } = trait_def.kind() {
                     // We reuse the same `def_id` to generate a blanket impl for the trait.
                     let impl_id = self.register_trait_impl_id(span, trait_def_id);
-                    let mut generics = trait_decl_ref
-                        .clone()
-                        .erase()
-                        .generics
-                        .with_target(GenericsSource::item(impl_id));
+                    let mut generics = trait_decl_ref.clone().erase().generics;
                     assert!(
                         generics.trait_refs.is_empty(),
                         "found trait alias with non-empty required predicates"
@@ -345,7 +341,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     generics.trait_refs = self.translate_trait_impl_exprs(span, &impl_exprs)?;
                     TraitRefKind::TraitImpl(TraitImplRef {
                         id: impl_id,
-                        generics: Box::new(generics),
+                        generics,
                     })
                 } else {
                     let parent_trait_refs = self.translate_trait_impl_exprs(span, &impl_exprs)?;

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -144,38 +144,37 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 }
 
                 // Return the instantiated ADT
-                TyKind::Adt(tref.id, *tref.generics)
+                TyKind::Adt(tref)
             }
             hax::TyKind::Str => {
-                trace!("Str");
-
-                let id = TypeId::Builtin(BuiltinTy::Str);
-                TyKind::Adt(id, GenericArgs::empty(GenericsSource::Builtin))
+                let tref = TypeDeclRef::new(
+                    TypeId::Builtin(BuiltinTy::Str),
+                    GenericArgs::empty(GenericsSource::Builtin),
+                );
+                TyKind::Adt(tref)
             }
             hax::TyKind::Array(ty, const_param) => {
-                trace!("Array");
-
                 let c = self.translate_constant_expr_to_const_generic(span, const_param)?;
-                let tys = vec![self.translate_ty(span, ty)?].into();
-                let cgs = vec![c].into();
-                let id = TypeId::Builtin(BuiltinTy::Array);
-                TyKind::Adt(
-                    id,
+                let ty = self.translate_ty(span, ty)?;
+                let tref = TypeDeclRef::new(
+                    TypeId::Builtin(BuiltinTy::Array),
                     GenericArgs::new(
                         Vector::new(),
-                        tys,
-                        cgs,
+                        [ty].into(),
+                        [c].into(),
                         Vector::new(),
                         GenericsSource::Builtin,
                     ),
-                )
+                );
+                TyKind::Adt(tref)
             }
             hax::TyKind::Slice(ty) => {
-                trace!("Slice");
-
-                let tys = vec![self.translate_ty(span, ty)?].into();
-                let id = TypeId::Builtin(BuiltinTy::Slice);
-                TyKind::Adt(id, GenericArgs::new_for_builtin(tys))
+                let ty = self.translate_ty(span, ty)?;
+                let tref = TypeDeclRef::new(
+                    TypeId::Builtin(BuiltinTy::Slice),
+                    GenericArgs::new_for_builtin([ty].into()),
+                );
+                TyKind::Adt(tref)
             }
             hax::TyKind::Ref(region, ty, mutability) => {
                 trace!("Ref");
@@ -200,15 +199,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 TyKind::RawPtr(ty, kind)
             }
             hax::TyKind::Tuple(substs) => {
-                trace!("Tuple");
-
                 let mut params = Vector::new();
                 for param in substs.iter() {
                     let param_ty = self.translate_ty(span, param)?;
                     params.push(param_ty);
                 }
-
-                TyKind::Adt(TypeId::Tuple, GenericArgs::new_for_builtin(params))
+                let tref = TypeDeclRef::new(TypeId::Tuple, GenericArgs::new_for_builtin(params));
+                TyKind::Adt(tref)
             }
 
             hax::TyKind::Param(param) => {
@@ -227,9 +224,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
 
             hax::TyKind::Foreign(def_id) => {
-                trace!("Foreign");
-                let adt_id = self.translate_type_id(span, def_id)?;
-                TyKind::Adt(adt_id, GenericArgs::empty(adt_id.generics_target()))
+                let tref = self.translate_type_decl_ref(span, def_id, &[], &[])?;
+                TyKind::Adt(tref)
             }
             hax::TyKind::Infer(_) => {
                 trace!("Infer");
@@ -272,7 +268,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
             hax::TyKind::Closure(def_id, args) => {
                 let tref = self.translate_closure_type_ref(span, def_id, args)?;
-                TyKind::Adt(tref.id, *tref.generics)
+                TyKind::Adt(tref)
             }
             hax::TyKind::Error => {
                 trace!("Error");

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -91,18 +91,23 @@ impl Pattern {
             return true;
         }
         match ty.kind() {
-            TyKind::Adt(TypeId::Adt(type_id), args) => {
-                let Some(type_name) = ctx.item_name(*type_id) else {
-                    return false;
-                };
-                self.matches_with_generics(ctx, type_name, Some(args))
+            TyKind::Adt(tref) => {
+                let args = &tref.generics;
+                match tref.id {
+                    TypeId::Adt(type_id) => {
+                        let Some(type_name) = ctx.item_name(type_id) else {
+                            return false;
+                        };
+                        self.matches_with_generics(ctx, type_name, Some(args))
+                    }
+                    TypeId::Builtin(builtin_ty) => {
+                        let name = builtin_ty.get_name();
+                        self.matches_with_generics(ctx, &name, Some(args))
+                    }
+                    TypeId::Tuple => false,
+                }
             }
-            TyKind::Adt(TypeId::Builtin(builtin_ty), args) => {
-                let name = builtin_ty.get_name();
-                self.matches_with_generics(ctx, &name, Some(args))
-            }
-            TyKind::Adt(TypeId::Tuple, _)
-            | TyKind::TypeVar(..)
+            TyKind::TypeVar(..)
             | TyKind::Literal(..)
             | TyKind::Never
             | TyKind::Ref(..)

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -190,7 +190,7 @@ impl PatElem {
                 let Some(timpl) = ctx.trait_impls.get(*impl_id) else {
                     return false;
                 };
-                let Some(trait_name) = ctx.item_name(timpl.impl_trait.trait_id) else {
+                let Some(trait_name) = ctx.item_name(timpl.impl_trait.id) else {
                     return false;
                 };
                 pat.matches_with_generics(ctx, trait_name, Some(&timpl.impl_trait.generics))

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1604,6 +1604,14 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImplId {
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for TraitImplRef {
+    fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let id = self.id.with_ctx(ctx);
+        let generics = self.generics.with_ctx(ctx);
+        write!(f, "{id}{generics}")
+    }
+}
+
 impl Display for TraitItemName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         write!(f, "{}", self.0)
@@ -1625,10 +1633,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
                 let clause = clause_id.to_pretty_string();
                 write!(f, "({id}::{type_name}::[{clause}])")
             }
-            TraitRefKind::TraitImpl(id, args) => {
-                let impl_ = id.with_ctx(ctx);
-                let args = args.with_ctx(ctx);
-                write!(f, "{impl_}{args}")
+            TraitRefKind::TraitImpl(impl_ref) => {
+                write!(f, "{}", impl_ref.with_ctx(ctx))
             }
             TraitRefKind::Clause(id) => write!(f, "{}", id.with_ctx(ctx)),
             TraitRefKind::BuiltinOrAuto {

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1538,7 +1538,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDeclId {
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitDeclRef {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let trait_id = self.trait_id.with_ctx(ctx);
+        let trait_id = self.id.with_ctx(ctx);
         let generics = self.generics.with_ctx(ctx);
         write!(f, "{trait_id}{generics}")
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -5,6 +5,7 @@ use crate::{
     gast,
     llbc_ast::{self as llbc, *},
     reorder_decls::*,
+    transform::utils::GenericsSource,
     ullbc_ast::{self as ullbc, *},
 };
 use either::Either;

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -91,8 +91,8 @@ impl CheckGenericsVisitor<'_> {
         tclause: &TraitClause,
         tref: &TraitRef,
     ) {
-        let clause_trait_id = tclause.trait_.skip_binder.trait_id;
-        let ref_trait_id = tref.trait_decl_ref.skip_binder.trait_id;
+        let clause_trait_id = tclause.trait_.skip_binder.id;
+        let ref_trait_id = tref.trait_decl_ref.skip_binder.id;
         if clause_trait_id != ref_trait_id {
             let args_fmt = &self.val_fmt_ctx();
             let tclause = tclause.with_ctx(params_fmt);
@@ -261,7 +261,7 @@ impl VisitAst for CheckGenericsVisitor<'_> {
             // TODO: check builtin generics.
             FunIdOrTraitMethodRef::Fun(FunId::Builtin(_)) => {}
             FunIdOrTraitMethodRef::Trait(trait_ref, method_name, _) => {
-                let trait_id = trait_ref.trait_decl_ref.skip_binder.trait_id;
+                let trait_id = trait_ref.trait_decl_ref.skip_binder.id;
                 self.assert_matches_method(trait_id, method_name, &x.generics);
             }
         }
@@ -270,18 +270,13 @@ impl VisitAst for CheckGenericsVisitor<'_> {
         self.assert_matches_item(x.id, &x.generics);
     }
     fn enter_trait_decl_ref(&mut self, x: &TraitDeclRef) {
-        self.assert_matches_item(x.trait_id, &x.generics);
+        self.assert_matches_item(x.id, &x.generics);
     }
     fn enter_trait_impl_ref(&mut self, x: &TraitImplRef) {
         self.assert_matches_item(x.id, &x.generics);
     }
     fn enter_trait_impl(&mut self, timpl: &TraitImpl) {
-        let Some(tdecl) = self
-            .ctx
-            .translated
-            .trait_decls
-            .get(timpl.impl_trait.trait_id)
-        else {
+        let Some(tdecl) = self.ctx.translated.trait_decls.get(timpl.impl_trait.id) else {
             return;
         };
         // See `lift_associated_item_clauses`
@@ -297,7 +292,7 @@ impl VisitAst for CheckGenericsVisitor<'_> {
             &tdecl_fmt,
             args_fmt,
             "trait parent clauses",
-            &GenericsSource::item(timpl.impl_trait.trait_id),
+            &GenericsSource::item(timpl.impl_trait.id),
             |tclause, tref| self.assert_clause_matches(&tdecl_fmt, tclause, tref),
         );
         let types_match = timpl.types.len() == tdecl.types.len()

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -9,6 +9,7 @@ use crate::{
     errors::Level,
     formatter::{AstFormatter, FmtCtx, IntoFormatter},
     pretty::FmtWithCtx,
+    transform::utils::GenericsSource,
 };
 
 use super::{ctx::TransformPass, TransformCtx};

--- a/charon/src/transform/duplicate_defaulted_methods.rs
+++ b/charon/src/transform/duplicate_defaulted_methods.rs
@@ -12,7 +12,7 @@ impl TransformPass for Transform {
             let Some(timpl) = ctx.translated.trait_impls.get_mut(impl_id) else {
                 continue;
             };
-            let Some(tdecl) = ctx.translated.trait_decls.get(timpl.impl_trait.trait_id) else {
+            let Some(tdecl) = ctx.translated.trait_decls.get(timpl.impl_trait.id) else {
                 continue;
             };
             if tdecl.methods.len() == timpl.methods.len() {

--- a/charon/src/transform/duplicate_defaulted_methods.rs
+++ b/charon/src/transform/duplicate_defaulted_methods.rs
@@ -21,7 +21,7 @@ impl TransformPass for Transform {
 
             // A `TraitRef` that points to this impl with the correct generics.
             let self_impl_ref = TraitImplRef {
-                impl_id: timpl.def_id,
+                id: timpl.def_id,
                 generics: Box::new(
                     timpl
                         .generics
@@ -29,10 +29,7 @@ impl TransformPass for Transform {
                 ),
             };
             let self_predicate = TraitRef {
-                kind: TraitRefKind::TraitImpl(
-                    self_impl_ref.impl_id,
-                    self_impl_ref.generics.clone(),
-                ),
+                kind: TraitRefKind::TraitImpl(self_impl_ref.clone()),
                 trait_decl_ref: RegionBinder::empty(timpl.impl_trait.clone()),
             };
             // Map of methods we already have in the impl.

--- a/charon/src/transform/duplicate_defaulted_methods.rs
+++ b/charon/src/transform/duplicate_defaulted_methods.rs
@@ -22,11 +22,7 @@ impl TransformPass for Transform {
             // A `TraitRef` that points to this impl with the correct generics.
             let self_impl_ref = TraitImplRef {
                 id: timpl.def_id,
-                generics: Box::new(
-                    timpl
-                        .generics
-                        .identity_args(GenericsSource::item(timpl.def_id)),
-                ),
+                generics: Box::new(timpl.generics.identity_args()),
             };
             let self_predicate = TraitRef {
                 kind: TraitRefKind::TraitImpl(self_impl_ref.clone()),
@@ -72,19 +68,9 @@ impl TransformPass for Transform {
                         generics: Box::new(
                             timpl
                                 .generics
-                                .identity_args_at_depth(
-                                    GenericsSource::item(timpl.def_id),
-                                    DeBruijnId::one(),
-                                )
+                                .identity_args_at_depth(DeBruijnId::one())
                                 .concat(
-                                    GenericsSource::item(new_fun_id),
-                                    &bound_fn.params.identity_args_at_depth(
-                                        GenericsSource::Method(
-                                            timpl.impl_trait.trait_id.into(),
-                                            name.clone(),
-                                        ),
-                                        DeBruijnId::zero(),
-                                    ),
+                                    &bound_fn.params.identity_args_at_depth(DeBruijnId::zero()),
                                 ),
                         ),
                     },

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -82,7 +82,7 @@ use macros::EnumAsGetters;
 
 use crate::{ast::*, formatter::IntoFormatter, ids::Vector, pretty::FmtWithCtx, register_error};
 
-use super::{ctx::TransformPass, TransformCtx};
+use super::{ctx::TransformPass, utils::GenericsSource, TransformCtx};
 
 /// Represent some `TraitRef`s as paths for easier manipulation.
 use trait_ref_path::*;
@@ -1285,9 +1285,7 @@ impl TransformPass for Transform {
                     kind: TraitRefKind::SelfId,
                     trait_decl_ref: RegionBinder::empty(TraitDeclRef {
                         trait_id: tr.def_id,
-                        generics: Box::new(
-                            tr.generics.identity_args(GenericsSource::item(tr.def_id)),
-                        ),
+                        generics: Box::new(tr.generics.identity_args()),
                     }),
                 };
                 modifications.compute_replacements(|path| {

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -19,7 +19,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         let trait_clauses = &mut args.trait_clauses;
         for i in trait_clauses.all_indices() {
             let clause = &trait_clauses[i];
-            if self.exclude.contains(&clause.trait_.skip_binder.trait_id) {
+            if self.exclude.contains(&clause.trait_.skip_binder.id) {
                 trait_clauses.remove(i);
             }
         }
@@ -28,10 +28,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         let trait_refs = &mut args.trait_refs;
         for i in trait_refs.all_indices() {
             let tref = &trait_refs[i];
-            if self
-                .exclude
-                .contains(&tref.trait_decl_ref.skip_binder.trait_id)
-            {
+            if self.exclude.contains(&tref.trait_decl_ref.skip_binder.id) {
                 trait_refs.remove(i);
             }
         }
@@ -40,7 +37,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         let trait_clauses = &mut tdecl.parent_clauses;
         for i in trait_clauses.all_indices() {
             let clause = &trait_clauses[i];
-            if self.exclude.contains(&clause.trait_.skip_binder.trait_id) {
+            if self.exclude.contains(&clause.trait_.skip_binder.id) {
                 trait_clauses.remove(i);
             }
         }
@@ -49,10 +46,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         let trait_refs = &mut timpl.parent_trait_refs;
         for i in trait_refs.all_indices() {
             let tref = &trait_refs[i];
-            if self
-                .exclude
-                .contains(&tref.trait_decl_ref.skip_binder.trait_id)
-            {
+            if self.exclude.contains(&tref.trait_decl_ref.skip_binder.id) {
                 trait_refs.remove(i);
             }
         }

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -36,6 +36,7 @@ pub mod skip_trait_refs_when_known;
 pub mod ullbc_to_llbc;
 pub mod unbind_item_vars;
 pub mod update_block_indices;
+pub mod utils;
 
 pub use ctx::TransformCtx;
 use ctx::{LlbcPass, TransformPass, UllbcPass};

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -158,10 +158,10 @@ impl VisitAst for UsageVisitor<'_> {
                 // This is the actual function we need to call!
                 // Whereas id is the trait method reference(?)
                 let fn_ref = fn_ref.apply(&impl_gargs).apply(&fn_ptr.generics);
-                let gargs_key = fn_ptr.generics.clone().concat(
-                    GenericsSource::Builtin,
-                    &t_ref.trait_decl_ref.skip_binder.generics,
-                );
+                let gargs_key = fn_ptr
+                    .generics
+                    .clone()
+                    .concat(&t_ref.trait_decl_ref.skip_binder.generics);
                 self.found_use_fn_hinted(&id, &gargs_key, (fn_ref.id, fn_ref.generics))
             }
             // These can't be monomorphized, since they're builtins
@@ -196,7 +196,7 @@ impl SubstVisitor<'_> {
             && let Some(subst_id) = of(any_id)
         {
             *id = *subst_id;
-            *gargs = GenericArgs::empty(GenericsSource::Builtin);
+            *gargs = GenericArgs::empty();
         } else {
             warn!("Substitution missing for {:?} / {:?}", id, gargs);
         }
@@ -250,10 +250,10 @@ impl VisitAstMut for SubstVisitor<'_> {
                 self.subst_use_fun(fun_id, &mut fn_ptr.generics)
             }
             FunIdOrTraitMethodRef::Trait(t_ref, _, fun_id) => {
-                let mut gargs_key = fn_ptr.generics.clone().concat(
-                    GenericsSource::Builtin,
-                    &t_ref.trait_decl_ref.skip_binder.generics,
-                );
+                let mut gargs_key = fn_ptr
+                    .generics
+                    .clone()
+                    .concat(&t_ref.trait_decl_ref.skip_binder.generics);
                 self.subst_use_fun(fun_id, &mut gargs_key);
                 fn_ptr.generics = Box::new(gargs_key);
             }
@@ -388,7 +388,7 @@ impl TransformPass for Transform {
         // Final list of monomorphized items: { (poly item, generic args) -> mono item }
         let mut data = PassData::new();
 
-        let empty_gargs = GenericArgs::empty(GenericsSource::Builtin);
+        let empty_gargs = GenericArgs::empty();
 
         // Find the roots of the mono item graph
         for (id, item) in ctx.translated.all_items_with_ids() {

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -57,13 +57,13 @@ impl TranslatedCrate {
         kind: &TraitRefKind,
     ) -> Option<(&TraitImpl, GenericArgs)> {
         match kind {
-            TraitRefKind::TraitImpl(impl_id, gargs) => {
-                let trait_impl = self.trait_impls.get(*impl_id).unwrap();
-                Some((trait_impl, (**gargs).clone()))
+            TraitRefKind::TraitImpl(impl_ref) => {
+                let trait_impl = self.trait_impls.get(impl_ref.id)?;
+                Some((trait_impl, impl_ref.generics.as_ref().clone()))
             }
             TraitRefKind::ParentClause(p, _, clause) => {
                 let (trait_impl, _) = self.find_trait_impl_and_gargs(p)?;
-                let t_ref = trait_impl.parent_trait_refs.get(*clause).unwrap();
+                let t_ref = trait_impl.parent_trait_refs.get(*clause)?;
                 self.find_trait_impl_and_gargs(&t_ref.kind)
             }
             _ => None,

--- a/charon/src/transform/ops_to_function_calls.rs
+++ b/charon/src/transform/ops_to_function_calls.rs
@@ -19,11 +19,10 @@ fn transform_st(s: &mut Statement) {
             };
             let func = FunIdOrTraitMethodRef::mk_builtin(id);
             let generics = GenericArgs::new(
-                vec![Region::Erased].into(),
-                vec![ty.clone()].into(),
-                vec![cg.clone()].into(),
-                vec![].into(),
-                GenericsSource::Builtin,
+                [Region::Erased].into(),
+                [ty.clone()].into(),
+                [cg.clone()].into(),
+                [].into(),
             );
             let func = FnOperand::Regular(FnPtr {
                 func: Box::new(func),
@@ -42,11 +41,10 @@ fn transform_st(s: &mut Statement) {
             let id = BuiltinFunId::ArrayRepeat;
             let func = FunIdOrTraitMethodRef::mk_builtin(id);
             let generics = GenericArgs::new(
-                vec![Region::Erased].into(),
-                vec![ty.clone()].into(),
-                vec![cg.clone()].into(),
-                vec![].into(),
-                GenericsSource::Builtin,
+                [Region::Erased].into(),
+                [ty.clone()].into(),
+                [cg.clone()].into(),
+                [].into(),
             );
             let func = FnOperand::Regular(FnPtr {
                 func: Box::new(func),
@@ -63,11 +61,10 @@ fn transform_st(s: &mut Statement) {
             let id = BuiltinFunId::PtrFromParts(is_mut.clone());
             let func = FunIdOrTraitMethodRef::mk_builtin(id);
             let generics = GenericArgs::new(
-                vec![Region::Erased].into(),
-                vec![ty.clone()].into(),
-                vec![].into(),
-                vec![].into(),
-                GenericsSource::Builtin,
+                [Region::Erased].into(),
+                [ty.clone()].into(),
+                [].into(),
+                [].into(),
             );
 
             let func = FnOperand::Regular(FnPtr {

--- a/charon/src/transform/reconstruct_boxes.rs
+++ b/charon/src/transform/reconstruct_boxes.rs
@@ -93,8 +93,8 @@ impl UllbcPass for Transform {
                 && alloc_use == malloc_dest
                 && box_make.is_local()
                 && box_make.local_id() == *target_var
-                && let TyKind::Adt(TypeId::Builtin(BuiltinTy::Box), generics) =
-                    b.locals[*target_var].ty.kind()
+                && let TyKind::Adt(ty_ref) = b.locals[*target_var].ty.kind()
+                && let TypeId::Builtin(BuiltinTy::Box) = ty_ref.id
                 && let Some((assign_idx_in_rest, val, span)) = rest.iter().enumerate().find_map(|(idx, st)| {
                     if let Statement {
                             content: RawStatement::Assign(box_deref, val),
@@ -113,7 +113,7 @@ impl UllbcPass for Transform {
                 at_5 = box_make.clone();
                 old_assign_idx = assign_idx_in_rest + 2; // +2 because rest skips the first two statements
                 value_to_write = val.clone();
-                box_generics = generics.clone();
+                box_generics = ty_ref.generics.clone();
                 second_block = *target_block_idx;
                 assign_span = *span;
                 unwind_target = *on_unwind;
@@ -160,7 +160,7 @@ impl UllbcPass for Transform {
                         func: Box::new(FunIdOrTraitMethodRef::Fun(FunId::Builtin(
                             BuiltinFunId::BoxNew,
                         ))),
-                        generics: Box::new(box_generics),
+                        generics: box_generics,
                     }),
                     args: vec![value_to_write],
                     dest: at_5,

--- a/charon/src/transform/remove_read_discriminant.rs
+++ b/charon/src/transform/remove_read_discriminant.rs
@@ -163,7 +163,8 @@ impl Transform {
                         && *fun_id == discriminant_intrinsic
                         // on a known enum...
                         && let ty = &fn_ptr.generics.types[0]
-                        && let TyKind::Adt(TypeId::Adt(type_id), _) = *ty.kind()
+                        && let TyKind::Adt(ty_ref) = ty.kind()
+                        && let TypeId::Adt(type_id) = ty_ref.id
                         && let Some(TypeDeclKind::Enum(variants)) =
                             ctx.translated.type_decls.get(type_id).map(|x| &x.kind)
                         // passing it a reference.

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -227,7 +227,7 @@ impl Deps {
             ItemKind::TraitDecl { trait_ref, .. } => {
                 self.parent_trait_decl = Some(trait_ref.trait_id)
             }
-            ItemKind::TraitImpl { impl_ref, .. } => self.parent_trait_impl = Some(impl_ref.impl_id),
+            ItemKind::TraitImpl { impl_ref, .. } => self.parent_trait_impl = Some(impl_ref.id),
             _ => {}
         }
     }

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -224,9 +224,7 @@ impl Deps {
 
     fn set_impl_or_trait_id(&mut self, kind: &ItemKind) {
         match kind {
-            ItemKind::TraitDecl { trait_ref, .. } => {
-                self.parent_trait_decl = Some(trait_ref.trait_id)
-            }
+            ItemKind::TraitDecl { trait_ref, .. } => self.parent_trait_decl = Some(trait_ref.id),
             ItemKind::TraitImpl { impl_ref, .. } => self.parent_trait_impl = Some(impl_ref.id),
             _ => {}
         }
@@ -362,7 +360,7 @@ fn compute_declarations_graph<'tcx>(ctx: &'tcx TransformCtx) -> Deps {
                 // `Self` clause. While the clause is implicit, we make sure to record the
                 // dependency manually.
                 if let ItemKind::TraitDecl { trait_ref, .. } = &d.kind {
-                    graph.insert_edge(trait_ref.trait_id.into());
+                    graph.insert_edge(trait_ref.id.into());
                 }
             }
             AnyTransItem::TraitDecl(d) => {

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -94,9 +94,8 @@ fn transform_constant_expr(
 
             // Build an `Aggregate` rvalue.
             let rval = {
-                let (adt_kind, generics) = val.ty.kind().as_adt().unwrap();
-                let aggregate_kind =
-                    AggregateKind::Adt(*adt_kind, variant, None, Box::new(generics.clone()));
+                let tref = val.ty.kind().as_adt().unwrap();
+                let aggregate_kind = AggregateKind::Adt(tref.clone(), variant, None);
                 Rvalue::Aggregate(aggregate_kind, fields)
             };
             let var = new_var(rval, val.ty);
@@ -110,12 +109,12 @@ fn transform_constant_expr(
                 .collect_vec();
 
             let len = ConstGeneric::Value(Literal::Scalar(ScalarValue::Usize(fields.len() as u64)));
-            let (adt_kind, generics) = val.ty.kind().as_adt().unwrap();
+            let tref = val.ty.kind().as_adt().unwrap();
             assert_matches!(
-                *adt_kind.as_builtin().unwrap(),
+                *tref.id.as_builtin().unwrap(),
                 BuiltinTy::Array | BuiltinTy::Slice
             );
-            let ty = generics.types[0].clone();
+            let ty = tref.generics.types[0].clone();
             let rval = Rvalue::Aggregate(AggregateKind::Array(ty, len), fields);
             let var = new_var(rval, val.ty);
 

--- a/charon/src/transform/skip_trait_refs_when_known.rs
+++ b/charon/src/transform/skip_trait_refs_when_known.rs
@@ -10,10 +10,10 @@ fn transform_call(ctx: &mut TransformCtx, span: Span, call: &mut Call) {
     let FunIdOrTraitMethodRef::Trait(trait_ref, name, _) = fn_ptr.func.as_ref() else {
         return;
     };
-    let TraitRefKind::TraitImpl(impl_id, impl_generics) = &trait_ref.kind else {
+    let TraitRefKind::TraitImpl(impl_ref) = &trait_ref.kind else {
         return;
     };
-    let Some(trait_impl) = &ctx.translated.trait_impls.get(*impl_id) else {
+    let Some(trait_impl) = &ctx.translated.trait_impls.get(impl_ref.id) else {
         return;
     };
     // Find the function declaration corresponding to this impl.
@@ -40,7 +40,7 @@ fn transform_call(ctx: &mut TransformCtx, span: Span, call: &mut Call) {
         bound_fn.clone(),
     );
     // Substitute the appropriate generics into the function call.
-    let fn_ref = fn_ref.apply(impl_generics).apply(method_generics);
+    let fn_ref = fn_ref.apply(&impl_ref.generics).apply(method_generics);
     fn_ptr.generics = fn_ref.generics;
     fn_ptr.func = Box::new(FunIdOrTraitMethodRef::Fun(FunId::Regular(fn_ref.id)));
 }

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -65,7 +65,7 @@ impl FunIdOrTraitMethodRef {
         match self {
             FunIdOrTraitMethodRef::Fun(fun_id) => fun_id.generics_target(),
             FunIdOrTraitMethodRef::Trait(trait_ref, name, _) => {
-                GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.trait_id, name.clone())
+                GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.id, name.clone())
             }
         }
     }

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -1,0 +1,72 @@
+use crate::ast::*;
+use crate::formatter::FmtCtx;
+use crate::pretty::FmtWithCtx;
+use derive_generic_visitor::*;
+use macros::EnumIsA;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, EnumIsA, Deserialize, Drive, DriveMut)]
+pub enum GenericsSource {
+    /// A top-level item.
+    Item(AnyTransId),
+    /// A trait method.
+    Method(TraitDeclId, TraitItemName),
+    /// A builtin item like `Box`.
+    Builtin,
+    /// Some other use of generics outside the main Charon ast.
+    Other,
+}
+
+impl GenericsSource {
+    pub fn item<I: Into<AnyTransId>>(id: I) -> Self {
+        Self::Item(id.into())
+    }
+
+    /// Return a path that represents the target item.
+    pub fn item_name(&self, translated: &TranslatedCrate, fmt_ctx: &FmtCtx) -> String {
+        match self {
+            GenericsSource::Item(id) => translated
+                .item_name(*id)
+                .unwrap()
+                .to_string_with_ctx(fmt_ctx),
+            GenericsSource::Method(trait_id, method_name) => format!(
+                "{}::{method_name}",
+                translated
+                    .item_name(*trait_id)
+                    .unwrap()
+                    .to_string_with_ctx(fmt_ctx),
+            ),
+            GenericsSource::Builtin => format!("<built-in>"),
+            GenericsSource::Other => format!("<unknown>"),
+        }
+    }
+}
+
+impl TypeId {
+    pub fn generics_target(&self) -> GenericsSource {
+        match *self {
+            TypeId::Adt(decl_id) => GenericsSource::item(decl_id),
+            TypeId::Tuple | TypeId::Builtin(..) => GenericsSource::Builtin,
+        }
+    }
+}
+impl FunId {
+    pub fn generics_target(&self) -> GenericsSource {
+        match *self {
+            FunId::Regular(fun_id) => GenericsSource::item(fun_id),
+            FunId::Builtin(..) => GenericsSource::Builtin,
+        }
+    }
+}
+impl FunIdOrTraitMethodRef {
+    pub fn generics_target(&self) -> GenericsSource {
+        match self {
+            FunIdOrTraitMethodRef::Fun(fun_id) => fun_id.generics_target(),
+            FunIdOrTraitMethodRef::Trait(trait_ref, name, _) => {
+                GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.trait_id, name.clone())
+            }
+        }
+    }
+}

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -234,7 +234,7 @@ fn predicate_origins() -> anyhow::Result<()> {
             "failed for {item_name}"
         );
         for (clause, (expected_origin, expected_trait_name)) in clauses.iter().zip(origins) {
-            let trait_name = trait_name(&crate_data, clause.trait_.skip_binder.trait_id);
+            let trait_name = trait_name(&crate_data, clause.trait_.skip_binder.id);
             assert_eq!(trait_name, expected_trait_name, "failed for {item_name}");
             assert_eq!(&clause.origin, &expected_origin, "failed for {item_name}");
         }

--- a/charon/tests/util/mod.rs
+++ b/charon/tests/util/mod.rs
@@ -109,7 +109,7 @@ pub fn repr_name(crate_data: &TranslatedCrate, n: &Name) -> String {
                 ImplElem::Trait(impl_id) => match crate_data.trait_impls.get(*impl_id) {
                     None => format!("<trait impl#{impl_id}>"),
                     Some(timpl) => {
-                        let trait_name = trait_name(crate_data, timpl.impl_trait.trait_id);
+                        let trait_name = trait_name(crate_data, timpl.impl_trait.id);
                         format!("<impl {trait_name} for ??>")
                     }
                 },


### PR DESCRIPTION
`GenericsSource` came from a time when I didn't have as clear a knowledge of how `GenericArgs` were used. This PR clarifies this usage by consistently using `{Type,Fun,Global,Trait}DeclRef`, `TraitImplRef`, and `FnPtr`. No `GenericArgs` are allowed outside of these anymore. There's still a bit a redundancy between `FnPtr` and `FunDeclRef` but that's for later.

While I was at it, now that OCaml visitors support reusing field names, I got rid of the overly long field names for these types.

ci: use https://github.com/AeneasVerif/aeneas/pull/546
ci: use https://github.com/AeneasVerif/eurydice/pull/219