### PR TITLE
Compute layouts on demand

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.127"
+let supported_charon_version = "0.1.128"

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1436,6 +1436,26 @@ and region_var_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ index; name } : region_var)
     | _ -> Error "")
 
+and repr_options_of_json (ctx : of_json_ctx) (js : json) :
+    (repr_options, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("align", align);
+          ("pack", pack);
+          ("c", c);
+          ("transparent", transparent);
+          ("explicit_discr_type", explicit_discr_type);
+        ] ->
+        let* align = option_of_json int_of_json ctx align in
+        let* pack = option_of_json int_of_json ctx pack in
+        let* c = bool_of_json ctx c in
+        let* transparent = bool_of_json ctx transparent in
+        let* explicit_discr_type = bool_of_json ctx explicit_discr_type in
+        Ok ({ align; pack; c; transparent; explicit_discr_type } : repr_options)
+    | _ -> Error "")
+
 and rvalue_of_json (ctx : of_json_ctx) (js : json) : (rvalue, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -1884,6 +1904,7 @@ and type_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("kind", kind);
           ("layout", layout);
           ("ptr_metadata", ptr_metadata);
+          ("repr", repr);
         ] ->
         let* def_id = type_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
@@ -1894,8 +1915,18 @@ and type_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* ptr_metadata =
           option_of_json ptr_metadata_of_json ctx ptr_metadata
         in
+        let* repr = option_of_json repr_options_of_json ctx repr in
         Ok
-          ({ def_id; item_meta; generics; src; kind; layout; ptr_metadata }
+          ({
+             def_id;
+             item_meta;
+             generics;
+             src;
+             kind;
+             layout;
+             ptr_metadata;
+             repr;
+           }
             : type_decl)
     | _ -> Error "")
 

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -846,6 +846,24 @@ and ptr_metadata =
       (** Metadata for [dyn Trait] and user-defined types that directly or
           indirectly contain a [dyn Trait]. *)
 
+(** The representation options as annotated by the user.
+
+    If all are false/None, then this is equivalent to [#[repr(Rust)]]. Some
+    combinations are ruled out by the compiler, e.g. align and pack.
+
+    NOTE: This does not include less common/unstable representations such as
+    [#[repr(simd)]] or the compiler internal [#[repr(linear)]]. Similarly, enum
+    discriminant representations are encoded in [[Variant::discriminant]] and
+    [[DiscriminantLayout]] instead. This only stores whether the discriminant
+    type was derived from an explicit annotation. *)
+and repr_options = {
+  align : int option;
+  pack : int option;
+  c : bool;
+  transparent : bool;
+  explicit_discr_type : bool;
+}
+
 (** Describes how we represent the active enum variant in memory. *)
 and tag_encoding =
   | Direct
@@ -891,6 +909,9 @@ and type_decl = {
           are unable to obtain the info. See
           [translate_types::{impl ItemTransCtx}::translate_ptr_metadata] for
           more details. *)
+  repr : repr_options option;
+      (** The representation options of this type declaration as annotated by
+          the user. Is [None] for foreign type declarations. *)
 }
 
 and type_decl_kind =
@@ -919,9 +940,9 @@ and variant = {
   fields : field list;
   discriminant : scalar_value;
       (** The discriminant value outputted by [std::mem::discriminant] for this
-          variant. This is different than the discriminant stored in memory (the
-          one controlled by [repr]). That one is described by
-          [[DiscriminantLayout]] and [[TagEncoding]]. *)
+          variant. This can be different than the discriminant stored in memory
+          (called [tag]). That one is described by [[DiscriminantLayout]] and
+          [[TagEncoding]]. *)
 }
 
 and variant_id = (VariantId.id[@visitors.opaque])

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.127"
+version = "0.1.128"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -494,6 +494,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.127"
+version = "0.1.128"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -49,7 +49,7 @@ colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
 derive_generic_visitor = "0.2.0"
-either = "1.15.0"
+either = { version = "1.15.0", features = ["serde"] }
 env_logger = { version = "0.11", features = ["color"] }
 flate2 = { version = "1.0.34", optional = true }
 indexmap = { version = "2.7.1", features = ["serde"] }

--- a/charon/src/ast/layout_computer.rs
+++ b/charon/src/ast/layout_computer.rs
@@ -1,0 +1,436 @@
+use std::{cmp::max, collections::HashMap};
+
+use either::Either;
+use serde::Serialize;
+
+use crate::ast::{
+    BuiltinTy, ByteCount, DeBruijnVar, Field, FieldId, Layout, TranslatedCrate, Ty, TyKind,
+    TypeDeclKind, TypeDeclRef, TypeId, TypeVarId, VariantLayout, Vector,
+};
+
+/// A utility to compute/lookup layouts of types from the crate's data.
+/// Uses memoization to not re-compute already requested type layouts.
+/// Should be constructed exactly once and kept around as long as the crate is used.
+///
+/// WARNING: Using this will lead to leaked memory to guarantee that computed layouts stay available.
+/// Since any crate should only have finitely many types, the memory usage is bounded.
+pub struct LayoutComputer<'a> {
+    memoized_layouts: HashMap<Ty, Either<&'a Layout, LayoutHint>>,
+    krate: &'a TranslatedCrate,
+}
+
+/// Minimal information about a type's layout that can be known without
+/// querying the rustc type layout algorithm.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LayoutHint {
+    /// The minimal size of the type.
+    ///
+    /// Includes the minimal sizes of all its fields (if known), but doesn't take
+    /// alignment and possible padding, or wide pointers into consideration.
+    pub min_size: ByteCount,
+    /// The minimal alignment.
+    ///
+    /// Corresponds to the greatest known alignment of the types fields.
+    pub min_alignment: ByteCount,
+    /// Whether thy type might be uninhabited.
+    /// This can be the case if there are type variables as parameters that
+    /// have influence on the layout of the type.
+    ///
+    /// Will only be set to false, if its guaranteed that it is inhabited.
+    pub possibly_uninhabited: bool,
+}
+
+impl<'a> LayoutComputer<'a> {
+    pub fn new<'b: 'a>(krate: &'b TranslatedCrate) -> Self {
+        Self {
+            memoized_layouts: HashMap::new(),
+            krate,
+        }
+    }
+
+    /// Compute the layout of a tuple as precise as possible.
+    ///
+    /// If the elements have different sizes and thus might need padding,
+    /// it returns a hint, otherwise the precise layout.
+    fn get_layout_of_tuple<'c, 't>(
+        &'c mut self,
+        type_decl_ref: &'t TypeDeclRef,
+    ) -> Option<Either<&'a Layout, LayoutHint>> {
+        let mut total_min_size = 0;
+        let mut max_align = 1;
+        let mut uninhabited_part = false;
+        let mut possibly_same_size = None;
+        let mut must_have_same_size = true;
+
+        for ty_arg in type_decl_ref.generics.types.iter() {
+            uninhabited_part |= ty_arg.is_possibly_uninhabited();
+            match self.get_layout_of(ty_arg) {
+                Some(Either::Left(l)) => {
+                    if let Some(size) = l.size {
+                        total_min_size += size;
+                        match possibly_same_size {
+                            Some(other_size) => {
+                                if size != other_size {
+                                    must_have_same_size = false;
+                                }
+                            }
+                            None => possibly_same_size = Some(size),
+                        }
+                    }
+                    if let Some(align) = l.align {
+                        max_align = max(max_align, align);
+                    }
+                }
+                Some(Either::Right(h)) => {
+                    total_min_size += h.min_size;
+                    max_align = max(max_align, h.min_alignment);
+                    must_have_same_size = false;
+                }
+                None => (),
+            }
+        }
+        // If all elements have the same size, there is cannot be any padding between the elements
+        // and we are guaranteed to get a layout (we just don't know the order of elements).
+        Some(
+            if must_have_same_size && let Some(size) = possibly_same_size {
+                let new_layout = Layout::mk_uniform_tuple(
+                    size,
+                    type_decl_ref.generics.types.elem_count(),
+                    max_align,
+                );
+                let layout_ref = Box::leak(Box::new(new_layout));
+                Either::Left(layout_ref)
+            } else {
+                Either::Right(LayoutHint {
+                    min_size: total_min_size,
+                    min_alignment: max_align,
+                    possibly_uninhabited: uninhabited_part,
+                })
+            },
+        )
+    }
+
+    /// Approximate a layout for a struct (or enum variant) based on the fields.
+    fn compute_layout_from_fields(
+        &mut self,
+        fields: &Vector<FieldId, Field>,
+        ty_var_map: &HashMap<TypeVarId, Ty>,
+    ) -> Option<Either<&'a Layout, LayoutHint>> {
+        let mut total_min_size = 0;
+        let mut max_align = 1;
+        let mut uninhabited_part = false;
+
+        // If it is a new-type struct, we should be able to get a layout.
+        if fields.elem_count() == 1 {
+            let field = fields.get(FieldId::from_raw(0)).unwrap();
+            let ty = if field.ty.is_type_var() {
+                let bound_ty_var = field.ty.as_type_var().unwrap();
+                match bound_ty_var {
+                    DeBruijnVar::Bound(_, id) | DeBruijnVar::Free(id) => ty_var_map.get(id)?,
+                }
+            } else {
+                &field.ty
+            };
+
+            match self.get_layout_of(ty) {
+                Some(Either::Left(l)) => {
+                    // Simply exchange the field_offsets and variants.
+                    let new_layout = Layout {
+                        variant_layouts: [VariantLayout {
+                            field_offsets: [0].into(),
+                            uninhabited: false,
+                            tag: None,
+                        }]
+                        .into(),
+                        ..l.clone()
+                    };
+                    let layout_ref = Box::leak(Box::new(new_layout));
+                    Some(Either::Left(layout_ref))
+                }
+                r => r,
+            }
+        } else {
+            for field in fields {
+                let ty = if field.ty.is_type_var() {
+                    let bound_ty_var = field.ty.as_type_var().unwrap();
+                    match bound_ty_var {
+                        DeBruijnVar::Bound(_, id) => ty_var_map.get(id)?,
+                        DeBruijnVar::Free(_) => unreachable!(),
+                    }
+                } else {
+                    &field.ty
+                };
+
+                uninhabited_part |= ty.is_possibly_uninhabited();
+                match self.get_layout_of(ty) {
+                    Some(Either::Left(l)) => {
+                        if let Some(size) = l.size {
+                            total_min_size += size;
+                        }
+                        if let Some(align) = l.align {
+                            max_align = max(max_align, align);
+                        }
+                    }
+                    Some(Either::Right(h)) => {
+                        total_min_size += h.min_size;
+                        max_align = max(max_align, h.min_alignment);
+                    }
+                    None => (),
+                }
+            }
+            Some(Either::Right(LayoutHint {
+                min_size: total_min_size,
+                min_alignment: max_align,
+                possibly_uninhabited: uninhabited_part,
+            }))
+        }
+    }
+
+    /// Tries to compute a layout hint for otherwise generic ADTs with the given type arguments.
+    ///
+    /// Most of time, we can't compute a full layout due to potential reordering and padding bytes.
+    fn get_layout_hint_for_generic_adt(
+        &mut self,
+        type_decl_ref: &TypeDeclRef,
+    ) -> Option<Either<&'a Layout, LayoutHint>> {
+        let generics = &*type_decl_ref.generics;
+        let type_decl_id = type_decl_ref.id.as_adt()?;
+        let type_decl = self.krate.type_decls.get(*type_decl_id)?;
+
+        // If we certainly can't instantiate all relevant type parameters, fail.
+        if generics.types.elem_count() != type_decl.generics.types.elem_count()
+            || generics.types.iter().find(|ty| ty.is_type_var()).is_some()
+        {
+            return None;
+        }
+
+        // Map the generic type parameter variables to the given instantiations.
+        let ty_var_map: HashMap<TypeVarId, Ty> = type_decl
+            .generics
+            .types
+            .iter()
+            .map(|ty_var| ty_var.index)
+            .zip(generics.types.iter().cloned())
+            .collect();
+
+        match &type_decl.kind {
+            TypeDeclKind::Struct(fields) => {
+                self.compute_layout_from_fields(fields, &ty_var_map)
+            }
+            TypeDeclKind::Enum(variants) => {
+                // Assume that there could be a niche and ignore the discriminant for the hint.
+                let variant_layouts: Vec<Option<Either<&'a Layout, LayoutHint>>> = variants.iter().map(|variant| self.compute_layout_from_fields(&variant.fields, &ty_var_map)).collect();
+                // If all variants have at least a layout hint, combine them.
+                if variant_layouts.iter().all(|l| l.is_some()) {
+                    let mut max_variant_size = 0;
+                    let mut max_variant_align = 1;
+                    let mut all_variants_inhabited = variants.elem_count() == 0;
+                    for variant_layout in variant_layouts {
+                        match variant_layout {
+                            Some(Either::Left(l)) => {
+                                all_variants_inhabited &= !l.uninhabited;
+                                if let Some(size) = l.size {
+                                    max_variant_size = max(max_variant_size,size);
+                                }
+                                if let Some(align) = l.align {
+                                    max_variant_align = max(max_variant_align, align);
+                                }
+                            }
+                            Some(Either::Right(h)) => {
+                                max_variant_size = max(max_variant_size,h.min_size);
+                                max_variant_align = max(max_variant_align, h.min_alignment);
+                                all_variants_inhabited &= !h.possibly_uninhabited;
+                            }
+                            None => (),
+                        };
+                    }
+                    Some(Either::Right(LayoutHint {
+                        min_size: max_variant_size,
+                        min_alignment: max_variant_align,
+                        // Enums are only considered uninhabited if they have no variants or all are uninhabited.
+                        possibly_uninhabited: all_variants_inhabited,
+                    }))
+                } else {
+                    None
+                }
+            },
+            TypeDeclKind::Union(_) // No idea about unions
+            | TypeDeclKind::Opaque // TODO: maybe hardcode layouts for some opaque types from std?
+            | TypeDeclKind::Alias(_)
+            | TypeDeclKind::Error(_) => None,
+        }
+    }
+
+    /// Computes or looks up layout of given type if possible or tries to produce a layout hint instead.
+    ///
+    /// If the layout was not already available, it will be computed and leaked to guarantee
+    /// that it stays available.
+    pub fn get_layout_of<'c, 't>(
+        &'c mut self,
+        ty: &'t Ty,
+    ) -> Option<Either<&'a Layout, LayoutHint>> {
+        // Check memoization.
+        if let Some(layout) = self.memoized_layouts.get(ty) {
+            return Some(*layout);
+        }
+
+        let res: Option<Either<&'a Layout, LayoutHint>> = match ty {
+            TyKind::Adt(type_decl_ref) => {
+                match type_decl_ref.id {
+                    TypeId::Adt(type_decl_id) => self
+                        .krate
+                        .type_decls
+                        .get(type_decl_id)
+                        .unwrap()
+                        .layout
+                        .as_ref()
+                        .map(|l| Either::Left(l))
+                        .or_else(|| self.get_layout_hint_for_generic_adt(type_decl_ref)),
+                    // Without recreating the layout computation mechanism from rustc, we cannot know the layout of a tuple, other than for the unit type.
+                    TypeId::Tuple => {
+                        if ty.is_unit() {
+                            let new_layout = Layout::mk_1zst_layout();
+                            let layout_ref = Box::leak(Box::new(new_layout));
+                            Some(Either::Left(layout_ref))
+                        } else {
+                            self.get_layout_of_tuple(type_decl_ref)
+                        }
+                    }
+                    TypeId::Builtin(builtin_ty) => {
+                        match builtin_ty {
+                            BuiltinTy::Box => {
+                                // Box has only two type parameters: the first is the boxed type, the second is the allocator.
+                                let boxed_ty = type_decl_ref
+                                    .generics
+                                    .types
+                                    .get(TypeVarId::from_usize(0))
+                                    .unwrap();
+                                Some(match boxed_ty.needs_metadata(&self.krate.type_decls) {
+                                    Some(true) => {
+                                        let new_layout = Layout::mk_ptr_layout_with_metadata(
+                                            self.krate.target_information.target_pointer_size,
+                                        );
+                                        let layout_ref = Box::leak(Box::new(new_layout));
+                                        Either::Left(layout_ref)
+                                    }
+                                    Some(false) => {
+                                        let new_layout = Layout::mk_ptr_layout_wo_metadata(
+                                            self.krate.target_information.target_pointer_size,
+                                        );
+                                        let layout_ref = Box::leak(Box::new(new_layout));
+                                        Either::Left(layout_ref)
+                                    }
+                                    None => Either::Right(LayoutHint {
+                                        min_size: self.krate.target_information.target_pointer_size,
+                                        min_alignment: self
+                                            .krate
+                                            .target_information
+                                            .target_pointer_size,
+                                        possibly_uninhabited: false,
+                                    }),
+                                })
+                            }
+                            // Slices are non-sized and can be handled as such.
+                            BuiltinTy::Slice | BuiltinTy::Str => {
+                                let new_layout = Layout::mk_unsized_layout();
+                                let layout_ref = Box::leak(Box::new(new_layout));
+                                Some(Either::Left(layout_ref))
+                            }
+                            BuiltinTy::Array => None,
+                        }
+                    }
+                }
+            }
+            TyKind::Literal(literal_ty) => {
+                let size =
+                    literal_ty.target_size(self.krate.target_information.target_pointer_size);
+                let new_layout = Layout::mk_simple_layout(size as u64);
+                let layout_ref = Box::leak(Box::new(new_layout));
+                Some(Either::Left(layout_ref))
+            }
+            TyKind::Ref(_, ty, _) | TyKind::RawPtr(ty, _) => {
+                Some(match ty.needs_metadata(&self.krate.type_decls) {
+                    Some(true) => {
+                        let new_layout = Layout::mk_ptr_layout_with_metadata(
+                            self.krate.target_information.target_pointer_size,
+                        );
+                        let layout_ref = Box::leak(Box::new(new_layout));
+                        Either::Left(layout_ref)
+                    }
+                    Some(false) => {
+                        let new_layout = Layout::mk_ptr_layout_wo_metadata(
+                            self.krate.target_information.target_pointer_size,
+                        );
+                        let layout_ref = Box::leak(Box::new(new_layout));
+                        Either::Left(layout_ref)
+                    }
+                    None => Either::Right(LayoutHint {
+                        min_size: self.krate.target_information.target_pointer_size,
+                        min_alignment: self.krate.target_information.target_pointer_size,
+                        possibly_uninhabited: false,
+                    }),
+                })
+            }
+            TyKind::DynTrait(_) => {
+                let new_layout = Layout::mk_unsized_layout();
+                let layout_ref = Box::leak(Box::new(new_layout));
+                Some(Either::Left(layout_ref))
+            }
+            // We cannot get a layout for TypeVar, TraitType, Never, DynTrait, Error, FnPtr (probably?), and FnDef (probably?)
+            _ => None,
+        };
+
+        // Update memoization.
+        if let Some(layout) = res {
+            self.memoized_layouts.insert(ty.clone(), layout);
+        }
+
+        res
+    }
+
+    /// Checks whether the type is known to be a ZST.
+    /// Computes the layout first if necessary.
+    pub fn is_known_zst(&mut self, ty: &Ty) -> bool {
+        match self.get_layout_of(ty) {
+            Some(Either::Left(l)) => {
+                if let Some(size) = l.size {
+                    size == 0
+                } else {
+                    false
+                }
+            }
+            // Since the hint could have min_size == 0 but not be a ZST, we also return false for it.
+            _ => false,
+        }
+    }
+
+    /// Checks whether the type is known to be uninhabited.
+    /// Computes the layout first if necessary.
+    pub fn is_known_uninhabited(&mut self, ty: &Ty) -> bool {
+        if ty.is_never() {
+            true
+        } else {
+            match self.get_layout_of(ty) {
+                Some(Either::Left(l)) => l.uninhabited,
+                // Since the hint can only tell whether a type is guarantee to be inhabited,
+                // we can never be sure that it is uninhabited.
+                Some(Either::Right(_)) => false,
+                None => false,
+            }
+        }
+    }
+
+    /// Checks whether the type is known to be inhabited.
+    /// Computes the layout first if necessary.
+    pub fn is_known_inhabited(&mut self, ty: &Ty) -> bool {
+        if ty.is_never() {
+            false
+        } else {
+            match self.get_layout_of(ty) {
+                Some(Either::Left(l)) => !l.uninhabited,
+                Some(Either::Right(h)) => !h.possibly_uninhabited,
+                None => false,
+            }
+        }
+    }
+}

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -4,6 +4,7 @@ pub mod expressions_utils;
 pub mod gast;
 pub mod gast_utils;
 pub mod krate;
+pub mod layout_computer;
 pub mod llbc_ast;
 pub mod llbc_ast_utils;
 pub mod meta;

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1103,6 +1103,7 @@ pub trait TyVisitable: Sized + AstVisitable {
         });
     }
 
+    /// Substitutes all bound variables with the corresponding arguments.
     fn substitute(self, generics: &GenericArgs) -> Self {
         self.substitute_with_self(generics, &TraitRefKind::SelfId)
     }
@@ -1112,6 +1113,7 @@ pub trait TyVisitable: Sized + AstVisitable {
         self
     }
 
+    /// Same as [`TyVisitable::substitute`], but also substitutes free variables.
     fn substitute_frees(self, generics: &GenericArgs) -> Self {
         self.substitute_with_self_frees(generics, &TraitRefKind::SelfId)
     }

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -345,6 +345,7 @@ impl ItemTransCtx<'_, '_> {
         };
         let layout = self.translate_layout(def.this());
         let ptr_metadata = self.translate_ptr_metadata(def.this());
+        let repr = self.translate_repr_options(def.this());
         let type_def = TypeDecl {
             def_id: trans_id,
             item_meta,
@@ -353,6 +354,7 @@ impl ItemTransCtx<'_, '_> {
             src,
             layout,
             ptr_metadata,
+            repr,
         };
 
         Ok(type_def)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -431,6 +431,7 @@ impl ItemTransCtx<'_, '_> {
             kind,
             layout: Some(layout),
             ptr_metadata: None,
+            repr: None,
         })
     }
 }

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -748,4 +748,21 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let int_ty = ty.kind().as_literal().unwrap().to_integer_ty().unwrap();
         Ok(ScalarValue::from_bits(int_ty, discr.val))
     }
+
+    pub fn translate_repr_options(&mut self, item: &hax::ItemRef) -> Option<ReprOptions> {
+        let rdefid = item.def_id.as_rust_def_id().unwrap();
+        if let Some(local_rdefid) = rdefid.as_local() {
+            let tcx = self.t_ctx.tcx;
+            let r_repr = tcx.repr_options_of_def(local_rdefid);
+            Some(ReprOptions {
+                align: r_repr.align.map(|a| a.bytes()),
+                pack: r_repr.pack.map(|a| a.bytes()),
+                c: r_repr.c(),
+                transparent: r_repr.transparent(),
+                explicit_discr_type: r_repr.int.is_some(),
+            })
+        } else {
+            None
+        }
+    }
 }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -588,5 +588,42 @@
       }
     ]
   },
-  "test_crate::NestedPointers": null
+  "test_crate::NestedPointers": null,
+  "test_crate::GenericC": null,
+  "test_crate::Instance": {
+    "size": 8,
+    "align": 4,
+    "discriminant_layout": null,
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0,
+          1,
+          4
+        ],
+        "uninhabited": false,
+        "tag": null
+      }
+    ]
+  },
+  "test_crate::InstanceGen": {
+    "size": 32,
+    "align": 8,
+    "discriminant_layout": null,
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0,
+          8,
+          16
+        ],
+        "uninhabited": false,
+        "tag": null
+      }
+    ]
+  },
+  "test_crate::InstanceGen2": null,
+  "test_crate::InstanceGen3": null
 }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -587,5 +587,6 @@
         }
       }
     ]
-  }
+  },
+  "test_crate::NestedPointers": null
 }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -591,13 +591,14 @@
   "test_crate::NestedPointers": null,
   "test_crate::GenericC": null,
   "test_crate::HasArray": {
-    "size": 32,
-    "align": 4,
+    "size": 40,
+    "align": 8,
     "discriminant_layout": null,
     "uninhabited": false,
     "variant_layouts": [
       {
         "field_offsets": [
+          8,
           0
         ],
         "uninhabited": false,
@@ -605,6 +606,7 @@
       }
     ]
   },
+  "test_crate::HasBoxWAlloc": null,
   "test_crate::Instance": {
     "size": 8,
     "align": 4,

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -590,6 +590,21 @@
   },
   "test_crate::NestedPointers": null,
   "test_crate::GenericC": null,
+  "test_crate::HasArray": {
+    "size": 32,
+    "align": 4,
+    "discriminant_layout": null,
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0
+        ],
+        "uninhabited": false,
+        "tag": null
+      }
+    ]
+  },
   "test_crate::Instance": {
     "size": 8,
     "align": 4,

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -16,8 +16,11 @@ fn type_layout() -> anyhow::Result<()> {
     let crate_data = translate_rust_text(
         r#"
         #![feature(never_type)]
+        #![feature(allocator_api)]
         use std::num::NonZero;
+        use std::ptr::NonNull;
         use std::fmt::Debug;
+        use std::alloc::Allocator;
 
         struct SimpleStruct {
             x: u32,
@@ -158,7 +161,12 @@ fn type_layout() -> anyhow::Result<()> {
         }
 
         struct HasArray {
-            a: [u32; 8]
+            a: [u32; 8],
+            b: NonNull<u8>,
+        }
+
+        struct HasBoxWAlloc<A: Allocator> {
+            b: Box<HasArray, A>
         }
 
         type Instance = GenericC<bool,u32>;
@@ -166,7 +174,7 @@ fn type_layout() -> anyhow::Result<()> {
         type InstanceGen2<'a,T: Sized> = GenericC<&'a T,T>;
         type InstanceGen3<'a,T: ?Sized> = GenericC<&'a T,i32>;
         "#,
-        &[],
+        &["--include=core::ptr::non_null::*"],
     )?;
 
     // Check whether niche discriminant computations are correct, i.e. reversible.

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use either::Either;
 use indexmap::IndexMap;
 
 use charon_lib::{
@@ -158,6 +157,10 @@ fn type_layout() -> anyhow::Result<()> {
             b: B
         }
 
+        struct HasArray {
+            a: [u32; 8]
+        }
+
         type Instance = GenericC<bool,u32>;
         type InstanceGen<'a,T> = GenericC<&'a T,&'static str>;
         type InstanceGen2<'a,T: Sized> = GenericC<&'a T,T>;
@@ -223,12 +226,9 @@ fn type_layout() -> anyhow::Result<()> {
                     let id = arg.ty.to_string_with_ctx(&ctx);
                     let _ = layouts_hints.insert(id, layout);
                 }
-            } else if tdecl.kind.is_alias()
-                && let Some(ref layout) = tdecl.layout
-            {
+            } else if tdecl.kind.is_alias() {
                 let aliased_ty = tdecl.kind.as_alias().unwrap();
                 let aliased_layout = layout_computer.get_layout_of(aliased_ty, generic_ctx);
-                assert_eq!(Some(Either::Left(layout)), aliased_layout);
                 let id = aliased_ty.to_string_with_ctx(&ctx);
                 let _ = layouts_hints.insert(id, aliased_layout);
             }

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -1,10 +1,10 @@
-#![feature(box_patterns)]
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
 
 use charon_lib::{
     ast::{layout_computer::LayoutComputer, *},
+    formatter::AstFormatter,
     pretty::{self, FmtWithCtx},
 };
 
@@ -144,6 +144,11 @@ fn type_layout() -> anyhow::Result<()> {
             First = 42,
             Second = 18446744073709551615,
         }
+
+        struct NestedPointers<N> {
+            x: (Box<N>, Box<N>),
+            n: N
+        }
         "#,
         &[],
     )?;
@@ -186,12 +191,28 @@ fn type_layout() -> anyhow::Result<()> {
     let mut ctx = pretty::formatter::FmtCtx::new();
     ctx.translated = Some(&crate_data);
     {
-        let mut visitor = DynVisitor::new_shared(|ty: &Ty| {
-            let layout = layout_computer.get_layout_of(ty);
+        // Visit all types without context.
+        let mut ty_visitor = DynVisitor::new_shared(|ty: &Ty| {
+            let layout = layout_computer.get_layout_of(ty, None);
             let id = ty.to_string_with_ctx(&ctx);
-            layouts_hints.insert(id, layout);
+            let _ = layouts_hints.insert(id, layout);
         });
-        let _ = crate_data.drive(&mut visitor);
+        let _ = crate_data.drive(&mut ty_visitor);
+    }
+    {
+        // Visit all type declarations with the corresponding context.
+        let mut tdecl_visitor = DynVisitor::new_shared(|tdecl: &TypeDecl| {
+            let generic_ctx = Some(&tdecl.generics);
+            let ctx = ctx.set_generics(&tdecl.generics);
+            if tdecl.kind.is_struct() {
+                for arg in tdecl.kind.as_struct().unwrap() {
+                    let layout = layout_computer.get_layout_of(&arg.ty, generic_ctx);
+                    let id = arg.ty.to_string_with_ctx(&ctx);
+                    let _ = layouts_hints.insert(id, layout);
+                }
+            }
+        });
+        let _ = crate_data.drive(&mut tdecl_visitor);
     }
     let layouts_hints_str = serde_json::to_string_pretty(&layouts_hints)?;
 
@@ -219,5 +240,93 @@ fn type_layout() -> anyhow::Result<()> {
         layouts_hints_str,
         &PathBuf::from("./tests/layouts_and_hints.json"),
     )?;
+    Ok(())
+}
+
+#[test]
+// Tests that the generic context of a declaration is correctly used to determine that pointers
+// need no metadata for type variables that are (implicitly) `Sized`.
+fn metadata() -> anyhow::Result<()> {
+    let crate_data = translate_rust_text(
+        r#"
+        struct HasSizedParams<'a, T,S> {
+            x: u32,
+            y: Box<T>,
+            z: &'a S
+        }
+
+        fn has_sized_params<'a,T: Sized,S>(_x: u32, y: Box<T>, _z: &'a S) -> &T {&*Box::leak(y)}
+        "#,
+        &[],
+    )?;
+
+    let mut layout_computer = LayoutComputer::new(&crate_data);
+    {
+        let mut tdecl_visitor = DynVisitor::new_shared(|tdecl: &TypeDecl| {
+            let generic_ctx = Some(&tdecl.generics);
+            if tdecl.kind.is_struct() {
+                for arg in tdecl.kind.as_struct().unwrap() {
+                    if arg.ty.is_box() {
+                        let tvar = arg
+                            .ty
+                            .as_adt()
+                            .unwrap()
+                            .generics
+                            .types
+                            .get(TypeVarId::ZERO)
+                            .unwrap();
+                        assert!(tvar.is_type_var());
+                        assert_eq!(tvar.needs_metadata(&crate_data, generic_ctx), Some(false));
+                        let arg_layout = layout_computer.get_layout_of(&arg.ty, generic_ctx);
+                        assert!(arg_layout.is_some_and(|e| e.is_left()));
+                    } else if arg.ty.is_ref() {
+                        let tvar = arg.ty.as_ref().unwrap().1;
+                        assert!(tvar.is_type_var());
+                        assert_eq!(tvar.needs_metadata(&crate_data, generic_ctx), Some(false));
+                        let arg_layout = layout_computer.get_layout_of(&arg.ty, generic_ctx);
+                        assert!(arg_layout.is_some_and(|e| e.is_left()));
+                    }
+                    assert_eq!(arg.ty.needs_metadata(&crate_data, generic_ctx), Some(false));
+                }
+            }
+        });
+        let _ = crate_data.drive(&mut tdecl_visitor);
+    }
+
+    let mut fun_sig_visitor = DynVisitor::new_shared(|fun_decl: &FunDecl| {
+        if fun_decl.item_meta.name.name[0].as_ident().unwrap().0 == "test_crate" {
+            let fun_sig = &fun_decl.signature;
+            let generic_ctx = Some(&fun_sig.generics);
+            for arg in &fun_sig.inputs {
+                if arg.is_box() {
+                    let tvar = arg
+                        .as_adt()
+                        .unwrap()
+                        .generics
+                        .types
+                        .get(TypeVarId::ZERO)
+                        .unwrap();
+                    assert!(tvar.is_type_var());
+                    assert_eq!(tvar.needs_metadata(&crate_data, generic_ctx), Some(false));
+                    let arg_layout = layout_computer.get_layout_of(arg, generic_ctx);
+                    assert!(arg_layout.is_some_and(|e| e.is_left()));
+                } else if arg.is_ref() {
+                    let tvar = arg.as_ref().unwrap().1;
+                    assert!(tvar.is_type_var());
+                    assert_eq!(tvar.needs_metadata(&crate_data, generic_ctx), Some(false));
+                    let arg_layout = layout_computer.get_layout_of(arg, generic_ctx);
+                    assert!(arg_layout.is_some_and(|e| e.is_left()));
+                }
+                assert_eq!(arg.needs_metadata(&crate_data, generic_ctx), Some(false));
+            }
+            let tvar = fun_sig.output.as_ref().unwrap().1;
+            assert!(tvar.is_type_var());
+            assert_eq!(tvar.needs_metadata(&crate_data, generic_ctx), Some(false));
+            let ret_layout = layout_computer.get_layout_of(&fun_sig.output, generic_ctx);
+            assert!(ret_layout.is_some_and(|e| e.is_left()));
+        }
+    });
+    let _ = crate_data.drive(&mut fun_sig_visitor);
+
     Ok(())
 }

--- a/charon/tests/layouts_and_hints.json
+++ b/charon/tests/layouts_and_hints.json
@@ -219,6 +219,141 @@
       "possibly_uninhabited": false
     }
   },
+  "@Type1": null,
+  "GenericC<bool, u32>[Sized<bool>, Sized<u32>]": {
+    "Left": {
+      "size": 8,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            1,
+            4
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "bool": {
+    "Left": {
+      "size": 1,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "GenericC<&'_0 (@Type0), &'static (Str)>[Sized<&'_ (missing(@Type0))>, Sized<&'_ (Str)>]": {
+    "Right": {
+      "min_size": 25,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "&'static (Str)": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Str": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (@Type0)": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "&'_ (Str)": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "GenericC<&'_0 (@Type0), @Type0>[Sized<&'_ (missing(@Type0))>, @TraitClause0]": {
+    "Right": {
+      "min_size": 9,
+      "min_alignment": 8,
+      "possibly_uninhabited": true
+    }
+  },
+  "GenericC<&'_0 (@Type0), i32>[Sized<&'_ (missing(@Type0))>, Sized<i32>]": {
+    "Right": {
+      "min_size": 13,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "i32": {
+    "Left": {
+      "size": 4,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
   "fn(*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": null,
   "*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
     "Left": {
@@ -348,7 +483,6 @@
       ]
     }
   },
-  "@Type1": null,
   "&'_1 (GenericButFixedSize<'_0, @Type0>[@TraitClause0])": {
     "Left": {
       "size": 8,
@@ -527,41 +661,6 @@
       ]
     }
   },
-  "&'_ (Str)": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
-    }
-  },
-  "Str": {
-    "Left": {
-      "size": null,
-      "align": null,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
-    }
-  },
   "&'_ (&'_ (@Type0))": {
     "Left": {
       "size": 8,
@@ -577,13 +676,6 @@
           "tag": null
         }
       ]
-    }
-  },
-  "&'_ (@Type0)": {
-    "Right": {
-      "min_size": 8,
-      "min_alignment": 8,
-      "possibly_uninhabited": false
     }
   },
   "&'_ ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": {
@@ -940,5 +1032,26 @@
     }
   },
   "N": null,
+  "A": null,
+  "B": null,
+  "GenericC<&'a (T), &'static (Str)>[Sized<&'_ (T)>, Sized<&'_ (Str)>]": {
+    "Left": {
+      "size": 32,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8,
+            16
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
   "fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null
 }

--- a/charon/tests/layouts_and_hints.json
+++ b/charon/tests/layouts_and_hints.json
@@ -212,6 +212,13 @@
       ]
     }
   },
+  "(alloc::boxed::Box<@Type0, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}], alloc::boxed::Box<@Type0, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}])": {
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
   "fn(*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": null,
   "*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
     "Left": {
@@ -895,5 +902,43 @@
       ]
     }
   },
-  "Self::NonZeroInner": null
+  "Self::NonZeroInner": null,
+  "T": null,
+  "alloc::boxed::Box<T, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}]": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "(alloc::boxed::Box<N, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}], alloc::boxed::Box<N, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}])": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "N": null,
+  "fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null
 }

--- a/charon/tests/layouts_and_hints.json
+++ b/charon/tests/layouts_and_hints.json
@@ -60,9 +60,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -78,9 +76,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -144,21 +140,10 @@
     }
   },
   "(u32, u32)": {
-    "Left": {
-      "size": 8,
-      "align": 4,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            4
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 4,
+      "possibly_uninhabited": false
     }
   },
   "u64": {
@@ -220,23 +205,26 @@
     }
   },
   "@Type1": null,
-  "GenericC<bool, u32>[Sized<bool>, Sized<u32>]": {
+  "Array<u32, 8 : usize>": {
     "Left": {
-      "size": 8,
+      "size": 32,
       "align": 4,
       "discriminant_layout": null,
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0,
-            1,
-            4
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
       ]
+    }
+  },
+  "GenericC<bool, u32>[Sized<bool>, Sized<u32>]": {
+    "Right": {
+      "min_size": 6,
+      "min_alignment": 4,
+      "possibly_uninhabited": false
     }
   },
   "bool": {
@@ -264,21 +252,10 @@
     }
   },
   "&'static (Str)": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "Str": {
@@ -289,9 +266,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -306,21 +281,10 @@
     }
   },
   "&'_ (Str)": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "GenericC<&'_0 (@Type0), @Type0>[Sized<&'_ (missing(@Type0))>, @TraitClause0]": {
@@ -356,21 +320,10 @@
   },
   "fn(*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": null,
   "*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "(dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
@@ -381,9 +334,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -409,21 +360,10 @@
   },
   "fn<'_0, '_1, '_2>(&'_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null,
   "&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "&'_0_1 mut (Formatter<'_0_2>)": {
@@ -679,21 +619,10 @@
     }
   },
   "&'_ ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "&'_ (&'_ (&'_ (@Type0)))": {
@@ -784,39 +713,17 @@
     }
   },
   "&'_2 (Str)": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "&'_3 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : missing('_3)))": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "(dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : missing('_3))": {
@@ -827,9 +734,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -854,7 +759,13 @@
       ]
     }
   },
-  "Result<NonNull<Slice<u8>>, AllocError>[Sized<NonNull<Slice<u8>>>, Sized<AllocError>]": null,
+  "Result<NonNull<Slice<u8>>, AllocError>[Sized<NonNull<Slice<u8>>>, Sized<AllocError>]": {
+    "Right": {
+      "min_size": 0,
+      "min_alignment": 1,
+      "possibly_uninhabited": false
+    }
+  },
   "NonNull<Slice<u8>>": null,
   "Slice<u8>": {
     "Left": {
@@ -864,9 +775,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -1014,43 +923,34 @@
     }
   },
   "(alloc::boxed::Box<N, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}], alloc::boxed::Box<N, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}])": {
-    "Left": {
-      "size": 16,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "N": null,
   "A": null,
   "B": null,
   "GenericC<&'a (T), &'static (Str)>[Sized<&'_ (T)>, Sized<&'_ (Str)>]": {
-    "Left": {
-      "size": 32,
-      "align": 8,
-      "discriminant_layout": null,
-      "uninhabited": false,
-      "variant_layouts": [
-        {
-          "field_offsets": [
-            0,
-            8,
-            16
-          ],
-          "uninhabited": false,
-          "tag": null
-        }
-      ]
+    "Right": {
+      "min_size": 25,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "GenericC<&'a (T), T>[Sized<&'_ (T)>, @TraitClause0]": {
+    "Right": {
+      "min_size": 9,
+      "min_alignment": 8,
+      "possibly_uninhabited": true
+    }
+  },
+  "GenericC<&'a (T), i32>[Sized<&'_ (T)>, Sized<i32>]": {
+    "Right": {
+      "min_size": 13,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
     }
   },
   "fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null

--- a/charon/tests/layouts_and_hints.json
+++ b/charon/tests/layouts_and_hints.json
@@ -1,0 +1,899 @@
+{
+  "Formatter<'_0_0>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "u32": {
+    "Left": {
+      "size": 4,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "@Type0": null,
+  "usize": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Slice<usize>": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "NonZero<u32>[Sized<u32>, {impl ZeroablePrimitive for u32}]": null,
+  "(dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : 'static)": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "@Type1_0": null,
+  "@Type0_0": null,
+  "alloc::boxed::Box<@Type0, Global>[@TraitClause0::parent_clause0, Sized<Global>, {impl Allocator for Global}]": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "Global": {
+    "Left": {
+      "size": 0,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "u8": {
+    "Left": {
+      "size": 1,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "!": null,
+  "(usize, &'_0 (@Type0))": {
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "&'_0 (@Type0)": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "(u32, u32)": {
+    "Left": {
+      "size": 8,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            4
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "u64": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "char": {
+    "Left": {
+      "size": 4,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "String": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "fn(*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": null,
+  "*mut (dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "(dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "()": {
+    "Left": {
+      "size": 0,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "fn<'_0, '_1, '_2>(&'_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null,
+  "&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_0_1 mut (Formatter<'_0_2>)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Formatter<'_0_2>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Result<(), Error>[Sized<()>, Sized<Error>]": {
+    "Right": {
+      "min_size": 0,
+      "min_alignment": 1,
+      "possibly_uninhabited": false
+    }
+  },
+  "Error": {
+    "Left": {
+      "size": 0,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "@Type1": null,
+  "&'_1 (GenericButFixedSize<'_0, @Type0>[@TraitClause0])": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "GenericButFixedSize<'_0, @Type0>[@TraitClause0]": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": {
+        "offset": 0,
+        "tag_ty": {
+          "Signed": "Isize"
+        },
+        "encoding": {
+          "Niche": {
+            "untagged_variant": 1
+          }
+        }
+      },
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [],
+          "uninhabited": false,
+          "tag": {
+            "Signed": [
+              "Isize",
+              "0"
+            ]
+          }
+        },
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_2 mut (Formatter<'_3>)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Formatter<'_3>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (GenericButFixedSize<'_, @Type0>[@TraitClause0])": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "GenericButFixedSize<'_, @Type0>[@TraitClause0]": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": {
+        "offset": 0,
+        "tag_ty": {
+          "Signed": "Isize"
+        },
+        "encoding": {
+          "Niche": {
+            "untagged_variant": 1
+          }
+        }
+      },
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [],
+          "uninhabited": false,
+          "tag": {
+            "Signed": [
+              "Isize",
+              "0"
+            ]
+          }
+        },
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ mut (Formatter<'_>)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Formatter<'_>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (Str)": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Str": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (&'_ (@Type0))": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (@Type0)": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
+  "&'_ ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_))": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_ (&'_ (&'_ (@Type0)))": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_1 mut (Formatter<'_2>)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Formatter<'_2>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_1 mut (Formatter<'_0>)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Formatter<'_0>": {
+    "Left": {
+      "size": 24,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            16,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_2 (Str)": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_3 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : missing('_3)))": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "(dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : missing('_3))": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Layout": {
+    "Left": {
+      "size": 16,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            8,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Result<NonNull<Slice<u8>>, AllocError>[Sized<NonNull<Slice<u8>>>, Sized<AllocError>]": null,
+  "NonNull<Slice<u8>>": null,
+  "Slice<u8>": {
+    "Left": {
+      "size": null,
+      "align": null,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "AllocError": {
+    "Left": {
+      "size": 0,
+      "align": 1,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "NonNull<u8>": null,
+  "&'_0 (NonZeroU32Inner)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "NonZeroU32Inner": {
+    "Left": {
+      "size": 4,
+      "align": 4,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_0 (u32)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_1 (&'_0 (@Type0))": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "core::fmt::Debug::{vtable}": {
+    "Left": {
+      "size": 32,
+      "align": 32,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0,
+            8,
+            16,
+            24
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "&'_0 (Global)": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "Self::NonZeroInner": null
+}

--- a/charon/tests/layouts_and_hints.json
+++ b/charon/tests/layouts_and_hints.json
@@ -25,9 +25,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -43,9 +41,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -115,9 +111,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -154,9 +148,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -171,9 +163,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -220,6 +210,48 @@
       ]
     }
   },
+  "NonNull<u8>": {
+    "Left": {
+      "size": 8,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
+  "alloc::boxed::Box<HasArray, @Type0>[MetaSized<HasArray>, @TraitClause0, @TraitClause1]": {
+    "Right": {
+      "min_size": 40,
+      "min_alignment": 8,
+      "possibly_uninhabited": true
+    }
+  },
+  "HasArray": {
+    "Left": {
+      "size": 40,
+      "align": 8,
+      "discriminant_layout": null,
+      "uninhabited": false,
+      "variant_layouts": [
+        {
+          "field_offsets": [
+            8,
+            0
+          ],
+          "uninhabited": false,
+          "tag": null
+        }
+      ]
+    }
+  },
   "GenericC<bool, u32>[Sized<bool>, Sized<u32>]": {
     "Right": {
       "min_size": 6,
@@ -235,9 +267,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -309,9 +339,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -349,9 +377,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -374,9 +400,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -423,6 +447,13 @@
       ]
     }
   },
+  "*const @Type0": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
   "&'_1 (GenericButFixedSize<'_0, @Type0>[@TraitClause0])": {
     "Left": {
       "size": 8,
@@ -431,9 +462,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -485,9 +514,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -520,9 +547,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -574,9 +599,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -609,9 +632,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -633,9 +654,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -650,9 +669,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -685,9 +702,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -761,12 +776,18 @@
   },
   "Result<NonNull<Slice<u8>>, AllocError>[Sized<NonNull<Slice<u8>>>, Sized<AllocError>]": {
     "Right": {
-      "min_size": 0,
-      "min_alignment": 1,
+      "min_size": 16,
+      "min_alignment": 8,
       "possibly_uninhabited": false
     }
   },
-  "NonNull<Slice<u8>>": null,
+  "NonNull<Slice<u8>>": {
+    "Right": {
+      "min_size": 16,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  },
   "Slice<u8>": {
     "Left": {
       "size": null,
@@ -797,7 +818,6 @@
       ]
     }
   },
-  "NonNull<u8>": null,
   "&'_0 (NonZeroU32Inner)": {
     "Left": {
       "size": 8,
@@ -806,9 +826,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -840,9 +858,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -857,9 +873,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -894,9 +908,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -913,9 +925,7 @@
       "uninhabited": false,
       "variant_layouts": [
         {
-          "field_offsets": [
-            0
-          ],
+          "field_offsets": [],
           "uninhabited": false,
           "tag": null
         }
@@ -932,6 +942,13 @@
   "N": null,
   "A": null,
   "B": null,
+  "alloc::boxed::Box<HasArray, A>[MetaSized<HasArray>, @TraitClause0, @TraitClause1]": {
+    "Right": {
+      "min_size": 40,
+      "min_alignment": 8,
+      "possibly_uninhabited": true
+    }
+  },
   "GenericC<&'a (T), &'static (Str)>[Sized<&'_ (T)>, Sized<&'_ (Str)>]": {
     "Right": {
       "min_size": 25,
@@ -953,5 +970,12 @@
       "possibly_uninhabited": false
     }
   },
-  "fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null
+  "fn<'_0, '_1, '_2>(&'_0_0 ((dyn exists<_dyn> [@TraitClause0]: Debug<_dyn> + _dyn : '_)), &'_0_1 mut (Formatter<'_0_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]": null,
+  "*const T": {
+    "Right": {
+      "min_size": 8,
+      "min_alignment": 8,
+      "possibly_uninhabited": false
+    }
+  }
 }


### PR DESCRIPTION
### Description
To take another step to having full layout information for as many types as possible, this PR introduces a new `LayoutComputer` (name up for discussion), which can be used to compute memoized layouts (or partial layouts I call `LayoutHint`s) for all kinds of types.

### Goal
This is meant to cater to the need of tools like my own (now in the process of being rewritten in Rust and using `charon_lib`) which want to know layout information about many types, not just those with a type declaration.

### Status

The PR contains a lot of assumptions about when we can get which information and many of these should be discussed in greater detail. Right now it tries to supports the following cases:

*  ADTs with a known layout in the type decl
* ADTs without a known layout in the type decl by trying to instantiate its generic type parameters
* Tuples (precise if all elements are of the same size, otherwise only a hint)
* Builtins (Box as a pointer type, Slice and Str as unsized types)
* Literals
* References and raw pointers (precise if we know whether they need to be wide, otherwise only a hint)
* DynTrait as unsized

All other types are given no layout or hint. This is especially unfortunate for opaque ADTs from `std` for which we could do a lot (e.g. `Result<NonZero<u32>,()>` doesn't get a layout because `NonZero` is opaque). We could probably try to hardcode some layout schema for some of these types.