### PR TITLE
Translate vtables with associated types

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.124"
+let supported_charon_version = "0.1.125"

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -317,30 +317,35 @@ and generic_args_to_string (env : 'a fmt_env) (generics : generic_args) : string
   in
   params ^ trait_refs
 
+and trait_instance_id_to_string (env : 'a fmt_env)
+    (implements : trait_decl_ref region_binder option)
+    (kind : trait_instance_id) : string =
+  match kind with
+  | Self -> "Self"
+  | TraitImpl impl_ref -> trait_impl_ref_to_string env impl_ref
+  | BuiltinOrAuto _ ->
+      region_binder_to_string trait_decl_ref_to_string env
+        (Option.get implements)
+  | Clause id -> trait_db_var_to_string env id
+  | ParentClause (tref, clause_id) ->
+      let inst_id = trait_ref_to_string env tref in
+      let clause_id = trait_clause_id_to_string env clause_id in
+      "parent(" ^ inst_id ^ ")::" ^ clause_id
+  | Dyn ->
+      let trait =
+        region_binder_to_string trait_decl_ref_to_string env
+          (Option.get implements)
+      in
+      "dyn(" ^ trait ^ ")"
+  | UnknownTrait msg -> "UNKNOWN(" ^ msg ^ ")"
+
 and trait_ref_to_string (env : 'a fmt_env) (tr : trait_ref) : string =
-  trait_instance_id_to_string env tr.trait_id
+  trait_instance_id_to_string env (Some tr.trait_decl_ref) tr.trait_id
 
 and trait_decl_ref_to_string (env : 'a fmt_env) (tr : trait_decl_ref) : string =
   let trait_id = trait_decl_id_to_string env tr.id in
   let generics = generic_args_to_string env tr.generics in
   trait_id ^ generics
-
-and trait_instance_id_to_string (env : 'a fmt_env) (id : trait_instance_id) :
-    string =
-  match id with
-  | Self -> "Self"
-  | TraitImpl impl_ref -> trait_impl_ref_to_string env impl_ref
-  | BuiltinOrAuto (trait, _, _) ->
-      region_binder_to_string trait_decl_ref_to_string env trait
-  | Clause id -> trait_db_var_to_string env id
-  | ParentClause (tref, clause_id) ->
-      let inst_id = trait_instance_id_to_string env tref.trait_id in
-      let clause_id = trait_clause_id_to_string env clause_id in
-      "parent(" ^ inst_id ^ ")::" ^ clause_id
-  | Dyn trait ->
-      let trait = region_binder_to_string trait_decl_ref_to_string env trait in
-      "dyn(" ^ trait ^ ")"
-  | UnknownTrait msg -> "UNKNOWN(" ^ msg ^ ")"
 
 and impl_elem_to_string (env : 'a fmt_env) (elem : impl_elem) : string =
   match elem with

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1738,15 +1738,8 @@ and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
         [
           ( "BuiltinOrAuto",
             `Assoc
-              [
-                ("trait_decl_ref", trait_decl_ref);
-                ("parent_trait_refs", parent_trait_refs);
-                ("types", types);
-              ] );
+              [ ("parent_trait_refs", parent_trait_refs); ("types", types) ] );
         ] ->
-        let* trait_decl_ref =
-          region_binder_of_json trait_decl_ref_of_json ctx trait_decl_ref
-        in
         let* parent_trait_refs =
           vector_of_json trait_clause_id_of_json trait_ref_of_json ctx
             parent_trait_refs
@@ -1757,10 +1750,8 @@ and trait_instance_id_of_json (ctx : of_json_ctx) (js : json) :
                (vector_of_json trait_clause_id_of_json trait_ref_of_json))
             ctx types
         in
-        Ok (BuiltinOrAuto (trait_decl_ref, parent_trait_refs, types))
-    | `Assoc [ ("Dyn", dyn) ] ->
-        let* dyn = region_binder_of_json trait_decl_ref_of_json ctx dyn in
-        Ok (Dyn dyn)
+        Ok (BuiltinOrAuto (parent_trait_refs, types))
+    | `String "Dyn" -> Ok Dyn
     | `Assoc [ ("Unknown", unknown) ] ->
         let* unknown = string_of_json ctx unknown in
         Ok (UnknownTrait unknown)

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -461,22 +461,18 @@ and trait_instance_id =
           including trait method declarations. Not present in trait
           implementations as we can use [TraitImpl] intead. *)
   | BuiltinOrAuto of
-      trait_decl_ref region_binder
-      * trait_ref list
-      * (trait_item_name * ty * trait_ref list) list
+      trait_ref list * (trait_item_name * ty * trait_ref list) list
       (** A trait implementation that is computed by the compiler, such as for
           built-in trait [Sized]. This morally points to an invisible [impl]
           block; as such it contains the information we may need from one.
 
           Fields:
-          - [trait_decl_ref]
           - [parent_trait_refs]: Exactly like the same field on [TraitImpl]: the
             [TraitRef]s required to satisfy the implied predicates on the trait
             declaration. E.g. since [FnMut: FnOnce], a built-in [T: FnMut] impl
             would have a [TraitRef] for [T: FnOnce].
           - [types]: The values of the associated types for this trait. *)
-  | Dyn of trait_decl_ref region_binder
-      (** The automatically-generated implementation for [dyn Trait]. *)
+  | Dyn  (** The automatically-generated implementation for [dyn Trait]. *)
   | UnknownTrait of string  (** For error reporting. *)
 
 (** A constraint over a trait associated type.

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.124"
+version = "0.1.125"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.124"
+version = "0.1.125"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -109,7 +109,6 @@ pub enum TraitRefKind {
     /// `Sized`. This morally points to an invisible `impl` block; as such it contains
     /// the information we may need from one.
     BuiltinOrAuto {
-        trait_decl_ref: PolyTraitDeclRef,
         /// Exactly like the same field on `TraitImpl`: the `TraitRef`s required to satisfy the
         /// implied predicates on the trait declaration. E.g. since `FnMut: FnOnce`, a built-in `T:
         /// FnMut` impl would have a `TraitRef` for `T: FnOnce`.
@@ -119,7 +118,7 @@ pub enum TraitRefKind {
     },
 
     /// The automatically-generated implementation for `dyn Trait`.
-    Dyn(PolyTraitDeclRef),
+    Dyn,
 
     /// For error reporting.
     #[charon::rename("UnknownTrait")]

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -711,7 +711,6 @@ impl TraitRef {
         });
         TraitRef {
             kind: TraitRefKind::BuiltinOrAuto {
-                trait_decl_ref: trait_decl_ref.clone(),
                 parent_trait_refs: parents,
                 types: Default::default(),
             },

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -283,7 +283,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 }
             }
             ImplExprAtom::Dyn => TraitRef {
-                kind: TraitRefKind::Dyn(trait_decl_ref.clone()),
+                kind: TraitRefKind::Dyn,
                 trait_decl_ref,
             },
             ImplExprAtom::Builtin {
@@ -352,7 +352,6 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                         })
                         .try_collect()?;
                     TraitRefKind::BuiltinOrAuto {
-                        trait_decl_ref: trait_decl_ref.clone(),
                         parent_trait_refs,
                         types,
                     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1687,9 +1687,9 @@ impl Display for TraitItemName {
     }
 }
 
-impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
+impl<C: AstFormatter> FmtWithCtx<C> for TraitRef {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match &self.kind {
             TraitRefKind::SelfId => write!(f, "Self"),
             TraitRefKind::ParentClause(sub, clause_id) => {
                 let sub = sub.with_ctx(ctx);
@@ -1706,12 +1706,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
                 write!(f, "{}", impl_ref.with_ctx(ctx))
             }
             TraitRefKind::Clause(id) => write!(f, "{}", id.with_ctx(ctx)),
-            TraitRefKind::BuiltinOrAuto {
-                trait_decl_ref: tr,
-                types,
-                ..
-            } => {
-                write!(f, "{}", tr.with_ctx(ctx))?;
+            TraitRefKind::BuiltinOrAuto { types, .. } => {
+                write!(f, "{}", self.trait_decl_ref.with_ctx(ctx))?;
                 if !types.is_empty() {
                     let types = types
                         .iter()
@@ -1724,15 +1720,9 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRefKind {
                 }
                 Ok(())
             }
-            TraitRefKind::Dyn(tr) => write!(f, "{}", tr.with_ctx(ctx)),
+            TraitRefKind::Dyn { .. } => write!(f, "{}", self.trait_decl_ref.with_ctx(ctx)),
             TraitRefKind::Unknown(msg) => write!(f, "UNKNOWN({msg})"),
         }
-    }
-}
-
-impl<C: AstFormatter> FmtWithCtx<C> for TraitRef {
-    fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.kind.fmt_with_ctx(ctx, f)
     }
 }
 

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -225,19 +225,18 @@ impl VisitAst for CheckGenericsVisitor<'_> {
             }
         }
     }
-    fn enter_trait_ref_kind(&mut self, x: &TraitRefKind) {
-        match x {
+    fn enter_trait_ref(&mut self, x: &TraitRef) {
+        match &x.kind {
             TraitRefKind::Clause(var) => {
                 if self.binder_stack.get_var(*var).is_none() {
                     self.error(format!("Found incorrect clause var: {var}"));
                 }
             }
             TraitRefKind::BuiltinOrAuto {
-                trait_decl_ref,
                 parent_trait_refs,
                 types,
             } => {
-                let trait_id = trait_decl_ref.skip_binder.id;
+                let trait_id = x.trait_decl_ref.skip_binder.id;
                 let target = GenericsSource::item(trait_id);
                 let Some(tdecl) = self.ctx.translated.trait_decls.get(trait_id) else {
                     return;

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -36,7 +36,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> @TraitClause0::Output

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -12,7 +12,7 @@ pub trait Index<Self, Idx, Self_Output>
     parent_clause1 : [@TraitClause1]: MetaSized<Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self_Output>
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self_Output>
 }
 
 // Full name: core::marker::Sized
@@ -41,7 +41,7 @@ where
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause2
     fn index<'_0> = {impl Index<I, Clause2_Output> for Array<T, const N : usize>}::index<'_0_0, T, I, Clause2_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I, Clause2_Output> for Array<T, const N : usize>}::{vtable}<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::ops::index::IndexMut
@@ -52,7 +52,7 @@ pub trait IndexMut<Self, Idx, Self_Clause1_Output>
     parent_clause1 : [@TraitClause1]: Index<Self, Idx, Self_Clause1_Output>
     parent_clause2 : [@TraitClause2]: MetaSized<Idx>
     fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx, Self_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::IndexMut::{vtable}<Idx, Self_Clause1_Output>
 }
 
 // Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for Array<T, const N : usize>}::index_mut
@@ -73,7 +73,7 @@ where
     parent_clause1 = {impl Index<I, Clause2_Output> for Array<T, const N : usize>}<T, I, Clause2_Clause1_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause1]
     parent_clause2 = @TraitClause1::parent_clause0
     fn index_mut<'_0> = {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, const N : usize>}::index_mut<'_0_0, T, I, Clause2_Clause1_Output, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, const N : usize>}::{vtable}<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::ops::drop::Drop
@@ -139,7 +139,7 @@ pub trait SliceIndex<Self, T, Self_Output>
     fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T, Self_Output>[Self]
     fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T, Self_Output>[Self]
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::slice::index::SliceIndex::{vtable}<T, Self_Output>
 }
 
 // Full name: core::slice::index::{impl Index<I, Clause2_Output> for Slice<T>}::index
@@ -160,7 +160,7 @@ where
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause3
     fn index<'_0> = {impl Index<I, Clause2_Output> for Slice<T>}::index<'_0_0, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I, Clause2_Output> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut
@@ -181,7 +181,7 @@ where
     parent_clause1 = {impl Index<I, Clause2_Output> for Slice<T>}<T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
     parent_clause2 = @TraitClause1::parent_clause0
     fn index_mut<'_0> = {impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut<'_0_0, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl IndexMut<I, Clause2_Output> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for Range<usize>[Sized<usize>]}
@@ -259,7 +259,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[Sized<usize>]}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[Sized<usize>]}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[Sized<usize>]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: core::slice::{Slice<T>}::len

--- a/charon/tests/ui/associated-types.out
+++ b/charon/tests/ui/associated-types.out
@@ -321,14 +321,14 @@ trait test_crate::loopy::Bar<Self, Self_BarTy>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_BarTy>
-    non-dyn-compatible
+    vtable: test_crate::loopy::Bar::{vtable}<Self_BarTy>
 }
 
 // Full name: test_crate::loopy::{impl test_crate::loopy::Bar<bool> for ()}
 impl test_crate::loopy::Bar<bool> for () {
     parent_clause0 = MetaSized<()>
     parent_clause1 = Sized<bool>
-    non-dyn-compatible
+    vtable: {impl test_crate::loopy::Bar<bool> for ()}::{vtable}
 }
 
 trait test_crate::loopy::Foo<Self>
@@ -339,7 +339,7 @@ trait test_crate::loopy::Foo<Self>
     parent_clause3 : [@TraitClause3]: test_crate::loopy::Bar<Self::FooTy, Self::Self_Clause3_BarTy>
     type FooTy
     type Self_Clause3_BarTy
-    non-dyn-compatible
+    vtable: test_crate::loopy::Foo::{vtable}<Self::FooTy>
 }
 
 // Full name: test_crate::loopy::{impl test_crate::loopy::Foo for ()}
@@ -350,7 +350,7 @@ impl test_crate::loopy::Foo for () {
     parent_clause3 = {impl test_crate::loopy::Bar<bool> for ()}
     type FooTy = ()
     type Self_Clause3_BarTy = bool
-    non-dyn-compatible
+    vtable: {impl test_crate::loopy::Foo for ()}::{vtable}
 }
 
 // Full name: test_crate::loopy::Baz
@@ -363,7 +363,7 @@ trait Baz<Self, T>
     parent_clause4 : [@TraitClause4]: Sized<Self::BazTy>
     type BazTy
     type Self_Clause3_BarTy
-    non-dyn-compatible
+    vtable: test_crate::loopy::Baz::{vtable}<T, Self::BazTy>
 }
 
 // Full name: test_crate::loopy::{impl Baz<()> for ()}
@@ -375,7 +375,7 @@ impl Baz<()> for () {
     parent_clause4 = Sized<usize>
     type BazTy = usize
     type Self_Clause3_BarTy = bool
-    non-dyn-compatible
+    vtable: {impl Baz<()> for ()}::{vtable}
 }
 
 trait test_crate::loopy_with_generics::Bar<'a, Self, T, U, Self_BarTy>
@@ -384,7 +384,7 @@ trait test_crate::loopy_with_generics::Bar<'a, Self, T, U, Self_BarTy>
     parent_clause1 : [@TraitClause1]: Sized<T>
     parent_clause2 : [@TraitClause2]: Sized<U>
     parent_clause3 : [@TraitClause3]: Sized<Self_BarTy>
-    non-dyn-compatible
+    vtable: test_crate::loopy_with_generics::Bar::{vtable}<'a, T, U, Self_BarTy>
 }
 
 // Full name: test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a (T)> for ()}
@@ -397,7 +397,7 @@ where
     parent_clause1 = Sized<u8>
     parent_clause2 = @TraitClause0
     parent_clause3 = Sized<&'_ (T)>
-    non-dyn-compatible
+    vtable: {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a (T)> for ()}::{vtable}<'a, T>[@TraitClause0]
 }
 
 trait test_crate::loopy_with_generics::Foo<'b, Self, T>
@@ -409,7 +409,7 @@ trait test_crate::loopy_with_generics::Foo<'b, Self, T>
     parent_clause4 : [@TraitClause4]: test_crate::loopy_with_generics::Bar<'b, Self::FooTy, u8, Option<T>[Self::parent_clause1], Self::Self_Clause4_BarTy>
     type FooTy
     type Self_Clause4_BarTy
-    non-dyn-compatible
+    vtable: test_crate::loopy_with_generics::Foo::{vtable}<'b, T, Self::FooTy>
 }
 
 // Full name: test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}
@@ -421,7 +421,7 @@ impl test_crate::loopy_with_generics::Foo<'static, u16> for () {
     parent_clause4 = {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a (T)> for ()}<'_, Option<u16>[Sized<u16>]>[Sized<Option<u16>[Sized<u16>]>]
     type FooTy = ()
     type Self_Clause4_BarTy = &'_ (Option<u16>[Sized<u16>])
-    non-dyn-compatible
+    vtable: {impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}::{vtable}
 }
 
 // Full name: test_crate::cow::Cow
@@ -445,7 +445,7 @@ where
     parent_clause1 : [@TraitClause1]: Sized<T>
     parent_clause2 : [@TraitClause2]: Sized<Self_X>
     parent_clause3 : [@TraitClause3]: Sized<Self_Item>
-    non-dyn-compatible
+    vtable: test_crate::params::Foo::{vtable}<'a, T, Self_X, Self_Item>
 }
 
 // Full name: test_crate::params::{impl test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (()), &'a ((Option<T>[@TraitClause0], &'a (())))> for ()}
@@ -458,7 +458,7 @@ where
     parent_clause1 = Sized<Option<T>[@TraitClause0]>
     parent_clause2 = Sized<&'_ (())>
     parent_clause3 = Sized<&'_ ((Option<T>[@TraitClause0], &'_ (())))>
-    non-dyn-compatible
+    vtable: {impl test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (()), &'a ((Option<T>[@TraitClause0], &'a (())))> for ()}::{vtable}<'a, T>[@TraitClause0]
 }
 
 

--- a/charon/tests/ui/closure-as-fn.out
+++ b/charon/tests/ui/closure-as-fn.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -29,7 +29,7 @@ pub trait FnOnce<Self, Args, Self_Output>
     parent_clause2 : [@TraitClause2]: Tuple<Args>
     parent_clause3 : [@TraitClause3]: Sized<Self_Output>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -41,7 +41,7 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
 
 // Full name: core::array::{Array<T, const N : usize>}::map
@@ -106,7 +106,7 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause1_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(@1: &'_0 (Self), @2: Args) -> Clause0_Clause1_Clause1_Output

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -30,7 +30,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -42,7 +42,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::array::from_fn

--- a/charon/tests/ui/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/dictionary_passing_style_woes.out
@@ -63,7 +63,7 @@ trait Iterator<Self, Self_Item>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Item>
-    non-dyn-compatible
+    vtable: test_crate::Iterator::{vtable}<Self_Item>
 }
 
 // Full name: test_crate::IntoIterator
@@ -73,7 +73,7 @@ trait IntoIterator<Self, Self_Item, Self_IntoIter>
     parent_clause1 : [@TraitClause1]: Sized<Self_Item>
     parent_clause2 : [@TraitClause2]: Sized<Self_IntoIter>
     parent_clause3 : [@TraitClause3]: Iterator<Self_IntoIter, Self_Item>
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self_Item, Self_IntoIter>
 }
 
 // Full name: test_crate::{impl IntoIterator<Clause1_Item, I> for I}
@@ -86,7 +86,7 @@ where
     parent_clause1 = @TraitClause1::parent_clause1
     parent_clause2 = @TraitClause0
     parent_clause3 = @TraitClause1
-    non-dyn-compatible
+    vtable: {impl IntoIterator<Clause1_Item, I> for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: test_crate::callee
@@ -128,7 +128,7 @@ trait X<Self, Self_Assoc>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
     fn method<'_0> = method<'_0_0, Self, Self_Assoc>[Self]
-    non-dyn-compatible
+    vtable: test_crate::X::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::X::method
@@ -141,7 +141,7 @@ trait A<Self, Self_Clause1_Assoc>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: X<Self, Self_Clause1_Assoc>
-    non-dyn-compatible
+    vtable: test_crate::A::{vtable}<Self_Clause1_Assoc>
 }
 
 // Full name: test_crate::B
@@ -149,7 +149,7 @@ trait B<Self, Self_Clause1_Assoc>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: X<Self, Self_Clause1_Assoc>
-    non-dyn-compatible
+    vtable: test_crate::B::{vtable}<Self_Clause1_Assoc>
 }
 
 // Full name: test_crate::a

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -86,7 +86,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -98,7 +98,16 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+}
+
+struct core::ops::function::Fn::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0)),
+  method_call: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0)), Args) -> Fn<(dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0), Args>::parent_clause1::parent_clause1::Output,
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+  super_trait_1: &'static (core::ops::function::FnMut::{vtable}<Args, Fn<(dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0), Args>::parent_clause1::parent_clause1::Output>),
 }
 
 // Full name: core::ops::function::Fn
@@ -110,7 +119,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn::call

--- a/charon/tests/ui/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.out
@@ -1,11 +1,357 @@
+# Final LLBC before serialization:
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:426:14:
-trait should be dyn-compatible
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: Thread panicked when extracting item `test_crate::{impl#4}`.
-  --> tests/ui/dyn-with-diamond-supertraits.rs:47:1
-   |
-47 | impl Join<i32> for i32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::ops::arith::Add
+#[lang_item("add")]
+pub trait Add<Self, Rhs>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Rhs>
+    parent_clause2 : [@TraitClause2]: Sized<Self::Output>
+    type Output
+    fn add = core::ops::arith::Add::add<Self, Rhs>[Self]
+    vtable: core::ops::arith::Add::{vtable}<Rhs, Self::Output>
+}
+
+// Full name: core::ops::arith::{impl Add<i32> for &'a (i32)}::add
+pub fn {impl Add<i32> for &'a (i32)}::add<'a>(@1: &'a (i32), @2: i32) -> i32
+
+// Full name: core::ops::arith::{impl Add<i32> for &'a (i32)}
+impl<'a> Add<i32> for &'a (i32) {
+    parent_clause0 = MetaSized<&'_ (i32)>
+    parent_clause1 = Sized<i32>
+    parent_clause2 = Sized<i32>
+    type Output = i32
+    fn add = {impl Add<i32> for &'a (i32)}::add<'a>
+    vtable: {impl Add<i32> for &'a (i32)}::{vtable}<'a>
+}
+
+#[lang_item("add")]
+pub fn core::ops::arith::Add::add<Self, Rhs>(@1: Self, @2: Rhs) -> @TraitClause0::Output
+where
+    [@TraitClause0]: Add<Self, Rhs>,
+
+// Full name: test_crate::Super
+trait Super<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<T>
+    fn super_method<'_0> = test_crate::Super::super_method<'_0_0, Self, T>[Self]
+    vtable: test_crate::Super::{vtable}<T>
+}
+
+fn test_crate::Super::super_method<'_0, Self, T>(@1: &'_0 (Self), @2: T) -> i32
+where
+    [@TraitClause0]: Super<Self, T>,
+
+// Full name: test_crate::Internal
+trait Internal<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Internal>
+    type Internal
+    fn internal_method<'_0> = test_crate::Internal::internal_method<'_0_0, Self>[Self]
+    vtable: test_crate::Internal::{vtable}<Self::Internal>
+}
+
+fn test_crate::Internal::internal_method<'_0, Self>(@1: &'_0 (Self)) -> @TraitClause0::Internal
+where
+    [@TraitClause0]: Internal<Self>,
+
+// Full name: test_crate::Left
+trait Left<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Internal<Self>
+    parent_clause2 : [@TraitClause2]: Sized<Self::Left>
+    type Left
+    fn left_method<'_0> = test_crate::Left::left_method<'_0_0, Self>[Self]
+    vtable: test_crate::Left::{vtable}<Self::Left, Self::parent_clause1::Internal>
+}
+
+fn test_crate::Left::left_method<'_0, Self>(@1: &'_0 (Self)) -> @TraitClause0::Left
+where
+    [@TraitClause0]: Left<Self>,
+
+// Full name: test_crate::Right
+trait Right<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Internal<Self>
+    parent_clause2 : [@TraitClause2]: Super<Self, T>
+    parent_clause3 : [@TraitClause3]: Sized<T>
+    parent_clause4 : [@TraitClause4]: Sized<Self::Right>
+    type Right
+    fn right_method<'_0> = test_crate::Right::right_method<'_0_0, Self, T>[Self]
+    vtable: test_crate::Right::{vtable}<T, Self::Right, Self::parent_clause1::Internal>
+}
+
+fn test_crate::Right::right_method<'_0, Self, T>(@1: &'_0 (Self)) -> @TraitClause0::Right
+where
+    [@TraitClause0]: Right<Self, T>,
+
+struct test_crate::Join::{vtable}<T, Ty0, Ty1, Ty2, Ty3> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3)),
+  method_join_method: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3))) -> (Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause1::Left, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause2::Right),
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+  super_trait_1: &'static (test_crate::Left::{vtable}<Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause1::Left, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause1::parent_clause1::Internal>),
+  super_trait_2: &'static (test_crate::Right::{vtable}<T, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause2::Right, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, T> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = Ty0 + @TraitClause1_0::parent_clause2::Right = Ty1 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty2 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = Ty3), T>::parent_clause1::parent_clause1::Internal>),
+}
+
+// Full name: test_crate::Join
+trait Join<Self, T>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Left<Self>
+    parent_clause2 : [@TraitClause2]: Right<Self, T>
+    parent_clause3 : [@TraitClause3]: Sized<T>
+    fn join_method<'_0> = test_crate::Join::join_method<'_0_0, Self, T>[Self]
+    vtable: test_crate::Join::{vtable}<T, Self::parent_clause1::Left, Self::parent_clause1::parent_clause1::Internal, Self::parent_clause2::Right, Self::parent_clause1::parent_clause1::Internal>
+}
+
+fn test_crate::Join::join_method<'_0, Self, T>(@1: &'_0 (Self)) -> (@TraitClause0::parent_clause1::Left, @TraitClause0::parent_clause2::Right)
+where
+    [@TraitClause0]: Join<Self, T>,
+
+// Full name: test_crate::{impl Super<i32> for i32}::super_method
+fn {impl Super<i32> for i32}::super_method<'_0>(@1: &'_0 (i32), @2: i32) -> i32
+{
+    let @0: i32; // return
+    let self@1: &'_ (i32); // arg #1
+    let arg@2: i32; // arg #2
+    let @3: &'_ (i32); // anonymous local
+    let @4: i32; // anonymous local
+
+    storage_live(@3)
+    @3 := copy (self@1)
+    storage_live(@4)
+    @4 := copy (arg@2)
+    @0 := {impl Add<i32> for &'a (i32)}::add<'_>(move (@3), move (@4))
+    storage_dead(@4)
+    storage_dead(@3)
+    return
+}
+
+// Full name: test_crate::{impl Super<i32> for i32}
+impl Super<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i32>
+    fn super_method<'_0> = {impl Super<i32> for i32}::super_method<'_0_0>
+    vtable: {impl Super<i32> for i32}::{vtable}
+}
+
+// Full name: test_crate::{impl Internal for i32}::internal_method
+fn {impl Internal for i32}::internal_method<'_0>(@1: &'_0 (i32)) -> i32
+{
+    let @0: i32; // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: i32; // anonymous local
+    let @3: i32; // anonymous local
+
+    storage_live(@3)
+    storage_live(@2)
+    @2 := copy (*(self@1))
+    @3 := copy (@2) panic.+ const (1 : i32)
+    @0 := move (@3)
+    storage_dead(@2)
+    return
+}
+
+// Full name: test_crate::{impl Internal for i32}
+impl Internal for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i32>
+    type Internal = i32
+    fn internal_method<'_0> = {impl Internal for i32}::internal_method<'_0_0>
+    vtable: {impl Internal for i32}::{vtable}
+}
+
+// Full name: test_crate::{impl Left for i32}::left_method
+fn {impl Left for i32}::left_method<'_0>(@1: &'_0 (i32)) -> i32
+{
+    let @0: i32; // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: i32; // anonymous local
+    let @3: i32; // anonymous local
+
+    storage_live(@3)
+    storage_live(@2)
+    @2 := copy (*(self@1))
+    @3 := copy (@2) panic.+ const (2 : i32)
+    @0 := move (@3)
+    storage_dead(@2)
+    return
+}
+
+// Full name: test_crate::{impl Left for i32}
+impl Left for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = {impl Internal for i32}
+    parent_clause2 = Sized<i32>
+    type Left = i32
+    fn left_method<'_0> = {impl Left for i32}::left_method<'_0_0>
+    vtable: {impl Left for i32}::{vtable}
+}
+
+// Full name: test_crate::{impl Right<i32> for i32}::right_method
+fn {impl Right<i32> for i32}::right_method<'_0>(@1: &'_0 (i32)) -> i32
+{
+    let @0: i32; // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: i32; // anonymous local
+    let @3: i32; // anonymous local
+    let @4: i32; // anonymous local
+    let @5: i32; // anonymous local
+    let @6: i32; // anonymous local
+    let @7: &'_ (i32); // anonymous local
+    let @8: i32; // anonymous local
+    let @9: i32; // anonymous local
+    let @10: &'_ (i32); // anonymous local
+    let @11: i32; // anonymous local
+
+    storage_live(@5)
+    storage_live(@8)
+    storage_live(@11)
+    storage_live(@2)
+    storage_live(@3)
+    storage_live(@4)
+    @4 := copy (*(self@1))
+    @5 := copy (@4) panic.+ const (3 : i32)
+    @3 := move (@5)
+    storage_dead(@4)
+    storage_live(@6)
+    storage_live(@7)
+    @7 := &*(self@1)
+    @6 := {impl Internal for i32}::internal_method<'_>(move (@7))
+    storage_dead(@7)
+    @8 := copy (@3) panic.+ copy (@6)
+    @2 := move (@8)
+    storage_dead(@6)
+    storage_dead(@3)
+    storage_live(@9)
+    storage_live(@10)
+    @10 := &*(self@1)
+    @9 := {impl Super<i32> for i32}::super_method<'_>(move (@10), const (10 : i32))
+    storage_dead(@10)
+    @11 := copy (@2) panic.+ copy (@9)
+    @0 := move (@11)
+    storage_dead(@9)
+    storage_dead(@2)
+    return
+}
+
+// Full name: test_crate::{impl Right<i32> for i32}
+impl Right<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = {impl Internal for i32}
+    parent_clause2 = {impl Super<i32> for i32}
+    parent_clause3 = Sized<i32>
+    parent_clause4 = Sized<i32>
+    type Right = i32
+    fn right_method<'_0> = {impl Right<i32> for i32}::right_method<'_0_0>
+    vtable: {impl Right<i32> for i32}::{vtable}
+}
+
+// Full name: test_crate::{impl Join<i32> for i32}::join_method
+fn {impl Join<i32> for i32}::join_method<'_0>(@1: &'_0 (i32)) -> (i32, i32)
+{
+    let @0: (i32, i32); // return
+    let self@1: &'_ (i32); // arg #1
+    let @2: i32; // anonymous local
+    let @3: &'_ (i32); // anonymous local
+    let @4: i32; // anonymous local
+    let @5: &'_ (i32); // anonymous local
+
+    storage_live(@2)
+    storage_live(@3)
+    @3 := &*(self@1)
+    @2 := {impl Left for i32}::left_method<'_>(move (@3))
+    storage_dead(@3)
+    storage_live(@4)
+    storage_live(@5)
+    @5 := &*(self@1)
+    @4 := {impl Right<i32> for i32}::right_method<'_>(move (@5))
+    storage_dead(@5)
+    @0 := (move (@2), move (@4))
+    storage_dead(@4)
+    storage_dead(@2)
+    return
+}
+
+// Full name: test_crate::{impl Join<i32> for i32}::{vtable}
+fn {impl Join<i32> for i32}::{vtable}() -> test_crate::Join::{vtable}<i32, i32, i32, i32, i32>
+{
+    let ret@0: test_crate::Join::{vtable}<i32, i32, i32, i32, i32>; // return
+    let @1: &'static (test_crate::Left::{vtable}<Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32), i32>::parent_clause1::Left, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32), i32>::parent_clause1::parent_clause1::Internal>); // anonymous local
+    let @2: &'static (test_crate::Right::{vtable}<i32, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32), i32>::parent_clause2::Right, Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32), i32>::parent_clause1::parent_clause1::Internal>); // anonymous local
+
+    storage_live(@1)
+    storage_live(@2)
+    @1 := &{impl Left for i32}::{vtable}
+    @2 := &{impl Right<i32> for i32}::{vtable}
+    ret@0 := test_crate::Join::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_join_method: const ({impl Join<i32> for i32}::join_method), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@1), super_trait_2: move (@2) }
+    return
+}
+
+// Full name: test_crate::{impl Join<i32> for i32}::{vtable}
+static {impl Join<i32> for i32}::{vtable}: test_crate::Join::{vtable}<i32, i32, i32, i32, i32> = {impl Join<i32> for i32}::{vtable}()
+
+// Full name: test_crate::{impl Join<i32> for i32}
+impl Join<i32> for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = {impl Left for i32}
+    parent_clause2 = {impl Right<i32> for i32}
+    parent_clause3 = Sized<i32>
+    fn join_method<'_0> = {impl Join<i32> for i32}::join_method<'_0_0>
+    vtable: {impl Join<i32> for i32}::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let @0: (); // return
+    let v@1: &'_ ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32)); // local
+    let @2: &'_ (i32); // anonymous local
+    let @3: &'_ (i32); // anonymous local
+    let @4: i32; // anonymous local
+    let @5: (i32, i32); // anonymous local
+    let @6: &'_ ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32)); // anonymous local
+
+    storage_live(v@1)
+    storage_live(@2)
+    storage_live(@3)
+    storage_live(@4)
+    @4 := const (97 : i32)
+    @3 := &@4
+    @2 := &*(@3)
+    v@1 := unsize_cast<&'_ (i32), &'_ ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32)), {impl Join<i32> for i32}>(move (@2))
+    storage_dead(@2)
+    storage_dead(@3)
+    storage_live(@5)
+    storage_live(@6)
+    @6 := &*(v@1)
+    @5 := Join<(dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::Left = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32), i32>::join_method<'_>(move (@6))
+    storage_dead(@6)
+    storage_dead(@5)
+    @0 := ()
+    storage_dead(@4)
+    storage_dead(v@1)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn-with-diamond-supertraits.rs
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.rs
@@ -1,6 +1,4 @@
-//@ known-failure
-/// This tests `dyn` with a diamond hierarchy between supertraits. Fails for now because we don't
-/// support dyn with associated types.
+/// This tests `dyn` with a diamond hierarchy between supertraits.
 
 trait Super<T> {
     fn super_method(&self, arg: T) -> i32;

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -194,7 +194,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -242,7 +242,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -293,7 +293,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -306,7 +306,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -360,7 +360,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -372,7 +372,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -439,7 +439,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::slice::iter::Iter
@@ -464,7 +464,7 @@ where
     parent_clause1 = Sized<&'_ (T)>
     type Item = &'a (T)
     fn next<'_0> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::iter::{impl IntoIterator for &'a (Slice<T>)}::into_iter
@@ -484,7 +484,7 @@ where
     type Item = &'a (T)
     type IntoIter = Iter<'a, T>[@TraitClause0]
     fn into_iter = {impl IntoIterator for &'a (Slice<T>)}::into_iter<'a, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for &'a (Slice<T>)}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: std::io::stdio::_eprint

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -87,7 +87,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> @TraitClause0::Output
@@ -102,7 +102,7 @@ pub trait Foo<Self>
     parent_clause2 : [@TraitClause2]: Clone<Self::Type>
     type Type
     fn get_ty<'_0> = test_crate::Foo::get_ty<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: test_crate::Foo::{vtable}<Self::Type>
 }
 
 pub fn test_crate::Foo::get_ty<'_0, Self>(@1: &'_0 (Self)) -> &'_0 (@TraitClause0::Type)
@@ -134,7 +134,7 @@ impl Foo for () {
     parent_clause2 = {impl Clone for u32}
     type Type = u32
     fn get_ty<'_0> = {impl Foo for ()}::get_ty<'_0_0>
-    non-dyn-compatible
+    vtable: {impl Foo for ()}::{vtable}
 }
 
 // Full name: test_crate::mk_foo

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -118,7 +118,7 @@ trait Trait<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Ty>
     parent_clause2 : [@TraitClause2]: Copy<Self::Ty>
     type Ty
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self::Ty>
 }
 
 // Full name: test_crate::copy_assoc_ty

--- a/charon/tests/ui/issue-297-cfg.out
+++ b/charon/tests/ui/issue-297-cfg.out
@@ -126,7 +126,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -174,7 +174,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -220,7 +220,7 @@ where
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = {impl IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::Extend
@@ -247,7 +247,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -260,7 +260,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -314,7 +314,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -326,7 +326,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -393,7 +393,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::slice::iter::Chunks
@@ -417,7 +417,7 @@ where
     parent_clause1 = Sized<&'_ (Slice<T>)>
     type Item = &'a (Slice<T>)
     fn next<'_0> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::{Slice<T>}::chunks

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> @TraitClause0::parent_clause1::Output

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -37,7 +37,7 @@ pub trait Try<Self>
     parent_clause1 : [@TraitClause1]: FromResidual<Self, ()>
     parent_clause2 : [@TraitClause2]: Sized<Self::Residual>
     type Residual
-    non-dyn-compatible
+    vtable: test_crate::Try::{vtable}<Self::Residual>
 }
 
 // Full name: test_crate::{impl FromResidual<()> for Option<T>[@TraitClause0]}
@@ -59,7 +59,7 @@ where
     parent_clause1 = {impl FromResidual<()> for Option<T>[@TraitClause0]}<T>[@TraitClause0]
     parent_clause2 = Sized<()>
     type Residual = ()
-    non-dyn-compatible
+    vtable: {impl Try for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
 }
 
 

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -30,7 +30,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -42,7 +42,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -30,7 +30,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -42,7 +42,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::option::Option

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -126,7 +126,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -174,7 +174,7 @@ where
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -226,7 +226,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -239,7 +239,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::iterator::Iterator::next
@@ -294,7 +294,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -306,7 +306,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -373,7 +373,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: test_crate::Trait
@@ -382,7 +382,7 @@ pub trait Trait<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::AssocType>
     type AssocType
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self::AssocType>
 }
 
 // Full name: test_crate::Alias

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -30,7 +30,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -42,7 +42,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 pub fn core::array::{Array<T, const N : usize>}::map<T, F, U, const N : usize>(@1: Array<T, const N : usize>, @2: F) -> Array<U, const N : usize>
@@ -246,7 +246,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::ops::range::Range
@@ -275,7 +275,7 @@ where
     parent_clause1 = @TraitClause0
     type Item = A
     fn next<'_0> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_0, A>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -323,7 +323,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -369,7 +369,7 @@ where
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = {impl IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::Extend
@@ -396,7 +396,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -409,7 +409,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -521,7 +521,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::panicking::AssertKind

--- a/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
+++ b/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
@@ -19,7 +19,7 @@ pub trait Trait1<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::T>
     parent_clause2 : [@TraitClause2]: Trait2<Self::T>
     type T
-    non-dyn-compatible
+    vtable: test_crate::Trait1::{vtable}<Self::T>
 }
 
 // Full name: test_crate::Trait2
@@ -29,7 +29,7 @@ pub trait Trait2<Self>
     parent_clause1 : [@TraitClause1]: Trait1<Self>
     parent_clause2 : [@TraitClause2]: Sized<Self::U>
     type U
-    non-dyn-compatible
+    vtable: test_crate::Trait2::{vtable}<Self::U, Self::parent_clause1::T>
 }
 
 

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -55,7 +55,7 @@ pub trait T3<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::T>
     parent_clause2 : [@TraitClause2]: T5<Self::T>
     type T
-    non-dyn-compatible
+    vtable: test_crate::T3::{vtable}<Self::T>
 }
 
 // Full name: test_crate::T5
@@ -65,7 +65,7 @@ pub trait T5<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::T>
     parent_clause2 : [@TraitClause2]: T4<Self::T>
     type T
-    non-dyn-compatible
+    vtable: test_crate::T5::{vtable}<Self::T>
 }
 
 // Full name: test_crate::T4
@@ -73,7 +73,7 @@ pub trait T4<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: T3<Self>
-    non-dyn-compatible
+    vtable: test_crate::T4::{vtable}<Self::parent_clause1::T>
 }
 
 // Full name: test_crate::T6

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -191,7 +191,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -203,7 +203,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::iter::adapters::map::Map
@@ -323,7 +323,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::default::Default
@@ -424,7 +424,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::iterator::Iterator
@@ -511,7 +511,7 @@ pub trait Iterator<Self>
     fn is_sorted_by<F, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<Self>, [@TraitClause2]: for<'_0, '_1> FnMut<F, (&'_0_0 (Self::Item), &'_0_1 (Self::Item))>, for<'_0, '_1> @TraitClause1_2::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[Self, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
     fn is_sorted_by_key<F, K, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<K>, [@TraitClause2]: Sized<Self>, [@TraitClause3]: FnMut<F, (Self::Item)>, [@TraitClause4]: PartialOrd<K, K>, @TraitClause1_3::parent_clause1::Output = K> = is_sorted_by_key<Self, F, K>[Self, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
     fn __iterator_get_unchecked<'_0, [@TraitClause0]: TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_0, Self>[Self, @TraitClause0_0]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -548,7 +548,7 @@ pub trait DoubleEndedIterator<Self>
     fn try_rfold<'_0, B, F, R, [@TraitClause0]: Sized<B>, [@TraitClause1]: Sized<F>, [@TraitClause2]: Sized<R>, [@TraitClause3]: Sized<Self>, [@TraitClause4]: FnMut<F, (B, Self::parent_clause1::Item)>, [@TraitClause5]: Try<R>, @TraitClause1_4::parent_clause1::Output = R, @TraitClause1_5::Output = B> = try_rfold<'_0_0, Self, B, F, R>[Self, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4, @TraitClause0_5]
     fn rfold<B, F, [@TraitClause0]: Sized<B>, [@TraitClause1]: Sized<F>, [@TraitClause2]: Sized<Self>, [@TraitClause3]: FnMut<F, (B, Self::parent_clause1::Item)>, @TraitClause1_3::parent_clause1::Output = B> = rfold<Self, B, F>[Self, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3]
     fn rfind<'_0, P, [@TraitClause0]: Sized<P>, [@TraitClause1]: Sized<Self>, [@TraitClause2]: for<'_0> FnMut<P, (&'_0_0 (Self::parent_clause1::Item))>, for<'_0> @TraitClause1_2::parent_clause1::Output = bool> = rfind<'_0_0, Self, P>[Self, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::exact_size::ExactSizeIterator
@@ -558,7 +558,7 @@ pub trait ExactSizeIterator<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn len<'_0> = len<'_0_0, Self>[Self]
     fn is_empty<'_0> = is_empty<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -1336,7 +1336,7 @@ where
     fn is_sorted_by<F, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<IntoIter<T, const N : usize>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> FnMut<F, (&'_0_0 (T), &'_0_1 (T))>, for<'_0, '_1> @TraitClause1_2::parent_clause1::Output = bool> = core::array::iter::{impl Iterator for IntoIter<T, const N : usize>[@TraitClause0]}::is_sorted_by<T, F, const N : usize>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
     fn is_sorted_by_key<F, K, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<K>, [@TraitClause2]: Sized<IntoIter<T, const N : usize>[@TraitClause0]>, [@TraitClause3]: FnMut<F, (T)>, [@TraitClause4]: PartialOrd<K, K>, @TraitClause1_3::parent_clause1::Output = K> = core::array::iter::{impl Iterator for IntoIter<T, const N : usize>[@TraitClause0]}::is_sorted_by_key<T, F, K, const N : usize>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
     fn __iterator_get_unchecked<'_0> = {impl Iterator for IntoIter<T, const N : usize>[@TraitClause0]}::__iterator_get_unchecked<'_0_0, T, const N : usize>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for IntoIter<T, const N : usize>[@TraitClause0]}::{vtable}<T, const N : usize>[@TraitClause0]
 }
 
 // Full name: core::array::iter::{impl IntoIterator for Array<T, const N : usize>}::into_iter
@@ -1356,7 +1356,7 @@ where
     type Item = T
     type IntoIter = IntoIter<T, const N : usize>[@TraitClause0]
     fn into_iter = {impl IntoIterator for Array<T, const N : usize>}::into_iter<T, const N : usize>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for Array<T, const N : usize>}::{vtable}<T, const N : usize>[@TraitClause0]
 }
 
 // Full name: core::ops::drop::Drop
@@ -1563,7 +1563,7 @@ where
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = {impl IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::Extend::extend
@@ -3064,7 +3064,7 @@ where
     fn is_sorted_by<F, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> FnMut<F, (&'_0_0 (&'a (T)), &'_0_1 (&'a (T)))>, for<'_0, '_1> @TraitClause1_2::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
     fn is_sorted_by_key<F, K, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<K>, [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3]: FnMut<F, (&'a (T))>, [@TraitClause4]: PartialOrd<K, K>, @TraitClause1_3::parent_clause1::Output = K> = core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
     fn __iterator_get_unchecked<'_0> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::iter::Chunks
@@ -3772,7 +3772,7 @@ where
     fn is_sorted_by<F, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> FnMut<F, (&'_0_0 (&'a (Slice<T>)), &'_0_1 (&'a (Slice<T>)))>, for<'_0, '_1> @TraitClause1_2::parent_clause1::Output = bool> = core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
     fn is_sorted_by_key<F, K, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<K>, [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4]: PartialOrd<K, K>, @TraitClause1_3::parent_clause1::Output = K> = core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
     fn __iterator_get_unchecked<'_0> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::iter::ChunksExact
@@ -4480,7 +4480,7 @@ where
     fn is_sorted_by<F, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2]: for<'_0, '_1> FnMut<F, (&'_0_0 (&'a (Slice<T>)), &'_0_1 (&'a (Slice<T>)))>, for<'_0, '_1> @TraitClause1_2::parent_clause1::Output = bool> = core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2]
     fn is_sorted_by_key<F, K, [@TraitClause0]: Sized<F>, [@TraitClause1]: Sized<K>, [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4]: PartialOrd<K, K>, @TraitClause1_3::parent_clause1::Output = K> = core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_0, @TraitClause0_1, @TraitClause0_2, @TraitClause0_3, @TraitClause0_4]
     fn __iterator_get_unchecked<'_0> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::{Slice<T>}::iter

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -297,7 +297,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::ops::range::Range
@@ -326,7 +326,7 @@ where
     parent_clause1 = @TraitClause0
     type Item = A
     fn next<'_0> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_0, A>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -374,7 +374,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -420,7 +420,7 @@ where
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = {impl IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::Extend
@@ -447,7 +447,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -460,7 +460,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -514,7 +514,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -526,7 +526,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -548,7 +548,7 @@ pub trait Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
     type Output
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
 }
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (@TraitClause0::Output)
@@ -563,7 +563,7 @@ pub trait IndexMut<Self, Idx>
     parent_clause1 : [@TraitClause1]: Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Idx>
     fn index_mut<'_0> = core::ops::index::IndexMut::index_mut<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::IndexMut::{vtable}<Idx, Self::parent_clause1::Output>
 }
 
 pub fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx>(@1: &'_0 mut (Self), @2: Idx) -> &'_0 mut (@TraitClause0::parent_clause1::Output)
@@ -624,7 +624,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::slice::index::private_slice_index::Sealed
@@ -655,7 +655,7 @@ pub trait SliceIndex<Self, T>
     fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>[Self]
     fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>[Self]
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>[Self]
-    non-dyn-compatible
+    vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
 pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> Option<&'_0 (@TraitClause0::Output)>[Sized<&'_0 (@TraitClause0::Output)>]
@@ -728,7 +728,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for usize}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>> for usize}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>> for usize}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>> for usize}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: alloc::alloc::Global
@@ -768,7 +768,7 @@ where
     parent_clause2 = @TraitClause3::parent_clause3
     type Output = @TraitClause3::Output
     fn index<'_0> = {impl Index<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
-    non-dyn-compatible
+    vtable: {impl Index<I> for Vec<T>[@TraitClause0, @TraitClause2]}::{vtable}<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
 }
 
 // Full name: alloc::vec::{impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut
@@ -791,7 +791,7 @@ where
     parent_clause1 = {impl Index<I> for Vec<T>[@TraitClause0, @TraitClause2]}<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
     parent_clause2 = @TraitClause1::parent_clause0
     fn index_mut<'_0> = {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut<'_0_0, T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
-    non-dyn-compatible
+    vtable: {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::{vtable}<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
 }
 
 // Full name: test_crate::test_loop1

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -21,7 +21,7 @@ pub trait Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
     type Output
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
 }
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (@TraitClause0::Output)
@@ -74,7 +74,7 @@ pub trait SliceIndex<Self, T>
     fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>[Self]
     fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>[Self]
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>[Self]
-    non-dyn-compatible
+    vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
 // Full name: core::slice::index::{impl Index<I> for Slice<T>}::index
@@ -96,7 +96,7 @@ where
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
     fn index<'_0> = {impl Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for RangeFrom<usize>[Sized<usize>]}
@@ -175,7 +175,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[Sized<usize>]}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[Sized<usize>]}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[Sized<usize>]}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>> for RangeFrom<usize>[Sized<usize>]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: alloc::alloc::Global

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -58,7 +58,7 @@ pub trait FnOnce::<closure<'_, '_>, (u8, u8)>
     parent_clause1 : [@TraitClause1]: Sized::<(u8, u8)>
     parent_clause2 : [@TraitClause2]: Tuple::<(u8, u8)>
     fn call_once = core::ops::function::FnOnce::call_once::<closure<'_, '_>, (u8, u8)>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<closure<'_, '_>, (u8, u8)><u8>
 }
 
 // Full name: core::ops::function::FnMut::<closure<'_, '_>, (u8, u8)>
@@ -70,7 +70,7 @@ pub trait FnMut::<closure<'_, '_>, (u8, u8)>
     parent_clause2 : [@TraitClause2]: Sized::<(u8, u8)>
     parent_clause3 : [@TraitClause3]: Tuple::<(u8, u8)>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut::<closure<'_, '_>, (u8, u8)><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}::<closure<'_, '_>, (u8, u8)><u8>
 }
 
 // Full name: core::ops::function::Fn::<closure<'_, '_>, (u8, u8)>
@@ -82,7 +82,7 @@ pub trait Fn::<closure<'_, '_>, (u8, u8)>
     parent_clause2 : [@TraitClause2]: Sized::<(u8, u8)>
     parent_clause3 : [@TraitClause3]: Tuple::<(u8, u8)>
     fn call<'_0> = core::ops::function::Fn::call::<closure<'_, '_>, (u8, u8)><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}::<closure<'_, '_>, (u8, u8)><u8>
 }
 
 pub fn core::ops::function::Fn::call<'_0>(@1: &'_0 (closure<'_, '_>), @2: (u8, u8)) -> u8

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -74,7 +74,7 @@ pub trait FnOnce::<closure, (u8)>
     parent_clause1 : [@TraitClause1]: Sized::<(u8)>
     parent_clause2 : [@TraitClause2]: Tuple::<(u8)>
     fn call_once = core::ops::function::FnOnce::call_once::<closure, (u8)>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<closure, (u8)><u8>
 }
 
 pub fn core::ops::function::FnOnce::call_once(@1: closure, @2: (u8)) -> u8

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -127,7 +127,7 @@ pub trait FnOnce::<test_crate::main::closure<'_>, (u8)>
     parent_clause1 : [@TraitClause1]: Sized::<(u8)>
     parent_clause2 : [@TraitClause2]: Tuple::<(u8)>
     fn call_once = core::ops::function::FnOnce::call_once::<test_crate::main::closure<'_>, (u8)>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<test_crate::main::closure<'_>, (u8)><u8>
 }
 
 // Full name: core::ops::function::FnMut::<test_crate::main::closure<'_>, (u8)>
@@ -139,7 +139,7 @@ pub trait FnMut::<test_crate::main::closure<'_>, (u8)>
     parent_clause2 : [@TraitClause2]: Sized::<(u8)>
     parent_clause3 : [@TraitClause3]: Tuple::<(u8)>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut::<test_crate::main::closure<'_>, (u8)><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}::<test_crate::main::closure<'_>, (u8)><u8>
 }
 
 // Full name: core::ops::function::Fn::<test_crate::main::closure<'_>, (u8)>
@@ -151,7 +151,7 @@ pub trait Fn::<test_crate::main::closure<'_>, (u8)>
     parent_clause2 : [@TraitClause2]: Sized::<(u8)>
     parent_clause3 : [@TraitClause3]: Tuple::<(u8)>
     fn call<'_0> = core::ops::function::Fn::call::<test_crate::main::closure<'_>, (u8)><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}::<test_crate::main::closure<'_>, (u8)><u8>
 }
 
 pub fn core::ops::function::Fn::call<'_0>(@1: &'_0 (test_crate::main::closure<'_>), @2: (u8)) -> u8
@@ -166,7 +166,7 @@ pub trait FnOnce::<test_crate::main::closure#1<'_>, (u8)>
     parent_clause1 : [@TraitClause1]: Sized::<(u8)>
     parent_clause2 : [@TraitClause2]: Tuple::<(u8)>
     fn call_once = core::ops::function::FnOnce::call_once::<test_crate::main::closure#1<'_>, (u8)>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<test_crate::main::closure#1<'_>, (u8)><u8>
 }
 
 // Full name: core::ops::function::FnMut::<test_crate::main::closure#1<'_>, (u8)>
@@ -178,7 +178,7 @@ pub trait FnMut::<test_crate::main::closure#1<'_>, (u8)>
     parent_clause2 : [@TraitClause2]: Sized::<(u8)>
     parent_clause3 : [@TraitClause3]: Tuple::<(u8)>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut::<test_crate::main::closure#1<'_>, (u8)><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}::<test_crate::main::closure#1<'_>, (u8)><u8>
 }
 
 pub fn core::ops::function::FnMut::call_mut<'_0>(@1: &'_0 mut (test_crate::main::closure#1<'_>), @2: (u8)) -> u8
@@ -197,7 +197,7 @@ pub trait FnOnce::<test_crate::main::closure#2, (u8)>
     parent_clause1 : [@TraitClause1]: Sized::<(u8)>
     parent_clause2 : [@TraitClause2]: Tuple::<(u8)>
     fn call_once = core::ops::function::FnOnce::call_once::<test_crate::main::closure#2, (u8)>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<test_crate::main::closure#2, (u8)><u8>
 }
 
 pub fn core::ops::function::FnOnce::call_once(@1: test_crate::main::closure#2, @2: (u8)) -> u8

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -97,7 +97,7 @@ note: the error occurred when translating `core::fmt::Display::{vtable}::<alloc:
 12 |     let _ = dyn_to_string(&str);
    |                           ----
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:375:14:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:376:17:
 incorrect `dyn_self`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `core::fmt::Display`.

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -111,7 +111,7 @@ pub trait FnOnce::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
     parent_clause1 : [@TraitClause1]: Sized::<(&'_ (u32))>
     parent_clause2 : [@TraitClause2]: Tuple::<(&'_ (u32))>
     fn call_once = call_once::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))><()>
 }
 
 // Full name: core::ops::function::FnMut::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
@@ -123,7 +123,7 @@ pub trait FnMut::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
     parent_clause2 : [@TraitClause2]: Sized::<(&'_ (u32))>
     parent_clause3 : [@TraitClause3]: Tuple::<(&'_ (u32))>
     fn call_mut<'_0> = call_mut::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))><()>
 }
 
 // Full name: core::ops::function::Fn::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
@@ -135,7 +135,7 @@ pub trait Fn::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))>
     parent_clause2 : [@TraitClause2]: Sized::<(&'_ (u32))>
     parent_clause3 : [@TraitClause3]: Tuple::<(&'_ (u32))>
     fn call<'_0> = call::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))><'_0_0>
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}::<for<'_0> foo::<u32><'_0_0>, (&'_ (u32))><()>
 }
 
 // Full name: core::ops::function::Fn::call

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -19,7 +19,7 @@ pub trait Deref<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self::Target>
     type Target
     fn deref<'_0> = core::ops::deref::Deref::deref<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::ops::deref::Deref::{vtable}<Self::Target>
 }
 
 #[lang_item("deref_method")]
@@ -33,7 +33,7 @@ pub trait DerefMut<Self>
 {
     parent_clause0 : [@TraitClause0]: Deref<Self>
     fn deref_mut<'_0> = core::ops::deref::DerefMut::deref_mut<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::ops::deref::DerefMut::{vtable}<Self::parent_clause0::Target>
 }
 
 #[lang_item("deref_mut_method")]
@@ -90,7 +90,7 @@ where
     parent_clause0 = @TraitClause0
     type Target = T
     fn deref<'_0> = {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref<'_0_0, T, A>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: alloc::boxed::{impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref_mut
@@ -107,7 +107,7 @@ where
 {
     parent_clause0 = {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<T, A>[@TraitClause0, @TraitClause1]
     fn deref_mut<'_0> = {impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref_mut<'_0_0, T, A>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: test_crate::Pair

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -118,7 +118,7 @@ pub trait BuildHasher<Self>
     parent_clause2 : [@TraitClause2]: Hasher<Self::Hasher>
     type Hasher
     fn build_hasher<'_0> = core::hash::BuildHasher::build_hasher<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::hash::BuildHasher::{vtable}<Self::Hasher>
 }
 
 pub fn core::hash::BuildHasher::build_hasher<'_0, Self>(@1: &'_0 (Self)) -> @TraitClause0::Hasher
@@ -146,7 +146,7 @@ pub trait Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
     type Output
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
 }
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (@TraitClause0::Output)
@@ -229,7 +229,7 @@ where
     parent_clause2 = @TraitClause2::parent_clause0
     type Output = V
     fn index<'_0> = {impl Index<&'_0 (Q)> for HashMap<K, V, S>[@TraitClause0, @TraitClause2, @TraitClause3]}::index<'_0, '_0_0, K, Q, V, S>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5, @TraitClause6, @TraitClause7, @TraitClause8, @TraitClause9]
-    non-dyn-compatible
+    vtable: {impl Index<&'_0 (Q)> for HashMap<K, V, S>[@TraitClause0, @TraitClause2, @TraitClause3]}::{vtable}<'_0, K, Q, V, S>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5, @TraitClause6, @TraitClause7, @TraitClause8, @TraitClause9]
 }
 
 // Full name: std::hash::random::RandomState
@@ -262,7 +262,7 @@ impl BuildHasher for RandomState {
     parent_clause2 = {impl Hasher for DefaultHasher}
     type Hasher = DefaultHasher
     fn build_hasher<'_0> = {impl BuildHasher for RandomState}::build_hasher<'_0_0>
-    non-dyn-compatible
+    vtable: {impl BuildHasher for RandomState}::{vtable}
 }
 
 // Full name: test_crate::get_or_insert

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -172,7 +172,7 @@ trait Foo<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::S>
     type S
-    non-dyn-compatible
+    vtable: test_crate::Foo::{vtable}<Self::S>
 }
 
 // Full name: test_crate::f

--- a/charon/tests/ui/ptr_no_provenance.out
+++ b/charon/tests/ui/ptr_no_provenance.out
@@ -258,7 +258,7 @@ pub trait Pointee<Self>
     parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
     parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
     type Metadata
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Pointee::{vtable}<Self::Metadata>
 }
 
 // Full name: core::ptr::metadata::Thin
@@ -267,7 +267,7 @@ where
     Self::parent_clause0::Metadata = (),
 {
     parent_clause0 : [@TraitClause0]: Pointee<Self>
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Thin::{vtable}<()>
 }
 
 // Full name: core::ptr::metadata::Thin::{impl Thin for Self}

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -126,7 +126,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -174,7 +174,7 @@ where
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -226,7 +226,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -239,7 +239,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::iterator::Iterator::next
@@ -308,7 +308,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -320,7 +320,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -387,7 +387,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::result::Result

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -31,7 +31,7 @@ pub trait MyTryFrom<Self, T>
     parent_clause2 : [@TraitClause2]: Sized<Self::Error>
     type Error
     fn from<[@TraitClause0]: Sized<Self>> = test_crate::MyTryFrom::from<Self, T>[Self, @TraitClause0_0]
-    non-dyn-compatible
+    vtable: test_crate::MyTryFrom::{vtable}<T, Self::Error>
 }
 
 pub fn test_crate::MyTryFrom::from<Self, T>(@1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause1, @TraitClause0::parent_clause2]
@@ -60,7 +60,7 @@ impl<'_0> MyTryFrom<&'_0 (bool)> for bool {
     parent_clause2 = Sized<()>
     type Error = ()
     fn from = {impl MyTryFrom<&'_0 (bool)> for bool}::from<'_0>
-    non-dyn-compatible
+    vtable: {impl MyTryFrom<&'_0 (bool)> for bool}::{vtable}<'_0>
 }
 
 

--- a/charon/tests/ui/regressions/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/regressions/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -43,7 +43,7 @@ pub trait FnOnce<Self, Args, Self_Output>
     parent_clause2 : [@TraitClause2]: Tuple<Args>
     parent_clause3 : [@TraitClause3]: Sized<Self_Output>
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -55,7 +55,7 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args, Self_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -67,7 +67,7 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause1_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(@1: &'_0 (Self), @2: Args) -> Clause0_Clause1_Clause1_Output
@@ -87,7 +87,7 @@ pub trait PrimeField<Self, Self_Repr>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Repr>
-    non-dyn-compatible
+    vtable: test_crate::PrimeField::{vtable}<Self_Repr>
 }
 
 // Full name: test_crate::SqrtTables

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -67,7 +67,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -79,7 +79,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -91,7 +91,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/assoc-constraint-on-assoc-ty-nested.out
+++ b/charon/tests/ui/simple/assoc-constraint-on-assoc-ty-nested.out
@@ -17,7 +17,7 @@ trait Trait<Self, Self_Assoc>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::IntoIterator
@@ -26,7 +26,7 @@ trait IntoIterator<Self, Self_IntoIter>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
     parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::IntoIntoIterator
@@ -35,7 +35,7 @@ trait IntoIntoIterator<Self, Self_IntoIntoIter, Self_Clause2_IntoIter>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_IntoIntoIter>
     parent_clause2 : [@TraitClause2]: IntoIterator<Self_IntoIntoIter, Self_Clause2_IntoIter>
-    non-dyn-compatible
+    vtable: test_crate::IntoIntoIterator::{vtable}<Self_IntoIntoIter>
 }
 
 // Full name: test_crate::foo

--- a/charon/tests/ui/simple/assoc-constraint-on-assoc-ty.2.out
+++ b/charon/tests/ui/simple/assoc-constraint-on-assoc-ty.2.out
@@ -17,7 +17,7 @@ trait Trait<Self, Self_Assoc>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::IntoIterator
@@ -26,7 +26,7 @@ trait IntoIterator<Self, Self_IntoIter>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
     parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::foo

--- a/charon/tests/ui/simple/assoc-constraint-on-assoc-ty.out
+++ b/charon/tests/ui/simple/assoc-constraint-on-assoc-ty.out
@@ -31,7 +31,7 @@ trait Trait<Self, Self_Assoc>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::takes_trait
@@ -55,7 +55,7 @@ trait IntoIterator<Self, Self_IntoIter>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
     parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::collect

--- a/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
+++ b/charon/tests/ui/simple/assoc-ty-via-supertrait-and-bounds.out
@@ -17,14 +17,14 @@ pub trait HasOutput<Self, Self_Output>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Output>
-    non-dyn-compatible
+    vtable: test_crate::HasOutput::{vtable}<Self_Output>
 }
 
 // Full name: test_crate::{impl HasOutput<()> for ()}
 impl HasOutput<()> for () {
     parent_clause0 = MetaSized<()>
     parent_clause1 = Sized<()>
-    non-dyn-compatible
+    vtable: {impl HasOutput<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::HasOutput2
@@ -32,14 +32,14 @@ pub trait HasOutput2<Self, Self_Clause1_Output>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: HasOutput<Self, Self_Clause1_Output>
-    non-dyn-compatible
+    vtable: test_crate::HasOutput2::{vtable}<Self_Clause1_Output>
 }
 
 // Full name: test_crate::{impl HasOutput2<()> for ()}
 impl HasOutput2<()> for () {
     parent_clause0 = MetaSized<()>
     parent_clause1 = {impl HasOutput<()> for ()}
-    non-dyn-compatible
+    vtable: {impl HasOutput2<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::Wrapper
@@ -58,7 +58,7 @@ where
 {
     parent_clause0 = MetaSized<Wrapper<T>[@TraitClause0]>
     parent_clause1 = @TraitClause1::parent_clause1
-    non-dyn-compatible
+    vtable: {impl HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: test_crate::{impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]}
@@ -69,7 +69,7 @@ where
 {
     parent_clause0 = MetaSized<Wrapper<T>[@TraitClause0]>
     parent_clause1 = {impl HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]}<T, Clause1_Clause1_Output>[@TraitClause0, @TraitClause1::parent_clause1]
-    non-dyn-compatible
+    vtable: {impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: test_crate::take

--- a/charon/tests/ui/simple/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/simple/assoc-type-with-fn-bound.out
@@ -29,7 +29,7 @@ pub trait FnOnce<Self, Args, Self_Output>
     parent_clause2 : [@TraitClause2]: Tuple<Args>
     parent_clause3 : [@TraitClause3]: Sized<Self_Output>
     fn call_once = call_once<Self, Args, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -41,7 +41,7 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args, Self_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -53,7 +53,7 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause1_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(@1: &'_0 (Self), @2: Args) -> Clause0_Clause1_Clause1_Output
@@ -77,7 +77,7 @@ pub trait Trait<Self, Self_Foo>
     parent_clause1 : [@TraitClause1]: Sized<Self_Foo>
     parent_clause2 : [@TraitClause2]: Fn<Self_Foo, (), ()>
     fn call<'_0> = test_crate::Trait::call<'_0_0, Self, Self_Foo>[Self]
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self_Foo>
 }
 
 pub fn test_crate::Trait::call<'_0, Self, Clause0_Foo>(@1: &'_0 (Self))
@@ -116,7 +116,7 @@ where
     parent_clause1 = @TraitClause1
     parent_clause2 = @TraitClause0
     fn call<'_0> = {impl Trait<F> for F}::call<'_0_0, F>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl Trait<F> for F}::{vtable}<F>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: test_crate::use_foo

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -30,14 +30,14 @@ pub trait Trait<Self, Self_Type>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Type>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<Self_Type>
 }
 
 // Full name: test_crate::{impl Trait<()> for ()}
 impl Trait<()> for () {
     parent_clause0 = MetaSized<()>
     parent_clause1 = Sized<()>
-    non-dyn-compatible
+    vtable: {impl Trait<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::HashMap

--- a/charon/tests/ui/simple/closure-capture-ref-by-move.out
+++ b/charon/tests/ui/simple/closure-capture-ref-by-move.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> @TraitClause0::parent_clause1::Output

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/closure-fnmut.out
+++ b/charon/tests/ui/simple/closure-fnmut.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> @TraitClause0::parent_clause1::Output

--- a/charon/tests/ui/simple/closure-fnonce.out
+++ b/charon/tests/ui/simple/closure-fnonce.out
@@ -48,7 +48,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 pub fn core::ops::function::FnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> @TraitClause0::Output

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/closure-with-drops.out
+++ b/charon/tests/ui/simple/closure-with-drops.out
@@ -52,7 +52,7 @@ pub trait FnOnce<Self, Args>
     parent_clause6 : [@TraitClause6]: Drop<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -66,7 +66,7 @@ pub trait FnMut<Self, Args>
     parent_clause4 : [@TraitClause4]: Drop<Self>
     parent_clause5 : [@TraitClause5]: Drop<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -80,7 +80,7 @@ pub trait Fn<Self, Args>
     parent_clause4 : [@TraitClause4]: Drop<Self>
     parent_clause5 : [@TraitClause5]: Drop<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
@@ -4,7 +4,7 @@
 trait HasAssoc<Self>
 {
     type Assoc
-    non-dyn-compatible
+    vtable: test_crate::HasAssoc::{vtable}<Self::Assoc>
 }
 
 // Full name: test_crate::Trait

--- a/charon/tests/ui/simple/dyn-fn.out
+++ b/charon/tests/ui/simple/dyn-fn.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,16 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+}
+
+struct core::ops::function::Fn::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0)),
+  method_call: fn<'_0>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0)), Args) -> Fn<(dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0), Args>::parent_clause1::parent_clause1::Output,
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+  super_trait_1: &'static (core::ops::function::FnMut::{vtable}<Args, Fn<(dyn exists<_dyn> [@TraitClause0]: Fn<_dyn, Args> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Output = Ty0), Args>::parent_clause1::parent_clause1::Output>),
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +77,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -1,92 +1,41 @@
-# Final LLBC before serialization:
+disabled backtrace
+warning[E9999]: Could not find a clause for `Binder { value: <T as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
+ --> tests/ui/simple/fewer-clauses-in-method-impl.rs:8:5
+  |
+8 |     fn method<T: Clone>() {}
+  |     ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: ⚠️ This is a bug in Hax's frontend.
+          Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
 
-// Full name: core::marker::MetaSized
-#[lang_item("meta_sized")]
-pub trait MetaSized<Self>
+warning: 1 warning emitted
 
-// Full name: core::marker::Sized
-#[lang_item("sized")]
-pub trait Sized<Self>
-{
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    non-dyn-compatible
-}
+error: Found inconsistent generics after transformations:
+       Mismatched builtin trait parent clauses:
+       target: Clone
+       expected: [[@TraitClause0]: Sized<missing(@Type1_0)>]
+            got: [MetaSized<()>, Clone<()>]
+       Visitor stack:
+         charon_lib::ast::types::TraitRef
+         charon_lib::ids::vector::Vector<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
+         charon_lib::ast::types::GenericArgs
+         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
+         charon_lib::ast::expressions::FnPtr
+         charon_lib::ast::gast::FnOperand
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         core::result::Result<charon_lib::ast::gast::Body, charon_lib::ast::gast::Opaque>
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+  --> tests/ui/simple/fewer-clauses-in-method-impl.rs:12:5
+   |
+12 |     <() as Trait>::method::<()>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-// Full name: core::clone::Clone
-#[lang_item("clone")]
-pub trait Clone<Self>
-{
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    fn clone<'_0> = clone<'_0_0, Self>[Self]
-    non-dyn-compatible
-}
-
-// Full name: core::clone::Clone::clone
-#[lang_item("clone_fn")]
-pub fn clone<'_0, Self>(@1: &'_0 (Self)) -> Self
-where
-    [@TraitClause0]: Clone<Self>,
-
-// Full name: core::marker::Copy
-#[lang_item("copy")]
-pub trait Copy<Self>
-{
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
-    non-dyn-compatible
-}
-
-// Full name: core::marker::Destruct
-#[lang_item("destruct")]
-pub trait Destruct<Self>
-{
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    vtable: core::marker::Destruct::{vtable}
-}
-
-// Full name: test_crate::Trait
-trait Trait<Self>
-{
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn method<T, [@TraitClause0]: Sized<T>, [@TraitClause1]: Copy<T>> = test_crate::Trait::method<Self, T>[Self, @TraitClause0_0, @TraitClause0_1]
-    non-dyn-compatible
-}
-
-fn test_crate::Trait::method<Self, T>()
-where
-    [@TraitClause0]: Trait<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-
-// Full name: test_crate::{impl Trait for ()}::method
-fn {impl Trait for ()}::method<T>()
-where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-{
-    let @0: (); // return
-
-    @0 := ()
-    @0 := ()
-    return
-}
-
-// Full name: test_crate::{impl Trait for ()}
-impl Trait for () {
-    parent_clause0 = MetaSized<()>
-    fn method<T, [@TraitClause0]: Sized<T>, [@TraitClause1]: Clone<T>> = {impl Trait for ()}::method<T>[@TraitClause0_0, @TraitClause0_1]
-    non-dyn-compatible
-}
-
-// Full name: test_crate::main
-fn main()
-{
-    let @0: (); // return
-
-    @0 := {impl Trait for ()}::method<()>[Sized<()>, Copy<()>]()
-    @0 := ()
-    return
-}
-
-
-
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.rs
@@ -1,3 +1,4 @@
+//@ known-failure
 //@ charon-args=--remove-associated-types=*
 trait Trait {
     fn method<T: Copy>();

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
@@ -27,7 +27,7 @@ trait HasType<Self, Self_Type>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Type>
-    non-dyn-compatible
+    vtable: test_crate::HasType::{vtable}<Self_Type>
 }
 
 // Full name: test_crate::HasMethod

--- a/charon/tests/ui/simple/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/simple/mem-discriminant-from-derive.out
@@ -169,7 +169,7 @@ pub trait DiscriminantKind<Self>
     parent_clause9 : [@TraitClause9]: Sync<Self::Discriminant>
     parent_clause10 : [@TraitClause10]: Unpin<Self::Discriminant>
     type Discriminant
-    non-dyn-compatible
+    vtable: core::marker::DiscriminantKind::{vtable}<Self::Discriminant>
 }
 
 // Full name: core::intrinsics::discriminant_value

--- a/charon/tests/ui/simple/method-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/method-with-assoc-type-constraint.out
@@ -31,7 +31,7 @@ pub trait IntoIterator<Self, Self_Item>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Item>
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self_Item>
 }
 
 // Full name: test_crate::FromIterator

--- a/charon/tests/ui/simple/multiple-promoteds.out
+++ b/charon/tests/ui/simple/multiple-promoteds.out
@@ -21,7 +21,7 @@ pub trait Add<Self, Rhs>
     parent_clause2 : [@TraitClause2]: Sized<Self::Output>
     type Output
     fn add = core::ops::arith::Add::add<Self, Rhs>[Self]
-    non-dyn-compatible
+    vtable: core::ops::arith::Add::{vtable}<Rhs, Self::Output>
 }
 
 // Full name: core::ops::arith::{impl Add<&'_0 (u32)> for &'_1 (u32)}::add
@@ -34,7 +34,7 @@ impl<'_0, '_1> Add<&'_0 (u32)> for &'_1 (u32) {
     parent_clause2 = Sized<u32>
     type Output = u32
     fn add = {impl Add<&'_0 (u32)> for &'_1 (u32)}::add<'_0, '_1>
-    non-dyn-compatible
+    vtable: {impl Add<&'_0 (u32)> for &'_1 (u32)}::{vtable}<'_0, '_1>
 }
 
 #[lang_item("add")]

--- a/charon/tests/ui/simple/nested-closure-trait-ref.out
+++ b/charon/tests/ui/simple/nested-closure-trait-ref.out
@@ -67,7 +67,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -79,7 +79,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -91,7 +91,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -67,7 +67,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -79,7 +79,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -91,7 +91,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -43,7 +43,7 @@ pub trait FnOnce<Self, Args, Self_Output>
     parent_clause2 : [@TraitClause2]: Tuple<Args>
     parent_clause3 : [@TraitClause3]: Sized<Self_Output>
     fn call_once = call_once<Self, Args, Self_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -55,7 +55,7 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args, Self_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -67,7 +67,7 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args, Self_Clause1_Clause1_Output>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(@1: &'_0 (Self), @2: Args) -> Clause0_Clause1_Clause1_Output

--- a/charon/tests/ui/simple/pointee_metadata.out
+++ b/charon/tests/ui/simple/pointee_metadata.out
@@ -206,7 +206,7 @@ pub trait Pointee<Self>
     parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
     parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
     type Metadata
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Pointee::{vtable}<Self::Metadata>
 }
 
 // Full name: core::ptr::const_ptr::{*const T}::to_raw_parts

--- a/charon/tests/ui/simple/promoted-closure-no-warns.out
+++ b/charon/tests/ui/simple/promoted-closure-no-warns.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -44,7 +44,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -56,7 +56,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -68,7 +68,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output

--- a/charon/tests/ui/simple/ptr_metadata.out
+++ b/charon/tests/ui/simple/ptr_metadata.out
@@ -258,7 +258,7 @@ pub trait Pointee<Self>
     parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
     parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
     type Metadata
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Pointee::{vtable}<Self::Metadata>
 }
 
 // Full name: core::ptr::metadata::Thin
@@ -267,7 +267,7 @@ where
     Self::parent_clause0::Metadata = (),
 {
     parent_clause0 : [@TraitClause0]: Pointee<Self>
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Thin::{vtable}<()>
 }
 
 // Full name: core::ptr::metadata::Thin::{impl Thin for Self}

--- a/charon/tests/ui/simple/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/simple/quantified-trait-type-constraint.out
@@ -17,7 +17,7 @@ trait Trait<'a, Self, Self_Type>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self_Type>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<'a, Self_Type>
 }
 
 // Full name: test_crate::foo

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -148,7 +148,7 @@ pub trait Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
     type Output
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
 }
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx>(@1: &'_0 (Self), @2: Idx) -> &'_0 (@TraitClause0::Output)
@@ -251,7 +251,7 @@ pub trait SliceIndex<Self, T>
     fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>[Self]
     fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>[Self]
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>[Self]
-    non-dyn-compatible
+    vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
 pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (@TraitClause0::Output)
@@ -285,7 +285,7 @@ where
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
     fn index<'_0> = {impl Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::slice_end_index_len_fail
@@ -953,7 +953,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[Sized<usize>]}::get
@@ -1466,7 +1466,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[Sized<usize>]}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[Sized<usize>]}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[Sized<usize>]}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[Sized<usize>]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: test_crate::slice_index_range

--- a/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
@@ -18,7 +18,7 @@ trait HasAssoc<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Assoc>
     type Assoc
-    non-dyn-compatible
+    vtable: test_crate::HasAssoc::{vtable}<Self::Assoc>
 }
 
 // Full name: test_crate::SuperTrait

--- a/charon/tests/ui/simple/trait-alias.out
+++ b/charon/tests/ui/simple/trait-alias.out
@@ -64,7 +64,7 @@ trait Trait<Self, T, Self_Item>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<T>
     parent_clause2 : [@TraitClause2]: Sized<Self_Item>
-    non-dyn-compatible
+    vtable: test_crate::Trait::{vtable}<T, Self_Item>
 }
 
 // Full name: test_crate::Struct
@@ -95,7 +95,7 @@ where
     parent_clause0 = MetaSized<Struct>
     parent_clause1 = @TraitClause0
     parent_clause2 = Sized<u32>
-    non-dyn-compatible
+    vtable: {impl Trait<T, u32> for Struct}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: test_crate::Alias

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -13,7 +13,7 @@ pub trait Index<Self, Idx>
     parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
     type Output
     fn index<'_0> = core::ops::index::Index::index<'_0_0, Self, Idx>[Self]
-    non-dyn-compatible
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
 }
 
 // Full name: core::marker::Sized
@@ -43,7 +43,7 @@ where
     parent_clause2 = @TraitClause2::parent_clause2
     type Output = @TraitClause2::Output
     fn index<'_0> = {impl Index<I> for Array<T, const N : usize>}::index<'_0_0, T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I> for Array<T, const N : usize>}::{vtable}<T, I, const N : usize>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::fmt::Arguments
@@ -144,7 +144,7 @@ pub trait SliceIndex<Self, T>
     fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut<Self, T>[Self]
     fn index<'_0> = core::slice::index::SliceIndex::index<'_0_0, Self, T>[Self]
     fn index_mut<'_0> = core::slice::index::SliceIndex::index_mut<'_0_0, Self, T>[Self]
-    non-dyn-compatible
+    vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
 pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(@1: Self, @2: &'_0 (T)) -> &'_0 (@TraitClause0::Output)
@@ -178,7 +178,7 @@ where
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
     fn index<'_0> = {impl Index<I> for Slice<T>}::index<'_0_0, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    non-dyn-compatible
+    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::slice_end_index_len_fail
@@ -801,7 +801,7 @@ where
     fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::get_unchecked_mut<T>[@TraitClause0]
     fn index<'_0> = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::index<'_0_0, T>[@TraitClause0]
     fn index_mut<'_0> = {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::index_mut<'_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl SliceIndex<Slice<T>> for Range<usize>[Sized<usize>]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -43,7 +43,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -55,7 +55,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = core::ops::function::FnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::Fn
@@ -67,7 +67,7 @@ pub trait Fn<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call<'_0> = core::ops::function::Fn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn core::ops::function::Fn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
@@ -893,7 +893,7 @@ pub trait ParentTrait0<Self>
     type W
     fn get_name<'_0> = get_name<'_0_0, Self>[Self]
     fn get_w<'_0> = test_crate::ParentTrait0::get_w<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: test_crate::ParentTrait0::{vtable}<Self::W>
 }
 
 // Full name: test_crate::ParentTrait0::get_name
@@ -918,7 +918,7 @@ pub trait ChildTrait<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: ParentTrait0<Self>
     parent_clause2 : [@TraitClause2]: ParentTrait1<Self>
-    non-dyn-compatible
+    vtable: test_crate::ChildTrait::{vtable}<Self::parent_clause1::W>
 }
 
 // Full name: test_crate::test_child_trait1
@@ -998,7 +998,7 @@ pub trait Iterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
-    non-dyn-compatible
+    vtable: test_crate::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: test_crate::IntoIterator
@@ -1013,7 +1013,7 @@ where
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: test_crate::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: test_crate::IntoIterator::into_iter
@@ -1045,7 +1045,7 @@ pub trait WithTarget<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Target>
     type Target
-    non-dyn-compatible
+    vtable: test_crate::WithTarget::{vtable}<Self::Target>
 }
 
 // Full name: test_crate::ParentTrait2
@@ -1055,7 +1055,7 @@ pub trait ParentTrait2<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::U>
     parent_clause2 : [@TraitClause2]: WithTarget<Self::U>
     type U
-    non-dyn-compatible
+    vtable: test_crate::ParentTrait2::{vtable}<Self::U>
 }
 
 // Full name: test_crate::ChildTrait2
@@ -1076,7 +1076,7 @@ impl WithTarget for u32 {
     parent_clause0 = MetaSized<u32>
     parent_clause1 = Sized<u32>
     type Target = u32
-    non-dyn-compatible
+    vtable: {impl WithTarget for u32}::{vtable}
 }
 
 // Full name: test_crate::{impl ParentTrait2 for u32}
@@ -1085,7 +1085,7 @@ impl ParentTrait2 for u32 {
     parent_clause1 = Sized<u32>
     parent_clause2 = {impl WithTarget for u32}
     type U = u32
-    non-dyn-compatible
+    vtable: {impl ParentTrait2 for u32}::{vtable}
 }
 
 // Full name: test_crate::{impl ChildTrait2 for u32}::convert
@@ -1114,7 +1114,7 @@ pub trait CFnOnce<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Self::Output>
     type Output
     fn call_once = test_crate::CFnOnce::call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: test_crate::CFnOnce::{vtable}<Args, Self::Output>
 }
 
 pub fn test_crate::CFnOnce::call_once<Self, Args>(@1: Self, @2: Args) -> @TraitClause0::Output
@@ -1128,7 +1128,7 @@ pub trait CFnMut<Self, Args>
     parent_clause1 : [@TraitClause1]: CFnOnce<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     fn call_mut<'_0> = test_crate::CFnMut::call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: test_crate::CFnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 pub fn test_crate::CFnMut::call_mut<'_0, Self, Args>(@1: &'_0 mut (Self), @2: Args) -> @TraitClause0::parent_clause1::Output
@@ -1142,7 +1142,7 @@ pub trait CFn<Self, Args>
     parent_clause1 : [@TraitClause1]: CFnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     fn call<'_0> = test_crate::CFn::call<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: test_crate::CFn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
 }
 
 pub fn test_crate::CFn::call<'_0, Self, Args>(@1: &'_0 (Self), @2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
@@ -1156,7 +1156,7 @@ pub trait GetTrait<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::W>
     type W
     fn get_w<'_0> = test_crate::GetTrait::get_w<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: test_crate::GetTrait::{vtable}<Self::W>
 }
 
 pub fn test_crate::GetTrait::get_w<'_0, Self>(@1: &'_0 (Self)) -> @TraitClause0::W
@@ -1321,7 +1321,7 @@ trait RecursiveImpl<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     parent_clause2 : [@TraitClause2]: RecursiveImpl<Self::Item>
     type Item
-    non-dyn-compatible
+    vtable: test_crate::RecursiveImpl::{vtable}<Self::Item>
 }
 
 // Full name: test_crate::{impl RecursiveImpl for ()}
@@ -1330,7 +1330,7 @@ impl RecursiveImpl for () {
     parent_clause1 = Sized<()>
     parent_clause2 = {impl RecursiveImpl for ()}
     type Item = ()
-    non-dyn-compatible
+    vtable: {impl RecursiveImpl for ()}::{vtable}
 }
 
 // Full name: test_crate::flabada
@@ -1377,7 +1377,7 @@ trait SliceIndex<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Output>
     type Output
-    non-dyn-compatible
+    vtable: test_crate::assoc_ty_trait_ref::SliceIndex::{vtable}<Self::Output>
 }
 
 // Full name: test_crate::assoc_ty_trait_ref::index

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -31,7 +31,7 @@ pub trait From<Self, T>
     parent_clause2 : [@TraitClause2]: Sized<Self::Error>
     type Error
     fn from<[@TraitClause0]: Sized<Self>> = test_crate::From::from<Self, T>[Self, @TraitClause0_0]
-    non-dyn-compatible
+    vtable: test_crate::From::{vtable}<T, Self::Error>
 }
 
 pub fn test_crate::From::from<Self, T>(@1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause1, @TraitClause0::parent_clause2]
@@ -60,7 +60,7 @@ impl<'_0> From<&'_0 (bool)> for bool {
     parent_clause2 = Sized<()>
     type Error = ()
     fn from = {impl From<&'_0 (bool)> for bool}::from<'_0>
-    non-dyn-compatible
+    vtable: {impl From<&'_0 (bool)> for bool}::{vtable}<'_0>
 }
 
 

--- a/charon/tests/ui/ullbc-control-flow.out
+++ b/charon/tests/ui/ullbc-control-flow.out
@@ -248,7 +248,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::ops::range::Range
@@ -277,7 +277,7 @@ where
     parent_clause1 = @TraitClause0
     type Item = A
     fn next<'_0> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_0, A>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -325,7 +325,7 @@ where
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -371,7 +371,7 @@ where
     type Item = @TraitClause1::Item
     type IntoIter = I
     fn into_iter = {impl IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    non-dyn-compatible
+    vtable: {impl IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::Extend
@@ -398,7 +398,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -411,7 +411,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -465,7 +465,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -477,7 +477,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -544,7 +544,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: test_crate::nested_loops_enum

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -265,7 +265,7 @@ pub trait Pointee<Self>
     parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
     parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
     type Metadata
-    non-dyn-compatible
+    vtable: core::ptr::metadata::Pointee::{vtable}<Self::Metadata>
 }
 
 // Full name: core::ptr::null

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -126,7 +126,7 @@ pub trait Iterator<Self>
     parent_clause1 : [@TraitClause1]: Sized<Self::Item>
     type Item
     fn next<'_0> = core::iter::traits::iterator::Iterator::next<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
 // Full name: core::iter::traits::accum::Sum
@@ -174,7 +174,7 @@ where
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::collect::IntoIterator::{vtable}<Self::Item, Self::IntoIter>
 }
 
 // Full name: core::iter::traits::collect::FromIterator
@@ -226,7 +226,7 @@ pub trait DoubleEndedIterator<Self>
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
     fn next_back<'_0> = next_back<'_0_0, Self>[Self]
-    non-dyn-compatible
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
@@ -239,7 +239,7 @@ pub trait ExactSizeIterator<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     parent_clause1 : [@TraitClause1]: Iterator<Self>
-    non-dyn-compatible
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
 }
 
 #[lang_item("next")]
@@ -293,7 +293,7 @@ pub trait FnOnce<Self, Args>
     parent_clause3 : [@TraitClause3]: Sized<Self::Output>
     type Output
     fn call_once = call_once<Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnMut
@@ -305,7 +305,7 @@ pub trait FnMut<Self, Args>
     parent_clause2 : [@TraitClause2]: Sized<Args>
     parent_clause3 : [@TraitClause3]: Tuple<Args>
     fn call_mut<'_0> = call_mut<'_0_0, Self, Args>[Self]
-    non-dyn-compatible
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
@@ -372,7 +372,7 @@ where
     parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
     parent_clause3 : [@TraitClause3]: Try<Self::TryType>
     type TryType
-    non-dyn-compatible
+    vtable: core::ops::try_trait::Residual::{vtable}<O, Self::TryType>
 }
 
 // Full name: core::slice::iter::Iter
@@ -397,7 +397,7 @@ where
     parent_clause1 = Sized<&'_ (T)>
     type Item = &'a (T)
     fn next<'_0> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_0_0, T>[@TraitClause0]
-    non-dyn-compatible
+    vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: core::slice::{Slice<T>}::iter


### PR DESCRIPTION
Rework of https://github.com/AeneasVerif/charon/pull/762 that lets hax give us the list of associated types. This is still missing associated type normalization but I'm leaving that for a subsequent PR.

ci: use https://github.com/AeneasVerif/eurydice/pull/278
ci: use https://github.com/AeneasVerif/aeneas/pull/605