### PR TITLE
Allow `FnDef`s of trait methods

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.111"
+let supported_charon_version = "0.1.112"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -665,7 +665,7 @@ and match_expr_with_const_generic (ctx : 'fun_body ctx) (c : match_config)
       match_name ctx c pat d.item_meta.name
   | _ -> false
 
-let builtin_fun_id_to_string (fid : E.builtin_fun_id) : string =
+let builtin_fun_id_to_string (fid : T.builtin_fun_id) : string =
   match fid with
   | BoxNew -> "alloc::boxed::{Box<@T, alloc::alloc::Global>}::new"
   | ArrayToSliceShared -> "ArrayToSliceShared"
@@ -681,7 +681,7 @@ let builtin_fun_id_to_string (fid : E.builtin_fun_id) : string =
       "std::ptr::from_raw_parts" ^ mut
 
 let match_fn_ptr (ctx : 'fun_body ctx) (c : match_config) (p : pattern)
-    (func : E.fn_ptr) : bool =
+    (func : T.fn_ptr) : bool =
   match func.func with
   | FunId (FBuiltin fid) -> (
       let to_name (s : string list) : T.name =
@@ -1103,7 +1103,7 @@ let name_with_generics_to_pattern (ctx : 'fun_body ctx) (c : to_pat_config)
 (** We use the [params] to compute proper names for the variables. Note that it
     is safe to provide empty generic parameters. *)
 let fn_ptr_to_pattern (ctx : 'fun_body ctx) (c : to_pat_config)
-    (params : T.generic_params) (func : E.fn_ptr) : pattern =
+    (params : T.generic_params) (func : T.fn_ptr) : pattern =
   (* Convert the function pointer to a pattern *)
   let m = compute_constraints_map params in
   let args = generic_args_to_pattern ctx c m func.generics in
@@ -1141,7 +1141,7 @@ let fn_ptr_to_pattern (ctx : 'fun_body ctx) (c : to_pat_config)
     (lazy
       (let fmt_env = ctx_to_fmt_env ctx in
        "fn_ptr_to_pattern:" ^ "\n- fn_ptr: "
-       ^ PrintExpressions.fn_ptr_to_string fmt_env func
+       ^ PrintTypes.fn_ptr_to_string fmt_env func
        ^ "\n- pattern: "
        ^ pattern_to_string { tgt = TkPattern } pat));
   assert (

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -121,37 +121,6 @@ and binop_to_string (binop : binop) : string =
   | Cmp -> "cmp"
   | Offset -> "offset"
 
-and builtin_fun_id_to_string (aid : builtin_fun_id) : string =
-  match aid with
-  | BoxNew -> "alloc::boxed::Box::new"
-  | ArrayToSliceShared -> "@ArrayToSliceShared"
-  | ArrayToSliceMut -> "@ArrayToSliceMut"
-  | ArrayRepeat -> "@ArrayRepeat"
-  | Index { is_array; mutability; is_range } ->
-      let ty = if is_array then "Array" else "Slice" in
-      let op = if is_range then "SubSlice" else "Index" in
-      let mutability = ref_kind_to_string mutability in
-      "@" ^ ty ^ op ^ mutability
-  | PtrFromParts mut ->
-      let mut = if mut = RMut then "Mut" else "" in
-      "@PtrFromParts" ^ mut
-
-and fun_id_to_string (env : 'a fmt_env) (fid : fun_id) : string =
-  match fid with
-  | FRegular fid -> fun_decl_id_to_string env fid
-  | FBuiltin aid -> builtin_fun_id_to_string aid
-
-and fun_id_or_trait_method_ref_to_string (env : 'a fmt_env)
-    (r : fun_id_or_trait_method_ref) : string =
-  match r with
-  | TraitMethod (trait_ref, method_name, _) ->
-      trait_ref_to_string env trait_ref ^ "::" ^ method_name
-  | FunId fid -> fun_id_to_string env fid
-
-and fn_ptr_to_string (env : 'a fmt_env) (ptr : fn_ptr) : string =
-  let generics = generic_args_to_string env ptr.generics in
-  fun_id_or_trait_method_ref_to_string env ptr.func ^ generics
-
 and constant_expr_to_string (env : 'a fmt_env) (cv : constant_expr) : string =
   match cv.value with
   | CLiteral lit ->

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -229,6 +229,37 @@ and const_generic_to_string (env : 'a fmt_env) (cg : const_generic) : string =
   | CgVar var -> const_generic_db_var_to_string env var
   | CgValue lit -> literal_to_string lit
 
+and builtin_fun_id_to_string (aid : builtin_fun_id) : string =
+  match aid with
+  | BoxNew -> "alloc::boxed::Box::new"
+  | ArrayToSliceShared -> "@ArrayToSliceShared"
+  | ArrayToSliceMut -> "@ArrayToSliceMut"
+  | ArrayRepeat -> "@ArrayRepeat"
+  | Index { is_array; mutability; is_range } ->
+      let ty = if is_array then "Array" else "Slice" in
+      let op = if is_range then "SubSlice" else "Index" in
+      let mutability = ref_kind_to_string mutability in
+      "@" ^ ty ^ op ^ mutability
+  | PtrFromParts mut ->
+      let mut = if mut = RMut then "Mut" else "" in
+      "@PtrFromParts" ^ mut
+
+and fun_id_to_string (env : 'a fmt_env) (fid : fun_id) : string =
+  match fid with
+  | FRegular fid -> fun_decl_id_to_string env fid
+  | FBuiltin aid -> builtin_fun_id_to_string aid
+
+and fun_id_or_trait_method_ref_to_string (env : 'a fmt_env)
+    (r : fun_id_or_trait_method_ref) : string =
+  match r with
+  | TraitMethod (trait_ref, method_name, _) ->
+      trait_ref_to_string env trait_ref ^ "::" ^ method_name
+  | FunId fid -> fun_id_to_string env fid
+
+and fn_ptr_to_string (env : 'a fmt_env) (ptr : fn_ptr) : string =
+  let generics = generic_args_to_string env ptr.generics in
+  fun_id_or_trait_method_ref_to_string env ptr.func ^ generics
+
 and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
   match ty with
   | TAdt tref -> type_decl_ref_to_string env tref
@@ -257,7 +288,7 @@ and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
       inputs ^ ty_to_string env output
   | TFnDef f ->
       let env = fmt_env_push_regions env f.binder_regions in
-      let fn = fun_decl_id_to_string env f.binder_value.id in
+      let fn = fn_ptr_to_string env f.binder_value in
       fn
   | TDynTrait _ -> "dyn (TODO)"
   | TError msg -> "type_error (\"" ^ msg ^ "\")"

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -630,23 +630,27 @@ let lookup_flat_method_sig (crate : 'a gcrate) (trait_id : trait_decl_id)
   Some s
 
 (* Lookup the signature of a `Ty::FnDef`. *)
-let lookup_fndef_sig (crate : 'a gcrate) (fn_def : fun_decl_ref region_binder) :
+let lookup_fndef_sig (crate : 'a gcrate) (fn_def : fn_ptr region_binder) :
     (ty list * ty) region_binder option =
-  let fun_decl_id = fn_def.binder_value.id in
-  let* fun_decl = LlbcAst.FunDeclId.Map.find_opt fun_decl_id crate.fun_decls in
-  (* Substitute the signature to be valid under the binder. *)
-  let fn_sig =
-    st_substitute_visitor#visit_fun_sig
-      (make_subst_from_generics fun_decl.signature.generics
-         fn_def.binder_value.generics)
-      fun_decl.signature
-  in
-  (* Rebind everything *)
-  Some
-    {
-      binder_regions = fn_def.binder_regions;
-      binder_value = (fn_sig.inputs, fn_sig.output);
-    }
+  match fn_def.binder_value.func with
+  | FunId (FRegular fun_decl_id) ->
+      let* fun_decl =
+        LlbcAst.FunDeclId.Map.find_opt fun_decl_id crate.fun_decls
+      in
+      (* Substitute the signature to be valid under the binder. *)
+      let fn_sig =
+        st_substitute_visitor#visit_fun_sig
+          (make_subst_from_generics fun_decl.signature.generics
+             fn_def.binder_value.generics)
+          fun_decl.signature
+      in
+      (* Rebind everything *)
+      Some
+        {
+          binder_regions = fn_def.binder_regions;
+          binder_value = (fn_sig.inputs, fn_sig.output);
+        }
+  | _ -> None
 
 (* Construct a set of generic arguments in the scope of `params` that matches
    `params` and feeds each required parameter with itself. E.g. given

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -120,50 +120,6 @@ and borrow_kind =
           <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.ClosureCapture>.
       *)
 
-(** An built-in function identifier, identifying a function coming from a
-    standard library. *)
-and builtin_fun_id =
-  | BoxNew  (** [alloc::boxed::Box::new] *)
-  | ArrayToSliceShared
-      (** Cast an array as a slice.
-
-          Converted from [UnOp::ArrayToSlice] *)
-  | ArrayToSliceMut
-      (** Cast an array as a slice.
-
-          Converted from [UnOp::ArrayToSlice] *)
-  | ArrayRepeat
-      (** [repeat(n, x)] returns an array where [x] has been replicated [n]
-          times.
-
-          We introduce this when desugaring the [ArrayRepeat] rvalue. *)
-  | Index of builtin_index_op
-      (** Converted from indexing [ProjectionElem]s. The signature depends on
-          the parameters. It could look like:
-          - [fn ArrayIndexShared<T,N>(&[T;N], usize) -> &T]
-          - [fn SliceIndexShared<T>(&[T], usize) -> &T]
-          - [fn ArraySubSliceShared<T,N>(&[T;N], usize, usize) -> &[T]]
-          - [fn SliceSubSliceMut<T>(&mut [T], usize, usize) -> &mut [T]]
-          - etc *)
-  | PtrFromParts of ref_kind
-      (** Build a raw pointer, from a data pointer and metadata. The metadata
-          can be unit, if building a thin pointer.
-
-          Converted from [AggregateKind::RawPtr] *)
-
-(** One of 8 built-in indexing operations. *)
-and builtin_index_op = {
-  is_array : bool;  (** Whether this is a slice or array. *)
-  mutability : ref_kind;
-      (** Whether we're indexing mutably or not. Determines the type ofreference
-          of the input and output. *)
-  is_range : bool;
-      (** Whether we're indexing a single element or a subrange. If [true], the
-          function takes two indices and the output is a slice; otherwise, the
-          function take one index and the output is a reference to a single
-          element. *)
-}
-
 (** For all the variants: the first type gives the source type, the second one
     gives the destination type. *)
 and cast_kind =
@@ -191,24 +147,6 @@ and field_proj_kind =
   | ProjTuple of int
       (** If we project from a tuple, the projection kind gives the arity of the
           tuple. *)
-
-and fn_ptr = { func : fun_id_or_trait_method_ref; generics : generic_args }
-
-(** A function identifier. See [crate::ullbc_ast::Terminator] *)
-and fun_id =
-  | FRegular of fun_decl_id
-      (** A "regular" function (function local to the crate, external function
-          not treated as a primitive one). *)
-  | FBuiltin of builtin_fun_id
-      (** A primitive function, coming from a standard library (for instance:
-          [alloc::boxed::Box::new]). TODO: rename to "Primitive" *)
-
-and fun_id_or_trait_method_ref =
-  | FunId of fun_id
-  | TraitMethod of trait_ref * trait_item_name * fun_decl_id
-      (** If a trait: the reference to the trait and the id of the trait method.
-          The fun decl id is not really necessary - we put it here for
-          convenience purposes. *)
 
 and local_id = (LocalId.id[@visitors.opaque])
 

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -17,10 +17,10 @@ module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
 
 (* Imports *)
-type builtin_fun_id = Expressions.builtin_fun_id [@@deriving show, ord]
-type fun_id = Expressions.fun_id [@@deriving show, ord]
+type builtin_fun_id = Types.builtin_fun_id [@@deriving show, ord]
+type fun_id = Types.fun_id [@@deriving show, ord]
 
-type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref
+type fun_id_or_trait_method_ref = Types.fun_id_or_trait_method_ref
 [@@deriving show, ord]
 
 type fun_decl_id = Types.fun_decl_id [@@deriving show, ord]

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1782,7 +1782,7 @@ and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
         in
         Ok (TFnPtr fn_ptr)
     | `Assoc [ ("FnDef", fn_def) ] ->
-        let* fn_def = region_binder_of_json fun_decl_ref_of_json ctx fn_def in
+        let* fn_def = region_binder_of_json fn_ptr_of_json ctx fn_def in
         Ok (TFnDef fn_def)
     | `Assoc [ ("Error", error) ] ->
         let* error = string_of_json ctx error in

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -1,5 +1,4 @@
 open Charon
-open Charon.Expressions
 open Charon.LlbcAst
 open Charon.Meta
 open Logging
@@ -123,7 +122,7 @@ module PatternTest = struct
             TypesUtils.generic_args_of_params decl.item_meta.span
               decl.signature.generics
           in
-          { func = FunId (FRegular decl.def_id); generics }
+          Types.{ func = FunId (FRegular decl.def_id); generics }
       | Some idx ->
           (* Find the nth function call in the function body. *)
           let rec list_stmt_calls (statement : statement) : call list =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.111"
+version = "0.1.112"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.111"
+version = "0.1.112"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -403,7 +403,9 @@ pub struct TraitMethodRef {
     pub method_decl_id: FunDeclId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumAsGetters, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, EnumAsGetters, Serialize, Deserialize, Drive, DriveMut, Hash,
+)]
 pub enum FunIdOrTraitMethodRef {
     #[charon::rename("FunId")]
     Fun(FunId),
@@ -425,7 +427,7 @@ impl From<FunDeclId> for FunIdOrTraitMethodRef {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut, Hash)]
 pub struct FnPtr {
     pub func: Box<FunIdOrTraitMethodRef>,
     pub generics: BoxedArgs,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -802,7 +802,7 @@ pub enum TyKind {
     /// lifetimes as arguments; given that the type here is polymorpohic in the late-bound
     /// variables (those that could appear in a function pointer type like `for<'a> fn(&'a u32)`),
     /// we need to bind them here.
-    FnDef(RegionBinder<FunDeclRef>),
+    FnDef(RegionBinder<FnPtr>),
     /// A type that could not be computed or was incorrect.
     #[drive(skip)]
     Error(String),

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -470,8 +470,9 @@ impl BodyTransCtx<'_, '_, '_> {
                             unreachable!("Non-closure type in PointerCoercion::ClosureFnPointer");
                         };
                         let fn_ref = self.translate_stateless_closure_as_fn_ref(span, closure)?;
-                        let fn_ptr: FnPtr = fn_ref.clone().erase().into();
-                        let src_ty = TyKind::FnDef(fn_ref).into_ty();
+                        let fn_ptr_bound = fn_ref.map(FunDeclRef::into);
+                        let fn_ptr: FnPtr = fn_ptr_bound.clone().erase();
+                        let src_ty = TyKind::FnDef(fn_ptr_bound).into_ty();
                         let operand = Operand::Const(Box::new(ConstantExpr {
                             value: RawConstantExpr::FnPtr(fn_ptr),
                             ty: src_ty.clone(),

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -230,16 +230,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 TyKind::FnPtr(sig)
             }
             hax::TyKind::FnDef { item, .. } => {
-                let fnref: RegionBinder<FnPtr> = self.translate_fn_ptr(span, item)?;
-                let fnref = fnref.map(|fref| FunDeclRef {
-                    id: *fref
-                        .func
-                        .as_fun()
-                        .expect("can't reference method as a function pointer")
-                        .as_regular()
-                        .expect("can't reference builtin function as a function pointer"),
-                    generics: fref.generics,
-                });
+                let fnref = self.translate_fn_ptr(span, item)?;
                 TyKind::FnDef(fnref)
             }
             hax::TyKind::Closure(args) => {

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -19,9 +19,9 @@ module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
 
 (* Imports *)
-type builtin_fun_id = Expressions.builtin_fun_id [@@deriving show, ord]
-type fun_id = Expressions.fun_id [@@deriving show, ord]
-type fun_id_or_trait_method_ref = Expressions.fun_id_or_trait_method_ref [@@deriving show, ord]
+type builtin_fun_id = Types.builtin_fun_id [@@deriving show, ord]
+type fun_id = Types.fun_id [@@deriving show, ord]
+type fun_id_or_trait_method_ref = Types.fun_id_or_trait_method_ref [@@deriving show, ord]
 type fun_decl_id = Types.fun_decl_id [@@deriving show, ord]
 
 (* __REPLACE0__ *)

--- a/charon/tests/ui/method-ref.out
+++ b/charon/tests/ui/method-ref.out
@@ -1,0 +1,52 @@
+# Final LLBC before serialization:
+
+// Full name: core::cmp::Ordering
+#[lang_item("Ordering")]
+pub enum Ordering {
+  Less,
+  Equal,
+  Greater,
+}
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+}
+
+// Full name: test_crate::Ord
+trait Ord<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn cmp<'_0, '_1> = cmp<'_0_0, '_0_1, Self>[Self]
+}
+
+// Full name: test_crate::Ord::cmp
+fn cmp<'_0, '_1, Self>(@1: &'_0 (Self), @2: &'_1 (Self)) -> Ordering
+where
+    [@TraitClause0]: Ord<Self>,
+
+// Full name: test_crate::min
+fn min<T>()
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Ord<T>,
+{
+    let @0: (); // return
+    let @1: for<'_0, '_1> @TraitClause1::cmp<'_0_0, '_0_1>; // anonymous local
+
+    storage_live(@1)
+    @1 := const (@TraitClause1::cmp<'_, '_>)
+    storage_dead(@1)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/method-ref.rs
+++ b/charon/tests/ui/method-ref.rs
@@ -1,0 +1,7 @@
+trait Ord {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering;
+}
+
+fn min<T: Ord>() {
+    let _ = T::cmp;
+}


### PR DESCRIPTION
`TyKind::FnDef` is now a `RegionBinder<FnPtr>`. 
Required some ugly tweaking in `monomorphize.rs`, since otherwise it would mono the `FnPtr` inside with the unbound region variables :/ Either way fingers crossed that whole file will disappear soonish :3
Fixes #742


ci: use https://github.com/AeneasVerif/eurydice/pull/233
ci: use https://github.com/AeneasVerif/aeneas/pull/571