### PR TITLE
Strings as globals

### DIFF
--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -250,6 +250,13 @@ pub struct CliOpts {
     #[serde(default)]
     pub raw_boxes: bool,
 
+    #[clap(
+        long = "string-globals",
+        help = "Convert string literals to globals containing the actual data."
+    )]
+    #[serde(default)]
+    pub strings_as_globals: bool,
+
     /// Named builtin sets of options. Currently used only for dependent projects, eveentually
     /// should be replaced with semantically-meaningful presets.
     #[clap(long = "preset")]
@@ -420,6 +427,8 @@ pub struct TranslateOptions {
     pub item_opacities: Vec<(NamePattern, ItemOpacity)>,
     /// List of traits for which we transform associated types to type parameters.
     pub remove_associated_types: Vec<NamePattern>,
+    /// Convert all string literals to globals, containing the actual data.
+    pub strings_as_globals: bool,
 }
 
 impl TranslateOptions {
@@ -502,6 +511,7 @@ impl TranslateOptions {
             raw_boxes: options.raw_boxes,
             remove_associated_types,
             translate_all_methods: options.translate_all_methods,
+            strings_as_globals: options.strings_as_globals,
         }
     }
 

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -34,6 +34,7 @@ pub mod remove_unused_self_clause;
 pub mod reorder_decls;
 pub mod simplify_constants;
 pub mod skip_trait_refs_when_known;
+pub mod strings_as_globals;
 pub mod ullbc_to_llbc;
 pub mod unbind_item_vars;
 pub mod update_block_indices;
@@ -95,6 +96,9 @@ pub static ULLBC_PASSES: &[Pass] = &[
     // it must happen before passes that insert statements like [simplify_constants].
     // **WARNING**: this pass works across calls, hence must happen after `merge_goto_chains`,
     UnstructuredBody(&reconstruct_boxes::Transform),
+    // # Micro-pass: substitute string literals with references to a global containing the string.
+    // Must be run before `simplify_constants`.
+    UnstructuredBody(&strings_as_globals::Transform),
     // # Micro-pass: desugar the constants to other values/operands as much
     // as possible.
     UnstructuredBody(&simplify_constants::Transform),

--- a/charon/src/transform/strings_as_globals.rs
+++ b/charon/src/transform/strings_as_globals.rs
@@ -231,6 +231,14 @@ impl UllbcPass for Transform {
             let fun_id = ctx.translated.fun_decls.reserve_slot();
             let global = global_decl_for_string(&str, *id, fun_id);
             let fun = fun_decl_for_string(&str, fun_id, *id);
+
+            ctx.translated
+                .item_names
+                .insert(AnyTransId::Global(*id), global.item_meta.name.clone());
+            ctx.translated
+                .item_names
+                .insert(AnyTransId::Fun(fun_id), fun.item_meta.name.clone());
+
             ctx.translated.global_decls.set_slot(*id, global);
             ctx.translated.fun_decls.set_slot(fun_id, fun);
         }

--- a/charon/src/transform/strings_as_globals.rs
+++ b/charon/src/transform/strings_as_globals.rs
@@ -1,0 +1,238 @@
+//! Strings (the `str` type) are really just `&[u8]` slices; however Charon handles strings
+//! as literal values, hiding the fact there is in fact a reference there.
+//! This pass allows translating strings into global variables containing the unsized array
+//! of bytes for that string.
+
+use derive_generic_visitor::Visitor;
+use std::collections::HashMap;
+
+use crate::transform::TransformCtx;
+use crate::ullbc_ast::*;
+
+use super::ctx::UllbcPass;
+
+fn str_ty() -> Ty {
+    TyKind::Ref(
+        Region::Static,
+        TyKind::Adt(TypeDeclRef {
+            id: TypeId::Builtin(BuiltinTy::Str),
+            generics: Box::new(GenericArgs::empty()),
+        })
+        .into_ty(),
+        RefKind::Shared,
+    )
+    .into_ty()
+}
+
+fn item_meta_for_str(str: String) -> ItemMeta {
+    ItemMeta {
+        name: Name {
+            name: vec![
+                PathElem::Ident("string_constant".to_string(), Disambiguator::ZERO),
+                PathElem::Monomorphized(Box::new(GenericArgs {
+                    const_generics: vec![ConstGeneric::Value(Literal::Str(str.clone()))].into(),
+                    regions: Vector::new(),
+                    types: Vector::new(),
+                    trait_refs: Vector::new(),
+                })),
+            ],
+        },
+        attr_info: AttrInfo {
+            attributes: vec![],
+            inline: None,
+            rename: None,
+            public: true,
+        },
+        is_local: false,
+        lang_item: None,
+        opacity: ItemOpacity::Transparent,
+        source_text: None,
+        span: Span::dummy(),
+    }
+}
+
+fn global_decl_for_string(str: &String, id: GlobalDeclId, fun: FunDeclId) -> GlobalDecl {
+    return GlobalDecl {
+        def_id: id,
+        item_meta: item_meta_for_str(str.clone()),
+        generics: GenericParams::empty(),
+        ty: str_ty(),
+        kind: ItemKind::TopLevel,
+        global_kind: GlobalKind::Static,
+        init: fun,
+    };
+}
+
+fn fun_decl_for_string(str: &String, id: FunDeclId, global: GlobalDeclId) -> FunDecl {
+    let str_bytes = str.as_bytes();
+    let u8_ty = TyKind::Literal(LiteralTy::UInt(UIntTy::U8)).into_ty();
+    let len_const = ConstGeneric::Value(Literal::Scalar(ScalarValue::Unsigned(
+        UIntTy::Usize,
+        str_bytes.len() as u128,
+    )));
+
+    // We want to generate a body that looks like:
+    //     arr: [u8; N] = [...]; // <-- string bytes
+    //     arr_ref: &[u8; N] = &arr;
+    //     slice: &[u8] = <unsize>(arr);
+    //     str: str = <transmute>(slice);
+    //     return str;
+    let mut body = ExprBody {
+        body: Vector::new(),
+        comments: vec![],
+        locals: Locals::default(),
+        span: Span::dummy(),
+    };
+    let ret = body.locals.new_var(Some("str".into()), str_ty());
+    let arr = body.locals.new_var(
+        Some("arr".into()),
+        TyKind::Adt(TypeDeclRef {
+            id: TypeId::Builtin(BuiltinTy::Array),
+            generics: Box::new(GenericArgs {
+                types: vec![u8_ty.clone()].into(),
+                const_generics: vec![len_const.clone()].into(),
+                regions: Vector::new(),
+                trait_refs: Vector::new(),
+            }),
+        })
+        .into_ty(),
+    );
+    let arr_ref = body.locals.new_var(
+        Some("arr_ref".into()),
+        TyKind::Ref(Region::Erased, arr.ty.clone(), RefKind::Shared).into_ty(),
+    );
+    let slice = body.locals.new_var(
+        Some("slice".into()),
+        TyKind::Ref(
+            Region::Erased,
+            TyKind::Adt(TypeDeclRef {
+                id: TypeId::Builtin(BuiltinTy::Slice),
+                generics: Box::new(GenericArgs::new_types(vec![u8_ty.clone()].into())),
+            })
+            .into_ty(),
+            RefKind::Shared,
+        )
+        .into_ty(),
+    );
+    let statements = vec![
+        RawStatement::Assign(
+            arr.clone(),
+            Rvalue::Aggregate(
+                AggregateKind::Array(u8_ty.clone(), len_const.clone()),
+                str_bytes
+                    .iter()
+                    .map(|byte| {
+                        Operand::Const(Box::new(ConstantExpr {
+                            value: RawConstantExpr::Literal(Literal::Scalar(
+                                ScalarValue::Unsigned(UIntTy::U8, *byte as u128),
+                            )),
+                            ty: u8_ty.clone(),
+                        }))
+                    })
+                    .collect(),
+            ),
+        ),
+        RawStatement::Assign(arr_ref.clone(), Rvalue::Ref(arr, BorrowKind::Shared)),
+        RawStatement::Assign(
+            slice.clone(),
+            Rvalue::UnaryOp(
+                UnOp::Cast(CastKind::Unsize(
+                    arr_ref.ty.clone(),
+                    slice.ty.clone(),
+                    UnsizingMetadata::Length(len_const),
+                )),
+                Operand::Move(arr_ref),
+            ),
+        ),
+        RawStatement::Assign(
+            ret.clone(),
+            Rvalue::UnaryOp(
+                UnOp::Cast(CastKind::Transmute(slice.ty.clone(), ret.ty.clone())),
+                Operand::Move(slice),
+            ),
+        ),
+    ];
+    let block = BlockData {
+        statements: statements
+            .into_iter()
+            .map(|stt| Statement::new(Span::dummy(), stt))
+            .collect(),
+        terminator: Terminator::new(Span::dummy(), RawTerminator::Return),
+    };
+    body.body.push(block);
+
+    FunDecl {
+        def_id: id,
+        body: Ok(Body::Unstructured(body)),
+        is_global_initializer: Some(global),
+        item_meta: item_meta_for_str(str.clone()),
+        kind: ItemKind::TopLevel,
+        signature: FunSig {
+            is_unsafe: false,
+            generics: GenericParams::empty(),
+            inputs: vec![],
+            output: str_ty(),
+        },
+    }
+}
+
+#[derive(Visitor)]
+struct StringVisitor<'a> {
+    data: &'a mut HashMap<String, GlobalDeclId>,
+    krate: &'a mut TranslatedCrate,
+}
+
+impl<'a> StringVisitor<'a> {
+    fn new(data: &'a mut HashMap<String, GlobalDeclId>, krate: &'a mut TranslatedCrate) -> Self {
+        Self { data, krate }
+    }
+
+    fn alloc(&mut self, str: &String) -> GlobalDeclRef {
+        let id = if let Some(global) = self.data.get(str) {
+            global.clone()
+        } else {
+            let id = self.krate.global_decls.reserve_slot();
+            self.data.insert(str.clone(), id.clone());
+            id
+        };
+        GlobalDeclRef {
+            id,
+            generics: Box::new(GenericArgs::empty()),
+        }
+    }
+}
+
+impl VisitAstMut for StringVisitor<'_> {
+    fn enter_constant_expr(&mut self, c: &mut ConstantExpr) {
+        match &mut c.value {
+            RawConstantExpr::Literal(Literal::Str(str)) => {
+                let gref = self.alloc(str);
+                c.value = RawConstantExpr::Global(gref);
+            }
+            _ => {}
+        }
+    }
+}
+
+pub struct Transform;
+impl UllbcPass for Transform {
+    fn transform_ctx(&self, ctx: &mut TransformCtx) {
+        // Check the option which instructs to ignore this pass
+        if !ctx.options.strings_as_globals {
+            return;
+        }
+
+        let mut substs = HashMap::new();
+        ctx.for_each_body(|ctx, body| {
+            let mut visitor = StringVisitor::new(&mut substs, &mut ctx.translated);
+            let _ = body.drive_mut(&mut visitor);
+        });
+        for (str, id) in substs.iter() {
+            let fun_id = ctx.translated.fun_decls.reserve_slot();
+            let global = global_decl_for_string(&str, *id, fun_id);
+            let fun = fun_decl_for_string(&str, fun_id, *id);
+            ctx.translated.global_decls.set_slot(*id, global);
+            ctx.translated.fun_decls.set_slot(fun_id, fun);
+        }
+    }
+}

--- a/charon/src/transform/strings_as_globals.rs
+++ b/charon/src/transform/strings_as_globals.rs
@@ -117,20 +117,10 @@ fn fun_decl_for_string(str: &String, id: FunDeclId, global: GlobalDeclId) -> Fun
     let statements = vec![
         RawStatement::Assign(
             arr.clone(),
-            Rvalue::Aggregate(
-                AggregateKind::Array(u8_ty.clone(), len_const.clone()),
-                str_bytes
-                    .iter()
-                    .map(|byte| {
-                        Operand::Const(Box::new(ConstantExpr {
-                            value: RawConstantExpr::Literal(Literal::Scalar(
-                                ScalarValue::Unsigned(UIntTy::U8, *byte as u128),
-                            )),
-                            ty: u8_ty.clone(),
-                        }))
-                    })
-                    .collect(),
-            ),
+            Rvalue::Use(Operand::Const(Box::new(ConstantExpr {
+                value: RawConstantExpr::RawMemory(str.clone().into_bytes()),
+                ty: arr.ty.clone(),
+            }))),
         ),
         RawStatement::Assign(arr_ref.clone(), Rvalue::Ref(arr, BorrowKind::Shared)),
         RawStatement::Assign(

--- a/charon/tests/ui/string_as_global.out
+++ b/charon/tests/ui/string_as_global.out
@@ -108,7 +108,7 @@ pub fn string_constant::<"Hello">() -> &'static (Str)
     storage_live(arr@1)
     storage_live(arr_ref@2)
     storage_live(slice@3)
-    arr@1 := [const (72 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
+    arr@1 := const (RawMemory([72, 101, 108, 108, 111]))
     arr_ref@2 := &arr@1
     slice@3 := @ArrayToSliceShared<'_, u8, 5 : usize>(move (arr_ref@2))
     str@0 := transmute<&'_ (Slice<u8>), &'static (Str)>(move (slice@3))
@@ -127,7 +127,7 @@ pub fn string_constant::<"hello">() -> &'static (Str)
     storage_live(arr@1)
     storage_live(arr_ref@2)
     storage_live(slice@3)
-    arr@1 := [const (104 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
+    arr@1 := const (RawMemory([104, 101, 108, 108, 111]))
     arr_ref@2 := &arr@1
     slice@3 := @ArrayToSliceShared<'_, u8, 5 : usize>(move (arr_ref@2))
     str@0 := transmute<&'_ (Slice<u8>), &'static (Str)>(move (slice@3))

--- a/charon/tests/ui/string_as_global.out
+++ b/charon/tests/ui/string_as_global.out
@@ -115,7 +115,7 @@ pub fn string_constant::<"Hello">() -> &'static (Str)
     return
 }
 
-pub static string_constant::<"Hello">: &'static (Str) = @Fun9()
+pub static string_constant::<"Hello">: &'static (Str) = string_constant::<"Hello">()
 
 pub fn string_constant::<"hello">() -> &'static (Str)
 {
@@ -134,7 +134,7 @@ pub fn string_constant::<"hello">() -> &'static (Str)
     return
 }
 
-pub static string_constant::<"hello">: &'static (Str) = @Fun10()
+pub static string_constant::<"hello">: &'static (Str) = string_constant::<"hello">()
 
 // Full name: test_crate::FOO
 fn FOO() -> &'static (Str)
@@ -143,7 +143,7 @@ fn FOO() -> &'static (Str)
     let @1: &'_ (Str); // anonymous local
 
     storage_live(@1)
-    @1 := @Global3
+    @1 := string_constant::<"hello">
     @0 := move (@1)
     return
 }
@@ -190,7 +190,7 @@ fn main()
     storage_live(_s@1)
     storage_live(@2)
     storage_live(@3)
-    @4 := @Global2
+    @4 := string_constant::<"Hello">
     @3 := move (@4)
     @2 := &*(@3)
     _s@1 := {impl ToString for T}::to_string<'_, Str>[MetaSized<Str>, {impl Display for Str}](move (@2))

--- a/charon/tests/ui/string_as_global.out
+++ b/charon/tests/ui/string_as_global.out
@@ -1,0 +1,207 @@
+# Final LLBC before serialization:
+
+// Full name: core::fmt::Error
+pub struct Error {}
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+}
+
+// Full name: core::result::Result
+#[lang_item("Result")]
+pub enum Result<T, E>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
+{
+  Ok(T),
+  Err(E),
+}
+
+// Full name: core::fmt::Display
+#[lang_item("Display")]
+pub trait Display<Self>
+{
+    fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>[Self]
+}
+
+pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+where
+    [@TraitClause0]: Display<Self>,
+
+// Full name: core::fmt::{impl Display for Str}::fmt
+pub fn {impl Display for Str}::fmt<'_0, '_1, '_2>(@1: &'_0 (Str), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+
+// Full name: core::fmt::{impl Display for Str}
+impl Display for Str {
+    fn fmt<'_0, '_1, '_2> = {impl Display for Str}::fmt<'_0_0, '_0_1, '_0_2>
+}
+
+// Full name: core::ops::drop::Drop
+#[lang_item("drop")]
+pub trait Drop<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn drop<'_0> = core::ops::drop::Drop::drop<'_0_0, Self>[Self]
+}
+
+pub fn core::ops::drop::Drop::drop<'_0, Self>(@1: &'_0 mut (Self))
+where
+    [@TraitClause0]: Drop<Self>,
+
+// Full name: alloc::string::String
+#[lang_item("String")]
+pub opaque type String
+
+// Full name: alloc::string::String::{impl Drop for String}::drop
+fn {impl Drop for String}::drop<'_0>(@1: &'_0 mut (String))
+
+// Full name: alloc::string::String::{impl Drop for String}
+impl Drop for String {
+    parent_clause0 = MetaSized<String>
+    fn drop<'_0> = {impl Drop for String}::drop<'_0_0>
+}
+
+// Full name: alloc::string::ToString
+#[lang_item("ToString")]
+pub trait ToString<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>[Self]
+}
+
+#[lang_item("to_string_method")]
+pub fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> String
+where
+    [@TraitClause0]: ToString<Self>,
+
+// Full name: alloc::string::{impl ToString for T}::to_string
+pub fn {impl ToString for T}::to_string<'_0, T>(@1: &'_0 (T)) -> String
+where
+    [@TraitClause0]: MetaSized<T>,
+    [@TraitClause1]: Display<T>,
+
+// Full name: alloc::string::{impl ToString for T}
+impl<T> ToString for T
+where
+    [@TraitClause0]: MetaSized<T>,
+    [@TraitClause1]: Display<T>,
+{
+    parent_clause0 = @TraitClause0
+    fn to_string<'_0> = {impl ToString for T}::to_string<'_0_0, T>[@TraitClause0, @TraitClause1]
+}
+
+pub fn string_constant::<"Hello">() -> &'static (Str)
+{
+    let str@0: &'static (Str); // return
+    let arr@1: Array<u8, 5 : usize>; // local
+    let arr_ref@2: &'_ (Array<u8, 5 : usize>); // local
+    let slice@3: &'_ (Slice<u8>); // local
+
+    storage_live(arr@1)
+    storage_live(arr_ref@2)
+    storage_live(slice@3)
+    arr@1 := [const (72 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
+    arr_ref@2 := &arr@1
+    slice@3 := @ArrayToSliceShared<'_, u8, 5 : usize>(move (arr_ref@2))
+    str@0 := transmute<&'_ (Slice<u8>), &'static (Str)>(move (slice@3))
+    return
+}
+
+pub static string_constant::<"Hello">: &'static (Str) = @Fun9()
+
+pub fn string_constant::<"hello">() -> &'static (Str)
+{
+    let str@0: &'static (Str); // return
+    let arr@1: Array<u8, 5 : usize>; // local
+    let arr_ref@2: &'_ (Array<u8, 5 : usize>); // local
+    let slice@3: &'_ (Slice<u8>); // local
+
+    storage_live(arr@1)
+    storage_live(arr_ref@2)
+    storage_live(slice@3)
+    arr@1 := [const (104 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
+    arr_ref@2 := &arr@1
+    slice@3 := @ArrayToSliceShared<'_, u8, 5 : usize>(move (arr_ref@2))
+    str@0 := transmute<&'_ (Slice<u8>), &'static (Str)>(move (slice@3))
+    return
+}
+
+pub static string_constant::<"hello">: &'static (Str) = @Fun10()
+
+// Full name: test_crate::FOO
+fn FOO() -> &'static (Str)
+{
+    let @0: &'_ (Str); // return
+    let @1: &'_ (Str); // anonymous local
+
+    storage_live(@1)
+    @1 := @Global3
+    @0 := move (@1)
+    return
+}
+
+// Full name: test_crate::FOO
+static FOO: &'static (Str) = FOO()
+
+// Full name: test_crate::BAR
+fn BAR() -> &'static (Slice<u8>)
+{
+    let @0: &'_ (Slice<u8>); // return
+    let @1: &'_ (Array<u8, 5 : usize>); // anonymous local
+    let @2: &'_ (Array<u8, 5 : usize>); // anonymous local
+    let @3: Array<u8, 5 : usize>; // anonymous local
+    let @4: &'_ (Array<u8, 5 : usize>); // anonymous local
+
+    storage_live(@3)
+    storage_live(@4)
+    storage_live(@1)
+    storage_live(@2)
+    @3 := [const (104 : u8), const (101 : u8), const (108 : u8), const (108 : u8), const (111 : u8)]
+    @4 := &@3
+    @2 := move (@4)
+    @1 := &*(@2)
+    @0 := @ArrayToSliceShared<'_, u8, 5 : usize>(move (@1))
+    storage_dead(@2)
+    storage_dead(@1)
+    return
+}
+
+// Full name: test_crate::BAR
+static BAR: &'static (Slice<u8>) = BAR()
+
+// Full name: test_crate::main
+fn main()
+{
+    let @0: (); // return
+    let _s@1: String; // local
+    let @2: &'_ (Str); // anonymous local
+    let @3: &'_ (Str); // anonymous local
+    let @4: &'_ (Str); // anonymous local
+
+    storage_live(@4)
+    storage_live(_s@1)
+    storage_live(@2)
+    storage_live(@3)
+    @4 := @Global2
+    @3 := move (@4)
+    @2 := &*(@3)
+    _s@1 := {impl ToString for T}::to_string<'_, Str>[MetaSized<Str>, {impl Display for Str}](move (@2))
+    storage_dead(@2)
+    storage_dead(@3)
+    @0 := ()
+    drop[{impl Drop for String}] _s@1
+    storage_dead(_s@1)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/string_as_global.rs
+++ b/charon/tests/ui/string_as_global.rs
@@ -1,0 +1,8 @@
+//@ charon-args=--string-globals
+
+static FOO: &str = "hello";
+static BAR: &[u8] = b"hello";
+
+fn main() {
+    let _s = "Hello".to_string();
+}


### PR DESCRIPTION
Add a `--string-globals` flag, that removes all string literals and replaces them with a reference to a array of `u8`. More precisely, the following substitution happens:
```rust
let s = "hello";
```
into
```rust
const string_constant::<"hello"> = {
	let arr: [u8; 5] = [105, 101, 108, 108, 111];
    let arr_ref: &[u8; 5] = &arr;
    let slice: &[u8] = <unsize>(move arr_ref);
    let str: &'static str = <transmute>(move slice);
    return str
}

let s = string_constant::<"hello">
```

Right now the `arr` value is defined using a `RawConstantExpr::RawMemory`, for a more compact representation; in a previous commit I did it with an array aggregate, but that is much more verbose and less compact. 
Another option I haven't done, that may be better, is that we decide that when `--string-globals` is toggled, `Literal::Str` doesn't represent a `&str` but a `str` (or rather, a `[u8; N]`, where `N` is the length of the string). This makes the [U]LLBC more readable and is a more compact representation, but it means we have a value that has two meanings depending on a flag, which is maybe not ideal.

Let me know what you think; I'm happy to change this as needed :) 