### PR TITLE
Translate `dyn Trait` method shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ nohup.out
 *#
 *.smt2
 .#*
+**/.DS_Store

--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.133"
+let supported_charon_version = "0.1.134"

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -79,6 +79,8 @@ and cast_kind_to_string (env : 'a fmt_env) (cast : cast_kind) : string =
       "cast<" ^ ty_to_string env src ^ "," ^ ty_to_string env tgt ^ ">"
   | CastUnsize (src, tgt, _) ->
       "unsize<" ^ ty_to_string env src ^ "," ^ ty_to_string env tgt ^ ">"
+  | CastConcretize (src, tgt) ->
+      "concretize<" ^ ty_to_string env src ^ "," ^ ty_to_string env tgt ^ ">"
 
 and nullop_to_string (env : 'a fmt_env) (op : nullop) : string =
   match op with

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -139,6 +139,20 @@ and cast_kind =
   | CastTransmute of ty * ty
       (** Reinterprets the bits of a value of one type as another type, i.e.
           exactly what [[std::mem::transmute]] does. *)
+  | CastConcretize of ty * ty
+      (** Converts a receiver type with [dyn Trait<...>] to a concrete type [T],
+          used in vtable method shims. Valid conversions are references, raw
+          pointers, and (optionally) boxes:
+          - [&[mut] dyn Trait<...>] -> [&[mut] T]
+          - [*[mut] dyn Trait<...>] -> [*[mut] T]
+          - [Box<dyn Trait<...>>] -> [Box<T>] when no [--raw-boxes]
+
+          For possible receivers, see:
+          https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility.
+          Other receivers, e.g., [Rc] should be unpacked before the cast and
+          re-boxed after. FIXME(ssyram): but this is not implemented yet,
+          namely, there may still be something like
+          [Rc<dyn Trait<...>> -> Rc<T>] in the types. *)
 
 and constant_expr = { kind : constant_expr_kind; ty : ty }
 

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -279,6 +279,10 @@ and cast_kind_of_json (ctx : of_json_ctx) (js : json) :
         let* x_0 = ty_of_json ctx x_0 in
         let* x_1 = ty_of_json ctx x_1 in
         Ok (CastTransmute (x_0, x_1))
+    | `Assoc [ ("Concretize", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = ty_of_json ctx x_1 in
+        Ok (CastConcretize (x_0, x_1))
     | _ -> Error "")
 
 and cli_options_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1102,6 +1102,7 @@ and item_source_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("VTableInstance", `Assoc [ ("impl_ref", impl_ref) ]) ] ->
         let* impl_ref = trait_impl_ref_of_json ctx impl_ref in
         Ok (VTableInstanceItem impl_ref)
+    | `String "VTableMethodShim" -> Ok VTableMethodShimItem
     | _ -> Error "")
 
 and layout_of_json (ctx : of_json_ctx) (js : json) : (layout, string) result =

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -769,6 +769,10 @@ and item_source =
 
           Fields:
           - [impl_ref] *)
+  | VTableMethodShimItem
+      (** The method shim wraps a concrete implementation of a method into a
+          function that takes [dyn Trait] as its [Self] type. This shim casts
+          the receiver to the known concrete type and calls the real method. *)
 
 (** Simplified type layout information.
 

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.133"
+version = "0.1.134"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.133"
+version = "0.1.134"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -202,6 +202,17 @@ pub enum CastKind {
     /// Reinterprets the bits of a value of one type as another type, i.e. exactly what
     /// [`std::mem::transmute`] does.
     Transmute(Ty, Ty),
+    /// Converts a receiver type with `dyn Trait<...>` to a concrete type `T`, used in vtable method shims.
+    /// Valid conversions are references, raw pointers, and (optionally) boxes:
+    /// - `&[mut] dyn Trait<...>` -> `&[mut] T`
+    /// - `*[mut] dyn Trait<...>` -> `*[mut] T`
+    /// - `Box<dyn Trait<...>>` -> `Box<T>` when no `--raw-boxes`
+    ///
+    /// For possible receivers, see: https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility.
+    /// Other receivers, e.g., `Rc` should be unpacked before the cast and re-boxed after.
+    /// FIXME(ssyram): but this is not implemented yet, namely, there may still be
+    ///     something like `Rc<dyn Trait<...>> -> Rc<T>` in the types.
+    Concretize(Ty, Ty),
 }
 
 #[derive(

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -133,6 +133,10 @@ pub enum ItemSource {
     },
     /// This is a vtable value for an impl.
     VTableInstance { impl_ref: TraitImplRef },
+    /// The method shim wraps a concrete implementation of a method into a function that takes `dyn
+    /// Trait` as its `Self` type. This shim casts the receiver to the known concrete type and
+    /// calls the real method.
+    VTableMethodShim,
 }
 
 /// A function definition

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -1047,7 +1047,9 @@ impl BodyTransCtx<'_, '_, '_> {
                     // We ignore the arguments
                     return Ok(TerminatorKind::Abort(AbortKind::Panic(Some(name))));
                 } else {
-                    let fn_ptr = self.translate_fn_ptr(span, item)?.erase();
+                    let fn_ptr = self
+                        .translate_fn_ptr(span, item, TransItemSourceKind::Fun)?
+                        .erase();
                     FnOperand::Regular(fn_ptr)
                 }
             }

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -129,7 +129,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 expressions::ConstantExprKind::Var(var)
             }
             ConstantExprKind::FnPtr(item) => {
-                let fn_ptr = self.translate_fn_ptr(span, item)?.erase();
+                let fn_ptr = self
+                    .translate_fn_ptr(span, item, TransItemSourceKind::Fun)?
+                    .erase();
                 expressions::ConstantExprKind::FnPtr(fn_ptr)
             }
             ConstantExprKind::Memory(bytes) => {

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -504,6 +504,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         &mut self,
         span: Span,
         item: &hax::ItemRef,
+        kind: TransItemSourceKind,
     ) -> Result<MaybeBuiltinFunDeclRef, Error> {
         match self.recognize_builtin_fun(item)? {
             Some(id) => {
@@ -514,7 +515,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     generics: Box::new(generics),
                 })
             }
-            None => self.translate_item(span, item, TransItemSourceKind::Fun),
+            None => self.translate_item(span, item, kind),
         }
     }
 
@@ -525,8 +526,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         &mut self,
         span: Span,
         item: &hax::ItemRef,
+        kind: TransItemSourceKind,
     ) -> Result<RegionBinder<FnPtr>, Error> {
-        let fun_item = self.translate_fun_item(span, item)?;
+        let fun_item = self.translate_fun_item(span, item, kind)?;
         let late_bound = match self.hax_def(item)?.kind() {
             hax::FullDefKind::Fn { sig, .. } | hax::FullDefKind::AssocFn { sig, .. } => {
                 Some(sig.as_ref().rebind(()))

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -165,11 +165,11 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             TransItemSourceKind::VTableMethod => {
-                // let Some(ItemId::Fun(id)) = trans_id else {
-                //     unreachable!()
-                // };
-                // let fun_decl = bt_ctx.translate_vtable_shim(id, item_meta, &def)?;
-                // self.translated.fun_decls.set_slot(id, fun_decl);
+                let Some(ItemId::Fun(id)) = trans_id else {
+                    unreachable!()
+                };
+                let fun_decl = bt_ctx.translate_vtable_shim(id, item_meta, &def)?;
+                self.translated.fun_decls.set_slot(id, fun_decl);
             }
         }
         Ok(())

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -362,6 +362,12 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 name.name
                     .push(PathElem::Ident("{vtable}".into(), Disambiguator::ZERO));
             }
+            TransItemSourceKind::VTableMethod => {
+                name.name.push(PathElem::Ident(
+                    "{vtable_method}".into(),
+                    Disambiguator::ZERO,
+                ));
+            }
             _ => {}
         }
         Ok(name)

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -223,14 +223,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
 
             hax::TyKind::Dynamic(self_ty, preds, region) => {
-                if self.monomorphize() {
-                    raise_error!(
-                        self,
-                        span,
-                        "`dyn Trait` is not yet supported with `--monomorphize`; \
-                        use `--monomorphize-conservative` instead"
-                    )
-                }
+                self.check_no_monomorphize(span)?;
                 let pred = self.translate_existential_predicates(span, self_ty, preds, region)?;
                 if let hax::ClauseKind::Trait(trait_predicate) =
                     preds.predicates[0].0.kind.hax_skip_binder_ref()

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -214,7 +214,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 TyKind::FnPtr(sig)
             }
             hax::TyKind::FnDef { item, .. } => {
-                let fnref = self.translate_fn_ptr(span, item)?;
+                let fnref = self.translate_fn_ptr(span, item, TransItemSourceKind::Fun)?;
                 TyKind::FnDef(fnref)
             }
             hax::TyKind::Closure(args) => {

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -288,6 +288,9 @@ impl<C: AstFormatter> FmtWithCtx<C> for CastKind {
             CastKind::Transmute(src, tgt) => {
                 write!(f, "transmute<{}, {}>", src.with_ctx(ctx), tgt.with_ctx(ctx))
             }
+            CastKind::Concretize(ty, ty1) => {
+                write!(f, "concretize<{}, {}>", ty.with_ctx(ctx), ty1.with_ctx(ctx))
+            }
         }
     }
 }

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -40,6 +40,31 @@ impl VisitorWithBinderStack for CheckGenericsVisitor<'_> {
 }
 
 impl CheckGenericsVisitor<'_> {
+    fn check_concretization_ty_match(&self, src_ty: &Ty, tar_ty: &Ty) {
+        match (src_ty.kind(), tar_ty.kind()) {
+            (TyKind::Ref(.., src_kind), TyKind::Ref(.., tar_kind)) => {
+                assert_eq!(src_kind, tar_kind);
+            }
+            (TyKind::RawPtr(.., src_kind), TyKind::RawPtr(.., tar_kind)) => {
+                assert_eq!(src_kind, tar_kind);
+            }
+            (
+                TyKind::Adt(TypeDeclRef { id: src_id, .. }),
+                TyKind::Adt(TypeDeclRef { id: tar_id, .. }),
+            ) => {
+                assert_eq!(src_id, tar_id);
+            }
+            _ => {
+                let fmt = &self.ctx.into_fmt();
+                self.error(format!(
+                    "Invalid concretization targets: from \"{}\" to \"{}\"",
+                    src_ty.with_ctx(fmt),
+                    tar_ty.with_ctx(fmt)
+                ));
+            }
+        }
+    }
+
     fn error(&self, message: impl Display) {
         let msg = format!(
             "Found inconsistent generics {}:\n{message}\n\
@@ -308,6 +333,15 @@ impl VisitAst for CheckGenericsVisitor<'_> {
                 self.assert_matches_method(trait_id, method_name, &x.generics);
             }
         }
+    }
+    fn visit_rvalue(&mut self, x: &Rvalue) -> ::std::ops::ControlFlow<Self::Break> {
+        match x {
+            Rvalue::UnaryOp(UnOp::Cast(CastKind::Concretize(src, tar)), _) => {
+                self.check_concretization_ty_match(src, tar);
+            }
+            _ => {}
+        }
+        Continue(())
     }
     fn enter_global_decl_ref(&mut self, x: &GlobalDeclRef) {
         self.assert_matches_item(x.id, &x.generics);

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1163,7 +1163,8 @@ impl VisitAstMut for UpdateItemBody<'_> {
             ItemSource::TopLevel
             | ItemSource::Closure { .. }
             | ItemSource::VTableTy { .. }
-            | ItemSource::VTableInstance { .. } => {}
+            | ItemSource::VTableInstance { .. }
+            | ItemSource::VTableMethodShim => {}
             // Inside method declarations, the implicit `Self` clause is the first clause.
             ItemSource::TraitDecl { trait_ref, .. } => self.process_trait_decl_ref(
                 trait_ref,

--- a/charon/tests/ui/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.out
@@ -301,6 +301,19 @@ fn {impl Join<i32> for i32}::join_method<'_0>(@1: &'_0 (i32)) -> (i32, i32)
     return
 }
 
+// Full name: test_crate::{impl Join<i32> for i32}::join_method::{vtable_method}
+fn {vtable_method}<'_0>(@1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::Left = i32))) -> (i32, i32)
+{
+    let @0: (i32, i32); // return
+    let @1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::Left = i32)); // arg #1
+    let @2: &'_0 (i32); // anonymous local
+
+    storage_live(@2)
+    @2 := concretize<&'_0 ((dyn exists<_dyn> [@TraitClause0]: Join<_dyn, i32> + _dyn : '_ + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause1::parent_clause1::Internal = i32 + @TraitClause1_0::parent_clause2::Right = i32 + @TraitClause1_0::parent_clause1::Left = i32)), &'_0 (i32)>(move (@1))
+    @0 := {impl Join<i32> for i32}::join_method<'_0>(move (@2))
+    return
+}
+
 // Full name: test_crate::{impl Join<i32> for i32}::{vtable}
 fn {impl Join<i32> for i32}::{vtable}() -> test_crate::Join::{vtable}<i32, i32, i32, i32, i32>
 {
@@ -318,7 +331,7 @@ fn {impl Join<i32> for i32}::{vtable}() -> test_crate::Join::{vtable}<i32, i32, 
     @3 := ()
     storage_live(@4)
     @4 := &{impl Right<i32> for i32}::{vtable}
-    ret@0 := test_crate::Join::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_join_method: const ({impl Join<i32> for i32}::join_method), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2), super_trait_2: move (@4) }
+    ret@0 := test_crate::Join::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_join_method: const ({vtable_method}<'_>), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2), super_trait_2: move (@4) }
     return
 }
 

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -89,22 +89,7 @@ note: the error occurred when translating `core::marker::MetaSized::<type_error(
 7 |     x.to_string()
   |     -------------
 error: `dyn Trait` is not yet supported with `--monomorphize`; use `--monomorphize-conservative` instead
- --> /rustc/library/core/src/fmt/mod.rs:1007:1
-
-note: the error occurred when translating `core::fmt::Display::{vtable}::<alloc::string::String>`, which is (transitively) used at the following location(s):
-  --> tests/ui/monomorphization/dyn-trait.rs:12:27
-   |
-12 |     let _ = dyn_to_string(&str);
-   |                           ----
-
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:374:17:
-incorrect `dyn_self`
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: Thread panicked when extracting item `core::fmt::Display`.
- --> /rustc/library/core/src/fmt/mod.rs:1007:1
-
-error: Failed to translate item Type(3).
- --> /rustc/library/core/src/fmt/mod.rs:1007:1
+ --> /rustc/library/alloc/src/string.rs:2624:1
 
 note: the error occurred when translating `alloc::string::{impl core::fmt::Display::<alloc::string::String>}::{vtable}`, which is (transitively) used at the following location(s):
   --> tests/ui/monomorphization/dyn-trait.rs:12:27
@@ -198,4 +183,4 @@ note: the error occurred when translating `alloc::string::ToString::to_string`, 
   |
 7 |     x.to_string()
   |     -------------
-ERROR Charon failed to translate this code (38 errors)
+ERROR Charon failed to translate this code (36 errors)

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -159,12 +159,26 @@ impl Clone for String {
 // Full name: alloc::string::{impl Display for String}::fmt
 pub fn {impl Display for String}::fmt<'_0, '_1, '_2>(@1: &'_0 (String), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
 
+// Full name: alloc::string::{impl Display for String}::fmt::{vtable_method}
+fn {vtable_method}<'_0, '_1, '_2>(@1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)), @2: &'_1 mut (Formatter<'_2>)) -> Result<(), Error>[Sized<()>, Sized<Error>]
+{
+    let @0: Result<(), Error>[Sized<()>, Sized<Error>]; // return
+    let @1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)); // arg #1
+    let @2: &'_1 mut (Formatter<'_2>); // arg #2
+    let @3: &'_0 (String); // anonymous local
+
+    storage_live(@3)
+    @3 := concretize<&'_0 ((dyn exists<_dyn> [@TraitClause0]: Display<_dyn> + _dyn : '_)), &'_0 (String)>(move (@1))
+    @0 := {impl Display for String}::fmt<'_0, '_1, '_2>(move (@3), move (@2))
+    return
+}
+
 // Full name: alloc::string::{impl Display for String}::{vtable}
 fn {impl Display for String}::{vtable}() -> core::fmt::Display::{vtable}
 {
     let ret@0: core::fmt::Display::{vtable}; // return
 
-    ret@0 := core::fmt::Display::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_fmt: const ({impl Display for String}::fmt) }
+    ret@0 := core::fmt::Display::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_fmt: const ({vtable_method}<'_, '_, '_>) }
     return
 }
 

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -713,6 +713,102 @@ trait Alias<Self>
     vtable: test_crate::Alias::{vtable}
 }
 
+struct test_crate::LifetimeTrait::{vtable}<Ty0> {
+  size: usize,
+  align: usize,
+  drop: fn(*mut (dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = Ty0)),
+  method_lifetime_method: fn<'a, '_1>(&'_0_1 ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = Ty0)), &'a (LifetimeTrait<(dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = Ty0)>::Ty)) -> &'a (LifetimeTrait<(dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = Ty0)>::Ty),
+  super_trait_0: &'static (core::marker::MetaSized::{vtable}),
+}
+
+// Full name: test_crate::LifetimeTrait
+trait LifetimeTrait<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Ty>
+    type Ty
+    fn lifetime_method<'a, '_1> = test_crate::LifetimeTrait::lifetime_method<'a, '_0_1, Self>[Self]
+    vtable: test_crate::LifetimeTrait::{vtable}<Self::Ty>
+}
+
+fn test_crate::LifetimeTrait::lifetime_method<'a, '_1, Self>(@1: &'_1 (Self), @2: &'a (@TraitClause0::Ty)) -> &'a (@TraitClause0::Ty)
+where
+    [@TraitClause0]: LifetimeTrait<Self>,
+
+// Full name: test_crate::{impl LifetimeTrait for i32}::lifetime_method
+fn {impl LifetimeTrait for i32}::lifetime_method<'a, '_1>(@1: &'_1 (i32), @2: &'a (i32)) -> &'a (i32)
+{
+    let @0: &'_ (i32); // return
+    let self@1: &'_ (i32); // arg #1
+    let arg@2: &'_ (i32); // arg #2
+    let @3: bool; // anonymous local
+    let @4: i32; // anonymous local
+    let @5: i32; // anonymous local
+
+    storage_live(@3)
+    storage_live(@4)
+    @4 := copy (*(self@1))
+    storage_live(@5)
+    @5 := copy (*(arg@2))
+    @3 := move (@4) > move (@5)
+    if move (@3) {
+    }
+    else {
+        storage_dead(@5)
+        storage_dead(@4)
+        panic(core::panicking::panic)
+    }
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_dead(@3)
+    @0 := copy (arg@2)
+    return
+}
+
+// Full name: test_crate::{impl LifetimeTrait for i32}::{vtable}
+fn {impl LifetimeTrait for i32}::{vtable}() -> test_crate::LifetimeTrait::{vtable}<i32>
+{
+    let ret@0: test_crate::LifetimeTrait::{vtable}<i32>; // return
+
+    ret@0 := test_crate::LifetimeTrait::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_lifetime_method: const ({impl LifetimeTrait for i32}::lifetime_method), super_trait_0: const (Opaque(missing supertrait vtable)) }
+    return
+}
+
+// Full name: test_crate::{impl LifetimeTrait for i32}::{vtable}
+static {impl LifetimeTrait for i32}::{vtable}: test_crate::LifetimeTrait::{vtable}<i32> = {impl LifetimeTrait for i32}::{vtable}()
+
+// Full name: test_crate::{impl LifetimeTrait for i32}
+impl LifetimeTrait for i32 {
+    parent_clause0 = MetaSized<i32>
+    parent_clause1 = Sized<i32>
+    type Ty = i32
+    fn lifetime_method<'a, '_1> = {impl LifetimeTrait for i32}::lifetime_method<'a, '_0_1>
+    vtable: {impl LifetimeTrait for i32}::{vtable}
+}
+
+// Full name: test_crate::use_lifetime_trait
+fn use_lifetime_trait<'a, '_1>(@1: &'_1 ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_1 + @TraitClause1_0::Ty = i32)), @2: &'a (i32)) -> &'a (i32)
+{
+    let @0: &'_ (i32); // return
+    let x@1: &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // arg #1
+    let y@2: &'_ (i32); // arg #2
+    let @3: &'_ (i32); // anonymous local
+    let @4: &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // anonymous local
+    let @5: &'_ (i32); // anonymous local
+
+    storage_live(@3)
+    storage_live(@4)
+    @4 := &*(x@1) with_metadata(copy (x@1.metadata))
+    storage_live(@5)
+    @5 := &*(y@2)
+    @3 := LifetimeTrait<(dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)>::lifetime_method<'_, '_>(move (@4), move (@5))
+    @0 := &*(@3)
+    storage_dead(@5)
+    storage_dead(@4)
+    storage_dead(@3)
+    return
+}
+
 // Full name: test_crate::use_alias
 fn use_alias<'_0>(@1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Both32And64<_dyn> + _dyn : '_0)))
 {
@@ -819,6 +915,32 @@ fn main()
     let @57: &'_ (i64); // anonymous local
     let @58: &'_ (i64); // anonymous local
     let @59: i64; // anonymous local
+    let b@60: &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // local
+    let @61: &'_ (i32); // anonymous local
+    let @62: &'_ (i32); // anonymous local
+    let @63: i32; // anonymous local
+    let @64: (&'_ (i32), &'_ (i32)); // anonymous local
+    let @65: &'_ (i32); // anonymous local
+    let @66: &'_ (i32); // anonymous local
+    let @67: &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // anonymous local
+    let @68: &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // anonymous local
+    let @69: &'_ (i32); // anonymous local
+    let @70: &'_ (i32); // anonymous local
+    let @71: i32; // anonymous local
+    let @72: &'_ (i32); // anonymous local
+    let @73: i32; // anonymous local
+    let left_val@74: &'_ (i32); // local
+    let right_val@75: &'_ (i32); // local
+    let @76: bool; // anonymous local
+    let @77: i32; // anonymous local
+    let @78: i32; // anonymous local
+    let kind@79: AssertKind; // local
+    let @80: AssertKind; // anonymous local
+    let @81: &'_ (i32); // anonymous local
+    let @82: &'_ (i32); // anonymous local
+    let @83: &'_ (i32); // anonymous local
+    let @84: &'_ (i32); // anonymous local
+    let @85: Option<Arguments<'_>>[Sized<Arguments<'_>>]; // anonymous local
 
     @0 := ()
     storage_live(x@1)
@@ -1002,7 +1124,85 @@ fn main()
         storage_dead(@56)
         storage_dead(@55)
         storage_dead(@52)
+        storage_live(b@60)
+        storage_live(@61)
+        storage_live(@62)
+        storage_live(@63)
+        @63 := const (42 : i32)
+        @62 := &@63
+        @61 := &*(@62)
+        b@60 := unsize_cast<&'_ (i32), &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)), {impl LifetimeTrait for i32}>(move (@61))
+        storage_dead(@61)
+        storage_dead(@62)
+        storage_live(@64)
+        storage_live(@65)
+        storage_live(@66)
+        storage_live(@67)
+        storage_live(@68)
+        @68 := &*(b@60) with_metadata(copy (b@60.metadata))
+        @67 := unsize_cast<&'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)), &'_ ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)), LifetimeTrait<(dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)>>(move (@68))
+        storage_dead(@68)
+        storage_live(@69)
+        storage_live(@70)
+        storage_live(@71)
+        @71 := const (10 : i32)
+        @70 := &@71
+        @69 := &*(@70)
+        @66 := use_lifetime_trait<'_, '_>(move (@67), move (@69))
+        storage_dead(@69)
+        storage_dead(@67)
+        @65 := &*(@66)
+        storage_live(@72)
+        storage_live(@73)
+        @73 := const (10 : i32)
+        @72 := &@73
+        @64 := (move (@65), move (@72))
+        storage_dead(@72)
+        storage_dead(@65)
+        storage_live(left_val@74)
+        left_val@74 := copy ((@64).0)
+        storage_live(right_val@75)
+        right_val@75 := copy ((@64).1)
+        storage_live(@76)
+        storage_live(@77)
+        @77 := copy (*(left_val@74))
+        storage_live(@78)
+        @78 := copy (*(right_val@75))
+        @76 := move (@77) == move (@78)
+        if move (@76) {
+        }
+        else {
+            storage_dead(@78)
+            storage_dead(@77)
+            storage_live(kind@79)
+            kind@79 := AssertKind::Eq {  }
+            storage_live(@80)
+            @80 := move (kind@79)
+            storage_live(@81)
+            storage_live(@82)
+            @82 := &*(left_val@74)
+            @81 := &*(@82)
+            storage_live(@83)
+            storage_live(@84)
+            @84 := &*(right_val@75)
+            @83 := &*(@84)
+            storage_live(@85)
+            @85 := Option::None {  }
+            panic(core::panicking::assert_failed)
+        }
+        storage_dead(@78)
+        storage_dead(@77)
+        storage_dead(@76)
+        storage_dead(right_val@75)
+        storage_dead(left_val@74)
+        storage_dead(@73)
+        storage_dead(@71)
+        storage_dead(@70)
+        storage_dead(@66)
+        storage_dead(@64)
         @0 := ()
+        storage_dead(@63)
+        storage_dead(b@60)
         storage_dead(@51)
         storage_dead(a@48)
         storage_dead(z@40)

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -267,6 +267,19 @@ fn {impl Checkable<i32> for i32}::check<'_0>(@1: &'_0 (i32)) -> bool
     return
 }
 
+// Full name: test_crate::{impl Checkable<i32> for i32}::check::{vtable_method}
+fn {impl Checkable<i32> for i32}::check::{vtable_method}<'_0>(@1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_))) -> bool
+{
+    let @0: bool; // return
+    let @1: &'_0 ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_)); // arg #1
+    let @2: &'_0 (i32); // anonymous local
+
+    storage_live(@2)
+    @2 := concretize<&'_0 ((dyn exists<_dyn> [@TraitClause0]: Checkable<_dyn, i32> + _dyn : '_)), &'_0 (i32)>(move (@1))
+    @0 := {impl Checkable<i32> for i32}::check<'_0>(move (@2))
+    return
+}
+
 // Full name: test_crate::{impl Checkable<i32> for i32}::{vtable}
 fn {impl Checkable<i32> for i32}::{vtable}() -> test_crate::Checkable::{vtable}<i32>
 {
@@ -278,7 +291,7 @@ fn {impl Checkable<i32> for i32}::{vtable}() -> test_crate::Checkable::{vtable}<
     @1 := ()
     storage_live(@2)
     @2 := &{impl Super<i32> for i32}::{vtable}
-    ret@0 := test_crate::Checkable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_check: const ({impl Checkable<i32> for i32}::check), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2) }
+    ret@0 := test_crate::Checkable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_check: const ({impl Checkable<i32> for i32}::check::{vtable_method}<'_>), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2) }
     return
 }
 
@@ -414,6 +427,23 @@ where
     return
 }
 
+// Full name: test_crate::{impl Modifiable<T> for i32}::modify::{vtable_method}
+fn {impl Modifiable<T> for i32}::modify::{vtable_method}<'_0, '_1, T>(@1: &'_0 mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)), @2: &'_1 (T)) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Clone<T>,
+{
+    let @0: T; // return
+    let @1: &'_0 mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)); // arg #1
+    let @2: &'_1 (T); // arg #2
+    let @3: &'_0 mut (i32); // anonymous local
+
+    storage_live(@3)
+    @3 := concretize<&'_0 mut ((dyn exists<_dyn> [@TraitClause0]: Modifiable<_dyn, T> + _dyn : '_)), &'_0 mut (i32)>(move (@1))
+    @0 := {impl Modifiable<T> for i32}::modify<'_0, '_1, T>[@TraitClause0, @TraitClause1](move (@3), move (@2))
+    return
+}
+
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
 fn {impl Modifiable<T> for i32}::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
 where
@@ -422,7 +452,7 @@ where
 {
     let ret@0: test_crate::Modifiable::{vtable}<T>; // return
 
-    ret@0 := test_crate::Modifiable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_modify: const ({impl Modifiable<T> for i32}::modify<T>[@TraitClause0, @TraitClause1]), super_trait_0: const (Opaque(missing supertrait vtable)) }
+    ret@0 := test_crate::Modifiable::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_modify: const ({impl Modifiable<T> for i32}::modify::{vtable_method}<'_, '_, T>[@TraitClause0, @TraitClause1]), super_trait_0: const (Opaque(missing supertrait vtable)) }
     return
 }
 
@@ -689,7 +719,7 @@ fn {impl Both32And64 for i32}::{vtable}() -> test_crate::Both32And64::{vtable}
     @3 := ()
     storage_live(@4)
     @4 := &{impl BaseOn<i64> for i32}::{vtable}
-    ret@0 := test_crate::Both32And64::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_both_operate: const (Opaque(shim for provided methods aren't yet supported)), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2), super_trait_2: move (@4) }
+    ret@0 := test_crate::Both32And64::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_both_operate: const (Opaque(shim for default methods aren't yet supported)), super_trait_0: const (Opaque(missing supertrait vtable)), super_trait_1: move (@2), super_trait_2: move (@4) }
     return
 }
 
@@ -765,12 +795,26 @@ fn {impl LifetimeTrait for i32}::lifetime_method<'a, '_1>(@1: &'_1 (i32), @2: &'
     return
 }
 
+// Full name: test_crate::{impl LifetimeTrait for i32}::lifetime_method::{vtable_method}
+fn {impl LifetimeTrait for i32}::lifetime_method::{vtable_method}<'a, '_1>(@1: &'_1 ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)), @2: &'a (i32)) -> &'a (i32)
+{
+    let @0: &'a (i32); // return
+    let @1: &'_1 ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)); // arg #1
+    let @2: &'a (i32); // arg #2
+    let @3: &'_1 (i32); // anonymous local
+
+    storage_live(@3)
+    @3 := concretize<&'_1 ((dyn exists<_dyn> [@TraitClause0]: LifetimeTrait<_dyn> + _dyn : '_ + @TraitClause1_0::Ty = i32)), &'_1 (i32)>(move (@1))
+    @0 := {impl LifetimeTrait for i32}::lifetime_method<'a, '_1>(move (@3), move (@2))
+    return
+}
+
 // Full name: test_crate::{impl LifetimeTrait for i32}::{vtable}
 fn {impl LifetimeTrait for i32}::{vtable}() -> test_crate::LifetimeTrait::{vtable}<i32>
 {
     let ret@0: test_crate::LifetimeTrait::{vtable}<i32>; // return
 
-    ret@0 := test_crate::LifetimeTrait::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_lifetime_method: const ({impl LifetimeTrait for i32}::lifetime_method), super_trait_0: const (Opaque(missing supertrait vtable)) }
+    ret@0 := test_crate::LifetimeTrait::{vtable} { size: const (Opaque(unknown size)), align: const (Opaque(unknown align)), drop: const (Opaque(unknown drop)), method_lifetime_method: const ({impl LifetimeTrait for i32}::lifetime_method::{vtable_method}<'_, '_>), super_trait_0: const (Opaque(missing supertrait vtable)) }
     return
 }
 

--- a/charon/tests/ui/vtables.rs
+++ b/charon/tests/ui/vtables.rs
@@ -64,6 +64,21 @@ impl BaseOn<i64> for i32 {
 impl Both32And64 for i32 {}
 trait Alias = Both32And64;
 
+trait LifetimeTrait {
+    type Ty;
+    fn lifetime_method<'a>(&self, arg: &'a Self::Ty) -> &'a Self::Ty;
+}
+impl LifetimeTrait for i32 {
+    type Ty = i32;
+    fn lifetime_method<'a>(&self, arg: &'a Self::Ty) -> &'a Self::Ty {
+        assert!(*self > *arg);
+        arg
+    }
+}
+fn use_lifetime_trait<'a>(x: &dyn LifetimeTrait<Ty = i32>, y: &'a i32) -> &'a i32 {
+    x.lifetime_method(y)
+}
+
 fn use_alias(x: &dyn Alias) {
     x.both_operate(&100, &200);
 }
@@ -78,4 +93,6 @@ fn main() {
     z.dummy();
     let a: &dyn Both32And64 = &42;
     a.both_operate(&100, &200);
+    let b: &dyn LifetimeTrait<Ty = i32> = &42;
+    assert_eq!(*use_lifetime_trait(b, &10), 10);
 }


### PR DESCRIPTION
This PR is split from #762 . It contains the part of the implementation for supporting vtable instances. For each *concrete* casting from `&T` to `&dyn Trait`, a global `static {impl Trait for T}::{vtable}` will be generated, which initialises the method fields with the method shims --- notably, when one calls a `method` from `&dyn Trait`, the receiver is `&dyn Trait` instead of the concrete type `&T`. This requires a bridging method that uses a `Concretize` cast to cast back from `&dyn Trait` to `&T` and then call the correct `method` within the user-defined `impl Trait for T`.

Note that this PR does not handle the virtual implementations, e.g., closures --- there is no explicit `impl Fn for CLOSURE` that is defined by the user. This will be fixed in the up-coming PR split from #762 .

Also, in this PR, the metadata fields of the vtable instances, i.e., the `size`, `align` and `drop` fields are not translated and are currently `Opaque`. This will also be partly alleviated in the up-coming PR from #762 .

ci: use https://github.com/AeneasVerif/aeneas/pull/619
ci: use https://github.com/AeneasVerif/eurydice/pull/294