### PR TITLE
Represent globals as places

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.122"
+let supported_charon_version = "0.1.123"

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -528,3 +528,15 @@ let find_local_transitive_dep (m : crate) (marked_externals : AnyDeclIdSet.t) :
     !edges;
   (* Return the spans *)
   SpanSet.elements !spans
+
+let map_statement (f : statement -> statement list) (b : block) : block =
+  let visitor =
+    object
+      inherit [_] map_statement_base as super
+
+      method! visit_block env b =
+        super#visit_block env
+          { b with statements = List.flatten (List.map f b.statements) }
+    end
+  in
+  visitor#visit_block () b

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -65,6 +65,9 @@ and place_to_string (env : 'a fmt_env) (p : place) : string =
   | PlaceProjection (subplace, pe) ->
       let subplace = place_to_string env subplace in
       projection_elem_to_string env subplace pe
+  | PlaceGlobal global_ref ->
+      let generics = generic_args_to_string env global_ref.generics in
+      global_decl_id_to_string env global_ref.id ^ generics
 
 and cast_kind_to_string (env : 'a fmt_env) (cast : cast_kind) : string =
   match cast with
@@ -176,15 +179,6 @@ and rvalue_to_string (env : 'a fmt_env) (rv : rvalue) : string =
           (ty_to_string env ty
           :: List.map (const_generic_to_string env) const_generics)
       ^ ">(" ^ place_to_string env place ^ ")"
-  | Global global_ref ->
-      let generics = generic_args_to_string env global_ref.generics in
-      "global " ^ global_decl_id_to_string env global_ref.id ^ generics
-  | GlobalRef (global_ref, RShared) ->
-      let generics = generic_args_to_string env global_ref.generics in
-      "&global " ^ global_decl_id_to_string env global_ref.id ^ generics
-  | GlobalRef (global_ref, RMut) ->
-      let generics = generic_args_to_string env global_ref.generics in
-      "&raw mut global " ^ global_decl_id_to_string env global_ref.id ^ generics
   | Repeat (v, _, len) ->
       "[" ^ operand_to_string env v ^ ";"
       ^ const_generic_to_string env len

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -174,8 +174,11 @@ and overflow_mode =
 and place = { kind : place_kind; ty : ty }
 
 and place_kind =
-  | PlaceLocal of local_id
-  | PlaceProjection of place * projection_elem
+  | PlaceLocal of local_id  (** A local variable in a function body. *)
+  | PlaceProjection of place * projection_elem  (** A subplace of a place. *)
+  | PlaceGlobal of global_decl_ref
+      (** A global (const or static). Not present in MIR; introduced in
+          [simplify_constants.rs]. *)
 
 (** Note that we don't have the equivalent of "downcasts". Downcasts are
     actually necessary, for instance when initializing enumeration values: the
@@ -226,7 +229,7 @@ and projection_elem =
       desugar those to regular ADTs, see [regularize_constant_adts.rs].
 
     [[RawConstantExpr::Global]] case: access to a global variable. We later
-    desugar it to a separate statement.
+    desugar it to a copy of a place global.
 
     [[RawConstantExpr::Ref]] case: reference to a constant value. We later
     desugar it to a separate statement.
@@ -302,13 +305,6 @@ and rvalue =
 
           Remark: in case of closures, the aggregated value groups the closure
           id together with its state. *)
-  | Global of global_decl_ref
-      (** Copy the value of the referenced global. Not present in MIR;
-          introduced in [simplify_constants.rs]. *)
-  | GlobalRef of global_decl_ref * ref_kind
-      (** Reference the value of the global. This has type [&T] or [*mut T]
-          depending on desired mutability. Not present in MIR; introduced in
-          [simplify_constants.rs]. *)
   | Len of place * ty * const_generic option
       (** Length of a memory location. The run-time length of e.g. a vector or a
           slice is represented differently (but pretty-prints the same, FIXME).

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1283,6 +1283,9 @@ and place_kind_of_json (ctx : of_json_ctx) (js : json) :
         let* x_0 = box_of_json place_of_json ctx x_0 in
         let* x_1 = projection_elem_of_json ctx x_1 in
         Ok (PlaceProjection (x_0, x_1))
+    | `Assoc [ ("Global", global) ] ->
+        let* global = global_decl_ref_of_json ctx global in
+        Ok (PlaceGlobal global)
     | _ -> Error "")
 
 and preset_of_json (ctx : of_json_ctx) (js : json) : (preset, string) result =
@@ -1463,13 +1466,6 @@ and rvalue_of_json (ctx : of_json_ctx) (js : json) : (rvalue, string) result =
         let* x_0 = aggregate_kind_of_json ctx x_0 in
         let* x_1 = list_of_json operand_of_json ctx x_1 in
         Ok (Aggregate (x_0, x_1))
-    | `Assoc [ ("Global", global) ] ->
-        let* global = global_decl_ref_of_json ctx global in
-        Ok (Global global)
-    | `Assoc [ ("GlobalRef", `List [ x_0; x_1 ]) ] ->
-        let* x_0 = global_decl_ref_of_json ctx x_0 in
-        let* x_1 = ref_kind_of_json ctx x_1 in
-        Ok (GlobalRef (x_0, x_1))
     | `Assoc [ ("Len", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = place_of_json ctx x_0 in
         let* x_1 = ty_of_json ctx x_1 in

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.122"
+version = "0.1.123"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.122"
+version = "0.1.123"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -27,8 +27,13 @@ pub struct Place {
 )]
 #[charon::variants_prefix("Place")]
 pub enum PlaceKind {
+    /// A local variable in a function body.
     Local(LocalId),
+    /// A subplace of a place.
     Projection(Box<Place>, ProjectionElem),
+    /// A global (const or static).
+    /// Not present in MIR; introduced in [simplify_constants.rs].
+    Global(GlobalDeclRef),
 }
 
 /// Note that we don't have the equivalent of "downcasts".
@@ -459,7 +464,7 @@ impl From<FunDeclRef> for FnPtr {
 /// We later desugar those to regular ADTs, see [regularize_constant_adts.rs].
 ///
 /// [`RawConstantExpr::Global`] case: access to a global variable. We later desugar it to
-/// a separate statement.
+/// a copy of a place global.
 ///
 /// [`RawConstantExpr::Ref`] case: reference to a constant value. We later desugar it to a separate
 /// statement.
@@ -611,13 +616,6 @@ pub enum Rvalue {
     /// Remark: in case of closures, the aggregated value groups the closure id
     /// together with its state.
     Aggregate(AggregateKind, Vec<Operand>),
-    /// Copy the value of the referenced global.
-    /// Not present in MIR; introduced in [simplify_constants.rs].
-    Global(GlobalDeclRef),
-    /// Reference the value of the global. This has type `&T` or `*mut T` depending on desired
-    /// mutability.
-    /// Not present in MIR; introduced in [simplify_constants.rs].
-    GlobalRef(GlobalDeclRef, RefKind),
     /// Length of a memory location. The run-time length of e.g. a vector or a slice is
     /// represented differently (but pretty-prints the same, FIXME).
     /// Should be seen as a function of signature:

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -10,6 +10,13 @@ impl Place {
         }
     }
 
+    pub fn new_global(global: GlobalDeclRef, ty: Ty) -> Place {
+        Place {
+            kind: PlaceKind::Global(global),
+            ty,
+        }
+    }
+
     pub fn ty(&self) -> &Ty {
         &self.ty
     }
@@ -29,13 +36,14 @@ impl Place {
     }
 
     #[deprecated(note = "use `local_id` instead")]
-    pub fn var_id(&self) -> LocalId {
+    pub fn var_id(&self) -> Option<LocalId> {
         self.local_id()
     }
-    pub fn local_id(&self) -> LocalId {
+    pub fn local_id(&self) -> Option<LocalId> {
         match &self.kind {
-            PlaceKind::Local(var_id) => *var_id,
+            PlaceKind::Local(var_id) => Some(*var_id),
             PlaceKind::Projection(subplace, _) => subplace.local_id(),
+            PlaceKind::Global(_) => None,
         }
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -933,9 +933,9 @@ impl BodyTransCtx<'_, '_, '_> {
                         let v =
                             ScalarValue::from_le_bytes(IntegerTy::Signed(int_ty), v.data_le_bytes);
                         let tgt = self.translate_basic_block_id(*tgt);
-                        Ok((v, tgt))
+                        (v, tgt)
                     })
-                    .try_collect()?;
+                    .collect();
                 let otherwise = self.translate_basic_block_id(*otherwise);
                 Ok(SwitchTargets::SwitchInt(
                     IntegerTy::Signed(int_ty),
@@ -952,9 +952,9 @@ impl BodyTransCtx<'_, '_, '_> {
                             v.data_le_bytes,
                         );
                         let tgt = self.translate_basic_block_id(*tgt);
-                        Ok((v, tgt))
+                        (v, tgt)
                     })
-                    .try_collect()?;
+                    .collect();
                 let otherwise = self.translate_basic_block_id(*otherwise);
                 Ok(SwitchTargets::SwitchInt(
                     IntegerTy::Unsigned(int_ty),

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -253,7 +253,7 @@ impl ItemTransCtx<'_, '_> {
         let fields: Vector<FieldId, Field> = args
             .upvar_tys
             .iter()
-            .map(|ty| {
+            .map(|ty| -> Result<Field, Error> {
                 let mut ty = self.translate_ty(span, ty)?;
                 // We supply fresh regions for the by-ref upvars.
                 if let TyKind::Ref(Region::Erased, deref_ty, kind) = ty.kind() {

--- a/charon/src/bin/charon-driver/translate/translate_functions.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions.rs
@@ -115,7 +115,7 @@ impl ItemTransCtx<'_, '_> {
         locals.new_var(None, output_ty);
         let args: Vec<_> = fields
             .iter()
-            .map(|field| {
+            .map(|field| -> Result<Operand, Error> {
                 let ty = self.translate_ty(span, &field.ty)?;
                 let place = locals.new_var(None, ty);
                 Ok(Operand::Move(place))

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -547,7 +547,7 @@ impl ItemTransCtx<'_, '_> {
         };
         let items: Vec<(TraitItemName, &hax::AssocItem)> = items
             .iter()
-            .map(|item| {
+            .map(|item| -> Result<_, Error> {
                 let name = self.t_ctx.translate_trait_item_name(&item.def_id)?;
                 Ok((name, item))
             })

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -344,7 +344,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     let parent_trait_refs = self.translate_trait_impl_exprs(span, &impl_exprs)?;
                     let types = types
                         .iter()
-                        .map(|(def_id, ty, impl_exprs)| {
+                        .map(|(def_id, ty, impl_exprs)| -> Result<_, Error> {
                             let name = self.t_ctx.translate_trait_item_name(def_id)?;
                             let ty = self.translate_ty(span, ty)?;
                             let trait_refs = self.translate_trait_impl_exprs(span, impl_exprs)?;

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -105,6 +105,15 @@ impl Error {
     }
 }
 
+impl<T: ToString> From<T> for Error {
+    fn from(err: T) -> Self {
+        Self {
+            span: Span::dummy(),
+            msg: err.to_string(),
+        }
+    }
+}
+
 /// Display an error without a specific location.
 pub fn display_unspanned_error(level: Level, msg: &str) {
     use annotate_snippets::*;

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1015,6 +1015,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Place {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
             PlaceKind::Local(var_id) => write!(f, "{}", var_id.with_ctx(ctx)),
+            PlaceKind::Global(global_ref) => global_ref.fmt_with_ctx(ctx, f),
             PlaceKind::Projection(subplace, projection) => {
                 let sub = subplace.with_ctx(ctx);
                 match projection {
@@ -1264,13 +1265,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                         write!(f, "*{} ({})", mutability, ops_s)
                     }
                 }
-            }
-            Rvalue::Global(global_ref) => write!(f, "{}", global_ref.with_ctx(ctx)),
-            Rvalue::GlobalRef(global_ref, RefKind::Shared) => {
-                write!(f, "&{}", global_ref.with_ctx(ctx))
-            }
-            Rvalue::GlobalRef(global_ref, RefKind::Mut) => {
-                write!(f, "&raw mut {}", global_ref.with_ctx(ctx))
             }
             Rvalue::Len(place, ..) => write!(f, "len({})", place.with_ctx(ctx)),
             Rvalue::Repeat(op, _ty, cg) => {

--- a/charon/src/transform/index_to_function_calls.rs
+++ b/charon/src/transform/index_to_function_calls.rs
@@ -27,7 +27,7 @@ struct IndexVisitor<'a> {
 impl<'a> IndexVisitor<'a> {
     fn fresh_var(&mut self, name: Option<String>, ty: Ty) -> Place {
         let var = self.locals.new_var(name, ty);
-        let live_kind = RawStatement::StorageLive(var.local_id());
+        let live_kind = RawStatement::StorageLive(var.local_id().unwrap());
         self.statements.push(Statement::new(self.span, live_kind));
         var
     }
@@ -139,7 +139,7 @@ impl<'a> IndexVisitor<'a> {
                 ),
             );
             self.statements.push(Statement::new(self.span, kind));
-            let dead_kind = RawStatement::StorageDead(len_var.local_id());
+            let dead_kind = RawStatement::StorageDead(len_var.local_id().unwrap());
             self.statements.push(Statement::new(self.span, dead_kind));
             args.push(Operand::Copy(index_var));
         } else {
@@ -224,8 +224,8 @@ impl VisitBodyMut for IndexVisitor<'_> {
             | Discriminant(..)
             | Len(..) => self.visit_inner_with_mutability(x, false),
 
-            Use(_) | NullaryOp(..) | UnaryOp(..) | BinaryOp(..) | Aggregate(..) | Global(..)
-            | GlobalRef(..) | Repeat(..) | ShallowInitBox(..) => self.visit_inner(x),
+            Use(_) | NullaryOp(..) | UnaryOp(..) | BinaryOp(..) | Aggregate(..) | Repeat(..)
+            | ShallowInitBox(..) => self.visit_inner(x),
         }
     }
 

--- a/charon/src/transform/prettify_cfg.rs
+++ b/charon/src/transform/prettify_cfg.rs
@@ -35,7 +35,8 @@ impl Transform {
             },
             ..,
         ] = seq
-            && locals[call.dest.local_id()].ty.kind().is_never()
+            && let Some(local_id) = call.dest.as_local()
+            && locals[local_id].ty.kind().is_never()
         {
             *second_abort = RawStatement::Nop;
             return Vec::new();

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -496,15 +496,12 @@ pub fn thing()
     let @3: u32; // anonymous local
     let @4: (); // anonymous local
     let @5: u32; // anonymous local
-    let @6: u32; // anonymous local
 
     storage_live(@3)
-    storage_live(@6)
     storage_live(x@1)
     storage_live(@2)
     // This comment belongs above the assignment to `x` and not above intermediate computations.
-    @6 := CONSTANT
-    @2 := move (@6) panic.>> const (3 : i32)
+    @2 := copy (CONSTANT) panic.>> const (3 : i32)
     @3 := copy (@2) panic.+ const (12 : u32)
     x@1 := move (@3)
     storage_dead(@2)

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -48,11 +48,8 @@ pub const X0: u32 = X0()
 pub fn X1() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    storage_live(@1)
-    @1 := MAX
-    @0 := move (@1)
+    @0 := copy (MAX)
     return
 }
 
@@ -243,12 +240,9 @@ pub fn unwrap_y() -> i32
 {
     let @0: i32; // return
     let @1: Wrap<i32>[Sized<i32>]; // anonymous local
-    let @2: Wrap<i32>[Sized<i32>]; // anonymous local
 
-    storage_live(@2)
     storage_live(@1)
-    @2 := Y
-    @1 := move (@2)
+    @1 := copy (Y)
     @0 := copy ((@1).value)
     storage_dead(@1)
     return
@@ -282,11 +276,8 @@ const Z1: i32 = Z1()
 pub fn get_z1() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    storage_live(@1)
-    @1 := Z1
-    @0 := move (@1)
+    @0 := copy (Z1)
     return
 }
 
@@ -328,11 +319,8 @@ pub const Q1: i32 = Q1()
 pub fn Q2() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    storage_live(@1)
-    @1 := Q1
-    @0 := move (@1)
+    @0 := copy (Q1)
     return
 }
 
@@ -343,11 +331,8 @@ pub const Q2: i32 = Q2()
 pub fn Q3() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    storage_live(@1)
-    @1 := Q2
-    @0 := add(move (@1), const (3 : i32))
+    @0 := add(copy (Q2), const (3 : i32))
     return
 }
 
@@ -360,19 +345,13 @@ pub fn get_z2() -> i32
     let @0: i32; // return
     let @1: i32; // anonymous local
     let @2: i32; // anonymous local
-    let @3: i32; // anonymous local
-    let @4: i32; // anonymous local
 
-    storage_live(@3)
-    storage_live(@4)
     storage_live(@1)
     storage_live(@2)
     @2 := get_z1()
-    @3 := Q3
-    @1 := add(move (@2), move (@3))
+    @1 := add(move (@2), copy (Q3))
     storage_dead(@2)
-    @4 := Q1
-    @0 := add(move (@4), move (@1))
+    @0 := add(copy (Q1), move (@1))
     storage_dead(@1)
     return
 }
@@ -416,11 +395,8 @@ pub static S2: u32 = S2()
 pub fn S3() -> Pair<u32, u32>[Sized<u32>, Sized<u32>]
 {
     let @0: Pair<u32, u32>[Sized<u32>, Sized<u32>]; // return
-    let @1: Pair<u32, u32>[Sized<u32>, Sized<u32>]; // anonymous local
 
-    storage_live(@1)
-    @1 := P3
-    @0 := move (@1)
+    @0 := copy (P3)
     return
 }
 
@@ -470,11 +446,8 @@ where
     [@TraitClause0]: Sized<T>,
 {
     let @0: usize; // return
-    let @1: usize; // anonymous local
 
-    storage_live(@1)
-    @1 := LEN<T, const N : usize>[@TraitClause0]
-    @0 := move (@1)
+    @0 := copy (LEN<T, const N : usize>[@TraitClause0])
     return
 }
 

--- a/charon/tests/ui/cross_compile_32_bit.out
+++ b/charon/tests/ui/cross_compile_32_bit.out
@@ -32,15 +32,12 @@ fn main()
     let a@7: HasPointerNiche; // local
     let @8: NonNull<usize>; // anonymous local
     let @9: *mut usize; // anonymous local
-    let @10: usize; // anonymous local
 
     storage_live(@6)
-    storage_live(@10)
     storage_live(x@1)
     x@1 := const (52 : usize)
     storage_live(y@2)
-    @10 := MAX
-    y@2 := move (@10)
+    y@2 := copy (MAX)
     storage_live(z@3)
     storage_live(@4)
     @4 := copy (y@2)

--- a/charon/tests/ui/cross_compile_big_endian.out
+++ b/charon/tests/ui/cross_compile_big_endian.out
@@ -39,15 +39,12 @@ fn main()
     let @6: usize; // anonymous local
     let a@7: u128; // local
     let b@8: HasBEDiscr; // local
-    let @9: usize; // anonymous local
 
     storage_live(@6)
-    storage_live(@9)
     storage_live(x@1)
     x@1 := const (52 : usize)
     storage_live(y@2)
-    @9 := MAX
-    y@2 := move (@9)
+    y@2 := copy (MAX)
     storage_live(z@3)
     storage_live(@4)
     @4 := copy (y@2)

--- a/charon/tests/ui/foreign-constant.out
+++ b/charon/tests/ui/foreign-constant.out
@@ -10,11 +10,8 @@ pub const CONSTANT: u8 = CONSTANT()
 fn foo() -> u8
 {
     let @0: u8; // return
-    let @1: u8; // anonymous local
 
-    storage_live(@1)
-    @1 := CONSTANT
-    @0 := move (@1)
+    @0 := copy (CONSTANT)
     return
 }
 

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -369,11 +369,8 @@ fn vec(@1: Vec<u32>[Sized<u32>, Sized<Global>])
 fn max() -> usize
 {
     let @0: usize; // return
-    let @1: usize; // anonymous local
 
-    storage_live(@1)
-    @1 := MAX
-    @0 := move (@1)
+    @0 := copy (MAX)
     return
 }
 

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -565,18 +565,16 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
     let @45: i16; // anonymous local
     let @46: usize; // anonymous local
     let @47: usize; // anonymous local
-    let @48: i16; // anonymous local
-    let @49: i16; // anonymous local
+    let @48: &'_ mut (Slice<i16>); // anonymous local
+    let @49: &'_ mut (i16); // anonymous local
     let @50: &'_ mut (Slice<i16>); // anonymous local
     let @51: &'_ mut (i16); // anonymous local
-    let @52: &'_ mut (Slice<i16>); // anonymous local
-    let @53: &'_ mut (i16); // anonymous local
+    let @52: &'_ (Slice<u8>); // anonymous local
+    let @53: &'_ (u8); // anonymous local
     let @54: &'_ (Slice<u8>); // anonymous local
     let @55: &'_ (u8); // anonymous local
     let @56: &'_ (Slice<u8>); // anonymous local
     let @57: &'_ (u8); // anonymous local
-    let @58: &'_ (Slice<u8>); // anonymous local
-    let @59: &'_ (u8); // anonymous local
 
     storage_live(@11)
     storage_live(bytes@13)
@@ -624,8 +622,6 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
     storage_live(@55)
     storage_live(@56)
     storage_live(@57)
-    storage_live(@58)
-    storage_live(@59)
     storage_live(sampled@3)
     sampled@3 := const (0 : usize)
     storage_live(@4)
@@ -659,11 +655,11 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                 storage_live(@15)
                 storage_live(@16)
                 @16 := const (0 : usize)
-                storage_live(@58)
-                @58 := &*(bytes@13)
-                storage_live(@59)
-                @59 := @SliceIndexShared<'_, u8>(move (@58), copy (@16))
-                @15 := copy (*(@59))
+                storage_live(@56)
+                @56 := &*(bytes@13)
+                storage_live(@57)
+                @57 := @SliceIndexShared<'_, u8>(move (@56), copy (@16))
+                @15 := copy (*(@57))
                 b1@14 := cast<u8, i16>(move (@15))
                 storage_dead(@15)
                 storage_dead(@16)
@@ -671,11 +667,11 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                 storage_live(@18)
                 storage_live(@19)
                 @19 := const (1 : usize)
-                storage_live(@56)
-                @56 := &*(bytes@13)
-                storage_live(@57)
-                @57 := @SliceIndexShared<'_, u8>(move (@56), copy (@19))
-                @18 := copy (*(@57))
+                storage_live(@54)
+                @54 := &*(bytes@13)
+                storage_live(@55)
+                @55 := @SliceIndexShared<'_, u8>(move (@54), copy (@19))
+                @18 := copy (*(@55))
                 b2@17 := cast<u8, i16>(move (@18))
                 storage_dead(@18)
                 storage_dead(@19)
@@ -683,11 +679,11 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                 storage_live(@21)
                 storage_live(@22)
                 @22 := const (2 : usize)
-                storage_live(@54)
-                @54 := &*(bytes@13)
-                storage_live(@55)
-                @55 := @SliceIndexShared<'_, u8>(move (@54), copy (@22))
-                @21 := copy (*(@55))
+                storage_live(@52)
+                @52 := &*(bytes@13)
+                storage_live(@53)
+                @53 := @SliceIndexShared<'_, u8>(move (@52), copy (@22))
+                @21 := copy (*(@53))
                 b3@20 := cast<u8, i16>(move (@21))
                 storage_dead(@21)
                 storage_dead(@22)
@@ -723,8 +719,7 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                 storage_live(@34)
                 storage_live(@35)
                 @35 := copy (d1@23)
-                @48 := FIELD_MODULUS
-                @34 := move (@35) < move (@48)
+                @34 := move (@35) < copy (FIELD_MODULUS)
                 if move (@34) {
                     storage_dead(@35)
                     storage_live(@36)
@@ -737,11 +732,11 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                         @38 := copy (d1@23)
                         storage_live(@39)
                         @39 := copy (sampled@3)
-                        storage_live(@50)
-                        @50 := &mut *(result@2)
-                        storage_live(@51)
-                        @51 := @SliceIndexMut<'_, i16>(move (@50), copy (@39))
-                        *(@51) := move (@38)
+                        storage_live(@48)
+                        @48 := &mut *(result@2)
+                        storage_live(@49)
+                        @49 := @SliceIndexMut<'_, i16>(move (@48), copy (@39))
+                        *(@49) := move (@38)
                         storage_dead(@38)
                         storage_dead(@39)
                         @40 := copy (sampled@3) panic.+ const (1 : usize)
@@ -760,8 +755,7 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                 storage_live(@41)
                 storage_live(@42)
                 @42 := copy (d2@28)
-                @49 := FIELD_MODULUS
-                @41 := move (@42) < move (@49)
+                @41 := move (@42) < copy (FIELD_MODULUS)
                 if move (@41) {
                     storage_dead(@42)
                     storage_live(@43)
@@ -774,11 +768,11 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
                         @45 := copy (d2@28)
                         storage_live(@46)
                         @46 := copy (sampled@3)
-                        storage_live(@52)
-                        @52 := &mut *(result@2)
-                        storage_live(@53)
-                        @53 := @SliceIndexMut<'_, i16>(move (@52), copy (@46))
-                        *(@53) := move (@45)
+                        storage_live(@50)
+                        @50 := &mut *(result@2)
+                        storage_live(@51)
+                        @51 := @SliceIndexMut<'_, i16>(move (@50), copy (@46))
+                        *(@51) := move (@45)
                         storage_dead(@45)
                         storage_dead(@46)
                         @47 := copy (sampled@3) panic.+ const (1 : usize)

--- a/charon/tests/ui/issue-507-cfg.out
+++ b/charon/tests/ui/issue-507-cfg.out
@@ -20,12 +20,10 @@ fn f0()
     let @2: (); // anonymous local
     let @3: bool; // anonymous local
     let x@4: u8; // local
-    let @5: u8; // anonymous local
 
     storage_live(@2)
     storage_live(@3)
     storage_live(x@4)
-    storage_live(@5)
     storage_live(@1)
     @1 := const (0 : i32) < const (1 : i32)
     if move (@1) {
@@ -39,8 +37,7 @@ fn f0()
         storage_dead(@3)
         storage_dead(@2)
         storage_live(x@4)
-        @5 := CONST
-        x@4 := move (@5)
+        x@4 := copy (CONST)
         @0 := ()
         storage_dead(x@4)
     }
@@ -70,7 +67,6 @@ fn f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
     let x@12: u8; // local
     let @13: (); // anonymous local
     let @14: (); // anonymous local
-    let @15: u8; // anonymous local
 
     storage_live(@6)
     storage_live(@7)
@@ -80,7 +76,6 @@ fn f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
     storage_live(@11)
     storage_live(x@12)
     storage_live(@13)
-    storage_live(@15)
     storage_live(previous_true_hints_seen@2)
     previous_true_hints_seen@2 := const (0 : usize)
     storage_live(i@3)
@@ -118,8 +113,7 @@ fn f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
                 if move (@10) {
                     storage_dead(@11)
                     storage_live(x@12)
-                    @15 := CONST
-                    x@12 := move (@15)
+                    x@12 := copy (CONST)
                     storage_dead(x@12)
                     storage_dead(@10)
                     continue 0

--- a/charon/tests/ui/max_char.out
+++ b/charon/tests/ui/max_char.out
@@ -13,11 +13,8 @@ pub const core::char::methods::{char}::MAX: char = core::char::methods::{char}::
 pub fn core::char::MAX() -> char
 {
     let @0: char; // return
-    let @1: char; // anonymous local
 
-    storage_live(@1)
-    @1 := core::char::methods::{char}::MAX
-    @0 := move (@1)
+    @0 := copy (core::char::methods::{char}::MAX)
     return
 }
 
@@ -28,12 +25,9 @@ fn main()
 {
     let @0: (); // return
     let _max_char@1: char; // local
-    let @2: char; // anonymous local
 
-    storage_live(@2)
     storage_live(_max_char@1)
-    @2 := core::char::MAX
-    _max_char@1 := move (@2)
+    _max_char@1 := copy (core::char::MAX)
     @0 := ()
     storage_dead(_max_char@1)
     @0 := ()

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -85,8 +85,7 @@ fn precondition_check(@1: *const (), @2: isize, @3: usize)
     let @24: u64; // anonymous local
     let @25: &'_ (Slice<&'_ (Str)>); // anonymous local
     let @26: &'_ (Slice<Argument<'_>>); // anonymous local
-    let @27: &'_ (Array<Argument<'_>, 0 : usize>); // anonymous local
-    let @28: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
+    let @27: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
 
     storage_live(@5)
     storage_live(pieces@7)
@@ -100,7 +99,6 @@ fn precondition_check(@1: *const (), @2: isize, @3: usize)
     storage_live(@23)
     storage_live(@24)
     storage_live(@27)
-    storage_live(@28)
     storage_live(@4)
     storage_live(overflow@19)
     storage_live(rhs@9)
@@ -168,10 +166,9 @@ fn precondition_check(@1: *const (), @2: isize, @3: usize)
     storage_live(@25)
     @25 := @ArrayToSliceShared<'_, &'_ (Str), 1 : usize>(copy (pieces@7))
     storage_live(@26)
-    @27 := {promoted_const}<'_, 1 : usize>
-    @26 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(move (@27))
-    @28 := Option::None {  }
-    @6 := Arguments { 0: move (@25), 1: move (@28), 2: move (@26) }
+    @26 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(copy ({promoted_const}<'_, 1 : usize>))
+    @27 := Option::None {  }
+    @6 := Arguments { 0: move (@25), 1: move (@27), 2: move (@26) }
     storage_dead(@26)
     storage_dead(@25)
     @5 := panic_nounwind_fmt<'_>(move (@6), const (false))

--- a/charon/tests/ui/remove-dynamic-checks.out
+++ b/charon/tests/ui/remove-dynamic-checks.out
@@ -697,12 +697,9 @@ pub fn test_crate::_#8() -> u32
 {
     let @0: u32; // return
     let @1: u32; // anonymous local
-    let @2: u32; // anonymous local
 
     storage_live(@1)
-    storage_live(@2)
-    @2 := test_crate::FOO
-    @1 := const (1 : u32) panic.+ move (@2)
+    @1 := const (1 : u32) panic.+ copy (test_crate::FOO)
     @0 := move (@1)
     return
 }
@@ -713,12 +710,9 @@ pub fn test_crate::_#9() -> u32
 {
     let @0: u32; // return
     let @1: u32; // anonymous local
-    let @2: u32; // anonymous local
 
     storage_live(@1)
-    storage_live(@2)
-    @2 := test_crate::FOO
-    @1 := const (10 : u32) panic.- move (@2)
+    @1 := const (10 : u32) panic.- copy (test_crate::FOO)
     @0 := move (@1)
     return
 }
@@ -729,12 +723,9 @@ pub fn test_crate::_#10() -> u32
 {
     let @0: u32; // return
     let @1: u32; // anonymous local
-    let @2: u32; // anonymous local
 
     storage_live(@1)
-    storage_live(@2)
-    @2 := test_crate::FOO
-    @1 := const (2 : u32) panic.* move (@2)
+    @1 := const (2 : u32) panic.* copy (test_crate::FOO)
     @0 := move (@1)
     return
 }
@@ -744,11 +735,8 @@ pub const test_crate::_#10: u32 = test_crate::_#10()
 pub fn test_crate::_#11() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    storage_live(@1)
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) panic.>> move (@1)
+    @0 := const (2 : u32) panic.>> copy (test_crate::FOO)
     return
 }
 
@@ -757,11 +745,8 @@ pub const test_crate::_#11: u32 = test_crate::_#11()
 pub fn test_crate::_#12() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    storage_live(@1)
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) panic.<< move (@1)
+    @0 := const (2 : u32) panic.<< copy (test_crate::FOO)
     return
 }
 
@@ -770,11 +755,8 @@ pub const test_crate::_#12: u32 = test_crate::_#12()
 pub fn test_crate::_#13() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    storage_live(@1)
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) panic.% move (@1)
+    @0 := const (2 : u32) panic.% copy (test_crate::FOO)
     return
 }
 
@@ -783,11 +765,8 @@ pub const test_crate::_#13: u32 = test_crate::_#13()
 pub fn test_crate::_#14() -> u32
 {
     let @0: u32; // return
-    let @1: u32; // anonymous local
 
-    storage_live(@1)
-    @1 := test_crate::FOO
-    @0 := const (2 : u32) panic./ move (@1)
+    @0 := const (2 : u32) panic./ copy (test_crate::FOO)
     return
 }
 
@@ -807,11 +786,8 @@ const test_crate::div_signed_with_constant::FOO: i32 = test_crate::div_signed_wi
 fn div_signed_with_constant() -> i32
 {
     let @0: i32; // return
-    let @1: i32; // anonymous local
 
-    storage_live(@1)
-    @1 := test_crate::div_signed_with_constant::FOO
-    @0 := move (@1) panic./ const (2 : i32)
+    @0 := copy (test_crate::div_signed_with_constant::FOO) panic./ const (2 : i32)
     return
 }
 

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -141,16 +141,11 @@ pub fn {impl Debug for u32}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (Fo
     let @4: u32; // anonymous local
     let @5: u32; // anonymous local
     let @6: u32; // anonymous local
-    let @7: u32; // anonymous local
-    let @8: u32; // anonymous local
 
-    storage_live(@7)
-    storage_live(@8)
     storage_live(@3)
     storage_live(@4)
     @4 := copy (((*(f@2)).0).flags)
-    @7 := DEBUG_LOWER_HEX_FLAG
-    @3 := move (@4) & move (@7)
+    @3 := move (@4) & copy (DEBUG_LOWER_HEX_FLAG)
     storage_dead(@4)
     switch move (@3) {
         0 : u32 => {
@@ -165,8 +160,7 @@ pub fn {impl Debug for u32}::fmt<'_0, '_1, '_2>(@1: &'_0 (u32), @2: &'_1 mut (Fo
     storage_live(@5)
     storage_live(@6)
     @6 := copy (((*(f@2)).0).flags)
-    @8 := DEBUG_UPPER_HEX_FLAG
-    @5 := move (@6) & move (@8)
+    @5 := move (@6) & copy (DEBUG_UPPER_HEX_FLAG)
     storage_dead(@6)
     switch move (@5) {
         0 : u32 => {

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -170,11 +170,7 @@ fn literal_casts()
     let @3: f64; // anonymous local
     let @4: u64; // anonymous local
     let @5: f64; // anonymous local
-    let @6: f64; // anonymous local
-    let @7: f32; // anonymous local
 
-    storage_live(@6)
-    storage_live(@7)
     storage_live(@1)
     @1 := cast<u64, u8>(const (0 : u64))
     storage_dead(@1)
@@ -185,12 +181,10 @@ fn literal_casts()
     @3 := cast<u64, f64>(const (0 : u64))
     storage_dead(@3)
     storage_live(@4)
-    @6 := MIN
-    @4 := cast<f64, u64>(move (@6))
+    @4 := cast<f64, u64>(copy (MIN))
     storage_dead(@4)
     storage_live(@5)
-    @7 := MAX
-    @5 := cast<f32, f64>(move (@7))
+    @5 := cast<f32, f64>(copy (MAX))
     storage_dead(@5)
     @0 := ()
     @0 := ()

--- a/charon/tests/ui/simple/promoted-literal-addition-overflow.out
+++ b/charon/tests/ui/simple/promoted-literal-addition-overflow.out
@@ -16,21 +16,15 @@ fn overflow() -> &'static (u32)
     let @4: &'_ (u32); // anonymous local
     let @5: u32; // anonymous local
     let @6: u32; // anonymous local
-    let @7: u32; // anonymous local
-    let @8: u32; // anonymous local
 
     storage_live(@2)
     storage_live(@3)
     storage_live(@4)
     storage_live(@5)
     storage_live(@6)
-    storage_live(@7)
-    storage_live(@8)
     storage_live(@1)
-    @7 := MAX
-    @2 := move (@7) panic.+ const (1 : u32)
-    @8 := MAX
-    @6 := move (@8) wrap.+ const (1 : u32)
+    @2 := copy (MAX) panic.+ const (1 : u32)
+    @6 := copy (MAX) wrap.+ const (1 : u32)
     @5 := move (@6)
     @4 := &@5
     @3 := move (@4)

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -981,9 +981,8 @@ where
     let @17: *const T; // anonymous local
     let self@18: usize; // local
     let self@19: bool; // local
-    let @20: usize; // anonymous local
+    let @20: Option<&'_ (Slice<T>)>[Sized<&'_ (Slice<T>)>]; // anonymous local
     let @21: Option<&'_ (Slice<T>)>[Sized<&'_ (Slice<T>)>]; // anonymous local
-    let @22: Option<&'_ (Slice<T>)>[Sized<&'_ (Slice<T>)>]; // anonymous local
 
     storage_live(self@4)
     storage_live(exclusive_end@6)
@@ -1002,17 +1001,15 @@ where
     storage_live(self@19)
     storage_live(@20)
     storage_live(@21)
-    storage_live(@22)
     storage_live(@3)
     storage_live(self@5)
     self@5 := &self@1
     storage_dead(self@5)
     self@4 := copy ((self@1).end)
-    @20 := MAX
-    @3 := copy (self@4) == move (@20)
+    @3 := copy (self@4) == copy (MAX)
     if move (@3) {
-        @21 := Option::None {  }
-        @0 := move (@21)
+        @20 := Option::None {  }
+        @0 := move (@20)
     }
     else {
         storage_live(self@18)
@@ -1034,8 +1031,8 @@ where
         @14 := copy (exclusive_end@6) < copy (self@8)
         if move (@14) {
             storage_dead(@14)
-            @22 := Option::None {  }
-            @0 := move (@22)
+            @21 := Option::None {  }
+            @0 := move (@21)
             storage_dead(@9)
             storage_dead(@11)
         }
@@ -1065,8 +1062,8 @@ where
             }
             else {
                 storage_dead(@10)
-                @22 := Option::None {  }
-                @0 := move (@22)
+                @21 := Option::None {  }
+                @0 := move (@21)
             }
             storage_dead(@9)
             storage_dead(@11)
@@ -1101,9 +1098,8 @@ where
     let @17: *mut T; // anonymous local
     let self@18: usize; // local
     let self@19: bool; // local
-    let @20: usize; // anonymous local
+    let @20: Option<&'_ mut (Slice<T>)>[Sized<&'_ mut (Slice<T>)>]; // anonymous local
     let @21: Option<&'_ mut (Slice<T>)>[Sized<&'_ mut (Slice<T>)>]; // anonymous local
-    let @22: Option<&'_ mut (Slice<T>)>[Sized<&'_ mut (Slice<T>)>]; // anonymous local
 
     storage_live(self@4)
     storage_live(exclusive_end@6)
@@ -1122,17 +1118,15 @@ where
     storage_live(self@19)
     storage_live(@20)
     storage_live(@21)
-    storage_live(@22)
     storage_live(@3)
     storage_live(self@5)
     self@5 := &self@1
     storage_dead(self@5)
     self@4 := copy ((self@1).end)
-    @20 := MAX
-    @3 := copy (self@4) == move (@20)
+    @3 := copy (self@4) == copy (MAX)
     if move (@3) {
-        @21 := Option::None {  }
-        @0 := move (@21)
+        @20 := Option::None {  }
+        @0 := move (@20)
     }
     else {
         storage_live(self@18)
@@ -1154,8 +1148,8 @@ where
         @14 := copy (exclusive_end@6) < copy (self@8)
         if move (@14) {
             storage_dead(@14)
-            @22 := Option::None {  }
-            @0 := move (@22)
+            @21 := Option::None {  }
+            @0 := move (@21)
             storage_dead(@9)
             storage_dead(@11)
         }
@@ -1185,8 +1179,8 @@ where
             }
             else {
                 storage_dead(@10)
-                @22 := Option::None {  }
-                @0 := move (@22)
+                @21 := Option::None {  }
+                @0 := move (@21)
             }
             storage_dead(@9)
             storage_dead(@11)
@@ -1346,7 +1340,6 @@ where
     let @10: usize; // anonymous local
     let self@11: usize; // local
     let self@12: bool; // local
-    let @13: usize; // anonymous local
 
     storage_live(self@4)
     storage_live(@6)
@@ -1356,14 +1349,12 @@ where
     storage_live(@10)
     storage_live(self@11)
     storage_live(self@12)
-    storage_live(@13)
     storage_live(@3)
     storage_live(self@5)
     self@5 := &self@1
     storage_dead(self@5)
     self@4 := copy ((self@1).end)
-    @13 := MAX
-    @3 := copy (self@4) == move (@13)
+    @3 := copy (self@4) == copy (MAX)
     if move (@3) {
     }
     else {
@@ -1413,7 +1404,6 @@ where
     let @10: usize; // anonymous local
     let self@11: usize; // local
     let self@12: bool; // local
-    let @13: usize; // anonymous local
 
     storage_live(self@4)
     storage_live(@6)
@@ -1423,14 +1413,12 @@ where
     storage_live(@10)
     storage_live(self@11)
     storage_live(self@12)
-    storage_live(@13)
     storage_live(@3)
     storage_live(self@5)
     self@5 := &self@1
     storage_dead(self@5)
     self@4 := copy ((self@1).end)
-    @13 := MAX
-    @3 := copy (self@4) == move (@13)
+    @3 := copy (self@4) == copy (MAX)
     if move (@3) {
     }
     else {

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -424,14 +424,12 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked::pr
     let @9: Array<&'_ (Str), 1 : usize>; // anonymous local
     let @10: &'_ (Slice<&'_ (Str)>); // anonymous local
     let @11: &'_ (Slice<Argument<'_>>); // anonymous local
-    let @12: &'_ (Array<Argument<'_>, 0 : usize>); // anonymous local
-    let @13: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
+    let @12: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
 
     storage_live(@5)
     storage_live(@6)
     storage_live(pieces@8)
     storage_live(@12)
-    storage_live(@13)
     storage_live(@4)
     @4 := copy (end@2) >= copy (start@1)
     if move (@4) {
@@ -455,10 +453,9 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked::pr
     storage_live(@10)
     @10 := @ArrayToSliceShared<'_, &'_ (Str), 1 : usize>(copy (pieces@8))
     storage_live(@11)
-    @12 := {promoted_const}<'_, 1 : usize>
-    @11 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(move (@12))
-    @13 := Option::None {  }
-    @7 := Arguments { 0: move (@10), 1: move (@13), 2: move (@11) }
+    @11 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(copy ({promoted_const}<'_, 1 : usize>))
+    @12 := Option::None {  }
+    @7 := Arguments { 0: move (@10), 1: move (@12), 2: move (@11) }
     storage_dead(@11)
     storage_dead(@10)
     @6 := panic_nounwind_fmt<'_>(move (@7), const (false))
@@ -536,14 +533,12 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked_mut
     let @9: Array<&'_ (Str), 1 : usize>; // anonymous local
     let @10: &'_ (Slice<&'_ (Str)>); // anonymous local
     let @11: &'_ (Slice<Argument<'_>>); // anonymous local
-    let @12: &'_ (Array<Argument<'_>, 0 : usize>); // anonymous local
-    let @13: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
+    let @12: Option<&'_ (Slice<Placeholder>)>[Sized<&'_ (Slice<Placeholder>)>]; // anonymous local
 
     storage_live(@5)
     storage_live(@6)
     storage_live(pieces@8)
     storage_live(@12)
-    storage_live(@13)
     storage_live(@4)
     @4 := copy (end@2) >= copy (start@1)
     if move (@4) {
@@ -567,10 +562,9 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked_mut
     storage_live(@10)
     @10 := @ArrayToSliceShared<'_, &'_ (Str), 1 : usize>(copy (pieces@8))
     storage_live(@11)
-    @12 := {promoted_const}<'_, 1 : usize>
-    @11 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(move (@12))
-    @13 := Option::None {  }
-    @7 := Arguments { 0: move (@10), 1: move (@13), 2: move (@11) }
+    @11 := @ArrayToSliceShared<'_, Argument<'_>, 0 : usize>(copy ({promoted_const}<'_, 1 : usize>))
+    @12 := Option::None {  }
+    @7 := Arguments { 0: move (@10), 1: move (@12), 2: move (@11) }
     storage_dead(@11)
     storage_dead(@10)
     @6 := panic_nounwind_fmt<'_>(move (@7), const (false))

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -21,25 +21,16 @@ fn constant()
     let @3: usize; // anonymous local
     let _ref_mut@4: &'_ mut (usize); // local
     let @5: usize; // anonymous local
-    let @6: usize; // anonymous local
-    let @7: usize; // anonymous local
-    let @8: usize; // anonymous local
 
-    storage_live(@6)
-    storage_live(@7)
-    storage_live(@8)
     storage_live(_val@1)
-    @6 := CONST
-    _val@1 := move (@6)
+    _val@1 := copy (CONST)
     storage_live(_ref@2)
     storage_live(@3)
-    @7 := CONST
-    @3 := move (@7)
+    @3 := copy (CONST)
     _ref@2 := &@3
     storage_live(_ref_mut@4)
     storage_live(@5)
-    @8 := CONST
-    @5 := move (@8)
+    @5 := copy (CONST)
     _ref_mut@4 := &mut @5
     @0 := ()
     storage_dead(@5)

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -1296,11 +1296,8 @@ where
     [@TraitClause2]: Trait<T>,
 {
     let @0: Result<T, i32>[@TraitClause0, Sized<i32>]; // return
-    let @1: Result<T, i32>[@TraitClause0, Sized<i32>]; // anonymous local
 
-    storage_live(@1)
-    @1 := FOO<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
-    @0 := move (@1)
+    @0 := copy (FOO<T, U>[@TraitClause0, @TraitClause1, @TraitClause2])
     return
 }
 
@@ -1312,11 +1309,8 @@ where
     [@TraitClause2]: Trait<U>,
 {
     let @0: Result<U, i32>[@TraitClause1, Sized<i32>]; // return
-    let @1: Result<U, i32>[@TraitClause1, Sized<i32>]; // anonymous local
 
-    storage_live(@1)
-    @1 := FOO<U, T>[@TraitClause1, @TraitClause0, @TraitClause2]
-    @0 := move (@1)
+    @0 := copy (FOO<U, T>[@TraitClause1, @TraitClause0, @TraitClause2])
     return
 }
 


### PR DESCRIPTION
Update of https://github.com/AeneasVerif/charon/pull/649 -- they're practically the same
The main notable difference is that when using the *value* of a global, it is copied, not moved, as moving a global would uninitialise it; e.g. here
```rust
const C = 0;
let a = C;
let b = C; // if C is moved, this is an error
```

ci: use https://github.com/AeneasVerif/aeneas/pull/586
ci: use https://github.com/AeneasVerif/eurydice/pull/251