### PR TITLE
Pin annotate-snippets

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "annotate-snippets"
 version = "0.11.5"
-source = "git+https://github.com/rust-lang/annotate-snippets-rs#74964e91d845e39fb549c4028452beffa7c6562b"
+source = "git+https://github.com/rust-lang/annotate-snippets-rs?rev=74964e91d845e39fb549c4028452beffa7c6562b#74964e91d845e39fb549c4028452beffa7c6562b"
 dependencies = [
  "anstyle",
  "unicode-width",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -40,7 +40,7 @@ path = "tests/cargo.rs"
 harness = false
 
 [dependencies]
-annotate-snippets = { git = "https://github.com/rust-lang/annotate-snippets-rs", version = "0.11.5" }
+annotate-snippets = { git = "https://github.com/rust-lang/annotate-snippets-rs", rev = "74964e91d845e39fb549c4028452beffa7c6562b", version = "0.11.5" }
 anstream = "0.6.18"
 anyhow = "1.0.81"
 assert_cmd = "2.0"


### PR DESCRIPTION
Cargo does not take into account the `Cargo.lock` of dependencies (as expected, since it does version resolution). This requires git dependencies to specify the correct commit in `Cargo.toml`. This fixes https://github.com/AeneasVerif/charon/issues/806.