### PR TITLE
Renaming

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.131"
+let supported_charon_version = "0.1.132"

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -229,7 +229,7 @@ let trait_impl_to_string (env : 'a fmt_env) (indent : string)
           indent1 ^ "parent_clause" ^ string_of_int i ^ " = "
           ^ trait_ref_to_string env trait_ref
           ^ "\n")
-        def.parent_trait_refs
+        def.implied_trait_refs
     in
     let consts =
       List.map

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -164,7 +164,7 @@ let trait_decl_to_string (env : 'a fmt_env) (indent : string)
           ^ " : "
           ^ trait_param_to_string env clause
           ^ "\n")
-        def.parent_clauses
+        def.implied_clauses
     in
     let consts =
       List.map

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -276,7 +276,7 @@ type trait_impl = {
       (** The information about the implemented trait. Note that this contains
           the instantiation of the "parent" clauses. *)
   generics : generic_params;
-  parent_trait_refs : trait_ref list;
+  implied_trait_refs : trait_ref list;
       (** The trait references for the parent clauses (see [TraitDecl]). *)
   consts : (trait_item_name * global_decl_ref) list;
       (** The implemented associated constants. *)

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -194,7 +194,7 @@ and trait_decl = {
   def_id : trait_decl_id;
   item_meta : item_meta;
   generics : generic_params;
-  parent_clauses : trait_param list;
+  implied_clauses : trait_param list;
       (** The "parent" clauses: the supertraits.
 
           Supertraits are actually regular where clauses, but we decided to have

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1610,7 +1610,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("def_id", def_id);
           ("item_meta", item_meta);
           ("generics", generics);
-          ("parent_clauses", parent_clauses);
+          ("implied_clauses", implied_clauses);
           ("consts", consts);
           ("types", types);
           ("methods", methods);
@@ -1619,9 +1619,9 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* def_id = trait_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
         let* generics = generic_params_of_json ctx generics in
-        let* parent_clauses =
+        let* implied_clauses =
           vector_of_json trait_clause_id_of_json trait_param_of_json ctx
-            parent_clauses
+            implied_clauses
         in
         let* consts = list_of_json trait_assoc_const_of_json ctx consts in
         let* types =
@@ -1636,7 +1636,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
              def_id;
              item_meta;
              generics;
-             parent_clauses;
+             implied_clauses;
              consts;
              types;
              methods;

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1672,7 +1672,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
           ("item_meta", item_meta);
           ("impl_trait", impl_trait);
           ("generics", generics);
-          ("parent_trait_refs", parent_trait_refs);
+          ("implied_trait_refs", implied_trait_refs);
           ("consts", consts);
           ("types", types);
           ("methods", methods);
@@ -1682,9 +1682,9 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
         let* item_meta = item_meta_of_json ctx item_meta in
         let* impl_trait = trait_decl_ref_of_json ctx impl_trait in
         let* generics = generic_params_of_json ctx generics in
-        let* parent_trait_refs =
+        let* implied_trait_refs =
           vector_of_json trait_clause_id_of_json trait_ref_of_json ctx
-            parent_trait_refs
+            implied_trait_refs
         in
         let* consts =
           list_of_json
@@ -1710,7 +1710,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
              item_meta;
              impl_trait;
              generics;
-             parent_trait_refs;
+             implied_trait_refs;
              consts;
              types;
              methods;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.131"
+version = "0.1.132"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.131"
+version = "0.1.132"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -330,7 +330,7 @@ pub struct TraitImpl {
     pub impl_trait: TraitDeclRef,
     pub generics: GenericParams,
     /// The trait references for the parent clauses (see [TraitDecl]).
-    pub parent_trait_refs: Vector<TraitClauseId, TraitRef>,
+    pub implied_trait_refs: Vector<TraitClauseId, TraitRef>,
     /// The implemented associated constants.
     pub consts: Vec<(TraitItemName, GlobalDeclRef)>,
     /// The implemented associated types.

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -261,7 +261,7 @@ pub struct TraitDecl {
     /// ```
     /// TODO: actually, as of today, we consider that all trait clauses of
     /// trait declarations are parent clauses.
-    pub parent_clauses: Vector<TraitClauseId, TraitParam>,
+    pub implied_clauses: Vector<TraitClauseId, TraitParam>,
     /// The associated constants declared in the trait.
     pub consts: Vec<TraitAssocConst>,
     /// The associated types declared in the trait. The binder binds the generic parameters of the

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -852,17 +852,17 @@ impl ItemTransCtx<'_, '_> {
         let vtable = self.translate_vtable_instance_ref(span, &trait_pred.trait_ref, def.this())?;
 
         // The trait refs which implement the parent clauses of the implemented trait decl.
-        let parent_trait_refs = self.translate_trait_impl_exprs(span, &implied_impl_exprs)?;
+        let implied_trait_refs = self.translate_trait_impl_exprs(span, &implied_impl_exprs)?;
 
         {
             // Debugging
             let ctx = self.into_fmt();
-            let refs = parent_trait_refs
+            let refs = implied_trait_refs
                 .iter()
                 .map(|c| c.with_ctx(&ctx))
                 .format("\n");
             trace!(
-                "Trait impl: {:?}\n- parent_trait_refs:\n{}",
+                "Trait impl: {:?}\n- implied_trait_refs:\n{}",
                 def.def_id(),
                 refs
             );
@@ -1012,7 +1012,7 @@ impl ItemTransCtx<'_, '_> {
             item_meta,
             impl_trait: implemented_trait,
             generics: self.into_generics(),
-            parent_trait_refs,
+            implied_trait_refs,
             consts,
             types,
             methods,
@@ -1055,7 +1055,7 @@ impl ItemTransCtx<'_, '_> {
 
         let mut generics = self.the_only_binder().params.identity_args();
         // Do the inverse operation: the trait considers the clauses as implied.
-        let parent_trait_refs = mem::take(&mut generics.trait_refs);
+        let implied_trait_refs = mem::take(&mut generics.trait_refs);
         let implemented_trait = TraitDeclRef {
             id: trait_id,
             generics: Box::new(generics),
@@ -1066,7 +1066,7 @@ impl ItemTransCtx<'_, '_> {
             item_meta,
             impl_trait: implemented_trait,
             generics: self.the_only_binder().params.clone(),
-            parent_trait_refs,
+            implied_trait_refs,
             consts: Default::default(),
             types: Default::default(),
             methods: Default::default(),
@@ -1148,7 +1148,8 @@ impl ItemTransCtx<'_, '_> {
         };
 
         let implemented_trait = self.translate_trait_predicate(span, &vimpl.trait_pred)?;
-        let parent_trait_refs = self.translate_trait_impl_exprs(span, &vimpl.implied_impl_exprs)?;
+        let implied_trait_refs =
+            self.translate_trait_impl_exprs(span, &vimpl.implied_impl_exprs)?;
 
         let mut types = vec![];
         // Monomorphic traits have no associated types.
@@ -1174,7 +1175,7 @@ impl ItemTransCtx<'_, '_> {
             item_meta,
             impl_trait: implemented_trait,
             generics,
-            parent_trait_refs,
+            implied_trait_refs,
             consts: vec![],
             types,
             methods: vec![],

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -584,7 +584,7 @@ impl ItemTransCtx<'_, '_> {
         // Register implied predicates.
         let mut preds =
             self.translate_predicates(implied_predicates, PredicateOrigin::WhereClauseOnTrait)?;
-        let parent_clauses = mem::take(&mut preds.trait_clauses);
+        let implied_clauses = mem::take(&mut preds.trait_clauses);
         // Consider the other predicates as required since the distinction doesn't matter for
         // non-trait-clauses.
         self.innermost_generics_mut().take_predicates_from(preds);
@@ -596,7 +596,7 @@ impl ItemTransCtx<'_, '_> {
             return Ok(TraitDecl {
                 def_id,
                 item_meta,
-                parent_clauses,
+                implied_clauses,
                 generics: self.into_generics(),
                 consts: Default::default(),
                 types: Default::default(),
@@ -804,7 +804,7 @@ impl ItemTransCtx<'_, '_> {
         Ok(TraitDecl {
             def_id,
             item_meta,
-            parent_clauses,
+            implied_clauses,
             generics: self.into_generics(),
             consts,
             types,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1679,13 +1679,13 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
         };
         write!(f, "{newline}{{")?;
 
-        let any_item = !self.parent_trait_refs.is_empty()
+        let any_item = !self.implied_trait_refs.is_empty()
             || !self.consts.is_empty()
             || !self.types.is_empty()
             || !self.methods.is_empty();
         if any_item {
             writeln!(f)?;
-            for (i, c) in self.parent_trait_refs.iter().enumerate() {
+            for (i, c) in self.implied_trait_refs.iter().enumerate() {
                 let i = TraitClauseId::new(i);
                 writeln!(f, "{TAB_INCR}parent_clause{i} = {}", c.with_ctx(ctx))?;
             }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1573,13 +1573,13 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
         let (generics, clauses) = self.generics.fmt_with_ctx_with_trait_clauses(ctx);
         write!(f, "{generics}{clauses}")?;
 
-        let any_item = !self.parent_clauses.is_empty()
+        let any_item = !self.implied_clauses.is_empty()
             || !self.consts.is_empty()
             || !self.types.is_empty()
             || !self.methods.is_empty();
         if any_item {
             write!(f, "\n{{\n")?;
-            for c in &self.parent_clauses {
+            for c in &self.implied_clauses {
                 writeln!(
                     f,
                     "{TAB_INCR}parent_clause{} : {}",

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -253,7 +253,7 @@ impl VisitAst for CheckGenericsVisitor<'_> {
                 let fmt = &self.ctx.into_fmt();
                 let args_fmt = &self.val_fmt_ctx();
                 self.zip_assert_match(
-                    &tdecl.parent_clauses,
+                    &tdecl.implied_clauses,
                     parent_trait_refs,
                     fmt,
                     args_fmt,
@@ -327,7 +327,7 @@ impl VisitAst for CheckGenericsVisitor<'_> {
         let tdecl_fmt = fmt1.push_binder(Cow::Borrowed(&tdecl.generics));
         let args_fmt = &self.val_fmt_ctx();
         self.zip_assert_match(
-            &tdecl.parent_clauses,
+            &tdecl.implied_clauses,
             &timpl.parent_trait_refs,
             &tdecl_fmt,
             args_fmt,

--- a/charon/src/transform/check_generics.rs
+++ b/charon/src/transform/check_generics.rs
@@ -328,7 +328,7 @@ impl VisitAst for CheckGenericsVisitor<'_> {
         let args_fmt = &self.val_fmt_ctx();
         self.zip_assert_match(
             &tdecl.implied_clauses,
-            &timpl.parent_trait_refs,
+            &timpl.implied_trait_refs,
             &tdecl_fmt,
             args_fmt,
             "trait parent clauses",

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -825,7 +825,7 @@ impl<'a> ComputeItemModifications<'a> {
                         set.insert_path(&path, assoc_ty.value);
                     }
                 }
-                for (clause_id, tref) in timpl.parent_trait_refs.iter_indexed() {
+                for (clause_id, tref) in timpl.implied_trait_refs.iter_indexed() {
                     let clause_path = TraitRefPath::parent_clause(clause_id);
                     for (path, ty) in self.compute_assoc_tys_for_tref(timpl.item_meta.span, tref) {
                         let path = path.on_tref(&clause_path);

--- a/charon/src/transform/expand_associated_types.rs
+++ b/charon/src/transform/expand_associated_types.rs
@@ -709,7 +709,7 @@ impl<'a> ComputeItemModifications<'a> {
                         replace.push(path);
                     }
                 }
-                for clause in &tr.parent_clauses {
+                for clause in &tr.implied_clauses {
                     for path in
                         self.compute_extra_params_for_clause(clause, TraitRefPath::parent_clause)
                     {
@@ -1147,7 +1147,7 @@ impl VisitAstMut for UpdateItemBody<'_> {
                 generics: Box::new(tdecl.generics.identity_args()),
             }),
         };
-        for (clause_id, clause) in tdecl.parent_clauses.iter_mut_indexed() {
+        for (clause_id, clause) in tdecl.implied_clauses.iter_mut_indexed() {
             let self_path = TraitRefKind::ParentClause(Box::new(self_tref.clone()), clause_id);
             self.process_poly_trait_decl_ref(&mut clause.trait_, self_path);
         }

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -45,7 +45,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         self.filter_trait_clauses(&mut tdecl.implied_clauses);
     }
     fn enter_trait_impl(&mut self, timpl: &mut TraitImpl) {
-        self.filter_trait_refs(&mut timpl.parent_trait_refs);
+        self.filter_trait_refs(&mut timpl.implied_trait_refs);
     }
     fn enter_trait_ref_kind(&mut self, x: &mut TraitRefKind) {
         if let TraitRefKind::BuiltinOrAuto {

--- a/charon/src/transform/hide_marker_traits.rs
+++ b/charon/src/transform/hide_marker_traits.rs
@@ -42,7 +42,7 @@ impl VisitAstMut for RemoveMarkersVisitor {
         self.filter_trait_refs(&mut args.trait_refs);
     }
     fn enter_trait_decl(&mut self, tdecl: &mut TraitDecl) {
-        self.filter_trait_clauses(&mut tdecl.parent_clauses);
+        self.filter_trait_clauses(&mut tdecl.implied_clauses);
     }
     fn enter_trait_impl(&mut self, timpl: &mut TraitImpl) {
         self.filter_trait_refs(&mut timpl.parent_trait_refs);

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -24,7 +24,7 @@ impl TransformPass for Transform {
                     let id_map =
                         mem::take(&mut assoc_ty.skip_binder.implied_clauses).map(|clause| {
                             let mut clause = clause.move_from_under_binder().unwrap();
-                            decl.parent_clauses.push_with(|id| {
+                            decl.implied_clauses.push_with(|id| {
                                 clause.clause_id = id;
                                 clause
                             })

--- a/charon/src/transform/lift_associated_item_clauses.rs
+++ b/charon/src/transform/lift_associated_item_clauses.rs
@@ -51,7 +51,7 @@ impl TransformPass for Transform {
                         let trait_ref = trait_ref.move_from_under_binder().unwrap();
                         // Note: this assumes that we listed the types in the same order as in the
                         // trait decl, which we do.
-                        timpl.parent_trait_refs.push(trait_ref);
+                        timpl.implied_trait_refs.push(trait_ref);
                     }
                 }
             }

--- a/charon/src/transform/monomorphize.rs
+++ b/charon/src/transform/monomorphize.rs
@@ -61,7 +61,7 @@ impl TranslatedCrate {
             }
             TraitRefKind::ParentClause(p, clause) => {
                 let (trait_impl, _) = self.find_trait_impl_and_gargs(p)?;
-                let t_ref = trait_impl.parent_trait_refs.get(*clause)?;
+                let t_ref = trait_impl.implied_trait_refs.get(*clause)?;
                 self.find_trait_impl_and_gargs(t_ref)
             }
             _ => None,

--- a/charon/src/transform/reorder_decls.rs
+++ b/charon/src/transform/reorder_decls.rs
@@ -399,7 +399,7 @@ fn compute_declarations_graph<'tcx>(ctx: &'tcx TransformCtx) -> Deps {
                     def_id: _,
                     item_meta: _,
                     generics,
-                    parent_clauses,
+                    implied_clauses: parent_clauses,
                     consts,
                     types,
                     methods,

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -30,7 +30,7 @@ fn items_by_name<'c>(crate_data: &'c TranslatedCrate) -> HashMap<String, Item<'c
             if let ItemRef::TraitDecl(tdecl) = &item {
                 // We do a little hack.
                 assert!(generics.trait_clauses.is_empty());
-                generics.trait_clauses = tdecl.parent_clauses.clone();
+                generics.trait_clauses = tdecl.implied_clauses.clone();
             }
             Item {
                 name_str: repr_name(crate_data, &item.item_meta().name),


### PR DESCRIPTION
Did TraitDecl.parent_clauses -> TraitDecl.implied_clauses, TraitImpl.parent_trait_refs -> TraitImpl.implied_trait_refs 

before doing 

DeBruijnVar -> Var (this one is likely to cause clashes in aeneas)

ci: use https://github.com/AeneasVerif/aeneas/pull/617
ci: use https://github.com/AeneasVerif/eurydice/pull/291