### PR TITLE
Make `TraitRef` recursive

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.116"
+let supported_charon_version = "0.1.117"

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -333,8 +333,8 @@ and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
   | BuiltinOrAuto (trait, _, _) ->
       region_binder_to_string trait_decl_ref_to_string env trait
   | Clause id -> trait_db_var_to_string env id
-  | ParentClause (inst_id, _decl_id, clause_id) ->
-      let inst_id = trait_instance_id_to_string env inst_id in
+  | ParentClause (tref, clause_id) ->
+      let inst_id = trait_instance_id_to_string env tref.trait_id in
       let clause_id = trait_clause_id_to_string env clause_id in
       "parent(" ^ inst_id ^ ")::" ^ clause_id
   | Dyn trait ->

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1707,11 +1707,10 @@ and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
           de_bruijn_var_of_json trait_clause_id_of_json ctx clause
         in
         Ok (Clause clause)
-    | `Assoc [ ("ParentClause", `List [ x_0; x_1; x_2 ]) ] ->
-        let* x_0 = box_of_json trait_instance_id_of_json ctx x_0 in
-        let* x_1 = trait_decl_id_of_json ctx x_1 in
-        let* x_2 = trait_clause_id_of_json ctx x_2 in
-        Ok (ParentClause (x_0, x_1, x_2))
+    | `Assoc [ ("ParentClause", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = box_of_json trait_ref_of_json ctx x_0 in
+        let* x_1 = trait_clause_id_of_json ctx x_1 in
+        Ok (ParentClause (x_0, x_1))
     | `String "SelfId" -> Ok Self
     | `Assoc
         [

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -435,15 +435,8 @@ and trait_instance_id =
                                ^^^^^^^
                                Clause(0)
           ]} *)
-  | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
+  | ParentClause of trait_ref * trait_clause_id
       (** A parent clause
-
-          Remark: the [TraitDeclId] gives the trait declaration which is
-          implemented by the instance id from which we take the parent clause
-          (see example below). It is not necessary and included for convenience.
-
-          Remark: Ideally we should store a full [TraitRef] instead, but hax
-          does not give us enough information to get the right generic args.
 
           Example:
           {@rust[
@@ -458,11 +451,9 @@ and trait_instance_id =
             fn g<T : Bar>(x : T) {
               x.f()
               ^^^^^
-              Parent(Clause(0), Bar, 1)::f(x)
-                                     ^
-                                     parent clause 1 of clause 0
-                                ^^^
-                         clause 0 implements Bar
+              Parent(Clause(0), 1)::f(x)
+                                ^
+                                parent clause 1 of clause 0
             }
           ]} *)
   | Self

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -470,9 +470,10 @@ and trait_instance_id =
 
           Fields:
           - [trait_decl_ref]
-          - [parent_trait_refs]: The [ImplExpr]s required to satisfy the implied
-            predicates on the trait declaration. E.g. since [FnMut: FnOnce], a
-            built-in [T: FnMut] impl would have an [ImplExpr] for [T: FnOnce].
+          - [parent_trait_refs]: Exactly like the same field on [TraitImpl]: the
+            [TraitRef]s required to satisfy the implied predicates on the trait
+            declaration. E.g. since [FnMut: FnOnce], a built-in [T: FnMut] impl
+            would have a [TraitRef] for [T: FnOnce].
           - [types]: The values of the associated types for this trait. *)
   | Dyn of trait_decl_ref region_binder
       (** The automatically-generated implementation for [dyn Trait]. *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 [[package]]
 name = "hax-adt-into"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#d30960bf206f65f89567937978ad8fa710eb79e8"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#32a73b42a18481965b78cfb00b01b5c62d1f237e"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#d30960bf206f65f89567937978ad8fa710eb79e8"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#32a73b42a18481965b78cfb00b01b5c62d1f237e"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#d30960bf206f65f89567937978ad8fa710eb79e8"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#32a73b42a18481965b78cfb00b01b5c62d1f237e"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.116"
+version = "0.1.117"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -58,13 +58,6 @@ pub enum TraitRefKind {
 
     /// A parent clause
     ///
-    /// Remark: the [TraitDeclId] gives the trait declaration which is
-    /// implemented by the instance id from which we take the parent clause
-    /// (see example below). It is not necessary and included for convenience.
-    ///
-    /// Remark: Ideally we should store a full `TraitRef` instead, but hax does not give us enough
-    /// information to get the right generic args.
-    ///
     /// Example:
     /// ```text
     /// trait Foo1 {}
@@ -78,21 +71,15 @@ pub enum TraitRefKind {
     /// fn g<T : Bar>(x : T) {
     ///   x.f()
     ///   ^^^^^
-    ///   Parent(Clause(0), Bar, 1)::f(x)
-    ///                          ^
-    ///                          parent clause 1 of clause 0
-    ///                     ^^^
-    ///              clause 0 implements Bar
+    ///   Parent(Clause(0), 1)::f(x)
+    ///                     ^
+    ///                     parent clause 1 of clause 0
     /// }
     /// ```
-    ParentClause(Box<TraitRefKind>, TraitDeclId, TraitClauseId),
+    ParentClause(Box<TraitRef>, TraitClauseId),
 
     /// A clause defined on an associated type. This variant is only used during translation; after
     /// the `lift_associated_item_clauses` pass, clauses on items become `ParentClause`s.
-    ///
-    /// Remark: the [TraitDeclId] gives the trait declaration which is
-    /// implemented by the trait implementation from which we take the item
-    /// (see below). It is not necessary and provided for convenience.
     ///
     /// Example:
     /// ```text
@@ -105,15 +92,13 @@ pub enum TraitRefKind {
     /// fn f<T : Foo>(x : T::W) {
     ///   x.bar1();
     ///   ^^^^^^^
-    ///   ItemClause(Clause(0), Foo, W, 1)
-    ///                              ^^^^
-    ///                              clause 1 from item W (from local clause 0)
-    ///                         ^^^
-    ///                local clause 0 implements Foo
+    ///   ItemClause(Clause(0), W, 1)
+    ///                         ^^^^
+    ///                         clause 1 from item W (from local clause 0)
     /// }
     /// ```
     #[charon::opaque]
-    ItemClause(Box<TraitRefKind>, TraitDeclId, TraitItemName, TraitClauseId),
+    ItemClause(Box<TraitRef>, TraitItemName, TraitClauseId),
 
     /// The implicit `Self: Trait` clause. Present inside trait declarations, including trait
     /// method declarations. Not present in trait implementations as we can use `TraitImpl` intead.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -110,9 +110,9 @@ pub enum TraitRefKind {
     /// the information we may need from one.
     BuiltinOrAuto {
         trait_decl_ref: PolyTraitDeclRef,
-        /// The `ImplExpr`s required to satisfy the implied predicates on the trait declaration.
-        /// E.g. since `FnMut: FnOnce`, a built-in `T: FnMut` impl would have an `ImplExpr` for `T:
-        /// FnOnce`.
+        /// Exactly like the same field on `TraitImpl`: the `TraitRef`s required to satisfy the
+        /// implied predicates on the trait declaration. E.g. since `FnMut: FnOnce`, a built-in `T:
+        /// FnMut` impl would have a `TraitRef` for `T: FnOnce`.
         parent_trait_refs: Vector<TraitClauseId, TraitRef>,
         /// The values of the associated types for this trait.
         types: Vec<(TraitItemName, Ty, Vector<TraitClauseId, TraitRef>)>,

--- a/charon/src/bin/charon-driver/translate/translate_drops.rs
+++ b/charon/src/bin/charon-driver/translate/translate_drops.rs
@@ -10,10 +10,8 @@ impl ItemTransCtx<'_, '_> {
         span: Span,
         def: &hax::FullDef,
     ) -> Result<Result<Body, Opaque>, Error> {
-        let (hax::FullDefKind::Struct { drop_glue, .. }
-        | hax::FullDefKind::Enum { drop_glue, .. }
-        | hax::FullDefKind::Union { drop_glue, .. }
-        | hax::FullDefKind::Closure { drop_glue, .. }) = def.kind()
+        let (hax::FullDefKind::Adt { drop_glue, .. } | hax::FullDefKind::Closure { drop_glue, .. }) =
+            def.kind()
         else {
             panic!("Unexpected def adt: {def:?}")
         };

--- a/charon/src/bin/charon-driver/translate/translate_functions.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions.rs
@@ -48,9 +48,6 @@ impl ItemTransCtx<'_, '_> {
             }
             hax::FullDefKind::Const { ty, .. }
             | hax::FullDefKind::AssocConst { ty, .. }
-            | hax::FullDefKind::AnonConst { ty, .. }
-            | hax::FullDefKind::InlineConst { ty, .. }
-            | hax::FullDefKind::PromotedConst { ty, .. }
             | hax::FullDefKind::Static { ty, .. } => {
                 let sig = hax::TyFnSig {
                     inputs: vec![],

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -338,13 +338,17 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             AssocTy { .. }
             | AssocFn { .. }
             | AssocConst { .. }
-            | AnonConst { .. }
-            | InlineConst { .. }
-            | PromotedConst { .. }
+            | Const {
+                kind:
+                    hax::ConstKind::AnonConst
+                    | hax::ConstKind::InlineConst
+                    | hax::ConstKind::PromotedConst,
+                ..
+            }
             | Closure { .. }
             | Ctor { .. }
             | Variant { .. } => {
-                let parent_def_id = def.parent.as_ref().unwrap();
+                let parent_def_id = def.def_id().parent.as_ref().unwrap();
                 let parent_def = self.hax_def(parent_def_id)?;
                 self.push_generics_for_def(span, &parent_def, true)?;
             }
@@ -369,18 +373,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             self.push_generic_params(&param_env.generics)?;
             // Add the predicates.
             let origin = match &def.kind {
-                FullDefKind::Struct { .. }
-                | FullDefKind::Union { .. }
-                | FullDefKind::Enum { .. }
+                FullDefKind::Adt { .. }
                 | FullDefKind::TyAlias { .. }
                 | FullDefKind::AssocTy { .. } => PredicateOrigin::WhereClauseOnType,
                 FullDefKind::Fn { .. }
                 | FullDefKind::AssocFn { .. }
                 | FullDefKind::Const { .. }
                 | FullDefKind::AssocConst { .. }
-                | FullDefKind::AnonConst { .. }
-                | FullDefKind::InlineConst { .. }
-                | FullDefKind::PromotedConst { .. }
                 | FullDefKind::Static { .. } => PredicateOrigin::WhereClauseOnFn,
                 FullDefKind::TraitImpl { .. } | FullDefKind::InherentImpl { .. } => {
                     PredicateOrigin::WhereClauseOnImpl

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -713,7 +713,9 @@ impl ItemTransCtx<'_, '_> {
                     ) -> ControlFlow<Self::Break> {
                         match kind {
                             TraitRefKind::SelfId => return ControlFlow::Break(UnhandledSelf),
-                            TraitRefKind::ParentClause(box TraitRefKind::SelfId, _, clause_id) => {
+                            TraitRefKind::ParentClause(sub, clause_id)
+                                if matches!(sub.kind, TraitRefKind::SelfId) =>
+                            {
                                 *kind = TraitRefKind::Clause(DeBruijnVar::bound(
                                     self.binder_depth,
                                     *clause_id,

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -474,7 +474,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
 impl<'tcx, 'ctx> TranslateCtx<'tcx> {
     /// Whether this item is in an `extern { .. }` block, in which case it has no body.
     pub(crate) fn is_extern_item(&mut self, def: &hax::FullDef) -> bool {
-        def.parent.as_ref().is_some_and(|parent| {
+        def.def_id().parent.as_ref().is_some_and(|parent| {
             self.hax_def(parent).is_ok_and(|parent_def| {
                 matches!(parent_def.kind(), hax::FullDefKind::ForeignMod { .. })
             })

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1652,16 +1652,16 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TraitRefKind::SelfId => write!(f, "Self"),
-            TraitRefKind::ParentClause(id, _decl_id, clause_id) => {
-                let id = id.with_ctx(ctx);
-                write!(f, "{id}::parent_clause{clause_id}")
+            TraitRefKind::ParentClause(sub, clause_id) => {
+                let sub = sub.with_ctx(ctx);
+                write!(f, "{sub}::parent_clause{clause_id}")
             }
-            TraitRefKind::ItemClause(id, _decl_id, type_name, clause_id) => {
-                let id = id.with_ctx(ctx);
+            TraitRefKind::ItemClause(sub, type_name, clause_id) => {
+                let sub = sub.with_ctx(ctx);
                 // Using on purpose `to_pretty_string` instead of `with_ctx`: the clause is local
                 // to the associated type, so it should not be referenced in the current context.
                 let clause = clause_id.to_pretty_string();
-                write!(f, "({id}::{type_name}::[{clause}])")
+                write!(f, "({sub}::{type_name}::[{clause}])")
             }
             TraitRefKind::TraitImpl(impl_ref) => {
                 write!(f, "{}", impl_ref.with_ctx(ctx))

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -47,20 +47,19 @@ impl TransformPass for Transform {
             use TraitRefKind::*;
             match trkind {
                 ItemClause(..) => take_mut::take(trkind, |trkind| {
-                    let ItemClause(trait_ref, trait_decl, item_name, item_clause_id) = trkind
-                    else {
+                    let ItemClause(tref, item_name, item_clause_id) = trkind else {
                         unreachable!()
                     };
                     let new_id = (|| {
                         let new_id = *trait_item_clause_ids
-                            .get(trait_decl)?
+                            .get(tref.trait_decl_ref.skip_binder.id)?
                             .get(&item_name)?
                             .get(item_clause_id)?;
                         Some(new_id)
                     })();
                     match new_id {
-                        Some(new_id) => ParentClause(trait_ref, trait_decl, new_id),
-                        None => ItemClause(trait_ref, trait_decl, item_name, item_clause_id),
+                        Some(new_id) => ParentClause(tref, new_id),
+                        None => ItemClause(tref, item_name, item_clause_id),
                     }
                 }),
                 BuiltinOrAuto {


### PR DESCRIPTION
It used to be that `TraitRefKind` was recursive; now a `TraitRefKind` may refer to a whole `TraitRef`, which amounts to adding some information about intermediate predicates.

ci: use https://github.com/AeneasVerif/aeneas/pull/578
ci: use https://github.com/AeneasVerif/eurydice/pull/243