### PR TITLE
Change `IntegerTy` and `ScalarValue` representations

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.118"
+let supported_charon_version = "0.1.117"

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.117"
+let supported_charon_version = "0.1.119"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -37,7 +37,6 @@ type 'body gfun_decl = {
 }
 [@@deriving show]
 
-(* Hand-written because the rust equivalent isn't generic *)
 type target_info = { target_pointer_size : int; is_little_endian : bool }
 [@@deriving show]
 

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -102,7 +102,6 @@ and gtranslated_crate_of_json
         let* name = string_of_json ctx name in
         let* options = cli_options_of_json ctx options in
         let* target_information = target_info_of_json ctx target_info in
-        target_ptr_size := target_information.target_pointer_size;
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -102,6 +102,7 @@ and gtranslated_crate_of_json
         let* name = string_of_json ctx name in
         let* options = cli_options_of_json ctx options in
         let* target_information = target_info_of_json ctx target_info in
+        target_ptr_size := target_information.target_pointer_size;
 
         let* declarations =
           list_of_json declaration_group_of_json ctx declarations

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -384,7 +384,7 @@ let literal_type_to_string (ty : T.literal_type) : string =
   match ty with
   | TBool -> "bool"
   | TChar -> "char"
-  | TInteger ty -> (
+  | TInt ty -> (
       match ty with
       | Isize -> "isize"
       | I8 -> "i8"
@@ -392,7 +392,7 @@ let literal_type_to_string (ty : T.literal_type) : string =
       | I32 -> "i32"
       | I64 -> "i64"
       | I128 -> "i128")
-  | TUnsignedInteger ty -> (
+  | TUInt ty -> (
       match ty with
       | Usize -> "usize"
       | U8 -> "u8"
@@ -428,7 +428,7 @@ let match_ref_kind (prk : ref_kind) (rk : T.ref_kind) : bool =
 
 let match_literal (pl : literal) (l : Values.literal) : bool =
   match (pl, l) with
-  | LInt pv, VScalar v -> pv = v.value
+  | LInt pv, VScalar v -> pv = Scalars.get_val v
   | LBool pv, VBool v -> pv = v
   | LChar pv, VChar v -> Uchar.of_char pv = v
   | _ -> false
@@ -900,7 +900,7 @@ let literal_type_to_pattern (c : to_pat_config) (lit : T.literal_type) : expr =
 
 let literal_to_pattern (_c : to_pat_config) (lit : Values.literal) : literal =
   match lit with
-  | VScalar sv -> LInt sv.value
+  | VScalar sv -> LInt (Scalars.get_val sv)
   | VBool v -> LBool v
   | VChar v when Uchar.is_char v -> LChar (Uchar.to_char v)
   | VChar _ ->

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -391,7 +391,9 @@ let literal_type_to_string (ty : T.literal_type) : string =
       | I16 -> "i16"
       | I32 -> "i32"
       | I64 -> "i64"
-      | I128 -> "i128"
+      | I128 -> "i128")
+  | TUnsignedInteger ty -> (
+      match ty with
       | Usize -> "usize"
       | U8 -> "u8"
       | U16 -> "u16"

--- a/charon-ml/src/PrintValues.ml
+++ b/charon-ml/src/PrintValues.ml
@@ -4,18 +4,18 @@ open Values
 open Types
 
 let integer_type_to_string = function
-  | Isize -> "isize"
-  | I8 -> "i8"
-  | I16 -> "i16"
-  | I32 -> "i32"
-  | I64 -> "i64"
-  | I128 -> "i128"
-  | Usize -> "usize"
-  | U8 -> "u8"
-  | U16 -> "u16"
-  | U32 -> "u32"
-  | U64 -> "u64"
-  | U128 -> "u128"
+  | Signed Isize -> "isize"
+  | Signed I8 -> "i8"
+  | Signed I16 -> "i16"
+  | Signed I32 -> "i32"
+  | Signed I64 -> "i64"
+  | Signed I128 -> "i128"
+  | Unsigned Usize -> "usize"
+  | Unsigned U8 -> "u8"
+  | Unsigned U16 -> "u16"
+  | Unsigned U32 -> "u32"
+  | Unsigned U64 -> "u64"
+  | Unsigned U128 -> "u128"
 
 let float_type_to_string = function
   | F16 -> "f16"
@@ -25,7 +25,8 @@ let float_type_to_string = function
 
 let literal_type_to_string (ty : literal_type) : string =
   match ty with
-  | TInteger ity -> integer_type_to_string ity
+  | TInteger ity -> integer_type_to_string (Signed ity)
+  | TUnsignedInteger uty -> integer_type_to_string (Unsigned uty)
   | TFloat fty -> float_type_to_string fty
   | TBool -> "bool"
   | TChar -> "char"

--- a/charon-ml/src/PrintValues.ml
+++ b/charon-ml/src/PrintValues.ml
@@ -25,8 +25,8 @@ let float_type_to_string = function
 
 let literal_type_to_string (ty : literal_type) : string =
   match ty with
-  | TInteger ity -> integer_type_to_string (Signed ity)
-  | TUnsignedInteger uty -> integer_type_to_string (Unsigned uty)
+  | TInt ity -> integer_type_to_string (Signed ity)
+  | TUInt uty -> integer_type_to_string (Unsigned uty)
   | TFloat fty -> float_type_to_string fty
   | TBool -> "bool"
   | TChar -> "char"
@@ -34,7 +34,9 @@ let literal_type_to_string (ty : literal_type) : string =
 let big_int_to_string (bi : big_int) : string = Z.to_string bi
 
 let scalar_value_to_string (sv : scalar_value) : string =
-  big_int_to_string sv.value ^ ": " ^ integer_type_to_string sv.int_ty
+  big_int_to_string (Scalars.get_val sv)
+  ^ ": "
+  ^ integer_type_to_string (Scalars.get_ty sv)
 
 let float_value_to_string (fv : float_value) : string =
   fv.float_value ^ ": " ^ float_type_to_string fv.float_ty

--- a/charon-ml/src/Scalars.ml
+++ b/charon-ml/src/Scalars.ml
@@ -93,15 +93,28 @@ let scalar_max ptr_size (int_ty : integer_type) : big_int =
 let check_int_in_range ptr_size (int_ty : integer_type) (i : big_int) : bool =
   Z.leq (scalar_min ptr_size int_ty) i && Z.leq i (scalar_max ptr_size int_ty)
 
+let get_val (scalar : scalar_value) =
+  match scalar with
+  | SignedScalar (_, v) | UnsignedScalar (_, v) -> v
+
+let get_ty (scalar : scalar_value) =
+  match scalar with
+  | SignedScalar (int_ty, _) -> Signed int_ty
+  | UnsignedScalar (uint_ty, _) -> Unsigned uint_ty
+
 (** Check that a scalar value is correct (the integer value it contains is in
     range) *)
 let check_scalar_value_in_range ptr_size (v : scalar_value) : bool =
-  check_int_in_range ptr_size v.int_ty v.value
+  check_int_in_range ptr_size (get_ty v) (get_val v)
 
 (** Make a scalar value, while checking the value is in range *)
 let mk_scalar ptr_size (int_ty : integer_type) (i : big_int) :
     (scalar_value, unit) result =
-  if check_int_in_range ptr_size int_ty i then Ok { value = i; int_ty }
+  if check_int_in_range ptr_size int_ty i then
+    Ok
+      (match int_ty with
+      | Signed int_ty -> SignedScalar (int_ty, i)
+      | Unsigned uint_ty -> UnsignedScalar (uint_ty, i))
   else Error ()
 
 let integer_type_is_signed (int_ty : integer_type) : bool =

--- a/charon-ml/src/Scalars.ml
+++ b/charon-ml/src/Scalars.ml
@@ -61,33 +61,33 @@ let usize_max ptr_size =
 
 let scalar_min ptr_size (int_ty : integer_type) : big_int =
   match int_ty with
-  | Isize -> isize_min ptr_size
-  | I8 -> i8_min
-  | I16 -> i16_min
-  | I32 -> i32_min
-  | I64 -> i64_min
-  | I128 -> i128_min
-  | Usize -> usize_min ptr_size
-  | U8 -> u8_min
-  | U16 -> u16_min
-  | U32 -> u32_min
-  | U64 -> u64_min
-  | U128 -> u128_min
+  | Signed Isize -> isize_min ptr_size
+  | Signed I8 -> i8_min
+  | Signed I16 -> i16_min
+  | Signed I32 -> i32_min
+  | Signed I64 -> i64_min
+  | Signed I128 -> i128_min
+  | Unsigned Usize -> usize_min ptr_size
+  | Unsigned U8 -> u8_min
+  | Unsigned U16 -> u16_min
+  | Unsigned U32 -> u32_min
+  | Unsigned U64 -> u64_min
+  | Unsigned U128 -> u128_min
 
 let scalar_max ptr_size (int_ty : integer_type) : big_int =
   match int_ty with
-  | Isize -> isize_max ptr_size
-  | I8 -> i8_max
-  | I16 -> i16_max
-  | I32 -> i32_max
-  | I64 -> i64_max
-  | I128 -> i128_max
-  | Usize -> usize_max ptr_size
-  | U8 -> u8_max
-  | U16 -> u16_max
-  | U32 -> u32_max
-  | U64 -> u64_max
-  | U128 -> u128_max
+  | Signed Isize -> isize_max ptr_size
+  | Signed I8 -> i8_max
+  | Signed I16 -> i16_max
+  | Signed I32 -> i32_max
+  | Signed I64 -> i64_max
+  | Signed I128 -> i128_max
+  | Unsigned Usize -> usize_max ptr_size
+  | Unsigned U8 -> u8_max
+  | Unsigned U16 -> u16_max
+  | Unsigned U32 -> u32_max
+  | Unsigned U64 -> u64_max
+  | Unsigned U128 -> u128_max
 
 (** Check that an integer value is in range *)
 let check_int_in_range ptr_size (int_ty : integer_type) (i : big_int) : bool =
@@ -106,5 +106,5 @@ let mk_scalar ptr_size (int_ty : integer_type) (i : big_int) :
 
 let integer_type_is_signed (int_ty : integer_type) : bool =
   match int_ty with
-  | Isize | I8 | I16 | I32 | I64 | I128 -> true
-  | Usize | U8 | U16 | U32 | U64 | U128 -> false
+  | Signed _ -> true
+  | Unsigned _ -> false

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -98,7 +98,7 @@ let subst_free_vars (subst : single_binder_subst) : subst =
 *)
 let subst_at_binder_zero (subst : single_binder_subst) : subst =
   let subst_if_zero subst nosubst = function
-    | Bound (0, id) -> subst id
+    | Bound (dbid, id) when dbid = 0 -> subst id
     | var -> nosubst var
   in
   {
@@ -113,7 +113,7 @@ let subst_at_binder_zero (subst : single_binder_subst) : subst =
     variables to remove the current binder level. *)
 let subst_remove_binder_zero (subst : single_binder_subst) : subst =
   let subst_remove_zero subst nosubst = function
-    | Bound (0, id) -> subst id
+    | Bound (dbid, id) when dbid = 0 -> subst id
     | Bound (dbid, varid) when dbid > 0 -> nosubst (Bound (dbid - 1, varid))
     | var -> nosubst var
   in

--- a/charon-ml/src/Types.ml
+++ b/charon-ml/src/Types.ml
@@ -10,7 +10,11 @@ type trait_db_var = trait_clause_id de_bruijn_var [@@deriving show]
 
 let all_signed_int_types = [ Isize; I8; I16; I32; I64; I128 ]
 let all_unsigned_int_types = [ Usize; U8; U16; U32; U64; U128 ]
-let all_int_types = List.append all_signed_int_types all_unsigned_int_types
+
+let all_int_types =
+  List.append
+    (List.map (fun i -> Signed i) all_signed_int_types)
+    (List.map (fun u -> Unsigned u) all_unsigned_int_types)
 
 (** The variant id for [Option::None] *)
 let option_none_id = VariantId.of_int 0

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -155,7 +155,8 @@ let ty_as_literal (ty : ty) : literal_type =
 
 let ty_as_integer (ty : ty) : integer_type =
   match ty_as_literal ty with
-  | TInteger ty -> ty
+  | TInteger ty -> Signed ty
+  | TUnsignedInteger ty -> Unsigned ty
   | _ -> raise (Failure "Unreachable")
 
 let const_generic_as_literal (cg : const_generic) : Values.literal =
@@ -168,11 +169,6 @@ let trait_instance_id_as_trait_impl (id : trait_instance_id) :
   match id with
   | TraitImpl impl_ref -> (impl_ref.id, impl_ref.generics)
   | _ -> raise (Failure "Unreachable")
-
-let is_signed (int_ty : integer_type) =
-  match int_ty with
-  | Isize | I8 | I16 | I32 | I64 | I128 -> true
-  | Usize | U8 | U16 | U32 | U64 | U128 -> false
 
 (* Make a debruijn variable of index 0 *)
 let zero_db_var (varid : 'id) : 'id de_bruijn_var = Bound (0, varid)
@@ -236,7 +232,7 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
 let mk_unit_ty : ty = TAdt { id = TTuple; generics = empty_generic_args }
 
 (** The usize type *)
-let mk_usize_ty : ty = TLiteral (TInteger Usize)
+let mk_usize_ty : ty = TLiteral (TUnsignedInteger Usize)
 
 let ty_as_opt_box (box_ty : ty) : ty option =
   match box_ty with

--- a/charon-ml/src/ValuesUtils.ml
+++ b/charon-ml/src/ValuesUtils.ml
@@ -7,5 +7,6 @@ let literal_as_scalar (v : literal) : scalar_value =
 
 let literal_type_is_integer (t : literal_type) : bool =
   match t with
-  | TInteger _ -> true
+  | TInt _ -> true
+  | TUInt _ -> true
   | _ -> false

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -25,6 +25,7 @@ type id_to_file_map = file FileId.Map.t
 type of_json_ctx = id_to_file_map
 
 let path_buf_of_json = string_of_json
+let target_ptr_size = ref 0
 
 let rec ___ = ()
 
@@ -1474,7 +1475,7 @@ and scalar_value_of_json (ctx : of_json_ctx) (js : json) :
         let* value = big_int_of_json bi in
         let* int_ty = integer_type_of_json ctx ty in
         let sv = { value; int_ty } in
-        if not (check_scalar_value_in_range sv) then
+        if not (check_scalar_value_in_range !target_ptr_size sv) then
           Error ("Scalar value not in range: " ^ show_scalar_value sv)
         else Ok sv
     | _ -> Error "")

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1463,7 +1463,7 @@ and scalar_value_of_json (ctx : of_json_ctx) (js : json) :
     (scalar_value, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ (ty, bi) ] ->
+    | `Assoc [ (_, `List [ ty; bi ]) ] ->
         let big_int_of_json (js : json) : (big_int, string) result =
           combine_error_msgs js __FUNCTION__
             (match js with
@@ -1472,11 +1472,11 @@ and scalar_value_of_json (ctx : of_json_ctx) (js : json) :
             | _ -> Error "")
         in
         let* value = big_int_of_json bi in
-        let* int_ty = integer_type_of_json ctx (`String ty) in
+        let* int_ty = integer_type_of_json ctx ty in
         let sv = { value; int_ty } in
         if not (check_scalar_value_in_range sv) then
-          raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv));
-        Ok sv
+          Error ("Scalar value not in range: " ^ show_scalar_value sv)
+        else Ok sv
     | _ -> Error "")
 
 and span_of_json (ctx : of_json_ctx) (js : json) : (span, string) result =

--- a/charon-ml/src/generated/Generated_Values.ml
+++ b/charon-ml/src/generated/Generated_Values.ml
@@ -10,19 +10,8 @@ type float_type = F16 | F32 | F64 | F128
     derive the Eq and Ord traits, which are not implemented for floats *)
 and float_value = { float_value : string; float_ty : float_type }
 
-and integer_type =
-  | Isize
-  | I8
-  | I16
-  | I32
-  | I64
-  | I128
-  | Usize
-  | U8
-  | U16
-  | U32
-  | U64
-  | U128
+and int_type = Isize | I8 | I16 | I32 | I64 | I128
+and integer_type = Signed of int_type | Unsigned of u_int_type
 
 (** A primitive value.
 
@@ -38,7 +27,8 @@ and literal =
 
 (** Types of primitive values. Either an integer, bool, char *)
 and literal_type =
-  | TInteger of integer_type
+  | TInteger of int_type
+  | TUnsignedInteger of u_int_type
   | TFloat of float_type
   | TBool
   | TChar
@@ -51,6 +41,8 @@ and scalar_value = {
   value : big_int;
   int_ty : integer_type;
 }
+
+and u_int_type = Usize | U8 | U16 | U32 | U64 | U128
 [@@deriving
   show,
   eq,

--- a/charon-ml/src/generated/Generated_Values.ml
+++ b/charon-ml/src/generated/Generated_Values.ml
@@ -10,8 +10,8 @@ type float_type = F16 | F32 | F64 | F128
     derive the Eq and Ord traits, which are not implemented for floats *)
 and float_value = { float_value : string; float_ty : float_type }
 
-and int_type = Isize | I8 | I16 | I32 | I64 | I128
-and integer_type = Signed of int_type | Unsigned of u_int_type
+and int_ty = Isize | I8 | I16 | I32 | I64 | I128
+and integer_type = Signed of int_ty | Unsigned of u_int_ty
 
 (** A primitive value.
 
@@ -27,22 +27,18 @@ and literal =
 
 (** Types of primitive values. Either an integer, bool, char *)
 and literal_type =
-  | TInteger of int_type
-  | TUnsignedInteger of u_int_type
+  | TInt of int_ty
+  | TUInt of u_int_ty
   | TFloat of float_type
   | TBool
   | TChar
 
 (** A scalar value. *)
-and scalar_value = {
-  (* Note that we use unbounded integers everywhere.
-   We then harcode the boundaries for the different types.
- *)
-  value : big_int;
-  int_ty : integer_type;
-}
+and scalar_value =
+  | UnsignedScalar of u_int_ty * big_int
+  | SignedScalar of int_ty * big_int
 
-and u_int_type = Usize | U8 | U16 | U32 | U64 | U128
+and u_int_ty = Usize | U8 | U16 | U32 | U64 | U128
 [@@deriving
   show,
   eq,

--- a/charon-ml/tests/Test_Deserialize.ml
+++ b/charon-ml/tests/Test_Deserialize.ml
@@ -65,6 +65,7 @@ let run_tests (folder : string) : unit =
               | Some v -> "Some " ^ PrintValues.scalar_value_to_string v
               | None -> "None"
             in
+            let ptr_size = m.target_information.target_pointer_size in
             Types.TypeDeclId.Map.iter
               (fun _ (ty_decl : Types.type_decl) ->
                 match ty_decl.Types.layout with
@@ -87,7 +88,8 @@ let run_tests (folder : string) : unit =
                             | None -> () (* Must be the untagged variant *)
                             | Some tag ->
                                 let roundtrip_var_id =
-                                  TypesUtils.get_variant_from_tag ty_decl tag
+                                  TypesUtils.get_variant_from_tag ptr_size
+                                    ty_decl tag
                                 in
                                 assert_eq roundtrip_var_id (Some var_id)
                                   (name ^ " with tag: "

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.118"
+version = "0.1.117"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.117"
+version = "0.1.119"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.118"
+version = "0.1.117"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.117"
+version = "0.1.119"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -344,11 +344,11 @@ pub enum BuiltinFunId {
     BoxNew,
     /// Cast an array as a slice.
     ///
-    /// Converted from [UnOp::ArrayToSlice]
+    /// Converted from `UnOp::ArrayToSlice`
     ArrayToSliceShared,
     /// Cast an array as a slice.
     ///
-    /// Converted from [UnOp::ArrayToSlice]
+    /// Converted from `UnOp::ArrayToSlice`
     ArrayToSliceMut,
     /// `repeat(n, x)` returns an array where `x` has been replicated `n` times.
     ///

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -503,7 +503,6 @@ pub struct Field {
     Ord,
     PartialOrd,
 )]
-#[charon::rename("IntType")]
 pub enum IntTy {
     Isize,
     I8,
@@ -529,7 +528,6 @@ pub enum IntTy {
     Ord,
     PartialOrd,
 )]
-#[charon::rename("UIntType")]
 pub enum UIntTy {
     Usize,
     U8,
@@ -676,8 +674,8 @@ pub struct TypeDeclRef {
 #[charon::rename("LiteralType")]
 #[charon::variants_prefix("T")]
 pub enum LiteralTy {
-    Integer(IntTy),
-    UnsignedInteger(UIntTy),
+    Int(IntTy),
+    UInt(UIntTy),
     Float(FloatTy),
     Bool,
     Char,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -503,20 +503,62 @@ pub struct Field {
     Ord,
     PartialOrd,
 )]
-#[charon::rename("IntegerType")]
-pub enum IntegerTy {
+#[charon::rename("IntType")]
+pub enum IntTy {
     Isize,
     I8,
     I16,
     I32,
     I64,
     I128,
+}
+
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    EnumIsA,
+    VariantName,
+    Serialize,
+    Deserialize,
+    Drive,
+    DriveMut,
+    Hash,
+    Ord,
+    PartialOrd,
+)]
+#[charon::rename("UIntType")]
+pub enum UIntTy {
     Usize,
     U8,
     U16,
     U32,
     U64,
     U128,
+}
+
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    EnumIsA,
+    VariantName,
+    Serialize,
+    Deserialize,
+    Drive,
+    DriveMut,
+    Hash,
+    Ord,
+    PartialOrd,
+)]
+#[charon::rename("IntegerType")]
+pub enum IntegerTy {
+    Signed(IntTy),
+    Unsigned(UIntTy),
 }
 
 #[derive(
@@ -634,7 +676,8 @@ pub struct TypeDeclRef {
 #[charon::rename("LiteralType")]
 #[charon::variants_prefix("T")]
 pub enum LiteralTy {
-    Integer(IntegerTy),
+    Integer(IntTy),
+    UnsignedInteger(UIntTy),
     Float(FloatTy),
     Bool,
     Char,

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -440,6 +440,25 @@ impl IntegerTy {
             _ => *self,
         }
     }
+
+    /// Important: this returns the target byte count for the types.
+    /// Must not be used for host types from rustc.
+    pub fn target_size(&self, ptr_size: ByteCount) -> usize {
+        match self {
+            IntegerTy::Isize => ptr_size as usize,
+            IntegerTy::I8 => size_of::<i8>(),
+            IntegerTy::I16 => size_of::<i16>(),
+            IntegerTy::I32 => size_of::<i32>(),
+            IntegerTy::I64 => size_of::<i64>(),
+            IntegerTy::I128 => size_of::<i128>(),
+            IntegerTy::Usize => ptr_size as usize,
+            IntegerTy::U8 => size_of::<u8>(),
+            IntegerTy::U16 => size_of::<u16>(),
+            IntegerTy::U32 => size_of::<u32>(),
+            IntegerTy::U64 => size_of::<u64>(),
+            IntegerTy::U128 => size_of::<u128>(),
+        }
+    }
 }
 
 /// A value of type `T` bound by the generic parameters of item

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -448,8 +448,8 @@ impl IntegerTy {
 impl LiteralTy {
     pub fn to_integer_ty(&self) -> Option<IntegerTy> {
         match self {
-            Self::Integer(int_ty) => Some(IntegerTy::Signed(*int_ty)),
-            Self::UnsignedInteger(uint_ty) => Some(IntegerTy::Unsigned(*uint_ty)),
+            Self::Int(int_ty) => Some(IntegerTy::Signed(*int_ty)),
+            Self::UInt(uint_ty) => Some(IntegerTy::Unsigned(*uint_ty)),
             _ => None,
         }
     }
@@ -560,17 +560,17 @@ impl Ty {
     /// Return true if this is a scalar type
     pub fn is_scalar(&self) -> bool {
         match self.kind() {
-            TyKind::Literal(kind) => kind.is_integer(),
+            TyKind::Literal(kind) => kind.is_int() || kind.is_uint(),
             _ => false,
         }
     }
 
     pub fn is_unsigned_scalar(&self) -> bool {
-        matches!(self.kind(), TyKind::Literal(LiteralTy::UnsignedInteger(_)))
+        matches!(self.kind(), TyKind::Literal(LiteralTy::UInt(_)))
     }
 
     pub fn is_signed_scalar(&self) -> bool {
-        matches!(self.kind(), TyKind::Literal(LiteralTy::Integer(_)))
+        matches!(self.kind(), TyKind::Literal(LiteralTy::Int(_)))
     }
 
     /// Return true if the type is Box

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -413,30 +413,14 @@ impl GenericArgs {
 }
 
 impl IntegerTy {
-    pub fn is_signed(&self) -> bool {
-        matches!(
-            self,
-            IntegerTy::Isize
-                | IntegerTy::I8
-                | IntegerTy::I16
-                | IntegerTy::I32
-                | IntegerTy::I64
-                | IntegerTy::I128
-        )
-    }
-
-    pub fn is_unsigned(&self) -> bool {
-        !(self.is_signed())
-    }
-
     pub fn to_unsigned(&self) -> Self {
         match self {
-            IntegerTy::Isize => IntegerTy::Usize,
-            IntegerTy::I8 => IntegerTy::U8,
-            IntegerTy::I16 => IntegerTy::U16,
-            IntegerTy::I32 => IntegerTy::U32,
-            IntegerTy::I64 => IntegerTy::U64,
-            IntegerTy::I128 => IntegerTy::U128,
+            IntegerTy::Signed(IntTy::Isize) => IntegerTy::Unsigned(UIntTy::Usize),
+            IntegerTy::Signed(IntTy::I8) => IntegerTy::Unsigned(UIntTy::U8),
+            IntegerTy::Signed(IntTy::I16) => IntegerTy::Unsigned(UIntTy::U16),
+            IntegerTy::Signed(IntTy::I32) => IntegerTy::Unsigned(UIntTy::U32),
+            IntegerTy::Signed(IntTy::I64) => IntegerTy::Unsigned(UIntTy::U64),
+            IntegerTy::Signed(IntTy::I128) => IntegerTy::Unsigned(UIntTy::U128),
             _ => *self,
         }
     }
@@ -445,18 +429,28 @@ impl IntegerTy {
     /// Must not be used for host types from rustc.
     pub fn target_size(&self, ptr_size: ByteCount) -> usize {
         match self {
-            IntegerTy::Isize => ptr_size as usize,
-            IntegerTy::I8 => size_of::<i8>(),
-            IntegerTy::I16 => size_of::<i16>(),
-            IntegerTy::I32 => size_of::<i32>(),
-            IntegerTy::I64 => size_of::<i64>(),
-            IntegerTy::I128 => size_of::<i128>(),
-            IntegerTy::Usize => ptr_size as usize,
-            IntegerTy::U8 => size_of::<u8>(),
-            IntegerTy::U16 => size_of::<u16>(),
-            IntegerTy::U32 => size_of::<u32>(),
-            IntegerTy::U64 => size_of::<u64>(),
-            IntegerTy::U128 => size_of::<u128>(),
+            IntegerTy::Signed(IntTy::Isize) => ptr_size as usize,
+            IntegerTy::Signed(IntTy::I8) => size_of::<i8>(),
+            IntegerTy::Signed(IntTy::I16) => size_of::<i16>(),
+            IntegerTy::Signed(IntTy::I32) => size_of::<i32>(),
+            IntegerTy::Signed(IntTy::I64) => size_of::<i64>(),
+            IntegerTy::Signed(IntTy::I128) => size_of::<i128>(),
+            IntegerTy::Unsigned(UIntTy::Usize) => ptr_size as usize,
+            IntegerTy::Unsigned(UIntTy::U8) => size_of::<u8>(),
+            IntegerTy::Unsigned(UIntTy::U16) => size_of::<u16>(),
+            IntegerTy::Unsigned(UIntTy::U32) => size_of::<u32>(),
+            IntegerTy::Unsigned(UIntTy::U64) => size_of::<u64>(),
+            IntegerTy::Unsigned(UIntTy::U128) => size_of::<u128>(),
+        }
+    }
+}
+
+impl LiteralTy {
+    pub fn to_integer_ty(&self) -> Option<IntegerTy> {
+        match self {
+            Self::Integer(int_ty) => Some(IntegerTy::Signed(*int_ty)),
+            Self::UnsignedInteger(uint_ty) => Some(IntegerTy::Unsigned(*uint_ty)),
+            _ => None,
         }
     }
 }
@@ -572,17 +566,11 @@ impl Ty {
     }
 
     pub fn is_unsigned_scalar(&self) -> bool {
-        match self.kind() {
-            TyKind::Literal(LiteralTy::Integer(kind)) => kind.is_unsigned(),
-            _ => false,
-        }
+        matches!(self.kind(), TyKind::Literal(LiteralTy::UnsignedInteger(_)))
     }
 
     pub fn is_signed_scalar(&self) -> bool {
-        match self.kind() {
-            TyKind::Literal(LiteralTy::Integer(kind)) => kind.is_signed(),
-            _ => false,
-        }
+        matches!(self.kind(), TyKind::Literal(LiteralTy::Integer(_)))
     }
 
     /// Return true if the type is Box

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -1,6 +1,6 @@
 //! Contains definitions for variables and constant values.
 
-use crate::ast::FloatTy;
+use crate::ast::{FloatTy, IntegerTy};
 use core::hash::Hash;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
@@ -68,20 +68,8 @@ pub enum Literal {
 )]
 #[drive(skip)]
 pub enum ScalarValue {
-    /// Using i64 to be safe
-    Isize(i64),
-    I8(i8),
-    I16(i16),
-    I32(i32),
-    I64(i64),
-    I128(i128),
-    /// Using u64 to be safe
-    Usize(u64),
-    U8(u8),
-    U16(u16),
-    U32(u32),
-    U64(u64),
-    U128(u128),
+    Unsigned(IntegerTy, u128),
+    Signed(IntegerTy, i128),
 }
 
 /// This is simlar to the Scalar value above. However, instead of storing

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -48,8 +48,6 @@ pub enum Literal {
 }
 
 /// A scalar value.
-// We encode it as `{ value: ??; int_ty: IntegerTy; }` in json and on the ocaml side. We therefore
-// use a custom (de)serializer.
 #[derive(
     Debug,
     PartialEq,
@@ -63,13 +61,23 @@ pub enum Literal {
     Hash,
     PartialOrd,
     Ord,
+    Serialize,
+    Deserialize,
     Drive,
     DriveMut,
 )]
 #[drive(skip)]
+#[charon::variants_suffix("Scalar")]
 pub enum ScalarValue {
-    Unsigned(UIntTy, u128),
-    Signed(IntTy, i128),
+    Unsigned(
+        UIntTy,
+        #[serde(with = "crate::ast::values_utils::scalar_value_ser_de")] u128,
+    ),
+
+    Signed(
+        IntTy,
+        #[serde(with = "crate::ast::values_utils::scalar_value_ser_de")] i128,
+    ),
 }
 
 /// This is simlar to the Scalar value above. However, instead of storing

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -1,6 +1,6 @@
 //! Contains definitions for variables and constant values.
 
-use crate::ast::{FloatTy, IntegerTy};
+use crate::ast::{FloatTy, IntTy, UIntTy};
 use core::hash::Hash;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
@@ -68,8 +68,8 @@ pub enum Literal {
 )]
 #[drive(skip)]
 pub enum ScalarValue {
-    Unsigned(IntegerTy, u128),
-    Signed(IntegerTy, i128),
+    Unsigned(UIntTy, u128),
+    Signed(IntTy, i128),
 }
 
 /// This is simlar to the Scalar value above. However, instead of storing

--- a/charon/src/ast/values_utils.rs
+++ b/charon/src/ast/values_utils.rs
@@ -1,6 +1,6 @@
 //! Implementations for [crate::values]
 use crate::ast::*;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeTupleVariant};
 
 #[derive(Debug, Clone)]
 pub enum ScalarError {
@@ -8,50 +8,84 @@ pub enum ScalarError {
     IncorrectSign,
     /// Out of bounds scalar
     OutOfBounds,
+    UnsupportedPtrSize,
 }
 /// Our redefinition of Result - we don't care much about the I/O part.
 pub type ScalarResult<T> = std::result::Result<T, ScalarError>;
 
+macro_rules! from_ne_bytes {
+    ($m:ident, $b:ident, [$(($i:ident, $s:ident, $n_ty:ty, $t:ty)),*]) => {
+        match $m {
+            $(
+                IntegerTy::$i => {
+                    let n = size_of::<$n_ty>();
+                    let b: [u8; _] = if cfg!(target_endian = "big"){
+                        $b[16-n..16].try_into().unwrap()
+                    } else {
+                        $b[0..n].try_into().unwrap()
+                    };
+                    ScalarValue::$s($m,<$n_ty>::from_ne_bytes(b) as $t)
+                }
+            )*
+        }
+    }
+}
+
 impl ScalarValue {
+    fn ptr_size_max(ptr_size: ByteCount, signed: bool) -> ScalarResult<u128> {
+        match ptr_size {
+            2 => Ok(if signed {
+                i16::MAX as u128
+            } else {
+                u16::MAX as u128
+            }),
+            4 => Ok(if signed {
+                i32::MAX as u128
+            } else {
+                u32::MAX as u128
+            }),
+            8 => Ok(if signed {
+                i64::MAX as u128
+            } else {
+                u64::MAX as u128
+            }),
+            _ => Err(ScalarError::UnsupportedPtrSize),
+        }
+    }
+
+    fn ptr_size_min(ptr_size: ByteCount, signed: bool) -> ScalarResult<i128> {
+        match ptr_size {
+            2 => Ok(if signed {
+                i16::MIN as i128
+            } else {
+                u16::MIN as i128
+            }),
+            4 => Ok(if signed {
+                i32::MIN as i128
+            } else {
+                u32::MIN as i128
+            }),
+            8 => Ok(if signed {
+                i64::MIN as i128
+            } else {
+                u64::MIN as i128
+            }),
+            _ => Err(ScalarError::UnsupportedPtrSize),
+        }
+    }
+
     pub fn get_integer_ty(&self) -> IntegerTy {
         match self {
-            ScalarValue::Isize(_) => IntegerTy::Isize,
-            ScalarValue::I8(_) => IntegerTy::I8,
-            ScalarValue::I16(_) => IntegerTy::I16,
-            ScalarValue::I32(_) => IntegerTy::I32,
-            ScalarValue::I64(_) => IntegerTy::I64,
-            ScalarValue::I128(_) => IntegerTy::I128,
-            ScalarValue::Usize(_) => IntegerTy::Usize,
-            ScalarValue::U8(_) => IntegerTy::U8,
-            ScalarValue::U16(_) => IntegerTy::U16,
-            ScalarValue::U32(_) => IntegerTy::U32,
-            ScalarValue::U64(_) => IntegerTy::U64,
-            ScalarValue::U128(_) => IntegerTy::U128,
+            ScalarValue::Signed(ty, _) | ScalarValue::Unsigned(ty, _) => *ty,
         }
     }
 
     pub fn is_int(&self) -> bool {
-        matches!(
-            self,
-            ScalarValue::Isize(_)
-                | ScalarValue::I8(_)
-                | ScalarValue::I16(_)
-                | ScalarValue::I32(_)
-                | ScalarValue::I64(_)
-                | ScalarValue::I128(_)
-        )
+        matches!(self, ScalarValue::Signed(_, _))
     }
 
     pub fn is_uint(&self) -> bool {
-        matches!(
-            self,
-            ScalarValue::Usize(_)
-                | ScalarValue::U8(_)
-                | ScalarValue::U16(_)
-                | ScalarValue::U32(_)
-                | ScalarValue::U64(_)
-                | ScalarValue::U128(_)
-        )
+        matches!(self, ScalarValue::Unsigned(_, _))
     }
 
     /// When computing the result of binary operations, we convert the values
@@ -59,19 +93,14 @@ impl ScalarValue {
     /// of course).
     pub fn as_uint(&self) -> ScalarResult<u128> {
         match self {
-            ScalarValue::Usize(v) => Ok(*v as u128),
-            ScalarValue::U8(v) => Ok(*v as u128),
-            ScalarValue::U16(v) => Ok(*v as u128),
-            ScalarValue::U32(v) => Ok(*v as u128),
-            ScalarValue::U64(v) => Ok(*v as u128),
-            ScalarValue::U128(v) => Ok(*v),
+            ScalarValue::Unsigned(ty, v) if ty.is_unsigned() => Ok(*v),
             _ => Err(ScalarError::IncorrectSign),
         }
     }
 
-    pub fn uint_is_in_bounds(ty: IntegerTy, v: u128) -> bool {
+    pub fn uint_is_in_bounds(ptr_size: ByteCount, ty: IntegerTy, v: u128) -> bool {
         match ty {
-            IntegerTy::Usize => v <= (usize::MAX as u128),
+            IntegerTy::Usize => v <= Self::ptr_size_max(ptr_size, false).unwrap(),
             IntegerTy::U8 => v <= (u8::MAX as u128),
             IntegerTy::U16 => v <= (u16::MAX as u128),
             IntegerTy::U32 => v <= (u32::MAX as u128),
@@ -83,18 +112,18 @@ impl ScalarValue {
 
     pub fn from_unchecked_uint(ty: IntegerTy, v: u128) -> ScalarValue {
         match ty {
-            IntegerTy::Usize => ScalarValue::Usize(v as u64),
-            IntegerTy::U8 => ScalarValue::U8(v as u8),
-            IntegerTy::U16 => ScalarValue::U16(v as u16),
-            IntegerTy::U32 => ScalarValue::U32(v as u32),
-            IntegerTy::U64 => ScalarValue::U64(v as u64),
-            IntegerTy::U128 => ScalarValue::U128(v),
+            IntegerTy::Usize
+            | IntegerTy::U8
+            | IntegerTy::U16
+            | IntegerTy::U32
+            | IntegerTy::U64
+            | IntegerTy::U128 => ScalarValue::Unsigned(ty, v),
             _ => panic!("Expected an unsigned integer kind"),
         }
     }
 
-    pub fn from_uint(ty: IntegerTy, v: u128) -> ScalarResult<ScalarValue> {
-        if !ScalarValue::uint_is_in_bounds(ty, v) {
+    pub fn from_uint(ptr_size: ByteCount, ty: IntegerTy, v: u128) -> ScalarResult<ScalarValue> {
+        if !ScalarValue::uint_is_in_bounds(ptr_size, ty, v) {
             trace!("Not in bounds for {:?}: {}", ty, v);
             Err(ScalarError::OutOfBounds)
         } else {
@@ -107,19 +136,17 @@ impl ScalarValue {
     /// of course).
     pub fn as_int(&self) -> ScalarResult<i128> {
         match self {
-            ScalarValue::Isize(v) => Ok(*v as i128),
-            ScalarValue::I8(v) => Ok(*v as i128),
-            ScalarValue::I16(v) => Ok(*v as i128),
-            ScalarValue::I32(v) => Ok(*v as i128),
-            ScalarValue::I64(v) => Ok(*v as i128),
-            ScalarValue::I128(v) => Ok(*v),
+            ScalarValue::Signed(ty, v) if ty.is_signed() => Ok(*v),
             _ => Err(ScalarError::IncorrectSign),
         }
     }
 
-    pub fn int_is_in_bounds(ty: IntegerTy, v: i128) -> bool {
+    pub fn int_is_in_bounds(ptr_size: ByteCount, ty: IntegerTy, v: i128) -> bool {
         match ty {
-            IntegerTy::Isize => v >= (isize::MIN as i128) && v <= (isize::MAX as i128),
+            IntegerTy::Isize => {
+                v >= Self::ptr_size_min(ptr_size, true).unwrap()
+                    && v <= Self::ptr_size_max(ptr_size, true).unwrap() as i128
+            }
             IntegerTy::I8 => v >= (i8::MIN as i128) && v <= (i8::MAX as i128),
             IntegerTy::I16 => v >= (i16::MIN as i128) && v <= (i16::MAX as i128),
             IntegerTy::I32 => v >= (i32::MIN as i128) && v <= (i32::MAX as i128),
@@ -131,96 +158,55 @@ impl ScalarValue {
 
     pub fn from_unchecked_int(ty: IntegerTy, v: i128) -> ScalarValue {
         match ty {
-            IntegerTy::Isize => ScalarValue::Isize(v as i64),
-            IntegerTy::I8 => ScalarValue::I8(v as i8),
-            IntegerTy::I16 => ScalarValue::I16(v as i16),
-            IntegerTy::I32 => ScalarValue::I32(v as i32),
-            IntegerTy::I64 => ScalarValue::I64(v as i64),
-            IntegerTy::I128 => ScalarValue::I128(v),
+            IntegerTy::Isize
+            | IntegerTy::I8
+            | IntegerTy::I16
+            | IntegerTy::I32
+            | IntegerTy::I64
+            | IntegerTy::I128 => ScalarValue::Signed(ty, v),
             _ => panic!("Expected a signed integer kind"),
-        }
-    }
-
-    pub fn from_le_bytes(ty: IntegerTy, b: [u8; 16]) -> ScalarValue {
-        match ty {
-            IntegerTy::Isize => {
-                let b: [u8; 8] = b[0..8].try_into().unwrap();
-                ScalarValue::Isize(i64::from_le_bytes(b))
-            }
-            IntegerTy::I8 => {
-                let b: [u8; 1] = b[0..1].try_into().unwrap();
-                ScalarValue::I8(i8::from_le_bytes(b))
-            }
-            IntegerTy::I16 => {
-                let b: [u8; 2] = b[0..2].try_into().unwrap();
-                ScalarValue::I16(i16::from_le_bytes(b))
-            }
-            IntegerTy::I32 => {
-                let b: [u8; 4] = b[0..4].try_into().unwrap();
-                ScalarValue::I32(i32::from_le_bytes(b))
-            }
-            IntegerTy::I64 => {
-                let b: [u8; 8] = b[0..8].try_into().unwrap();
-                ScalarValue::I64(i64::from_le_bytes(b))
-            }
-            IntegerTy::I128 => {
-                let b: [u8; 16] = b[0..16].try_into().unwrap();
-                ScalarValue::I128(i128::from_le_bytes(b))
-            }
-            IntegerTy::Usize => {
-                let b: [u8; 8] = b[0..8].try_into().unwrap();
-                ScalarValue::Usize(u64::from_le_bytes(b))
-            }
-            IntegerTy::U8 => {
-                let b: [u8; 1] = b[0..1].try_into().unwrap();
-                ScalarValue::U8(u8::from_le_bytes(b))
-            }
-            IntegerTy::U16 => {
-                let b: [u8; 2] = b[0..2].try_into().unwrap();
-                ScalarValue::U16(u16::from_le_bytes(b))
-            }
-            IntegerTy::U32 => {
-                let b: [u8; 4] = b[0..4].try_into().unwrap();
-                ScalarValue::U32(u32::from_le_bytes(b))
-            }
-            IntegerTy::U64 => {
-                let b: [u8; 8] = b[0..8].try_into().unwrap();
-                ScalarValue::U64(u64::from_le_bytes(b))
-            }
-            IntegerTy::U128 => {
-                let b: [u8; 16] = b[0..16].try_into().unwrap();
-                ScalarValue::U128(u128::from_le_bytes(b))
-            }
         }
     }
 
     /// Most integers are represented as `u128` by rustc. We must be careful not to sign-extend.
     pub fn to_bits(&self) -> u128 {
         match *self {
-            ScalarValue::Usize(v) => v as u128,
-            ScalarValue::U8(v) => v as u128,
-            ScalarValue::U16(v) => v as u128,
-            ScalarValue::U32(v) => v as u128,
-            ScalarValue::U64(v) => v as u128,
-            ScalarValue::U128(v) => v,
-            ScalarValue::Isize(v) => v as usize as u128,
-            ScalarValue::I8(v) => v as u8 as u128,
-            ScalarValue::I16(v) => v as u16 as u128,
-            ScalarValue::I32(v) => v as u32 as u128,
-            ScalarValue::I64(v) => v as u64 as u128,
-            ScalarValue::I128(v) => v as u128,
+            ScalarValue::Unsigned(_, v) => v,
+            ScalarValue::Signed(_, v) => u128::from_be_bytes(v.to_ne_bytes()),
         }
     }
 
+    pub fn from_bytes(ty: IntegerTy, bytes: [u8; 16]) -> Self {
+        from_ne_bytes!(
+            ty,
+            bytes,
+            [
+                (Isize, Signed, isize, i128),
+                (I8, Signed, i8, i128),
+                (I16, Signed, i16, i128),
+                (I32, Signed, i32, i128),
+                (I64, Signed, i64, i128),
+                (I128, Signed, i128, i128),
+                (Usize, Unsigned, usize, u128),
+                (U8, Unsigned, u8, u128),
+                (U16, Unsigned, u16, u128),
+                (U32, Unsigned, u32, u128),
+                (U64, Unsigned, u64, u128),
+                (U128, Unsigned, u128, u128)
+            ]
+        )
+    }
+
     pub fn from_bits(ty: IntegerTy, bits: u128) -> Self {
-        Self::from_le_bytes(ty, bits.to_le_bytes())
+        let bytes = bits.to_ne_bytes();
+        Self::from_bytes(ty, bytes)
     }
 
     /// **Warning**: most constants are stored as u128 by rustc. When converting
     /// to i128, it is not correct to do `v as i128`, we must reinterpret the
     /// bits (see [ScalarValue::from_le_bytes]).
-    pub fn from_int(ty: IntegerTy, v: i128) -> ScalarResult<ScalarValue> {
-        if !ScalarValue::int_is_in_bounds(ty, v) {
+    pub fn from_int(ptr_size: ByteCount, ty: IntegerTy, v: i128) -> ScalarResult<ScalarValue> {
+        if !ScalarValue::int_is_in_bounds(ptr_size, ty, v) {
             Err(ScalarError::OutOfBounds)
         } else {
             Ok(ScalarValue::from_unchecked_int(ty, v))
@@ -244,21 +230,19 @@ impl Serialize for ScalarValue {
         let enum_name = "ScalarValue";
         let variant_name = self.variant_name();
         let (variant_index, _variant_arity) = self.variant_index_arity();
-        let v = match self {
-            ScalarValue::Isize(i) => i.to_string(),
-            ScalarValue::I8(i) => i.to_string(),
-            ScalarValue::I16(i) => i.to_string(),
-            ScalarValue::I32(i) => i.to_string(),
-            ScalarValue::I64(i) => i.to_string(),
-            ScalarValue::I128(i) => i.to_string(),
-            ScalarValue::Usize(i) => i.to_string(),
-            ScalarValue::U8(i) => i.to_string(),
-            ScalarValue::U16(i) => i.to_string(),
-            ScalarValue::U32(i) => i.to_string(),
-            ScalarValue::U64(i) => i.to_string(),
-            ScalarValue::U128(i) => i.to_string(),
+        let mut tv =
+            serializer.serialize_tuple_variant(enum_name, variant_index, variant_name, 2)?;
+        match self {
+            ScalarValue::Signed(ty, i) => {
+                tv.serialize_field(ty)?;
+                tv.serialize_field(&i.to_string())?;
+            }
+            ScalarValue::Unsigned(ty, i) => {
+                tv.serialize_field(ty)?;
+                tv.serialize_field(&i.to_string())?;
+            }
         };
-        serializer.serialize_newtype_variant(enum_name, variant_index, variant_name, &v)
+        tv.end()
     }
 }
 
@@ -278,20 +262,36 @@ impl<'de> Deserialize<'de> for ScalarValue {
                 mut map: A,
             ) -> Result<Self::Value, A::Error> {
                 use serde::de::Error;
-                let (k, v): (String, String) = map.next_entry()?.expect("Malformed ScalarValue");
+                let (k, (ty, i)): (String, (String, String)) =
+                    map.next_entry()?.expect("Malformed ScalarValue");
+                let ty = match ty.as_str() {
+                    "Isize" => IntegerTy::Isize,
+                    "I8" => IntegerTy::I8,
+                    "I16" => IntegerTy::I16,
+                    "I32" => IntegerTy::I32,
+                    "I64" => IntegerTy::I64,
+                    "I128" => IntegerTy::I128,
+                    "Usize" => IntegerTy::Usize,
+                    "U8" => IntegerTy::U8,
+                    "U16" => IntegerTy::U16,
+                    "U32" => IntegerTy::U32,
+                    "U64" => IntegerTy::U64,
+                    "U128" => IntegerTy::U128,
+                    _ => {
+                        return Err(A::Error::custom(format!(
+                            "{ty} is not a valid type for a ScalarValue"
+                        )));
+                    }
+                };
                 Ok(match k.as_str() {
-                    "Isize" => ScalarValue::Isize(v.parse().unwrap()),
-                    "I8" => ScalarValue::I8(v.parse().unwrap()),
-                    "I16" => ScalarValue::I16(v.parse().unwrap()),
-                    "I32" => ScalarValue::I32(v.parse().unwrap()),
-                    "I64" => ScalarValue::I64(v.parse().unwrap()),
-                    "I128" => ScalarValue::I128(v.parse().unwrap()),
-                    "Usize" => ScalarValue::Usize(v.parse().unwrap()),
-                    "U8" => ScalarValue::U8(v.parse().unwrap()),
-                    "U16" => ScalarValue::U16(v.parse().unwrap()),
-                    "U32" => ScalarValue::U32(v.parse().unwrap()),
-                    "U64" => ScalarValue::U64(v.parse().unwrap()),
-                    "U128" => ScalarValue::U128(v.parse().unwrap()),
+                    "Signed" => {
+                        let i = i.parse().unwrap();
+                        ScalarValue::Signed(ty, i)
+                    }
+                    "Unsigned" => {
+                        let i = i.parse().unwrap();
+                        ScalarValue::Unsigned(ty, i)
+                    }
                     _ => {
                         return Err(A::Error::custom(format!(
                             "{k} is not a valid type for a ScalarValue"
@@ -301,5 +301,26 @@ impl<'de> Deserialize<'de> for ScalarValue {
             }
         }
         deserializer.deserialize_map(Visitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_big_endian_scalars() -> ScalarResult<()> {
+        let u128 = 0x12345678901234567890123456789012u128;
+        let ne_bytes = u128.to_ne_bytes();
+
+        let ne_scalar = ScalarValue::from_bytes(IntegerTy::U128, ne_bytes);
+        assert_eq!(ne_scalar, ScalarValue::Unsigned(IntegerTy::U128, u128));
+
+        let i64 = 0x1234567890123456i64;
+        let ne_bytes = (i64 as i128).to_ne_bytes();
+        let ne_scalar = ScalarValue::from_bytes(IntegerTy::I64, ne_bytes);
+        assert_eq!(ne_scalar, ScalarValue::Signed(IntegerTy::I64, i64 as i128));
+
+        Ok(())
     }
 }

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -44,7 +44,7 @@ use indexmap::IndexMap;
         AbortKind, Assert, BinOp, Body, BorrowKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy, Call,
         CastKind, ClosureInfo, ClosureKind, ConstGenericVar, ConstGenericVarId,
         Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
-        FnOperand, FunId, FunIdOrTraitMethodRef, FunSig, ImplElem, IntegerTy, Literal, LiteralTy,
+        FnOperand, FunId, FunIdOrTraitMethodRef, FunSig, ImplElem, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::Block, llbc_ast::ExprBody, llbc_ast::RawStatement, llbc_ast::Switch,
         Locals, Name, NullOp, Opaque, Operand, PathElem, PlaceKind, ProjectionElem, RawConstantExpr,
         RefKind, RegionId, RegionVar, ScalarValue, TraitItemName,
@@ -142,7 +142,7 @@ impl<K: Any, T: AstVisitable> AstVisitable for IndexMap<K, T> {
     // Types that are ignored when encountered.
     skip(
         AbortKind, BinOp, BorrowKind, ConstantExpr, ConstGeneric, FieldId, FieldProjKind,
-        TypeDeclRef, FunDeclId, FunIdOrTraitMethodRef, GenericArgs, GlobalDeclRef, IntegerTy,
+        TypeDeclRef, FunDeclId, FunIdOrTraitMethodRef, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId, LocalId,
         TraitRef,
     ),

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -907,11 +907,12 @@ impl BodyTransCtx<'_, '_, '_> {
                 let then_block = self.translate_basic_block_id(*target);
                 Ok(SwitchTargets::If(if_block, then_block))
             }
-            LiteralTy::Integer(int_ty) => {
+            LiteralTy::Int(int_ty) => {
                 let targets: Vec<(ScalarValue, BlockId)> = targets
                     .iter()
                     .map(|(v, tgt)| {
-                        let v = ScalarValue::from_bytes(IntegerTy::Signed(int_ty), v.data_le_bytes);
+                        let v =
+                            ScalarValue::from_le_bytes(IntegerTy::Signed(int_ty), v.data_le_bytes);
                         let tgt = self.translate_basic_block_id(*tgt);
                         Ok((v, tgt))
                     })
@@ -923,12 +924,14 @@ impl BodyTransCtx<'_, '_, '_> {
                     otherwise,
                 ))
             }
-            LiteralTy::UnsignedInteger(int_ty) => {
+            LiteralTy::UInt(int_ty) => {
                 let targets: Vec<(ScalarValue, BlockId)> = targets
                     .iter()
                     .map(|(v, tgt)| {
-                        let v =
-                            ScalarValue::from_bytes(IntegerTy::Unsigned(int_ty), v.data_le_bytes);
+                        let v = ScalarValue::from_le_bytes(
+                            IntegerTy::Unsigned(int_ty),
+                            v.data_le_bytes,
+                        );
                         let tgt = self.translate_basic_block_id(*tgt);
                         Ok((v, tgt))
                     })

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -221,6 +221,7 @@ impl BodyTransCtx<'_, '_, '_> {
                 // Compute the type of the value *before* projection - we use this
                 // to disambiguate
                 let subplace = self.translate_place(span, hax_subplace)?;
+                let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
                 let place = match kind {
                     hax::ProjectionElem::Deref => subplace.project(ProjectionElem::Deref, ty),
                     hax::ProjectionElem::Field(field_kind) => {
@@ -305,8 +306,11 @@ impl BodyTransCtx<'_, '_, '_> {
                         from_end,
                         min_length: _,
                     } => {
-                        let offset =
-                            Operand::Const(Box::new(ScalarValue::Usize(offset).to_constant()));
+                        let offset = Operand::Const(Box::new(
+                            ScalarValue::from_uint(ptr_size, IntegerTy::Usize, offset as u128)
+                                .unwrap()
+                                .to_constant(),
+                        ));
                         subplace.project(
                             ProjectionElem::Index {
                                 offset: Box::new(offset),
@@ -316,8 +320,16 @@ impl BodyTransCtx<'_, '_, '_> {
                         )
                     }
                     &hax::ProjectionElem::Subslice { from, to, from_end } => {
-                        let from = Operand::Const(Box::new(ScalarValue::Usize(from).to_constant()));
-                        let to = Operand::Const(Box::new(ScalarValue::Usize(to).to_constant()));
+                        let from = Operand::Const(Box::new(
+                            ScalarValue::from_uint(ptr_size, IntegerTy::Usize, from as u128)
+                                .unwrap()
+                                .to_constant(),
+                        ));
+                        let to = Operand::Const(Box::new(
+                            ScalarValue::from_uint(ptr_size, IntegerTy::Usize, to as u128)
+                                .unwrap()
+                                .to_constant(),
+                        ));
                         subplace.project(
                             ProjectionElem::Subslice {
                                 from: Box::new(from),
@@ -573,13 +585,19 @@ impl BodyTransCtx<'_, '_, '_> {
                     .iter()
                     .map(|op| self.translate_operand(span, op))
                     .try_collect()?;
+                let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
 
                 match aggregate_kind {
                     hax::AggregateKind::Array(ty) => {
                         let t_ty = self.translate_ty(span, ty)?;
-                        let cg = ConstGeneric::Value(Literal::Scalar(ScalarValue::Usize(
-                            operands_t.len() as u64,
-                        )));
+                        let cg = ConstGeneric::Value(Literal::Scalar(
+                            ScalarValue::from_uint(
+                                ptr_size,
+                                IntegerTy::Usize,
+                                operands_t.len() as u128,
+                            )
+                            .unwrap(),
+                        ));
                         Ok(Rvalue::Aggregate(
                             AggregateKind::Array(t_ty, cg),
                             operands_t,
@@ -893,7 +911,7 @@ impl BodyTransCtx<'_, '_, '_> {
                 let targets: Vec<(ScalarValue, BlockId)> = targets
                     .iter()
                     .map(|(v, tgt)| {
-                        let v = ScalarValue::from_le_bytes(int_ty, v.data_le_bytes);
+                        let v = ScalarValue::from_bytes(int_ty, v.data_le_bytes);
                         let tgt = self.translate_basic_block_id(*tgt);
                         Ok((v, tgt))
                     })

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -22,26 +22,25 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 use hax::ConstantInt;
                 let scalar = match i {
                     ConstantInt::Int(v, int_type) => {
-                        use hax::IntTy;
                         let ty = match int_type {
-                            IntTy::Isize => IntegerTy::Isize,
-                            IntTy::I8 => IntegerTy::I8,
-                            IntTy::I16 => IntegerTy::I16,
-                            IntTy::I32 => IntegerTy::I32,
-                            IntTy::I64 => IntegerTy::I64,
-                            IntTy::I128 => IntegerTy::I128,
+                            hax::IntTy::Isize => IntTy::Isize,
+                            hax::IntTy::I8 => IntTy::I8,
+                            hax::IntTy::I16 => IntTy::I16,
+                            hax::IntTy::I32 => IntTy::I32,
+                            hax::IntTy::I64 => IntTy::I64,
+                            hax::IntTy::I128 => IntTy::I128,
                         };
                         ScalarValue::Signed(ty, *v)
                     }
                     ConstantInt::Uint(v, int_type) => {
                         use hax::UintTy;
                         let ty = match int_type {
-                            UintTy::Usize => IntegerTy::Usize,
-                            UintTy::U8 => IntegerTy::U8,
-                            UintTy::U16 => IntegerTy::U16,
-                            UintTy::U32 => IntegerTy::U32,
-                            UintTy::U64 => IntegerTy::U64,
-                            UintTy::U128 => IntegerTy::U128,
+                            UintTy::Usize => UIntTy::Usize,
+                            UintTy::U8 => UIntTy::U8,
+                            UintTy::U16 => UIntTy::U16,
+                            UintTy::U32 => UIntTy::U32,
+                            UintTy::U64 => UIntTy::U64,
+                            UintTy::U128 => UIntTy::U128,
                         };
                         ScalarValue::Unsigned(ty, *v)
                     }

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -22,26 +22,11 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 use hax::ConstantInt;
                 let scalar = match i {
                     ConstantInt::Int(v, int_type) => {
-                        let ty = match int_type {
-                            hax::IntTy::Isize => IntTy::Isize,
-                            hax::IntTy::I8 => IntTy::I8,
-                            hax::IntTy::I16 => IntTy::I16,
-                            hax::IntTy::I32 => IntTy::I32,
-                            hax::IntTy::I64 => IntTy::I64,
-                            hax::IntTy::I128 => IntTy::I128,
-                        };
+                        let ty = Self::translate_hax_int_ty(int_type);
                         ScalarValue::Signed(ty, *v)
                     }
-                    ConstantInt::Uint(v, int_type) => {
-                        use hax::UintTy;
-                        let ty = match int_type {
-                            UintTy::Usize => UIntTy::Usize,
-                            UintTy::U8 => UIntTy::U8,
-                            UintTy::U16 => UIntTy::U16,
-                            UintTy::U32 => UIntTy::U32,
-                            UintTy::U64 => UIntTy::U64,
-                            UintTy::U128 => UIntTy::U128,
-                        };
+                    ConstantInt::Uint(v, uint_type) => {
+                        let ty = Self::translate_hax_uint_ty(uint_type);
                         ScalarValue::Unsigned(ty, *v)
                     }
                 };

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -23,25 +23,27 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 let scalar = match i {
                     ConstantInt::Int(v, int_type) => {
                         use hax::IntTy;
-                        match int_type {
-                            IntTy::Isize => ScalarValue::Isize(*v as i64),
-                            IntTy::I8 => ScalarValue::I8(*v as i8),
-                            IntTy::I16 => ScalarValue::I16(*v as i16),
-                            IntTy::I32 => ScalarValue::I32(*v as i32),
-                            IntTy::I64 => ScalarValue::I64(*v as i64),
-                            IntTy::I128 => ScalarValue::I128(*v),
-                        }
+                        let ty = match int_type {
+                            IntTy::Isize => IntegerTy::Isize,
+                            IntTy::I8 => IntegerTy::I8,
+                            IntTy::I16 => IntegerTy::I16,
+                            IntTy::I32 => IntegerTy::I32,
+                            IntTy::I64 => IntegerTy::I64,
+                            IntTy::I128 => IntegerTy::I128,
+                        };
+                        ScalarValue::Signed(ty, *v)
                     }
                     ConstantInt::Uint(v, int_type) => {
                         use hax::UintTy;
-                        match int_type {
-                            UintTy::Usize => ScalarValue::Usize(*v as u64),
-                            UintTy::U8 => ScalarValue::U8(*v as u8),
-                            UintTy::U16 => ScalarValue::U16(*v as u16),
-                            UintTy::U32 => ScalarValue::U32(*v as u32),
-                            UintTy::U64 => ScalarValue::U64(*v as u64),
-                            UintTy::U128 => ScalarValue::U128(*v),
-                        }
+                        let ty = match int_type {
+                            UintTy::Usize => IntegerTy::Usize,
+                            UintTy::U8 => IntegerTy::U8,
+                            UintTy::U16 => IntegerTy::U16,
+                            UintTy::U32 => IntegerTy::U32,
+                            UintTy::U64 => IntegerTy::U64,
+                            UintTy::U128 => IntegerTy::U128,
+                        };
+                        ScalarValue::Unsigned(ty, *v)
                     }
                 };
                 Literal::Scalar(scalar)

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -40,6 +40,29 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         }
     }
 
+    pub(crate) fn translate_hax_int_ty(int_ty: &hax::IntTy) -> IntTy {
+        match int_ty {
+            hax::IntTy::Isize => IntTy::Isize,
+            hax::IntTy::I8 => IntTy::I8,
+            hax::IntTy::I16 => IntTy::I16,
+            hax::IntTy::I32 => IntTy::I32,
+            hax::IntTy::I64 => IntTy::I64,
+            hax::IntTy::I128 => IntTy::I128,
+        }
+    }
+
+    pub(crate) fn translate_hax_uint_ty(uint_ty: &hax::UintTy) -> UIntTy {
+        use hax::UintTy;
+        match uint_ty {
+            UintTy::Usize => UIntTy::Usize,
+            UintTy::U8 => UIntTy::U8,
+            UintTy::U16 => UIntTy::U16,
+            UintTy::U32 => UIntTy::U32,
+            UintTy::U64 => UIntTy::U64,
+            UintTy::U128 => UIntTy::U128,
+        }
+    }
+
     /// Translate a Ty.
     ///
     /// Typically used in this module to translate the fields of a structure/
@@ -64,24 +87,11 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let kind = match ty.kind() {
             hax::TyKind::Bool => TyKind::Literal(LiteralTy::Bool),
             hax::TyKind::Char => TyKind::Literal(LiteralTy::Char),
-            hax::TyKind::Int(int_ty) => TyKind::Literal(LiteralTy::Integer(match int_ty {
-                hax::IntTy::Isize => IntTy::Isize,
-                hax::IntTy::I8 => IntTy::I8,
-                hax::IntTy::I16 => IntTy::I16,
-                hax::IntTy::I32 => IntTy::I32,
-                hax::IntTy::I64 => IntTy::I64,
-                hax::IntTy::I128 => IntTy::I128,
-            })),
-            hax::TyKind::Uint(int_ty) => {
-                use hax::UintTy;
-                TyKind::Literal(LiteralTy::UnsignedInteger(match int_ty {
-                    UintTy::Usize => UIntTy::Usize,
-                    UintTy::U8 => UIntTy::U8,
-                    UintTy::U16 => UIntTy::U16,
-                    UintTy::U32 => UIntTy::U32,
-                    UintTy::U64 => UIntTy::U64,
-                    UintTy::U128 => UIntTy::U128,
-                }))
+            hax::TyKind::Int(int_ty) => {
+                TyKind::Literal(LiteralTy::Int(Self::translate_hax_int_ty(int_ty)))
+            }
+            hax::TyKind::Uint(uint_ty) => {
+                TyKind::Literal(LiteralTy::UInt(Self::translate_hax_uint_ty(uint_ty)))
             }
             hax::TyKind::Float(float_ty) => {
                 use hax::FloatTy;

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1068,7 +1068,7 @@ fn generate_ml(
             "ScalarValue",
             indoc!(
                 r#"
-                | `Assoc [ (ty, bi) ] ->
+                `Assoc [ (_, `List [ ty; bi ]) ] ->
                     let big_int_of_json (js : json) : (big_int, string) result =
                       combine_error_msgs js __FUNCTION__
                         (match js with
@@ -1077,11 +1077,12 @@ fn generate_ml(
                         | _ -> Error "")
                     in
                     let* value = big_int_of_json bi in
-                    let* int_ty = integer_type_of_json ctx (`String ty) in
+                    let* int_ty = integer_type_of_json ctx ty in
                     let sv = { value; int_ty } in
                     if not (check_scalar_value_in_range sv) then
-                      raise (Failure ("Scalar value not in range: " ^ show_scalar_value sv));
-                    Ok sv
+                      Error ("Scalar value not in range: " ^ show_scalar_value sv)
+                    else
+                      Ok sv
                 "#
             ),
         ),

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -1079,7 +1079,7 @@ fn generate_ml(
                     let* value = big_int_of_json bi in
                     let* int_ty = integer_type_of_json ctx ty in
                     let sv = { value; int_ty } in
-                    if not (check_scalar_value_in_range sv) then
+                    if not (check_scalar_value_in_range !target_ptr_size sv) then
                       Error ("Scalar value not in range: " ^ show_scalar_value sv)
                     else
                       Ok sv

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -176,6 +176,7 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
         TyKind::Literal(LiteralTy::Bool) => "bool_of_json".to_string(),
         TyKind::Literal(LiteralTy::Char) => "char_of_json".to_string(),
         TyKind::Literal(LiteralTy::Integer(_)) => "int_of_json".to_string(),
+        TyKind::Literal(LiteralTy::UnsignedInteger(_)) => "int_of_json".to_string(),
         TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
         TyKind::Adt(tref) => {
             let mut expr = Vec::new();
@@ -219,6 +220,7 @@ fn type_to_ocaml_name(ctx: &GenerateCtx, ty: &Ty) -> String {
         TyKind::Literal(LiteralTy::Bool) => "bool".to_string(),
         TyKind::Literal(LiteralTy::Char) => "(Uchar.t [@visitors.opaque])".to_string(),
         TyKind::Literal(LiteralTy::Integer(_)) => "int".to_string(),
+        TyKind::Literal(LiteralTy::UnsignedInteger(_)) => "int".to_string(),
         TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
         TyKind::Adt(tref) => {
             let mut args = tref
@@ -1068,7 +1070,7 @@ fn generate_ml(
             "ScalarValue",
             indoc!(
                 r#"
-                `Assoc [ (_, `List [ ty; bi ]) ] ->
+                `Assoc [ (polarity, `List [ ty; bi ]) ] ->
                     let big_int_of_json (js : json) : (big_int, string) result =
                       combine_error_msgs js __FUNCTION__
                         (match js with
@@ -1077,7 +1079,7 @@ fn generate_ml(
                         | _ -> Error "")
                     in
                     let* value = big_int_of_json bi in
-                    let* int_ty = integer_type_of_json ctx ty in
+                    let* int_ty = integer_type_of_json ctx (`Assoc [ (polarity, ty) ]) in
                     let sv = { value; int_ty } in
                     if not (check_scalar_value_in_range !target_ptr_size sv) then
                       Error ("Scalar value not in range: " ^ show_scalar_value sv)

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -175,8 +175,16 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
     match ty.kind() {
         TyKind::Literal(LiteralTy::Bool) => "bool_of_json".to_string(),
         TyKind::Literal(LiteralTy::Char) => "char_of_json".to_string(),
-        TyKind::Literal(LiteralTy::Integer(_)) => "int_of_json".to_string(),
-        TyKind::Literal(LiteralTy::UnsignedInteger(_)) => "int_of_json".to_string(),
+        TyKind::Literal(LiteralTy::Int(int_ty)) => match int_ty {
+            // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
+            IntTy::I128 => "big_int_of_json".to_string(),
+            _ => "int_of_json".to_string(),
+        },
+        TyKind::Literal(LiteralTy::UInt(uint_ty)) => match uint_ty {
+            // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
+            UIntTy::U128 => "big_int_of_json".to_string(),
+            _ => "int_of_json".to_string(),
+        },
         TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
         TyKind::Adt(tref) => {
             let mut expr = Vec::new();
@@ -219,8 +227,16 @@ fn type_to_ocaml_name(ctx: &GenerateCtx, ty: &Ty) -> String {
     match ty.kind() {
         TyKind::Literal(LiteralTy::Bool) => "bool".to_string(),
         TyKind::Literal(LiteralTy::Char) => "(Uchar.t [@visitors.opaque])".to_string(),
-        TyKind::Literal(LiteralTy::Integer(_)) => "int".to_string(),
-        TyKind::Literal(LiteralTy::UnsignedInteger(_)) => "int".to_string(),
+        TyKind::Literal(LiteralTy::Int(int_ty)) => match int_ty {
+            // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
+            IntTy::I128 => "big_int".to_string(),
+            _ => "int".to_string(),
+        },
+        TyKind::Literal(LiteralTy::UInt(uint_ty)) => match uint_ty {
+            // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
+            UIntTy::U128 => "big_int".to_string(),
+            _ => "int".to_string(),
+        },
         TyKind::Literal(LiteralTy::Float(_)) => "float_of_json".to_string(),
         TyKind::Adt(tref) => {
             let mut args = tref
@@ -1022,19 +1038,6 @@ fn generate_ml(
     let manual_type_impls = &[
         // Hand-written because we replace the `FileId` with the corresponding file.
         ("FileId", "file"),
-        // Hand-written because the rust version is an enum with custom (de)serialization
-        // functions.
-        (
-            "ScalarValue",
-            indoc!(
-                "
-                (* Note that we use unbounded integers everywhere.
-                   We then harcode the boundaries for the different types.
-                 *)
-                { value : big_int; int_ty : integer_type }
-                "
-            ),
-        ),
         // Handwritten because we use `indexed_var` as a hack to be able to reuse field names.
         // TODO: remove the need for this hack.
         ("RegionVar", "(region_id, string option) indexed_var"),
@@ -1062,30 +1065,6 @@ fn generate_ml(
                     let file = FileId.Map.find file_id ctx in
                     Ok file
                 "#,
-            ),
-        ),
-        // Hand-written because the rust version is an enum with custom (de)serialization
-        // functions.
-        (
-            "ScalarValue",
-            indoc!(
-                r#"
-                `Assoc [ (polarity, `List [ ty; bi ]) ] ->
-                    let big_int_of_json (js : json) : (big_int, string) result =
-                      combine_error_msgs js __FUNCTION__
-                        (match js with
-                        | `Int i -> Ok (Z.of_int i)
-                        | `String is -> Ok (Z.of_string is)
-                        | _ -> Error "")
-                    in
-                    let* value = big_int_of_json bi in
-                    let* int_ty = integer_type_of_json ctx (`Assoc [ (polarity, ty) ]) in
-                    let sv = { value; int_ty } in
-                    if not (check_scalar_value_in_range !target_ptr_size sv) then
-                      Error ("Scalar value not in range: " ^ show_scalar_value sv)
-                    else
-                      Ok sv
-                "#
             ),
         ),
     ];

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -26,6 +26,12 @@ type id_to_file_map = file FileId.Map.t
 type of_json_ctx = id_to_file_map
 
 let path_buf_of_json = string_of_json
-let target_ptr_size = ref 0
+
+let big_int_of_json _ (js : json) : (big_int, string) result =
+    combine_error_msgs js __FUNCTION__
+      (match js with
+      | `Int i -> Ok (Z.of_int i)
+      | `String is -> Ok (Z.of_string is)
+      | _ -> Error "")
 
 (* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -26,5 +26,6 @@ type id_to_file_map = file FileId.Map.t
 type of_json_ctx = id_to_file_map
 
 let path_buf_of_json = string_of_json
+let target_ptr_size = ref 0
 
 (* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/templates/Meta.ml
+++ b/charon/src/bin/generate-ml/templates/Meta.ml
@@ -8,6 +8,7 @@
     code-generation code is in `charon/src/bin/generate-ml`.
  *)
 
+
 type path_buf = string
 [@@deriving show, ord, eq]
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1264,18 +1264,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
 impl Display for ScalarValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         match self {
-            ScalarValue::Isize(v) => write!(f, "{v} : isize"),
-            ScalarValue::I8(v) => write!(f, "{v} : i8"),
-            ScalarValue::I16(v) => write!(f, "{v} : i16"),
-            ScalarValue::I32(v) => write!(f, "{v} : i32"),
-            ScalarValue::I64(v) => write!(f, "{v} : i64"),
-            ScalarValue::I128(v) => write!(f, "{v} : i128"),
-            ScalarValue::Usize(v) => write!(f, "{v} : usize"),
-            ScalarValue::U8(v) => write!(f, "{v} : u8"),
-            ScalarValue::U16(v) => write!(f, "{v} : u16"),
-            ScalarValue::U32(v) => write!(f, "{v} : u32"),
-            ScalarValue::U64(v) => write!(f, "{v} : u64"),
-            ScalarValue::U128(v) => write!(f, "{v} : u128"),
+            ScalarValue::Signed(ty, v) => write!(f, "{v} : {}", ty),
+            ScalarValue::Unsigned(ty, v) => write!(f, "{v} : {}", ty),
         }
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -908,8 +908,8 @@ impl Display for Literal {
 impl Display for LiteralTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LiteralTy::Integer(ty) => write!(f, "{ty}"),
-            LiteralTy::UnsignedInteger(ty) => write!(f, "{ty}"),
+            LiteralTy::Int(ty) => write!(f, "{ty}"),
+            LiteralTy::UInt(ty) => write!(f, "{ty}"),
             LiteralTy::Float(ty) => write!(f, "{ty}"),
             LiteralTy::Char => write!(f, "char"),
             LiteralTy::Bool => write!(f, "bool"),

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -827,21 +827,37 @@ impl<C: AstFormatter> FmtWithCtx<C> for ImplElem {
     }
 }
 
+impl Display for IntTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+        match self {
+            IntTy::Isize => write!(f, "isize"),
+            IntTy::I8 => write!(f, "i8"),
+            IntTy::I16 => write!(f, "i16"),
+            IntTy::I32 => write!(f, "i32"),
+            IntTy::I64 => write!(f, "i64"),
+            IntTy::I128 => write!(f, "i128"),
+        }
+    }
+}
+
+impl Display for UIntTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+        match self {
+            UIntTy::Usize => write!(f, "usize"),
+            UIntTy::U8 => write!(f, "u8"),
+            UIntTy::U16 => write!(f, "u16"),
+            UIntTy::U32 => write!(f, "u32"),
+            UIntTy::U64 => write!(f, "u64"),
+            UIntTy::U128 => write!(f, "u128"),
+        }
+    }
+}
+
 impl Display for IntegerTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         match self {
-            IntegerTy::Isize => write!(f, "isize"),
-            IntegerTy::I8 => write!(f, "i8"),
-            IntegerTy::I16 => write!(f, "i16"),
-            IntegerTy::I32 => write!(f, "i32"),
-            IntegerTy::I64 => write!(f, "i64"),
-            IntegerTy::I128 => write!(f, "i128"),
-            IntegerTy::Usize => write!(f, "usize"),
-            IntegerTy::U8 => write!(f, "u8"),
-            IntegerTy::U16 => write!(f, "u16"),
-            IntegerTy::U32 => write!(f, "u32"),
-            IntegerTy::U64 => write!(f, "u64"),
-            IntegerTy::U128 => write!(f, "u128"),
+            IntegerTy::Signed(int_ty) => write!(f, "{int_ty}"),
+            IntegerTy::Unsigned(uint_ty) => write!(f, "{uint_ty}"),
         }
     }
 }
@@ -893,6 +909,7 @@ impl Display for LiteralTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LiteralTy::Integer(ty) => write!(f, "{ty}"),
+            LiteralTy::UnsignedInteger(ty) => write!(f, "{ty}"),
             LiteralTy::Float(ty) => write!(f, "{ty}"),
             LiteralTy::Char => write!(f, "char"),
             LiteralTy::Bool => write!(f, "bool"),

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -114,7 +114,7 @@ impl<'a> IndexVisitor<'a> {
         if from_end {
             // `storage_live(len_var)`
             // `len_var = len(p)`
-            let usize_ty = TyKind::Literal(LiteralTy::UnsignedInteger(UIntTy::Usize)).into_ty();
+            let usize_ty = TyKind::Literal(LiteralTy::UInt(UIntTy::Usize)).into_ty();
             let len_var = self.fresh_var(None, usize_ty.clone());
             let kind = RawStatement::Assign(
                 len_var.clone(),

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -114,7 +114,7 @@ impl<'a> IndexVisitor<'a> {
         if from_end {
             // `storage_live(len_var)`
             // `len_var = len(p)`
-            let usize_ty = TyKind::Literal(LiteralTy::Integer(IntegerTy::Usize)).into_ty();
+            let usize_ty = TyKind::Literal(LiteralTy::UnsignedInteger(UIntTy::Usize)).into_ty();
             let len_var = self.fresh_var(None, usize_ty.clone());
             let kind = RawStatement::Assign(
                 len_var.clone(),

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -108,7 +108,10 @@ fn transform_constant_expr(
                 .map(|x| transform_constant_expr(span, Box::new(x), new_var))
                 .collect_vec();
 
-            let len = ConstGeneric::Value(Literal::Scalar(ScalarValue::Usize(fields.len() as u64)));
+            let len = ConstGeneric::Value(Literal::Scalar(ScalarValue::Unsigned(
+                IntegerTy::Usize,
+                fields.len() as u128,
+            )));
             let tref = val.ty.kind().as_adt().unwrap();
             assert_matches!(
                 *tref.id.as_builtin().unwrap(),

--- a/charon/src/transform/simplify_constants.rs
+++ b/charon/src/transform/simplify_constants.rs
@@ -109,7 +109,7 @@ fn transform_constant_expr(
                 .collect_vec();
 
             let len = ConstGeneric::Value(Literal::Scalar(ScalarValue::Unsigned(
-                IntegerTy::Usize,
+                UIntTy::Usize,
                 fields.len() as u128,
             )));
             let tref = val.ty.kind().as_adt().unwrap();

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -378,11 +378,17 @@ fn discriminants() -> anyhow::Result<()> {
     }
     assert_eq!(
         get_enum_discriminants(&crate_data.type_decls[0]),
-        vec![ScalarValue::Isize(0), ScalarValue::Isize(1)]
+        vec![
+            ScalarValue::Signed(IntegerTy::Isize, 0),
+            ScalarValue::Signed(IntegerTy::Isize, 1)
+        ]
     );
     assert_eq!(
         get_enum_discriminants(&crate_data.type_decls[1]),
-        vec![ScalarValue::U32(3), ScalarValue::U32(42)]
+        vec![
+            ScalarValue::Unsigned(IntegerTy::U32, 3),
+            ScalarValue::Unsigned(IntegerTy::U32, 42)
+        ]
     );
     Ok(())
 }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -379,15 +379,15 @@ fn discriminants() -> anyhow::Result<()> {
     assert_eq!(
         get_enum_discriminants(&crate_data.type_decls[0]),
         vec![
-            ScalarValue::Signed(IntegerTy::Isize, 0),
-            ScalarValue::Signed(IntegerTy::Isize, 1)
+            ScalarValue::Signed(IntTy::Isize, 0),
+            ScalarValue::Signed(IntTy::Isize, 1)
         ]
     );
     assert_eq!(
         get_enum_discriminants(&crate_data.type_decls[1]),
         vec![
-            ScalarValue::Unsigned(IntegerTy::U32, 3),
-            ScalarValue::Unsigned(IntegerTy::U32, 42)
+            ScalarValue::Unsigned(UIntTy::U32, 3),
+            ScalarValue::Unsigned(UIntTy::U32, 42)
         ]
     );
     Ok(())

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -553,5 +553,39 @@
         "tag": null
       }
     ]
+  },
+  "test_crate::MaxBitsDiscr": {
+    "size": 16,
+    "align": 16,
+    "discriminant_layout": {
+      "offset": 0,
+      "tag_ty": {
+        "Unsigned": "U128"
+      },
+      "encoding": "Direct"
+    },
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [],
+        "uninhabited": false,
+        "tag": {
+          "Unsigned": [
+            "U128",
+            "42"
+          ]
+        }
+      },
+      {
+        "field_offsets": [],
+        "uninhabited": false,
+        "tag": {
+          "Unsigned": [
+            "U128",
+            "18446744073709551615"
+          ]
+        }
+      }
+    ]
   }
 }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -38,7 +38,9 @@
     "align": 1,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U8",
+      "tag_ty": {
+        "Unsigned": "U8"
+      },
       "encoding": "Direct"
     },
     "uninhabited": false,
@@ -70,7 +72,9 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U32",
+      "tag_ty": {
+        "Unsigned": "U32"
+      },
       "encoding": "Direct"
     },
     "uninhabited": false,
@@ -118,7 +122,9 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U32",
+      "tag_ty": {
+        "Unsigned": "U32"
+      },
       "encoding": {
         "Niche": {
           "untagged_variant": 1
@@ -247,7 +253,9 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U32",
+      "tag_ty": {
+        "Unsigned": "U32"
+      },
       "encoding": "Direct"
     },
     "uninhabited": false,
@@ -294,7 +302,9 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 8,
-      "tag_ty": "Isize",
+      "tag_ty": {
+        "Signed": "Isize"
+      },
       "encoding": {
         "Niche": {
           "untagged_variant": 1
@@ -334,7 +344,9 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U32",
+      "tag_ty": {
+        "Unsigned": "U32"
+      },
       "encoding": {
         "Niche": {
           "untagged_variant": 0
@@ -377,7 +389,9 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "I32",
+      "tag_ty": {
+        "Signed": "I32"
+      },
       "encoding": "Direct"
     },
     "uninhabited": false,
@@ -423,7 +437,9 @@
     "align": 1,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "I8",
+      "tag_ty": {
+        "Signed": "I8"
+      },
       "encoding": "Direct"
     },
     "uninhabited": false,
@@ -465,7 +481,9 @@
     "align": 4,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "U32",
+      "tag_ty": {
+        "Unsigned": "U32"
+      },
       "encoding": {
         "Niche": {
           "untagged_variant": 2
@@ -506,7 +524,9 @@
     "align": 8,
     "discriminant_layout": {
       "offset": 0,
-      "tag_ty": "Isize",
+      "tag_ty": {
+        "Signed": "Isize"
+      },
       "encoding": {
         "Niche": {
           "untagged_variant": 1

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -47,14 +47,20 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U8": "0"
+          "Unsigned": [
+            "U8",
+            "0"
+          ]
         }
       },
       {
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U8": "1"
+          "Unsigned": [
+            "U8",
+            "1"
+          ]
         }
       }
     ]
@@ -73,7 +79,10 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U32": "0"
+          "Unsigned": [
+            "U32",
+            "0"
+          ]
         }
       },
       {
@@ -83,7 +92,10 @@
         ],
         "uninhabited": false,
         "tag": {
-          "U32": "1"
+          "Unsigned": [
+            "U32",
+            "1"
+          ]
         }
       },
       {
@@ -93,7 +105,10 @@
         ],
         "uninhabited": false,
         "tag": {
-          "U32": "2"
+          "Unsigned": [
+            "U32",
+            "2"
+          ]
         }
       }
     ]
@@ -116,7 +131,10 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U32": "0"
+          "Unsigned": [
+            "U32",
+            "0"
+          ]
         }
       },
       {
@@ -248,7 +266,10 @@
         ],
         "uninhabited": false,
         "tag": {
-          "U32": "1"
+          "Unsigned": [
+            "U32",
+            "1"
+          ]
         }
       }
     ]
@@ -286,7 +307,10 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "Isize": "0"
+          "Signed": [
+            "Isize",
+            "0"
+          ]
         }
       },
       {
@@ -330,14 +354,20 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U32": "1114112"
+          "Unsigned": [
+            "U32",
+            "1114112"
+          ]
         }
       },
       {
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U32": "1114113"
+          "Unsigned": [
+            "U32",
+            "1114113"
+          ]
         }
       }
     ]
@@ -358,7 +388,10 @@
         ],
         "uninhabited": false,
         "tag": {
-          "I32": "12"
+          "Signed": [
+            "I32",
+            "12"
+          ]
         }
       },
       {
@@ -367,14 +400,20 @@
         ],
         "uninhabited": false,
         "tag": {
-          "I32": "43"
+          "Signed": [
+            "I32",
+            "43"
+          ]
         }
       },
       {
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "I32": "123456"
+          "Signed": [
+            "I32",
+            "123456"
+          ]
         }
       }
     ]
@@ -393,21 +432,30 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "I8": "-1"
+          "Signed": [
+            "I8",
+            "-1"
+          ]
         }
       },
       {
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "I8": "0"
+          "Signed": [
+            "I8",
+            "0"
+          ]
         }
       },
       {
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "I8": "1"
+          "Signed": [
+            "I8",
+            "1"
+          ]
         }
       }
     ]
@@ -430,7 +478,10 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "U32": "0"
+          "Unsigned": [
+            "U32",
+            "0"
+          ]
         }
       },
       {
@@ -468,7 +519,10 @@
         "field_offsets": [],
         "uninhabited": false,
         "tag": {
-          "Isize": "0"
+          "Signed": [
+            "Isize",
+            "0"
+          ]
         }
       },
       {

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -134,6 +134,12 @@ fn type_layout() -> anyhow::Result<()> {
             First,
             Second(&'a T),
         }
+
+        #[repr(u128)]
+        enum MaxBitsDiscr {
+            First = 42,
+            Second = 18446744073709551615,
+        }
         "#,
     )?;
 


### PR DESCRIPTION
Based on https://github.com/AeneasVerif/charon/pull/766#discussion_r2195220005 and https://github.com/AeneasVerif/charon/pull/766#discussion_r2195319340

Changes `ScalarValue` to only differentiate between signed and unsigned and store 128 bit and the integer type either way. Also changes that the `IntegerTy` is now split into two types, `IntTy` and `UIntTy` following the model from `hax`.

I can't say whether this is the best way to do everything, but it at least seems to work (i.e. the test succeed). Will stay a draft until we have decided whether this is the way we want to represent scalar values and integer types.

Will also fail tests in CI until we figured out how to handle alternative targets.

ci: use https://github.com/AeneasVerif/eurydice/pull/247
ci: use https://github.com/AeneasVerif/aeneas/pull/579