### PR TITLE
Generate explicit structs and values for trait vtables

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.121"
+let supported_charon_version = "0.1.122"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -209,6 +209,9 @@ type trait_decl = {
           The binder contains the type parameters specific to the method. The
           [FunDeclRef] then provides a full list of arguments to the pointed-to
           function. *)
+  vtable : type_decl_ref option;
+      (** The virtual table struct for this trait, if it has one. It is
+          guaranteed that the trait has a vtable iff it is dyn-compatible. *)
 }
 [@@deriving
   show,
@@ -256,6 +259,9 @@ type trait_impl = {
       (** The associated types declared in the trait. *)
   methods : (trait_item_name * fun_decl_ref binder) list;
       (** The implemented methods *)
+  vtable : global_decl_ref option;
+      (** The virtual table instance for this trait implementation. This is
+          [Some] iff the trait is dyn-compatible. *)
 }
 [@@deriving
   show,

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1041,6 +1041,12 @@ and item_kind_of_json (ctx : of_json_ctx) (js : json) :
         let* item_name = trait_item_name_of_json ctx item_name in
         let* reuses_default = bool_of_json ctx reuses_default in
         Ok (TraitImplItem (impl_ref, trait_ref, item_name, reuses_default))
+    | `Assoc [ ("VTableTy", `Assoc [ ("dyn_predicate", dyn_predicate) ]) ] ->
+        let* dyn_predicate = dyn_predicate_of_json ctx dyn_predicate in
+        Ok (VTableTyItem dyn_predicate)
+    | `Assoc [ ("VTableInstance", `Assoc [ ("impl_ref", impl_ref) ]) ] ->
+        let* impl_ref = trait_impl_ref_of_json ctx impl_ref in
+        Ok (VTableInstanceItem impl_ref)
     | _ -> Error "")
 
 and item_meta_of_json (ctx : of_json_ctx) (js : json) :
@@ -1569,6 +1575,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("type_defaults", _);
           ("type_clauses", _);
           ("methods", methods);
+          ("vtable", vtable);
         ] ->
         let* def_id = trait_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
@@ -1589,6 +1596,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
                (binder_of_json fun_decl_ref_of_json))
             ctx methods
         in
+        let* vtable = option_of_json type_decl_ref_of_json ctx vtable in
         Ok
           ({
              def_id;
@@ -1598,6 +1606,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
              consts;
              types;
              methods;
+             vtable;
            }
             : trait_decl)
     | _ -> Error "")
@@ -1634,6 +1643,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
           ("types", types);
           ("type_clauses", _);
           ("methods", methods);
+          ("vtable", vtable);
         ] ->
         let* def_id = trait_impl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
@@ -1659,6 +1669,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
                (binder_of_json fun_decl_ref_of_json))
             ctx methods
         in
+        let* vtable = option_of_json global_decl_ref_of_json ctx vtable in
         Ok
           ({
              def_id;
@@ -1669,6 +1680,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
              consts;
              types;
              methods;
+             vtable;
            }
             : trait_impl)
     | _ -> Error "")

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -717,6 +717,17 @@ and item_kind =
           - [reuses_default]: True if the trait decl had a default
             implementation for this function/const and this item is a copy of
             the default item. *)
+  | VTableTyItem of dyn_predicate
+      (** This is a vtable struct for a trait.
+
+          Fields:
+          - [dyn_predicate]: The [dyn Trait] predicate implemented by this
+            vtable. *)
+  | VTableInstanceItem of trait_impl_ref
+      (** This is a vtable value for an impl.
+
+          Fields:
+          - [impl_ref] *)
 
 (** Meta information about an item (function, trait decl, trait impl, type decl,
     global). *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 [[package]]
 name = "hax-adt-into"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#8eded279c596625a2da6c0de20eeaa064f286896"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#1a06fb019d3baac3cdf1d03068eaae49c1714b74"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#8eded279c596625a2da6c0de20eeaa064f286896"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#1a06fb019d3baac3cdf1d03068eaae49c1714b74"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.3.1"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#8eded279c596625a2da6c0de20eeaa064f286896"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#1a06fb019d3baac3cdf1d03068eaae49c1714b74"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charon"
-version = "0.1.121"
+version = "0.1.122"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.121"
+version = "0.1.122"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -471,6 +471,7 @@ impl From<FunDeclRef> for FnPtr {
 /// reading the constant `a.b` is translated to `{ _1 = const a; _2 = (_1.0) }`.
 #[derive(
     Debug,
+    Hash,
     PartialEq,
     Eq,
     Clone,
@@ -485,7 +486,6 @@ impl From<FunDeclRef> for FnPtr {
 #[charon::variants_prefix("C")]
 pub enum RawConstantExpr {
     Literal(Literal),
-    ///
     /// In most situations:
     /// Enumeration with one variant with no fields, structure with
     /// no fields, unit (encoded as a 0-tuple).
@@ -553,7 +553,7 @@ pub enum RawConstantExpr {
     Opaque(String),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct ConstantExpr {
     pub value: RawConstantExpr,
     pub ty: Ty,

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -127,6 +127,13 @@ pub enum ItemKind {
         #[drive(skip)]
         reuses_default: bool,
     },
+    /// This is a vtable struct for a trait.
+    VTableTy {
+        /// The `dyn Trait` predicate implemented by this vtable.
+        dyn_predicate: DynPredicate,
+    },
+    /// This is a vtable value for an impl.
+    VTableInstance { impl_ref: TraitImplRef },
 }
 
 /// A function definition
@@ -279,6 +286,9 @@ pub struct TraitDecl {
     /// The binder contains the type parameters specific to the method. The `FunDeclRef` then
     /// provides a full list of arguments to the pointed-to function.
     pub methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
+    /// The virtual table struct for this trait, if it has one.
+    /// It is guaranteed that the trait has a vtable iff it is dyn-compatible.
+    pub vtable: Option<TypeDeclRef>,
 }
 
 /// A trait **implementation**.
@@ -313,6 +323,9 @@ pub struct TraitImpl {
     pub type_clauses: Vec<(TraitItemName, Vector<TraitClauseId, TraitRef>)>,
     /// The implemented methods
     pub methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
+    /// The virtual table instance for this trait implementation. This is `Some` iff the trait is
+    /// dyn-compatible.
+    pub vtable: Option<GlobalDeclRef>,
 }
 
 /// A function operand is used in function calls.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -412,6 +412,47 @@ impl GenericArgs {
     }
 }
 
+impl IntTy {
+    /// Important: this returns the target byte count for the types.
+    /// Must not be used for host types from rustc.
+    pub fn target_size(&self, ptr_size: ByteCount) -> usize {
+        match self {
+            IntTy::Isize => ptr_size as usize,
+            IntTy::I8 => size_of::<i8>(),
+            IntTy::I16 => size_of::<i16>(),
+            IntTy::I32 => size_of::<i32>(),
+            IntTy::I64 => size_of::<i64>(),
+            IntTy::I128 => size_of::<i128>(),
+        }
+    }
+}
+impl UIntTy {
+    /// Important: this returns the target byte count for the types.
+    /// Must not be used for host types from rustc.
+    pub fn target_size(&self, ptr_size: ByteCount) -> usize {
+        match self {
+            UIntTy::Usize => ptr_size as usize,
+            UIntTy::U8 => size_of::<u8>(),
+            UIntTy::U16 => size_of::<u16>(),
+            UIntTy::U32 => size_of::<u32>(),
+            UIntTy::U64 => size_of::<u64>(),
+            UIntTy::U128 => size_of::<u128>(),
+        }
+    }
+}
+impl FloatTy {
+    /// Important: this returns the target byte count for the types.
+    /// Must not be used for host types from rustc.
+    pub fn target_size(&self) -> usize {
+        match self {
+            FloatTy::F16 => size_of::<u16>(),
+            FloatTy::F32 => size_of::<u32>(),
+            FloatTy::F64 => size_of::<u64>(),
+            FloatTy::F128 => size_of::<u128>(),
+        }
+    }
+}
+
 impl IntegerTy {
     pub fn to_unsigned(&self) -> Self {
         match self {
@@ -429,18 +470,8 @@ impl IntegerTy {
     /// Must not be used for host types from rustc.
     pub fn target_size(&self, ptr_size: ByteCount) -> usize {
         match self {
-            IntegerTy::Signed(IntTy::Isize) => ptr_size as usize,
-            IntegerTy::Signed(IntTy::I8) => size_of::<i8>(),
-            IntegerTy::Signed(IntTy::I16) => size_of::<i16>(),
-            IntegerTy::Signed(IntTy::I32) => size_of::<i32>(),
-            IntegerTy::Signed(IntTy::I64) => size_of::<i64>(),
-            IntegerTy::Signed(IntTy::I128) => size_of::<i128>(),
-            IntegerTy::Unsigned(UIntTy::Usize) => ptr_size as usize,
-            IntegerTy::Unsigned(UIntTy::U8) => size_of::<u8>(),
-            IntegerTy::Unsigned(UIntTy::U16) => size_of::<u16>(),
-            IntegerTy::Unsigned(UIntTy::U32) => size_of::<u32>(),
-            IntegerTy::Unsigned(UIntTy::U64) => size_of::<u64>(),
-            IntegerTy::Unsigned(UIntTy::U128) => size_of::<u128>(),
+            IntegerTy::Signed(ty) => ty.target_size(ptr_size),
+            IntegerTy::Unsigned(ty) => ty.target_size(ptr_size),
         }
     }
 }
@@ -451,6 +482,18 @@ impl LiteralTy {
             Self::Int(int_ty) => Some(IntegerTy::Signed(*int_ty)),
             Self::UInt(uint_ty) => Some(IntegerTy::Unsigned(*uint_ty)),
             _ => None,
+        }
+    }
+
+    /// Important: this returns the target byte count for the types.
+    /// Must not be used for host types from rustc.
+    pub fn target_size(&self, ptr_size: ByteCount) -> usize {
+        match self {
+            LiteralTy::Int(int_ty) => int_ty.target_size(ptr_size),
+            LiteralTy::UInt(uint_ty) => uint_ty.target_size(ptr_size),
+            LiteralTy::Float(float_ty) => float_ty.target_size(),
+            LiteralTy::Char => 4,
+            LiteralTy::Bool => 1,
         }
     }
 }

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -501,6 +501,25 @@ impl BodyTransCtx<'_, '_, '_> {
                             }
                             hax::UnsizingMetadata::VTablePtr(impl_expr) => {
                                 let tref = self.translate_trait_impl_expr(span, impl_expr)?;
+                                match &impl_expr.r#impl {
+                                    hax::ImplExprAtom::Concrete(tref) => {
+                                        // Ensure the vtable type is translated.
+                                        let _: GlobalDeclId = self.register_item(
+                                            span,
+                                            tref,
+                                            TransItemSourceKind::VTableInstance(
+                                                TraitImplSource::Normal,
+                                            ),
+                                        );
+                                    }
+                                    // TODO(dyn): more ways of registering vtable instance?
+                                    _ => {
+                                        trace!(
+                                            "impl_expr not triggering registering vtable: {:?}",
+                                            impl_expr
+                                        )
+                                    }
+                                };
                                 UnsizingMetadata::VTablePtr(tref)
                             }
                             hax::UnsizingMetadata::Unknown => UnsizingMetadata::Unknown,

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -78,15 +78,7 @@ impl ItemTransCtx<'_, '_> {
         } else {
             None
         };
-        let signature = self.translate_region_binder(span, &args.fn_sig, |ctx, sig| {
-            let inputs = sig
-                .inputs
-                .iter()
-                .map(|x| ctx.translate_ty(span, x))
-                .try_collect()?;
-            let output = ctx.translate_ty(span, &sig.output)?;
-            Ok((inputs, output))
-        })?;
+        let signature = self.translate_fun_sig(span, &args.fn_sig)?;
         Ok(ClosureInfo {
             kind,
             fn_once_impl,

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -539,6 +539,7 @@ pub fn translate<'tcx, 'ctx>(
         file_to_id: Default::default(),
         items_to_translate: Default::default(),
         processed: Default::default(),
+        translate_stack: Default::default(),
         cached_item_metas: Default::default(),
         cached_names: Default::default(),
     };

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -49,6 +49,8 @@ pub struct TranslateCtx<'tcx> {
     pub items_to_translate: BTreeSet<TransItemSource>,
     /// The declaration we've already processed (successfully or not).
     pub processed: HashSet<TransItemSource>,
+    /// Stack of the translations currently happening. Used to avoid accidental cycles.
+    pub translate_stack: Vec<AnyTransId>,
     /// Cache the names to compute them only once each.
     pub cached_names: HashMap<RustcItem, Name>,
     /// Cache the `ItemMeta`s to compute them only once each.

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -462,6 +462,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     }
 
     /// Translate the generics and predicates of this item and its parents.
+    /// This adds generic parameters and predicates to the current environment (as a binder in `self.binding_levels`).
+    /// This is necessary to translate types that depend on these generics (such as `Ty` and `TraitRef`).
+    /// The constructed `GenericParams` can be recovered at the end using `self.into_generics()` and stored in the translated item.
     pub(crate) fn translate_def_generics(
         &mut self,
         span: Span,

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -356,6 +356,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 name.name
                     .push(PathElem::Ident("as_fn".into(), Disambiguator::ZERO));
             }
+            TransItemSourceKind::VTable
+            | TransItemSourceKind::VTableInstance(..)
+            | TransItemSourceKind::VTableInstanceInitializer(..) => {
+                name.name
+                    .push(PathElem::Ident("{vtable}".into(), Disambiguator::ZERO));
+            }
             _ => {}
         }
         Ok(name)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -1,9 +1,52 @@
-use crate::translate::{translate_generics::BindingLevel, translate_predicates::PredicateLocation};
+use super::{
+    translate_crate::TransItemSourceKind, translate_ctx::*, translate_generics::BindingLevel,
+    translate_predicates::PredicateLocation,
+};
 
-use super::translate_ctx::*;
-use charon_lib::ast::*;
+use charon_lib::ids::Vector;
+use charon_lib::ullbc_ast::*;
 use hax_frontend_exporter as hax;
+use itertools::Itertools;
 
+fn dummy_public_attr_info() -> AttrInfo {
+    AttrInfo {
+        public: true,
+        ..Default::default()
+    }
+}
+
+fn usize_ty() -> Ty {
+    Ty::new(TyKind::Literal(LiteralTy::UInt(UIntTy::Usize)))
+}
+
+/// Takes a `T` valid in the context of a trait ref and transforms it into a `T` valid in the
+/// context of its vtable definition, i.e. no longer mentions `Self`. If `new_self` is `Some`, we
+/// replace any mention of `Self` with it; otherwise we panic if `Self` is mentioned.
+fn dynify<T: TyVisitable>(mut x: T, new_self: Option<Ty>) -> T {
+    struct ReplaceSelfVisitor(Option<Ty>);
+    impl VarsVisitor for ReplaceSelfVisitor {
+        fn visit_type_var(&mut self, v: TypeDbVar) -> Option<Ty> {
+            if let DeBruijnVar::Bound(DeBruijnId::ZERO, type_id) = v {
+                // Replace type 0 and decrement the others.
+                Some(if let Some(new_id) = type_id.index().checked_sub(1) {
+                    TyKind::TypeVar(DeBruijnVar::Bound(DeBruijnId::ZERO, TypeVarId::new(new_id)))
+                        .into_ty()
+                } else {
+                    self.0.clone().expect(
+                        "Found unexpected `Self` 
+                        type when constructing vtable",
+                    )
+                })
+            } else {
+                None
+            }
+        }
+    }
+    x.visit_vars(&mut ReplaceSelfVisitor(new_self));
+    x
+}
+
+//// Translate the `dyn Trait` type.
 impl ItemTransCtx<'_, '_> {
     pub fn check_at_most_one_pred_has_methods(
         &mut self,
@@ -73,4 +116,635 @@ impl ItemTransCtx<'_, '_> {
         };
         Ok(DynPredicate { binder })
     }
+}
+
+//// Generate the vtable struct.
+impl ItemTransCtx<'_, '_> {
+    /// Query whether a trait is dyn compatible.
+    /// TODO(dyn): for now we return `false` if the trait has any associated types, as we don't
+    /// handle associated types in vtables.
+    pub fn trait_is_dyn_compatible(&mut self, def_id: &hax::DefId) -> Result<bool, Error> {
+        let def = self.poly_hax_def(def_id)?;
+        Ok(match def.kind() {
+            hax::FullDefKind::Trait {
+                dyn_self: Some(dyn_self),
+                ..
+            }
+            | hax::FullDefKind::TraitAlias {
+                dyn_self: Some(dyn_self),
+                ..
+            } => {
+                match dyn_self.kind() {
+                    // `dyn_self` looks like `dyn Trait<Args.., Ty0 = .., Ty1 = ..>`. The first
+                    // predicate is `_: Trait<Args..>`, the rest are type constraints. Hence the
+                    // trait recursively has no assoc types iff `preds.len() == 1`.
+                    hax::TyKind::Dynamic(_, preds, _) => preds.predicates.len() == 1,
+                    _ => panic!("unexpected `dyn_self`: {dyn_self:?}"),
+                }
+            }
+            _ => false,
+        })
+    }
+
+    /// Check whether this trait ref is of the form `Self: Trait<...>`.
+    fn pred_is_for_self(&self, tref: &hax::TraitRef) -> bool {
+        let first_ty = tref
+            .generic_args
+            .iter()
+            .filter_map(|arg| match arg {
+                hax::GenericArg::Type(ty) => Some(ty),
+                _ => None,
+            })
+            .next();
+        match first_ty {
+            None => false,
+            Some(first_ty) => match first_ty.kind() {
+                hax::TyKind::Param(param_ty) if param_ty.index == 0 => {
+                    assert_eq!(param_ty.name, "Self");
+                    true
+                }
+                _ => false,
+            },
+        }
+    }
+
+    /// Given a trait ref, return a reference to its vtable struct, if it is dyn compatible.
+    pub fn translate_vtable_struct_ref(
+        &mut self,
+        span: Span,
+        tref: &hax::TraitRef,
+    ) -> Result<Option<TypeDeclRef>, Error> {
+        if !self.trait_is_dyn_compatible(&tref.def_id)? {
+            return Ok(None);
+        }
+        // Don't enqueue the vtable for translation by default. It will be enqueued if used in a
+        // `dyn Trait`.
+        let mut vtable_ref: TypeDeclRef =
+            self.translate_item_no_enqueue(span, tref, TransItemSourceKind::VTable)?;
+        // Remove the `Self` type variable from the generic parameters.
+        vtable_ref
+            .generics
+            .types
+            .remove_and_shift_ids(TypeVarId::ZERO);
+        Ok(Some(vtable_ref))
+    }
+
+    /// Add a `method_name: fn(...) -> ...` field for the method.
+    fn add_method_to_vtable_def(
+        &mut self,
+        span: Span,
+        trait_def: &hax::FullDef,
+        mut mk_field: impl FnMut(String, Ty),
+        item: &hax::AssocItem,
+    ) -> Result<(), Error> {
+        let item_def_id = &item.def_id;
+        let item_def = self.hax_def(
+            &trait_def
+                .this()
+                .with_def_id(&self.t_ctx.hax_state, item_def_id),
+        )?;
+        let hax::FullDefKind::AssocFn {
+            sig,
+            vtable_safe: true,
+            ..
+        } = item_def.kind()
+        else {
+            return Ok(());
+        };
+
+        let item_name = self.t_ctx.translate_trait_item_name(item_def_id)?;
+        // It's ok to translate the method signature in the context of the trait because
+        // `vtable_safe: true` ensures the method has no generics of its own.
+        let sig = self.translate_fun_sig(span, sig)?;
+        let ty = TyKind::FnPtr(sig).into_ty();
+
+        mk_field(format!("method_{}", item_name.0), ty);
+        Ok(())
+    }
+
+    /// Add `super_trait_n: &'static SuperTraitNVTable` fields.
+    fn add_supertraits_to_vtable_def(
+        &mut self,
+        span: Span,
+        mut mk_field: impl FnMut(String, Ty),
+        implied_predicates: &hax::GenericPredicates,
+    ) -> Result<(), Error> {
+        let mut counter = (0..).into_iter();
+        for (clause, _span) in &implied_predicates.predicates {
+            if let hax::ClauseKind::Trait(pred) = clause.kind.hax_skip_binder_ref() {
+                // If a clause looks like `Self: OtherTrait<...>`, we consider it a supertrait.
+                if !self.pred_is_for_self(&pred.trait_ref) {
+                    continue;
+                }
+                let vtbl_struct = self
+                    .translate_region_binder(span, &clause.kind, |ctx, _| {
+                        ctx.translate_vtable_struct_ref(span, &pred.trait_ref)
+                    })?
+                    .erase()
+                    .expect("parent trait should be dyn compatible");
+                let ty = Ty::new(TyKind::Ref(
+                    Region::Static,
+                    Ty::new(TyKind::Adt(vtbl_struct)),
+                    RefKind::Shared,
+                ));
+                mk_field(format!("super_trait_{}", counter.next().unwrap()), ty);
+            }
+        }
+        Ok(())
+    }
+
+    fn gen_vtable_struct_fields(
+        &mut self,
+        span: Span,
+        trait_def: &hax::FullDef,
+        implied_predicates: &hax::GenericPredicates,
+    ) -> Result<Vector<FieldId, Field>, Error> {
+        let mut fields = Vector::new();
+        let mut mk_field = |name, ty| {
+            fields.push(Field {
+                span,
+                attr_info: dummy_public_attr_info(),
+                name: Some(name),
+                ty,
+            });
+        };
+
+        // Add the basic fields.
+        // Field: `size: usize`
+        mk_field("size".into(), usize_ty());
+        // Field: `align: usize`
+        mk_field("align".into(), usize_ty());
+        // Field: `drop: fn(*mut Self)`
+        mk_field("drop".into(), {
+            let self_ty = TyKind::TypeVar(DeBruijnVar::new_at_zero(TypeVarId::ZERO)).into_ty();
+            let self_ptr = TyKind::RawPtr(self_ty, RefKind::Mut).into_ty();
+            Ty::new(TyKind::FnPtr(RegionBinder::empty((
+                [self_ptr].into(),
+                Ty::mk_unit(),
+            ))))
+        });
+
+        // Add the method pointers (trait aliases don't have methods).
+        if let hax::FullDefKind::Trait { items, .. } = trait_def.kind() {
+            for item in items {
+                self.add_method_to_vtable_def(span, trait_def, &mut mk_field, item)?;
+            }
+        }
+
+        // Add the supertrait vtables.
+        self.add_supertraits_to_vtable_def(span, &mut mk_field, implied_predicates)?;
+
+        Ok(fields)
+    }
+
+    /// Construct the type of the vtable for this trait.
+    ///
+    /// It's a struct that has for generics the generics of the trait + one parameter for each
+    /// associated type of the trait and its parents.
+    /// TODO(dyn): add the associated types.
+    ///
+    /// struct TraitVTable<TraitArgs.., AssocTys..> {
+    ///   size: usize,
+    ///   align: usize,
+    ///   drop: fn(*mut dyn Trait<...>),
+    ///   method_name: fn(&dyn Trait<...>, Args..) -> Output,
+    ///   ... other methods
+    ///   super_trait_0: &'static SuperTrait0VTable
+    ///   ... other supertraits
+    /// }
+    pub(crate) fn translate_vtable_struct(
+        mut self,
+        type_id: TypeDeclId,
+        item_meta: ItemMeta,
+        trait_def: &hax::FullDef,
+    ) -> Result<TypeDecl, Error> {
+        let span = item_meta.span;
+        if !self.trait_is_dyn_compatible(trait_def.def_id())? {
+            raise_error!(
+                self,
+                span,
+                "Trying to compute the vtable type \
+                for a non-dyn-compatible trait"
+            );
+        }
+
+        self.translate_def_generics(span, trait_def)?;
+        // TODO(dyn): add the associated types.
+
+        let (hax::FullDefKind::Trait {
+            dyn_self,
+            implied_predicates,
+            ..
+        }
+        | hax::FullDefKind::TraitAlias {
+            dyn_self,
+            implied_predicates,
+            ..
+        }) = trait_def.kind()
+        else {
+            panic!()
+        };
+        let Some(dyn_self) = dyn_self else {
+            panic!("Trying to generate a vtable for a non-dyn-compatible trait")
+        };
+
+        // The `dyn Trait<Args..>` type for this trait.
+        let mut dyn_self = self.translate_ty(span, dyn_self)?;
+        // First construct fields that use the real method signatures (which may use the `Self`
+        // type). We fixup the types and generics below.
+        let mut fields = self.gen_vtable_struct_fields(span, trait_def, implied_predicates)?;
+
+        // let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
+        // let ptr_align = ptr_size;
+        // let layout = Layout {
+        //     // everything is of the same size as a pointer
+        //     size: Some((fields.iter().count() as u64) * ptr_size),
+        //     align: Some(ptr_align as u64),
+        //     discriminant_layout: None,
+        //     uninhabited: false,
+        //     // TODO
+        //     variant_layouts: Vector::new(),
+        // };
+        //
+
+        // Replace any use of `Self` with `dyn Trait<...>`, and remove the `Self` type variable
+        // from the generic parameters.
+        let mut generics = self.into_generics();
+        {
+            dyn_self = dynify(dyn_self, None);
+            generics = dynify(generics, Some(dyn_self.clone()));
+            fields = dynify(fields, Some(dyn_self.clone()));
+            generics.types.remove_and_shift_ids(TypeVarId::ZERO);
+            generics.types.iter_mut().for_each(|ty| {
+                ty.index -= 1;
+            });
+        }
+
+        let dyn_predicate = dyn_self
+            .kind()
+            .as_dyn_trait()
+            .expect("incorrect `dyn_self`");
+        Ok(TypeDecl {
+            def_id: type_id,
+            item_meta: item_meta,
+            generics: generics,
+            src: ItemKind::VTableTy {
+                dyn_predicate: dyn_predicate.clone(),
+            },
+            kind: TypeDeclKind::Struct(fields),
+            // TODO: construct a reasonable layout
+            layout: None,
+            ptr_metadata: None,
+        })
+    }
+}
+
+//// Generate a vtable value.
+impl ItemTransCtx<'_, '_> {
+    pub fn translate_vtable_instance_ref(
+        &mut self,
+        span: Span,
+        trait_ref: &hax::TraitRef,
+        impl_ref: &hax::ItemRef,
+    ) -> Result<Option<GlobalDeclRef>, Error> {
+        if !self.trait_is_dyn_compatible(&trait_ref.def_id)? {
+            return Ok(None);
+        }
+        // Don't enqueue the vtable for translation by default. It will be enqueued if used in a
+        // `dyn Trait` coercion.
+        // TODO(dyn): To do this properly we'd need to know for each clause whether it ultimately
+        // ends up used in a vtable cast.
+        let vtable_ref: GlobalDeclRef = self.translate_item_no_enqueue(
+            span,
+            impl_ref,
+            TransItemSourceKind::VTableInstance(TraitImplSource::Normal),
+        )?;
+        Ok(Some(vtable_ref))
+    }
+
+    /// Local helper function to get the vtable struct reference and trait declaration reference
+    fn get_vtable_instance_info<'a>(
+        &mut self,
+        span: Span,
+        impl_def: &'a hax::FullDef,
+        impl_kind: &TraitImplSource,
+    ) -> Result<(TraitImplRef, TraitDeclRef, TypeDeclRef), Error> {
+        let implemented_trait = match impl_def.kind() {
+            hax::FullDefKind::TraitImpl { trait_pred, .. } => &trait_pred.trait_ref,
+            _ => unreachable!(),
+        };
+        let vtable_struct_ref = self
+            .translate_vtable_struct_ref(span, implemented_trait)?
+            .expect("trait should be dyn-compatible");
+        let implemented_trait = self.translate_trait_decl_ref(span, implemented_trait)?;
+        let impl_ref = self.translate_item(
+            span,
+            impl_def.this(),
+            TransItemSourceKind::TraitImpl(*impl_kind),
+        )?;
+        Ok((impl_ref, implemented_trait, vtable_struct_ref))
+    }
+
+    /// E.g.,
+    /// global <T..., VT...>
+    ///     trait::{vtable_instance}::<ImplTy<T...>> :
+    ///         trait::{vtable}<VT...> = trait::{vtable}<VT...> {
+    ///     drop: &ignore / &<ImplTy<T...> as Drop>::drop,
+    ///     size: size_of(<ImplTy<T...>>),
+    ///     align: align_of(<ImplTy<T...>>),
+    ///     method_0: &<ImplTy<T...> as Trait>::method_0::{shim},
+    ///     method_1: &<ImplTy<T...> as Trait>::method_1::{shim},
+    ///     ...
+    ///     super_trait_0: &SuperTrait0<VT...>::{vtable_instance}::<ImplTy<T...>>,
+    ///     super_trait_1: &SuperTrait1<VT...>::{vtable_instance}::<ImplTy<T...>>,
+    ///     ...
+    /// }
+    pub(crate) fn translate_vtable_instance(
+        mut self,
+        global_id: GlobalDeclId,
+        item_meta: ItemMeta,
+        impl_def: &hax::FullDef,
+        impl_kind: &TraitImplSource,
+    ) -> Result<GlobalDecl, Error> {
+        let span = item_meta.span;
+        self.translate_def_generics(span, impl_def)?;
+
+        let (impl_ref, _, vtable_struct_ref) =
+            self.get_vtable_instance_info(span, impl_def, impl_kind)?;
+        // Initializer function for this global.
+        let init = self.register_item(
+            span,
+            impl_def.this(),
+            TransItemSourceKind::VTableInstanceInitializer(*impl_kind),
+        );
+
+        Ok(GlobalDecl {
+            def_id: global_id,
+            item_meta,
+            generics: self.into_generics(),
+            kind: ItemKind::VTableInstance { impl_ref },
+            // it should be static to have its own address
+            global_kind: GlobalKind::Static,
+            ty: Ty::new(TyKind::Adt(vtable_struct_ref)),
+            init,
+        })
+    }
+
+    fn add_method_to_vtable_value(
+        &mut self,
+        span: Span,
+        impl_def: &hax::FullDef,
+        item: &hax::ImplAssocItem,
+        mut mk_field: impl FnMut(RawConstantExpr),
+    ) -> Result<(), Error> {
+        // Exit if the item isn't a vtable safe method.
+        match self.poly_hax_def(&item.decl_def_id)?.kind() {
+            hax::FullDefKind::AssocFn {
+                vtable_safe: true, ..
+            } => {}
+            _ => return Ok(()),
+        }
+
+        let const_kind = match &item.value {
+            hax::ImplAssocItemValue::Provided {
+                def_id: item_def_id,
+                ..
+            } => {
+                // The method is vtable safe so it has no generics, hence we can reuse the impl
+                // generics.
+                let item_ref = impl_def.this().with_def_id(self.hax_state(), item_def_id);
+                let shim_ref =
+                    self.translate_item(span, &item_ref, TransItemSourceKind::VTableMethod)?;
+                RawConstantExpr::FnPtr(shim_ref)
+            }
+            hax::ImplAssocItemValue::DefaultedFn { .. } => RawConstantExpr::Opaque(
+                "shim for provided methods \
+                    aren't yet supported"
+                    .to_string(),
+            ),
+            _ => return Ok(()),
+        };
+
+        mk_field(const_kind);
+
+        Ok(())
+    }
+
+    fn add_supertraits_to_vtable_value(
+        &mut self,
+        span: Span,
+        trait_def: &hax::FullDef,
+        impl_def: &hax::FullDef,
+        mut mk_field: impl FnMut(RawConstantExpr),
+    ) -> Result<(), Error> {
+        let hax::FullDefKind::TraitImpl {
+            implied_impl_exprs, ..
+        } = impl_def.kind()
+        else {
+            unreachable!()
+        };
+        let hax::FullDefKind::Trait {
+            implied_predicates, ..
+        } = trait_def.kind()
+        else {
+            unreachable!()
+        };
+        for ((clause, _), impl_expr) in implied_predicates.predicates.iter().zip(implied_impl_exprs)
+        {
+            if let hax::ClauseKind::Trait(pred) = clause.kind.hax_skip_binder_ref() {
+                // If a clause looks like `Self: OtherTrait<...>`, we consider it a supertrait.
+                if !self.pred_is_for_self(&pred.trait_ref) {
+                    continue;
+                }
+            }
+
+            let vtable_def_ref = self
+                .translate_region_binder(span, &impl_expr.r#trait, |ctx, tref| {
+                    ctx.translate_vtable_struct_ref(span, tref)
+                })?
+                .erase()
+                .expect("parent trait should be dyn compatible");
+            let fn_ptr_ty = TyKind::Adt(vtable_def_ref).into_ty();
+            let kind = match &impl_expr.r#impl {
+                hax::ImplExprAtom::Concrete(impl_item) => {
+                    let vtable_instance_ref = self
+                        .translate_region_binder(span, &impl_expr.r#trait, |ctx, tref| {
+                            ctx.translate_vtable_instance_ref(span, tref, impl_item)
+                        })?
+                        .erase()
+                        .expect("parent trait should be dyn compatible");
+                    let global = Box::new(ConstantExpr {
+                        value: RawConstantExpr::Global(vtable_instance_ref),
+                        ty: fn_ptr_ty,
+                    });
+                    RawConstantExpr::Ref(global)
+                }
+                // TODO(dyn): builtin impls
+                _ => RawConstantExpr::Opaque("missing supertrait vtable".into()),
+            };
+            mk_field(kind);
+        }
+        Ok(())
+    }
+
+    /// Generate the body of the vtable instance function.
+    /// This is for `impl Trait for T` implementation, it does NOT handle builtin impls.
+    /// ```ignore
+    /// let ret@0 : VTable;
+    /// ret@0 = VTable { ... };
+    /// return;
+    /// ```
+    fn gen_vtable_instance_init_body(
+        &mut self,
+        span: Span,
+        impl_def: &hax::FullDef,
+        vtable_struct_ref: TypeDeclRef,
+    ) -> Result<Body, Error> {
+        let mut locals = Locals {
+            arg_count: 0,
+            locals: Vector::new(),
+        };
+        let ret_ty = Ty::new(TyKind::Adt(vtable_struct_ref.clone()));
+        let ret_place = locals.new_var(Some("ret".into()), ret_ty.clone());
+
+        let hax::FullDefKind::TraitImpl {
+            trait_pred, items, ..
+        } = impl_def.kind()
+        else {
+            unreachable!()
+        };
+        let trait_def = self.hax_def(&trait_pred.trait_ref)?;
+
+        // Retreive the expected field types from the struct definition. This avoids complicated
+        // substitutions.
+        let field_tys = {
+            let vtable_decl_id = vtable_struct_ref.id.as_adt().unwrap().clone();
+            let AnyTransItem::Type(vtable_def) =
+                self.t_ctx.get_or_translate(vtable_decl_id.into())?
+            else {
+                unreachable!()
+            };
+            let TypeDeclKind::Struct(fields) = &vtable_def.kind else {
+                unreachable!()
+            };
+            fields
+                .iter()
+                .map(|f| &f.ty)
+                .cloned()
+                .map(|ty| ty.substitute(&vtable_struct_ref.generics))
+                .collect_vec()
+        };
+
+        let mut statements = vec![];
+        let mut aggregate_fields = vec![];
+        // For each vtable field, assign the desired value to a new local.
+        let mut field_ty_iter = field_tys.into_iter();
+        let mut mk_field = |kind| {
+            let ty = field_ty_iter.next().unwrap();
+            aggregate_fields.push(Operand::Const(Box::new(ConstantExpr { value: kind, ty })));
+        };
+
+        // TODO(dyn): provide values
+        mk_field(RawConstantExpr::Opaque("unknown size".to_string()));
+        mk_field(RawConstantExpr::Opaque("unknown align".to_string()));
+        mk_field(RawConstantExpr::Opaque("unknown drop".to_string()));
+
+        for item in items {
+            self.add_method_to_vtable_value(span, impl_def, item, &mut mk_field)?;
+        }
+
+        self.add_supertraits_to_vtable_value(span, &trait_def, impl_def, &mut mk_field)?;
+
+        if field_ty_iter.next().is_some() {
+            raise_error!(
+                self,
+                span,
+                "Missed some fields in vtable value construction"
+            )
+        }
+
+        // Construct the final struct.
+        statements.push(Statement::new(
+            span,
+            RawStatement::Assign(
+                ret_place,
+                Rvalue::Aggregate(
+                    AggregateKind::Adt(vtable_struct_ref.clone(), None, None),
+                    aggregate_fields,
+                ),
+            ),
+        ));
+
+        let block = BlockData {
+            statements,
+            terminator: Terminator::new(span, RawTerminator::Return),
+        };
+
+        Ok(Body::Unstructured(GExprBody {
+            span,
+            locals,
+            comments: Vec::new(),
+            body: [block].into(),
+        }))
+    }
+
+    pub(crate) fn translate_vtable_instance_init(
+        mut self,
+        init_func_id: FunDeclId,
+        item_meta: ItemMeta,
+        impl_def: &hax::FullDef,
+        impl_kind: &TraitImplSource,
+    ) -> Result<FunDecl, Error> {
+        let span = item_meta.span;
+        self.translate_def_generics(span, impl_def)?;
+
+        let (impl_ref, _, vtable_struct_ref) =
+            self.get_vtable_instance_info(span, impl_def, impl_kind)?;
+        let init_for = self.register_item(
+            span,
+            impl_def.this(),
+            TransItemSourceKind::VTableInstance(*impl_kind),
+        );
+
+        // Signature: `() -> VTable`.
+        let sig = FunSig {
+            is_unsafe: false,
+            generics: self.the_only_binder().params.clone(),
+            inputs: vec![],
+            output: Ty::new(TyKind::Adt(vtable_struct_ref.clone())),
+        };
+
+        let body = match impl_kind {
+            TraitImplSource::Normal => {
+                let body = self.gen_vtable_instance_init_body(span, impl_def, vtable_struct_ref)?;
+                Ok(body)
+            }
+            _ => {
+                raise_error!(
+                    self,
+                    span,
+                    "Don't know how to generate a vtable for a virtual impl {impl_kind:?}"
+                );
+            }
+        };
+
+        Ok(FunDecl {
+            def_id: init_func_id,
+            item_meta: item_meta,
+            signature: sig,
+            kind: ItemKind::VTableInstance { impl_ref },
+            is_global_initializer: Some(init_for),
+            body,
+        })
+    }
+
+    // pub(crate) fn translate_vtable_shim(
+    //     self,
+    //     _fun_id: FunDeclId,
+    //     item_meta: ItemMeta,
+    //     _impl_func_def: &hax::FullDef,
+    // ) -> Result<FunDecl, Error> {
+    //     let span = item_meta.span;
+    //     raise_error!(self, span, "unimplemented")
+    // }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1569,6 +1569,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
                 let (params, fn_ref) = bound_fn.fmt_split(ctx);
                 writeln!(f, "{TAB_INCR}fn {name}{params} = {fn_ref}")?;
             }
+            // TODO(dyn)
+            // if let Some(vtb_ref) = &self.vtable {
+            //     writeln!(f, "{TAB_INCR}vtable: {}", vtb_ref.with_ctx(ctx))?;
+            // } else {
+            //     writeln!(f, "{TAB_INCR}non-dyn-compatible")?;
+            // }
             write!(f, "}}")?;
         }
         Ok(())

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -1177,7 +1177,10 @@ impl VisitAstMut for UpdateItemBody<'_> {
     }
     fn enter_item_kind(&mut self, kind: &mut ItemKind) {
         match kind {
-            ItemKind::TopLevel | ItemKind::Closure { .. } => {}
+            ItemKind::TopLevel
+            | ItemKind::Closure { .. }
+            | ItemKind::VTableTy { .. }
+            | ItemKind::VTableInstance { .. } => {}
             // Inside method declarations, the implicit `Self` clause is the first clause.
             ItemKind::TraitDecl { trait_ref, .. } => self.process_trait_decl_ref(
                 trait_ref,

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -406,6 +406,7 @@ fn compute_declarations_graph<'tcx>(ctx: &'tcx TransformCtx) -> Deps {
                     type_defaults,
                     type_clauses,
                     methods,
+                    vtable,
                 } = d;
                 // Visit the traits referenced in the generics
                 let _ = generics.drive(&mut graph);
@@ -418,6 +419,7 @@ fn compute_declarations_graph<'tcx>(ctx: &'tcx TransformCtx) -> Deps {
                 let _ = consts.drive(&mut graph);
                 let _ = types.drive(&mut graph);
                 let _ = type_defaults.drive(&mut graph);
+                let _ = vtable.drive(&mut graph);
 
                 // We consider that a trait decl only contains the function/constant signatures.
                 // Therefore we don't explore the default const/method ids.

--- a/charon/tests/ptr-metadata.json
+++ b/charon/tests/ptr-metadata.json
@@ -12,6 +12,7 @@
   "test_crate::GenericNotLastField": "None",
   "test_crate::GenericBehindIndirection": "None",
   "test_crate::ThinGeneric": null,
+  "test_crate::Showable::{vtable}": null,
   "alloc::alloc::Global": "None",
   "core::cmp::Ordering": "None",
   "core::option::Option": "None",

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -1,5 +1,13 @@
 # Final LLBC before serialization:
 
+struct core::cmp::PartialEq::{vtable}<Rhs> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: PartialEq<_dyn, Rhs> + _dyn : '_)),
+  method_eq: fn<'_0, '_1>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: PartialEq<_dyn, Rhs> + _dyn : '_)), &'_0_1 (Rhs)) -> bool,
+  method_ne: fn<'_0, '_1>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: PartialEq<_dyn, Rhs> + _dyn : '_)), &'_0_1 (Rhs)) -> bool,
+}
+
 // Full name: core::cmp::PartialEq
 #[lang_item("eq")]
 pub trait PartialEq<Self, Rhs>
@@ -36,6 +44,13 @@ where
 {
   Ok(T),
   Err(E),
+}
+
+struct core::fmt::Display::{vtable} {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)),
+  method_fmt: fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>],
 }
 
 // Full name: core::fmt::Display

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -42,6 +42,9 @@ error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphi
  --> /rustc/library/core/src/fmt/mod.rs:1003:1
 
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
+ --> /rustc/library/core/src/fmt/mod.rs:1003:1
+
+error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
  --> /rustc/library/core/src/fmt/mod.rs:1028:5
 
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
@@ -52,7 +55,7 @@ note: the error occurred when translating `core::fmt::Display::<type_error("`dyn
   |
 7 |     x.to_string()
   |     -------------
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 476 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `core::fmt::Display::fmt::<Str>`, which is (transitively) used at the following location(s):
@@ -60,7 +63,7 @@ note: the error occurred when translating `core::fmt::Display::fmt::<Str>`, whic
    |
 11 |     let str: String = "hello".to_string();
    |                       -------------------
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 476 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `core::fmt::Display::fmt::<alloc::string::String>`, which is (transitively) used at the following location(s):
@@ -79,10 +82,10 @@ note: the error occurred when translating `core::fmt::Display::fmt::<type_error(
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
  --> /rustc/library/core/src/fmt/mod.rs:1028:5
 
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 476 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 576 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 598 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `core::fmt::{impl core::fmt::Display::<Str>}::fmt`, which is (transitively) used at the following location(s):
@@ -90,7 +93,7 @@ note: the error occurred when translating `core::fmt::{impl core::fmt::Display::
    |
 11 |     let str: String = "hello".to_string();
    |                       -------------------
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 476 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `core::fmt::Display::fmt`, which is (transitively) used at the following location(s):
@@ -112,12 +115,44 @@ error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphi
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
  --> /rustc/library/core/src/marker.rs:179:1
 
+error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
+ --> /rustc/library/core/src/marker.rs:179:1
+
 note: the error occurred when translating `core::marker::MetaSized::<type_error("`dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead")>`, which is (transitively) used at the following location(s):
  --> tests/ui/monomorphization/dyn-trait.rs:7:5
   |
 7 |     x.to_string()
   |     -------------
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 642 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
+ --> /rustc/library/core/src/fmt/mod.rs:1003:1
+
+note: the error occurred when translating `core::fmt::Display::{vtable}::<alloc::string::String>`, which is (transitively) used at the following location(s):
+  --> tests/ui/monomorphization/dyn-trait.rs:12:27
+   |
+12 |     let _ = dyn_to_string(&str);
+   |                           ----
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+ --> /rustc/library/core/src/fmt/mod.rs:562:1
+
+
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:375:14:
+incorrect `dyn_self`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Thread panicked when extracting item `core::fmt::Display`.
+ --> /rustc/library/core/src/fmt/mod.rs:1003:1
+
+error: Failed to translate item Type(3).
+ --> /rustc/library/core/src/fmt/mod.rs:1003:1
+
+note: the error occurred when translating `alloc::string::{impl core::fmt::Display::<alloc::string::String>}::{vtable}`, which is (transitively) used at the following location(s):
+  --> tests/ui/monomorphization/dyn-trait.rs:12:27
+   |
+12 |     let _ = dyn_to_string(&str);
+   |                           ----
+error: Item `alloc::string::{impl#23}` caused errors; ignoring.
+ --> /rustc/library/alloc/src/string.rs:2623:1
+
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 671 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `alloc::string::{impl core::fmt::Display::<alloc::string::String>}::fmt`, which is (transitively) used at the following location(s):
@@ -125,7 +160,7 @@ note: the error occurred when translating `alloc::string::{impl core::fmt::Displ
    |
 12 |     let _ = dyn_to_string(&str);
    |                           ----
-error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 476 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
+error: Item is not monomorphic: Mono(ItemRef { contents: Node { id: Id { id: 498 }, value: ItemRefContents { def_id: core::fmt::Formatter, generic_args: [Lifetime(Region { kind: ReBound(0, BoundRegion { var: 2, kind: Anon }) })], impl_exprs: [], in_trait: None, has_param: true } } })
  --> /rustc/library/core/src/fmt/mod.rs:562:1
 
 note: the error occurred when translating `core::fmt::Display::fmt`, which is (transitively) used at the following location(s):
@@ -141,6 +176,9 @@ note: the error occurred when translating `alloc::string::ToString::<type_error(
   |
 7 |     x.to_string()
   |     -------------
+error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
+ --> /rustc/library/alloc/src/string.rs:2780:1
+
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
  --> /rustc/library/alloc/src/string.rs:2780:1
 
@@ -186,6 +224,9 @@ error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphi
  --> /rustc/library/alloc/src/string.rs:2805:1
 
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
+ --> /rustc/library/alloc/src/string.rs:2805:1
+
+error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
  --> /rustc/library/alloc/src/string.rs:2807:5
 
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
@@ -211,4 +252,4 @@ note: the error occurred when translating `alloc::string::ToString::to_string`, 
   |
 7 |     x.to_string()
   |     -------------
-ERROR Charon failed to translate this code (37 errors)
+ERROR Charon failed to translate this code (46 errors)

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -1,5 +1,15 @@
 disabled backtrace
 warning[E9999]: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
+  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:21:1
+   |
+21 | impl MyIterator for A {
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: ⚠️ This is a bug in Hax's frontend.
+           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+
+disabled backtrace
+warning[E9999]: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
   --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:9:5
    |
 9  | /     fn flatten(self) -> Flatten<Self>
@@ -33,6 +43,6 @@ error: Error during trait resolution: Could not find a clause for `Binder { valu
 18 | struct Flatten<I: MyIterator<Item: Copy>>(I);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 2 warnings emitted
+warning: 3 warnings emitted
 
 ERROR Charon failed to translate this code (2 errors)

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -56,6 +56,13 @@ where
   Err(E),
 }
 
+struct core::fmt::Debug::{vtable} {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)),
+  method_fmt: fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>],
+}
+
 // Full name: core::fmt::Debug
 #[lang_item("Debug")]
 pub trait Debug<Self>

--- a/charon/tests/ui/simple/generic-cast-to-dyn.out
+++ b/charon/tests/ui/simple/generic-cast-to-dyn.out
@@ -1,11 +1,22 @@
 # Final LLBC before serialization:
 
+// Full name: core::any::TypeId
+pub opaque type TypeId
+
 // Full name: core::marker::MetaSized
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: core::any::TypeId
-pub opaque type TypeId
+struct core::any::Any::{vtable}
+where
+    (dyn exists<_dyn> [@TraitClause0]: Any<_dyn> + _dyn : '_) : 'static,
+{
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Any<_dyn> + _dyn : '_)),
+  method_type_id: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Any<_dyn> + _dyn : '_))) -> TypeId,
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+}
 
 // Full name: core::any::Any
 #[lang_item("Any")]

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -38,6 +38,13 @@ where
   Err(E),
 }
 
+struct core::fmt::Display::{vtable} {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)),
+  method_fmt: fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>],
+}
+
 // Full name: core::fmt::Display
 #[lang_item("Display")]
 pub trait Display<Self>
@@ -142,6 +149,18 @@ impl Clone for String {
 
 // Full name: alloc::string::{impl Display for String}::fmt
 pub fn {impl Display for String}::fmt<'_0, '_1, '_2>(@1: &'_0 (String), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+
+// Full name: alloc::string::{impl Display for String}::{vtable}
+fn {impl Display for String}::{vtable}() -> core::fmt::Display::{vtable}
+{
+    let ret@0: core::fmt::Display::{vtable}; // return
+
+    ret@0 := core::fmt::Display::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_fmt: const ({impl Display for String}::fmt) }
+    return
+}
+
+// Full name: alloc::string::{impl Display for String}::{vtable}
+static {impl Display for String}::{vtable}: core::fmt::Display::{vtable} = {impl Display for String}::{vtable}()
 
 // Full name: alloc::string::{impl Display for String}
 impl Display for String {

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -1,0 +1,1042 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+}
+
+// Full name: core::clone::Clone
+#[lang_item("clone")]
+pub trait Clone<Self>
+{
+    parent_clause0 : [@TraitClause0]: Sized<Self>
+    fn clone<'_0> = core::clone::Clone::clone<'_0_0, Self>[Self]
+}
+
+#[lang_item("clone_fn")]
+pub fn core::clone::Clone::clone<'_0, Self>(@1: &'_0 (Self)) -> Self
+where
+    [@TraitClause0]: Clone<Self>,
+
+// Full name: core::clone::impls::{impl Clone for i32}::clone
+pub fn {impl Clone for i32}::clone<'_0>(@1: &'_0 (i32)) -> i32
+
+// Full name: core::clone::impls::{impl Clone for i32}
+impl Clone for i32 {
+    parent_clause0 = Sized<i32>
+    fn clone<'_0> = {impl Clone for i32}::clone<'_0_0>
+}
+
+// Full name: core::fmt::Error
+pub struct Error {}
+
+// Full name: core::fmt::Arguments
+#[lang_item("format_arguments")]
+pub opaque type Arguments<'a>
+where
+    'a : 'a,
+
+// Full name: core::result::Result
+#[lang_item("Result")]
+pub enum Result<T, E>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<E>,
+{
+  Ok(T),
+  Err(E),
+}
+
+// Full name: core::fmt::Display
+#[lang_item("Display")]
+pub trait Display<Self>
+{
+    fn fmt<'_0, '_1, '_2> = core::fmt::Display::fmt<'_0_0, '_0_1, '_0_2, Self>[Self]
+}
+
+pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+where
+    [@TraitClause0]: Display<Self>,
+
+// Full name: core::fmt::{impl Display for Str}::fmt
+pub fn {impl Display for Str}::fmt<'_0, '_1, '_2>(@1: &'_0 (Str), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+
+// Full name: core::fmt::{impl Display for Str}
+impl Display for Str {
+    fn fmt<'_0, '_1, '_2> = {impl Display for Str}::fmt<'_0_0, '_0_1, '_0_2>
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+}
+
+// Full name: core::ops::drop::Drop
+#[lang_item("drop")]
+pub trait Drop<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn drop<'_0> = core::ops::drop::Drop::drop<'_0_0, Self>[Self]
+}
+
+pub fn core::ops::drop::Drop::drop<'_0, Self>(@1: &'_0 mut (Self))
+where
+    [@TraitClause0]: Drop<Self>,
+
+// Full name: core::option::Option
+#[lang_item("Option")]
+pub enum Option<T>
+where
+    [@TraitClause0]: Sized<T>,
+{
+  None,
+  Some(T),
+}
+
+// Full name: core::panicking::AssertKind
+pub enum AssertKind {
+  Eq,
+  Ne,
+  Match,
+}
+
+// Full name: alloc::string::String
+#[lang_item("String")]
+pub opaque type String
+
+// Full name: alloc::string::String::{impl Drop for String}::drop
+fn {impl Drop for String}::drop<'_0>(@1: &'_0 mut (String))
+
+// Full name: alloc::string::String::{impl Drop for String}
+impl Drop for String {
+    parent_clause0 = MetaSized<String>
+    fn drop<'_0> = {impl Drop for String}::drop<'_0_0>
+}
+
+// Full name: alloc::string::{String}::is_empty
+pub fn is_empty<'_0>(@1: &'_0 (String)) -> bool
+
+// Full name: alloc::string::{impl Clone for String}::clone
+pub fn {impl Clone for String}::clone<'_0>(@1: &'_0 (String)) -> String
+
+// Full name: alloc::string::{impl Clone for String}
+impl Clone for String {
+    parent_clause0 = Sized<String>
+    fn clone<'_0> = {impl Clone for String}::clone<'_0_0>
+}
+
+// Full name: alloc::string::ToString
+#[lang_item("ToString")]
+pub trait ToString<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn to_string<'_0> = alloc::string::ToString::to_string<'_0_0, Self>[Self]
+}
+
+#[lang_item("to_string_method")]
+pub fn alloc::string::ToString::to_string<'_0, Self>(@1: &'_0 (Self)) -> String
+where
+    [@TraitClause0]: ToString<Self>,
+
+// Full name: alloc::string::{impl ToString for T}::to_string
+pub fn {impl ToString for T}::to_string<'_0, T>(@1: &'_0 (T)) -> String
+where
+    [@TraitClause0]: MetaSized<T>,
+    [@TraitClause1]: Display<T>,
+
+// Full name: alloc::string::{impl ToString for T}
+impl<T> ToString for T
+where
+    [@TraitClause0]: MetaSized<T>,
+    [@TraitClause1]: Display<T>,
+{
+    parent_clause0 = @TraitClause0
+    fn to_string<'_0> = {impl ToString for T}::to_string<'_0_0, T>[@TraitClause0, @TraitClause1]
+}
+
+// Full name: test_crate::Super
+trait Super<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<T>
+    fn super_method<'_0> = test_crate::Super::super_method<'_0_0, Self, T>[Self]
+}
+
+fn test_crate::Super::super_method<'_0, Self, T>(@1: &'_0 (Self), @2: T) -> i32
+where
+    [@TraitClause0]: Super<Self, T>,
+
+struct test_crate::Checkable::{vtable}<T> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, T> + _dyn : '_)),
+  method_check: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, T> + _dyn : '_))) -> bool,
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+  super_trait_1: &'static (test_crate::Super::{vtable}<T>),
+}
+
+// Full name: test_crate::Checkable
+trait Checkable<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Super<Self, T>
+    parent_clause2 : [@TraitClause2]: Sized<T>
+    fn check<'_0> = test_crate::Checkable::check<'_0_0, Self, T>[Self]
+}
+
+fn test_crate::Checkable::check<'_0, Self, T>(@1: &'_0 (Self)) -> bool
+where
+    [@TraitClause0]: Checkable<Self, T>,
+
+// Full name: test_crate::{impl Super<i32> for i32}::super_method
+fn {impl Super<i32> for i32}::super_method<'_0>(@1: &'_0 (i32), @2: i32) -> i32
+{
+    let @0: i32; // return
+    let self@1: &'_ (i32); // arg #1
+    let arg@2: i32; // arg #2
+    let @3: i32; // anonymous local
+    let @4: i32; // anonymous local
+    let @5: i32; // anonymous local
+
+    storage_live(@5)
+    storage_live(@3)
+    @3 := copy (*(self@1))
+    storage_live(@4)
+    @4 := copy (arg@2)
+    @5 := copy (@3) panic.+ copy (@4)
+    @0 := move (@5)
+    storage_dead(@4)
+    storage_dead(@3)
+    return
+}
+
+// Full name: test_crate::{impl Super<i32> for i32}
+impl Super<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i32>
+    fn super_method<'_0> = {impl Super<i32> for i32}::super_method<'_0_0>
+}
+
+// Full name: test_crate::{impl Checkable<i32> for i32}::check
+fn {impl Checkable<i32> for i32}::check<'_0>(@1: &'_0 (i32)) -> bool
+{
+    let @0: bool; // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: i32; // anonymous local
+    let @3: &'_ (i32); // anonymous local
+
+    storage_live(@2)
+    storage_live(@3)
+    @3 := &*(self@1)
+    @2 := {impl Super<i32> for i32}::super_method<'_>(move (@3), const (10 : i32))
+    storage_dead(@3)
+    @0 := move (@2) > const (0 : i32)
+    storage_dead(@2)
+    return
+}
+
+// Full name: test_crate::{impl Checkable<i32> for i32}::{vtable}
+fn {impl Checkable<i32> for i32}::{vtable}() -> test_crate::Checkable::{vtable}<i32>
+{
+    let ret@0: test_crate::Checkable::{vtable}<i32>; // return
+    let @1: &'static (test_crate::Super::{vtable}<i32>); // anonymous local
+
+    storage_live(@1)
+    @1 := &{impl Super<i32> for i32}::{vtable}
+    ret@0 := test_crate::Checkable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_check: const ({impl Checkable<i32> for i32}::check), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@1) }
+    return
+}
+
+// Full name: test_crate::{impl Checkable<i32> for i32}::{vtable}
+static {impl Checkable<i32> for i32}::{vtable}: test_crate::Checkable::{vtable}<i32> = {impl Checkable<i32> for i32}::{vtable}()
+
+// Full name: test_crate::{impl Checkable<i32> for i32}
+impl Checkable<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = {impl Super<i32> for i32}
+    parent_clause2 = Sized<i32>
+    fn check<'_0> = {impl Checkable<i32> for i32}::check<'_0_0>
+}
+
+struct test_crate::NoParam::{vtable} {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)),
+  method_dummy: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_))),
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+}
+
+// Full name: test_crate::NoParam
+trait NoParam<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    fn dummy<'_0> = test_crate::NoParam::dummy<'_0_0, Self>[Self]
+}
+
+fn test_crate::NoParam::dummy<'_0, Self>(@1: &'_0 (Self))
+where
+    [@TraitClause0]: NoParam<Self>,
+
+// Full name: test_crate::{impl NoParam for i32}::dummy
+fn {impl NoParam for i32}::dummy<'_0>(@1: &'_0 (i32))
+{
+    let @0: (); // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: (); // anonymous local
+    let @3: bool; // anonymous local
+    let @4: i32; // anonymous local
+
+    storage_live(@2)
+    storage_live(@3)
+    storage_live(@4)
+    @4 := copy (*(self@1))
+    @3 := move (@4) > const (0 : i32)
+    if move (@3) {
+    }
+    else {
+        storage_dead(@4)
+        panic(core::panicking::panic)
+    }
+    storage_dead(@4)
+    storage_dead(@3)
+    storage_dead(@2)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl NoParam for i32}
+impl NoParam for i32 {
+    parent_clause0 = MetaSized<i32>
+    fn dummy<'_0> = {impl NoParam for i32}::dummy<'_0_0>
+}
+
+// Full name: test_crate::to_dyn_obj
+fn to_dyn_obj<'_0, T>(@1: &'_0 (T)) -> &'_0 ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_0))
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: NoParam<T>,
+{
+    let @0: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // return
+    let arg@1: &'_ (T); // arg #1
+    let @2: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // anonymous local
+    let @3: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // anonymous local
+    let @4: &'_ (T); // anonymous local
+
+    storage_live(@2)
+    storage_live(@3)
+    storage_live(@4)
+    @4 := &*(arg@1)
+    @3 := unsize_cast<&'_ (T), &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)), @TraitClause1>(move (@4))
+    storage_dead(@4)
+    @2 := &*(@3)
+    @0 := unsize_cast<&'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)), &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)), NoParam<(dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)>>(move (@2))
+    storage_dead(@3)
+    storage_dead(@2)
+    return
+}
+
+struct test_crate::Modifiable::{vtable}<T> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)),
+  method_modify: fn<'_0, '_1>(&'_0_0 mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)), &'_0_1 (T)) -> T,
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+}
+
+// Full name: test_crate::Modifiable
+trait Modifiable<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<T>
+    fn modify<'_0, '_1> = test_crate::Modifiable::modify<'_0_0, '_0_1, Self, T>[Self]
+}
+
+fn test_crate::Modifiable::modify<'_0, '_1, Self, T>(@1: &'_0 mut (Self), @2: &'_1 (T)) -> T
+where
+    [@TraitClause0]: Modifiable<Self, T>,
+
+// Full name: test_crate::{impl Modifiable<T> for i32}::modify
+fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(@1: &'_0 mut (i32), @2: &'_1 (T)) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+{
+    let @0: T; // return
+    let self@1: &'_ mut (i32); // arg #1
+    let arg@2: &'_ (T); // arg #2
+    let @3: i32; // anonymous local
+    let @4: &'_ (T); // anonymous local
+
+    storage_live(@3)
+    @3 := copy (*(self@1)) panic.+ const (1 : i32)
+    *(self@1) := move (@3)
+    storage_live(@4)
+    @4 := &*(arg@2)
+    @0 := @TraitClause1::clone<'_>(move (@4))
+    storage_dead(@4)
+    return
+}
+
+// Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
+fn {impl Modifiable<T> for i32}::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+{
+    let ret@0: test_crate::Modifiable::{vtable}<T>; // return
+
+    ret@0 := test_crate::Modifiable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_modify: const ({impl Modifiable<T> for i32}::modify<T>[@TraitClause0, @TraitClause1]), super_trait_0: const (Opaque(missing supertrait vtable)) }
+    return
+}
+
+// Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
+static {impl Modifiable<T> for i32}::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+ = {impl Modifiable<T> for i32}::{vtable}()
+
+// Full name: test_crate::{impl Modifiable<T> for i32}
+impl<T> Modifiable<T> for i32
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+{
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = @TraitClause0
+    fn modify<'_0, '_1> = {impl Modifiable<T> for i32}::modify<'_0_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+}
+
+// Full name: test_crate::modify_trait_object
+fn modify_trait_object<'_0, T>(@1: &'_0 (T)) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+{
+    let @0: T; // return
+    let arg@1: &'_ (T); // arg #1
+    let x@2: &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)); // local
+    let @3: &'_ mut (i32); // anonymous local
+    let @4: &'_ mut (i32); // anonymous local
+    let @5: i32; // anonymous local
+    let @6: &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)); // anonymous local
+    let @7: &'_ (T); // anonymous local
+
+    storage_live(x@2)
+    storage_live(@3)
+    storage_live(@4)
+    storage_live(@5)
+    @5 := const (199 : i32)
+    @4 := &mut @5
+    @3 := &mut *(@4)
+    x@2 := unsize_cast<&'_ mut (i32), &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)), {impl Modifiable<T> for i32}<T>[@TraitClause0, @TraitClause1]>(move (@3))
+    storage_dead(@3)
+    storage_dead(@4)
+    storage_live(@6)
+    @6 := &two-phase-mut *(x@2)
+    storage_live(@7)
+    @7 := &*(arg@1)
+    @0 := Modifiable<(dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_), T>::modify<'_, '_>(move (@6), move (@7))
+    storage_dead(@7)
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_dead(x@2)
+    return
+}
+
+// Full name: test_crate::BaseOn
+trait BaseOn<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<T>
+    fn operate_on<'_0, '_1> = test_crate::BaseOn::operate_on<'_0_0, '_0_1, Self, T>[Self]
+}
+
+fn test_crate::BaseOn::operate_on<'_0, '_1, Self, T>(@1: &'_0 (Self), @2: &'_1 (T))
+where
+    [@TraitClause0]: BaseOn<Self, T>,
+
+struct test_crate::Both32And64::{vtable} {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)),
+  method_both_operate: fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)), &'_0_1 (i32), &'_0_2 (i64)),
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+  super_trait_1: &'static (test_crate::BaseOn::{vtable}<i32>),
+  super_trait_2: &'static (test_crate::BaseOn::{vtable}<i64>),
+}
+
+// Full name: test_crate::Both32And64
+trait Both32And64<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: BaseOn<Self, i32>
+    parent_clause2 : [@TraitClause2]: BaseOn<Self, i64>
+    fn both_operate<'_0, '_1, '_2> = both_operate<'_0_0, '_0_1, '_0_2, Self>[Self]
+}
+
+// Full name: test_crate::Both32And64::both_operate
+fn both_operate<'_0, '_1, '_2, Self>(@1: &'_0 (Self), @2: &'_1 (i32), @3: &'_2 (i64))
+where
+    [@TraitClause0]: Both32And64<Self>,
+{
+    let @0: (); // return
+    let self@1: &'_ (Self); // arg #1
+    let t32@2: &'_ (i32); // arg #2
+    let t64@3: &'_ (i64); // arg #3
+    let @4: (); // anonymous local
+    let @5: &'_ (Self); // anonymous local
+    let @6: &'_ (i32); // anonymous local
+    let @7: (); // anonymous local
+    let @8: &'_ (Self); // anonymous local
+    let @9: &'_ (i64); // anonymous local
+
+    storage_live(@4)
+    storage_live(@5)
+    @5 := &*(self@1)
+    storage_live(@6)
+    @6 := &*(t32@2)
+    @4 := @TraitClause0::parent_clause1::operate_on<'_, '_>(move (@5), move (@6))
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_live(@7)
+    storage_live(@8)
+    @8 := &*(self@1)
+    storage_live(@9)
+    @9 := &*(t64@3)
+    @7 := @TraitClause0::parent_clause2::operate_on<'_, '_>(move (@8), move (@9))
+    storage_dead(@9)
+    storage_dead(@8)
+    storage_dead(@7)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl BaseOn<i32> for i32}::operate_on
+fn {impl BaseOn<i32> for i32}::operate_on<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i32))
+{
+    let @0: (); // return
+    let self@1: &'_ (i32); // arg #1
+    let t@2: &'_ (i32); // arg #2
+    let @3: (); // anonymous local
+    let @4: bool; // anonymous local
+    let @5: i32; // anonymous local
+    let @6: i32; // anonymous local
+
+    storage_live(@3)
+    storage_live(@4)
+    storage_live(@5)
+    @5 := copy (*(self@1))
+    storage_live(@6)
+    @6 := copy (*(t@2))
+    @4 := move (@5) > move (@6)
+    if move (@4) {
+    }
+    else {
+        storage_dead(@6)
+        storage_dead(@5)
+        panic(core::panicking::panic)
+    }
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_dead(@3)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl BaseOn<i32> for i32}
+impl BaseOn<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i32>
+    fn operate_on<'_0, '_1> = {impl BaseOn<i32> for i32}::operate_on<'_0_0, '_0_1>
+}
+
+// Full name: test_crate::{impl BaseOn<i64> for i32}::operate_on
+fn {impl BaseOn<i64> for i32}::operate_on<'_0, '_1>(@1: &'_0 (i32), @2: &'_1 (i64))
+{
+    let @0: (); // return
+    let self@1: &'_ (i32); // arg #1
+    let t@2: &'_ (i64); // arg #2
+    let @3: (); // anonymous local
+    let @4: bool; // anonymous local
+    let @5: i64; // anonymous local
+    let @6: i32; // anonymous local
+    let @7: i64; // anonymous local
+
+    storage_live(@3)
+    storage_live(@4)
+    storage_live(@5)
+    storage_live(@6)
+    @6 := copy (*(self@1))
+    @5 := cast<i32, i64>(move (@6))
+    storage_dead(@6)
+    storage_live(@7)
+    @7 := copy (*(t@2))
+    @4 := move (@5) > move (@7)
+    if move (@4) {
+    }
+    else {
+        storage_dead(@7)
+        storage_dead(@5)
+        panic(core::panicking::panic)
+    }
+    storage_dead(@7)
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_dead(@3)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl BaseOn<i64> for i32}
+impl BaseOn<i64> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i64>
+    fn operate_on<'_0, '_1> = {impl BaseOn<i64> for i32}::operate_on<'_0_0, '_0_1>
+}
+
+fn test_crate::{impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(@1: &'_0 (i32), @2: &'_1 (i32), @3: &'_2 (i64))
+{
+    let @0: (); // return
+    let self@1: &'_ (i32); // arg #1
+    let t32@2: &'_ (i32); // arg #2
+    let t64@3: &'_ (i64); // arg #3
+    let @4: (); // anonymous local
+    let @5: &'_ (i32); // anonymous local
+    let @6: &'_ (i32); // anonymous local
+    let @7: (); // anonymous local
+    let @8: &'_ (i32); // anonymous local
+    let @9: &'_ (i64); // anonymous local
+
+    storage_live(@4)
+    storage_live(@5)
+    @5 := &*(self@1)
+    storage_live(@6)
+    @6 := &*(t32@2)
+    @4 := {impl Both32And64 for i32}::parent_clause1::operate_on<'_, '_>(move (@5), move (@6))
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_live(@7)
+    storage_live(@8)
+    @8 := &*(self@1)
+    storage_live(@9)
+    @9 := &*(t64@3)
+    @7 := {impl Both32And64 for i32}::parent_clause2::operate_on<'_, '_>(move (@8), move (@9))
+    storage_dead(@9)
+    storage_dead(@8)
+    storage_dead(@7)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
+fn {impl Both32And64 for i32}::{vtable}() -> test_crate::Both32And64::{vtable}
+{
+    let ret@0: test_crate::Both32And64::{vtable}; // return
+    let @1: &'static (test_crate::BaseOn::{vtable}<i32>); // anonymous local
+    let @2: &'static (test_crate::BaseOn::{vtable}<i64>); // anonymous local
+
+    storage_live(@1)
+    storage_live(@2)
+    @1 := &{impl BaseOn<i32> for i32}::{vtable}
+    @2 := &{impl BaseOn<i64> for i32}::{vtable}
+    ret@0 := test_crate::Both32And64::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_both_operate: const (Opaque(shim for provided methods aren't yet supported)), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@1), super_trait_2: move (@2) }
+    return
+}
+
+// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
+static {impl Both32And64 for i32}::{vtable}: test_crate::Both32And64::{vtable} = {impl Both32And64 for i32}::{vtable}()
+
+// Full name: test_crate::{impl Both32And64 for i32}
+impl Both32And64 for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = {impl BaseOn<i32> for i32}
+    parent_clause2 = {impl BaseOn<i64> for i32}
+    fn both_operate<'_0, '_1, '_2> = test_crate::{impl Both32And64 for i32}::both_operate<'_0_0, '_0_1, '_0_2>
+}
+
+// Full name: test_crate::Alias
+trait Alias<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Both32And64<Self>
+}
+
+// Full name: test_crate::use_alias
+fn use_alias<'_0>(@1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_0)))
+{
+    let @0: (); // return
+    let x@1: &'_ ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)); // arg #1
+    let @2: (); // anonymous local
+    let @3: &'_ ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)); // anonymous local
+    let @4: &'_ (i32); // anonymous local
+    let @5: &'_ (i32); // anonymous local
+    let @6: i32; // anonymous local
+    let @7: &'_ (i64); // anonymous local
+    let @8: &'_ (i64); // anonymous local
+    let @9: i64; // anonymous local
+
+    storage_live(@2)
+    storage_live(@3)
+    @3 := &*(x@1)
+    storage_live(@4)
+    storage_live(@5)
+    storage_live(@6)
+    @6 := const (100 : i32)
+    @5 := &@6
+    @4 := &*(@5)
+    storage_live(@7)
+    storage_live(@8)
+    storage_live(@9)
+    @9 := const (200 : i64)
+    @8 := &@9
+    @7 := &*(@8)
+    @2 := Both32And64<(dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)>::both_operate<'_, '_, '_>(move (@3), move (@4), move (@7))
+    storage_dead(@7)
+    storage_dead(@4)
+    storage_dead(@3)
+    storage_dead(@9)
+    storage_dead(@8)
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_dead(@2)
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let @0: (); // return
+    let x@1: &'_ ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_)); // local
+    let @2: &'_ (i32); // anonymous local
+    let @3: &'_ (i32); // anonymous local
+    let @4: i32; // anonymous local
+    let @5: (); // anonymous local
+    let @6: bool; // anonymous local
+    let @7: &'_ ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_)); // anonymous local
+    let y@8: &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, i32> + _dyn : '_)); // local
+    let @9: &'_ mut (i32); // anonymous local
+    let @10: &'_ mut (i32); // anonymous local
+    let @11: i32; // anonymous local
+    let @12: (); // anonymous local
+    let @13: bool; // anonymous local
+    let @14: &'_ (String); // anonymous local
+    let @15: String; // anonymous local
+    let @16: &'_ (String); // anonymous local
+    let @17: &'_ (String); // anonymous local
+    let @18: String; // anonymous local
+    let @19: &'_ (Str); // anonymous local
+    let @20: &'_ (Str); // anonymous local
+    let @21: (); // anonymous local
+    let @22: (&'_ (i32), &'_ (i32)); // anonymous local
+    let @23: &'_ (i32); // anonymous local
+    let @24: i32; // anonymous local
+    let @25: &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, i32> + _dyn : '_)); // anonymous local
+    let @26: &'_ (i32); // anonymous local
+    let @27: &'_ mut (i32); // anonymous local
+    let @28: i32; // anonymous local
+    let @29: &'_ (i32); // anonymous local
+    let @30: i32; // anonymous local
+    let left_val@31: &'_ (i32); // local
+    let right_val@32: &'_ (i32); // local
+    let @33: bool; // anonymous local
+    let @34: i32; // anonymous local
+    let @35: i32; // anonymous local
+    let kind@36: AssertKind; // local
+    let @37: AssertKind; // anonymous local
+    let @38: &'_ (i32); // anonymous local
+    let @39: &'_ (i32); // anonymous local
+    let @40: &'_ (i32); // anonymous local
+    let @41: &'_ (i32); // anonymous local
+    let @42: Option<Arguments<'_>>[Sized<Arguments<'_>>]; // anonymous local
+    let z@43: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // local
+    let @44: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // anonymous local
+    let @45: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // anonymous local
+    let @46: &'_ (i32); // anonymous local
+    let @47: &'_ (i32); // anonymous local
+    let @48: i32; // anonymous local
+    let @49: (); // anonymous local
+    let @50: &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)); // anonymous local
+    let a@51: &'_ ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)); // local
+    let @52: &'_ (i32); // anonymous local
+    let @53: &'_ (i32); // anonymous local
+    let @54: i32; // anonymous local
+    let @55: (); // anonymous local
+    let @56: &'_ ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)); // anonymous local
+    let @57: &'_ (i32); // anonymous local
+    let @58: &'_ (i32); // anonymous local
+    let @59: i32; // anonymous local
+    let @60: &'_ (i64); // anonymous local
+    let @61: &'_ (i64); // anonymous local
+    let @62: i64; // anonymous local
+
+    storage_live(@21)
+    storage_live(@22)
+    storage_live(@23)
+    storage_live(@24)
+    storage_live(@25)
+    storage_live(@26)
+    storage_live(@27)
+    storage_live(@28)
+    storage_live(@29)
+    storage_live(@30)
+    storage_live(left_val@31)
+    storage_live(right_val@32)
+    storage_live(@33)
+    storage_live(@34)
+    storage_live(@35)
+    storage_live(kind@36)
+    storage_live(@37)
+    storage_live(@38)
+    storage_live(@39)
+    storage_live(@40)
+    storage_live(@41)
+    storage_live(@42)
+    storage_live(z@43)
+    storage_live(@44)
+    storage_live(@45)
+    storage_live(@46)
+    storage_live(@47)
+    storage_live(@48)
+    storage_live(@49)
+    storage_live(@50)
+    storage_live(a@51)
+    storage_live(@52)
+    storage_live(@53)
+    storage_live(@54)
+    storage_live(@55)
+    storage_live(@56)
+    storage_live(@57)
+    storage_live(@58)
+    storage_live(@59)
+    storage_live(@60)
+    storage_live(@61)
+    storage_live(@62)
+    storage_live(x@1)
+    storage_live(@2)
+    storage_live(@3)
+    storage_live(@4)
+    @4 := const (42 : i32)
+    @3 := &@4
+    @2 := &*(@3)
+    x@1 := unsize_cast<&'_ (i32), &'_ ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_)), {impl Checkable<i32> for i32}>(move (@2))
+    storage_dead(@2)
+    storage_dead(@3)
+    storage_live(@5)
+    storage_live(@6)
+    storage_live(@7)
+    @7 := &*(x@1)
+    @6 := Checkable<(dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_), i32>::check<'_>(move (@7))
+    if move (@6) {
+    }
+    else {
+        storage_dead(@7)
+        panic(core::panicking::panic)
+    }
+    storage_dead(@7)
+    storage_dead(@6)
+    storage_dead(@5)
+    storage_live(y@8)
+    storage_live(@9)
+    storage_live(@10)
+    storage_live(@11)
+    @11 := const (99 : i32)
+    @10 := &mut @11
+    @9 := &mut *(@10)
+    y@8 := unsize_cast<&'_ mut (i32), &'_ mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, i32> + _dyn : '_)), {impl Modifiable<T> for i32}<i32>[Sized<i32>, {impl Clone for i32}]>(move (@9))
+    storage_dead(@9)
+    storage_dead(@10)
+    storage_live(@12)
+    storage_live(@13)
+    storage_live(@14)
+    storage_live(@15)
+    storage_live(@16)
+    storage_live(@17)
+    storage_live(@18)
+    storage_live(@19)
+    storage_live(@20)
+    @20 := const ("Hello")
+    @19 := &*(@20)
+    @18 := {impl ToString for T}::to_string<'_, Str>[MetaSized<Str>, {impl Display for Str}](move (@19))
+    storage_dead(@19)
+    @17 := &@18
+    @16 := &*(@17)
+    @15 := modify_trait_object<'_, String>[Sized<String>, {impl Clone for String}](move (@16))
+    @14 := &@15
+    storage_dead(@16)
+    @13 := is_empty<'_>(move (@14))
+    if move (@13) {
+    }
+    else {
+        storage_dead(@14)
+        drop[{impl Drop for String}] @15
+        drop[{impl Drop for String}] @18
+        storage_dead(@20)
+        storage_dead(@18)
+        storage_dead(@17)
+        storage_dead(@15)
+        storage_dead(@13)
+        storage_dead(@12)
+        storage_live(@21)
+        storage_live(@22)
+        storage_live(@23)
+        storage_live(@24)
+        storage_live(@25)
+        @25 := &two-phase-mut *(y@8)
+        storage_live(@26)
+        storage_live(@27)
+        storage_live(@28)
+        @28 := const (100 : i32)
+        @27 := &mut @28
+        @26 := &*(@27)
+        @24 := Modifiable<(dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, i32> + _dyn : '_), i32>::modify<'_, '_>(move (@25), move (@26))
+        storage_dead(@26)
+        storage_dead(@25)
+        @23 := &@24
+        storage_live(@29)
+        storage_live(@30)
+        @30 := const (100 : i32)
+        @29 := &@30
+        @22 := (move (@23), move (@29))
+        storage_dead(@29)
+        storage_dead(@23)
+        storage_live(left_val@31)
+        left_val@31 := copy ((@22).0)
+        storage_live(right_val@32)
+        right_val@32 := copy ((@22).1)
+        storage_live(@33)
+        storage_live(@34)
+        @34 := copy (*(left_val@31))
+        storage_live(@35)
+        @35 := copy (*(right_val@32))
+        @33 := move (@34) == move (@35)
+        if move (@33) {
+        }
+        else {
+            storage_dead(@35)
+            storage_dead(@34)
+            storage_live(kind@36)
+            kind@36 := AssertKind::Eq {  }
+            storage_live(@37)
+            @37 := move (kind@36)
+            storage_live(@38)
+            storage_live(@39)
+            @39 := &*(left_val@31)
+            @38 := &*(@39)
+            storage_live(@40)
+            storage_live(@41)
+            @41 := &*(right_val@32)
+            @40 := &*(@41)
+            storage_live(@42)
+            @42 := Option::None {  }
+            panic(core::panicking::assert_failed)
+        }
+        storage_dead(@35)
+        storage_dead(@34)
+        storage_dead(@33)
+        storage_dead(right_val@32)
+        storage_dead(left_val@31)
+        storage_dead(@30)
+        storage_dead(@28)
+        storage_dead(@27)
+        storage_dead(@24)
+        storage_dead(@22)
+        storage_dead(@21)
+        storage_live(z@43)
+        storage_live(@44)
+        storage_live(@45)
+        storage_live(@46)
+        storage_live(@47)
+        storage_live(@48)
+        @48 := const (42 : i32)
+        @47 := &@48
+        @46 := &*(@47)
+        @45 := to_dyn_obj<'_, i32>[Sized<i32>, {impl NoParam for i32}](move (@46))
+        @44 := &*(@45)
+        z@43 := unsize_cast<&'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)), &'_ ((dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)), NoParam<(dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)>>(move (@44))
+        storage_dead(@46)
+        storage_dead(@44)
+        storage_dead(@48)
+        storage_dead(@47)
+        storage_dead(@45)
+        storage_live(@49)
+        storage_live(@50)
+        @50 := &*(z@43)
+        @49 := NoParam<(dyn exists<_dyn> [@TraitClause0]: NoParam<_dyn> + _dyn : '_)>::dummy<'_>(move (@50))
+        storage_dead(@50)
+        storage_dead(@49)
+        storage_live(a@51)
+        storage_live(@52)
+        storage_live(@53)
+        storage_live(@54)
+        @54 := const (42 : i32)
+        @53 := &@54
+        @52 := &*(@53)
+        a@51 := unsize_cast<&'_ (i32), &'_ ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)), {impl Both32And64 for i32}>(move (@52))
+        storage_dead(@52)
+        storage_dead(@53)
+        storage_live(@55)
+        storage_live(@56)
+        @56 := &*(a@51)
+        storage_live(@57)
+        storage_live(@58)
+        storage_live(@59)
+        @59 := const (100 : i32)
+        @58 := &@59
+        @57 := &*(@58)
+        storage_live(@60)
+        storage_live(@61)
+        storage_live(@62)
+        @62 := const (200 : i64)
+        @61 := &@62
+        @60 := &*(@61)
+        @55 := Both32And64<(dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_)>::both_operate<'_, '_, '_>(move (@56), move (@57), move (@60))
+        storage_dead(@60)
+        storage_dead(@57)
+        storage_dead(@56)
+        storage_dead(@62)
+        storage_dead(@61)
+        storage_dead(@59)
+        storage_dead(@58)
+        storage_dead(@55)
+        @0 := ()
+        storage_dead(@54)
+        storage_dead(a@51)
+        storage_dead(z@43)
+        storage_dead(@11)
+        storage_dead(y@8)
+        storage_dead(@4)
+        storage_dead(x@1)
+        @0 := ()
+        return
+    }
+    storage_dead(@14)
+    drop[{impl Drop for String}] @15
+    drop[{impl Drop for String}] @18
+    storage_dead(@20)
+    storage_dead(@18)
+    storage_dead(@17)
+    storage_dead(@15)
+    panic(core::panicking::panic)
+}
+
+
+

--- a/charon/tests/ui/vtables.rs
+++ b/charon/tests/ui/vtables.rs
@@ -1,0 +1,81 @@
+#![feature(trait_alias)]
+trait Super<T> {
+    fn super_method(&self, arg: T) -> i32;
+}
+trait Checkable<T>: Super<T> {
+    fn check(&self) -> bool;
+}
+impl Super<i32> for i32 {
+    fn super_method(&self, arg: i32) -> i32 {
+        *self + arg
+    }
+}
+impl Checkable<i32> for i32 {
+    fn check(&self) -> bool {
+        self.super_method(10) > 0
+    }
+}
+
+trait NoParam {
+    fn dummy(&self);
+}
+impl NoParam for i32 {
+    fn dummy(&self) {
+        assert!(*self > 0);
+    }
+}
+fn to_dyn_obj<T: NoParam>(arg: &T) -> &dyn NoParam {
+    arg
+}
+
+trait Modifiable<T> {
+    fn modify(&mut self, arg: &T) -> T;
+}
+impl<T: Clone> Modifiable<T> for i32 {
+    fn modify(&mut self, arg: &T) -> T {
+        *self += 1;
+        arg.clone()
+    }
+}
+fn modify_trait_object<T: Clone>(arg: &T) -> T {
+    let x: &mut dyn Modifiable<T> = &mut 199;
+    x.modify(arg)
+}
+
+trait BaseOn<T> {
+    fn operate_on(&self, t: &T);
+}
+trait Both32And64: BaseOn<i32> + BaseOn<i64> {
+    fn both_operate(&self, t32: &i32, t64: &i64) {
+        self.operate_on(t32);
+        self.operate_on(t64);
+    }
+}
+impl BaseOn<i32> for i32 {
+    fn operate_on(&self, t: &i32) {
+        assert!(*self > *t);
+    }
+}
+impl BaseOn<i64> for i32 {
+    fn operate_on(&self, t: &i64) {
+        assert!(*self as i64 > *t);
+    }
+}
+impl Both32And64 for i32 {}
+trait Alias = Both32And64;
+
+fn use_alias(x: &dyn Alias) {
+    x.both_operate(&100, &200);
+}
+
+fn main() {
+    let x: &dyn Checkable<i32> = &42;
+    assert!(x.check());
+    let y: &mut dyn Modifiable<i32> = &mut 99;
+    assert!(!modify_trait_object(&"Hello".to_string()).is_empty());
+    assert_eq!(y.modify(&mut 100), 100);
+    let z: &dyn NoParam = to_dyn_obj(&42);
+    z.dummy();
+    let a: &dyn Both32And64 = &42;
+    a.both_operate(&100, &200);
+}


### PR DESCRIPTION
This is a rework of #762 to make it robust and fix incorrect generics handling. This gives each (dyn-compatible) trait a vtable struct and each (dyn-compatible) impl a static that holds the vtable value. Some bits are missing but the main part is done.

cc #123 