### PR TITLE
mono: exclude methods with predicates too

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -807,7 +807,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 [[package]]
 name = "hax-adt-into"
 version = "0.3.4"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#193c439128a22a124ca3745c9836fbcd2a63e53b"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#68926ebc7b2ad598935215dd8daa13ea420db05d"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter"
 version = "0.3.4"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#193c439128a22a124ca3745c9836fbcd2a63e53b"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#68926ebc7b2ad598935215dd8daa13ea420db05d"
 dependencies = [
  "extension-traits",
  "hax-adt-into",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "hax-frontend-exporter-options"
 version = "0.3.4"
-source = "git+https://github.com/AeneasVerif/hax?branch=main#193c439128a22a124ca3745c9836fbcd2a63e53b"
+source = "git+https://github.com/AeneasVerif/hax?branch=main#68926ebc7b2ad598935215dd8daa13ea420db05d"
 dependencies = [
  "hax-adt-into",
  "schemars",

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -645,7 +645,7 @@ impl ItemTransCtx<'_, '_> {
             };
             let poly_item_def = self.poly_hax_def(item_def_id)?;
             let (item_src, item_def) = if self.monomorphize() {
-                if poly_item_def.has_own_generics() {
+                if poly_item_def.has_own_generics_or_predicates() {
                     // Skip items that have generics of their own (as rustc defines these). This
                     // skips GAT and generic methods. This does not skip methods with late-bound
                     // lifetimes as these aren't considered generic arguments to the method itself
@@ -891,7 +891,7 @@ impl ItemTransCtx<'_, '_> {
                 _ => unreachable!(),
             };
             let (item_src, item_def) = if self.monomorphize() {
-                if poly_item_def.has_own_generics() {
+                if poly_item_def.has_own_generics_or_predicates() {
                     continue;
                 } else {
                     let item = match &impl_item.value {

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -1,48 +1,160 @@
-disabled backtrace
-warning[E9999]: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
-  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:21:1
-   |
-21 | impl MyIterator for A {
-   | ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ⚠️ This is a bug in Hax's frontend.
-           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+# Final LLBC before serialization:
 
-disabled backtrace
-warning[E9999]: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
-  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:9:5
-   |
-9  | /     fn flatten(self) -> Flatten<Self>
-10 | |     where
-11 | |         Self: Sized,
-12 | |         Self::Item: Copy,
-   | |_________________________^
-   |
-   = note: ⚠️ This is a bug in Hax's frontend.
-           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+// Full name: core::marker::MetaSized::<A>
+#[lang_item("meta_sized")]
+pub trait MetaSized::<A>
 
-disabled backtrace
-warning[E9999]: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
-  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:18:1
-   |
-18 | struct Flatten<I: MyIterator<Item: Copy>>(I);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ⚠️ This is a bug in Hax's frontend.
-           Please report this error to https://github.com/hacspec/hax/issues with some context (e.g. the current crate)!
+// Full name: core::marker::MetaSized::<B>
+#[lang_item("meta_sized")]
+pub trait MetaSized::<B>
 
-error: Error during trait resolution: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
-  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:18:1
-   |
-18 | struct Flatten<I: MyIterator<Item: Copy>>(I);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// Full name: alloc::string::String
+#[lang_item("String")]
+pub opaque type String
 
-error: Error during trait resolution: Could not find a clause for `Binder { value: <std::string::String as std::marker::Copy>, bound_vars: [] }` in the current context: `Unimplemented`
-  --> tests/ui/monomorphization/unsatisfied-method-bounds.rs:18:1
-   |
-18 | struct Flatten<I: MyIterator<Item: Copy>>(I);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fn UNIT_METADATA()
+{
+    let @0: (); // return
 
-warning: 3 warnings emitted
+    @0 := ()
+    return
+}
 
-ERROR Charon failed to translate this code (2 errors)
+const UNIT_METADATA: () = @Fun1()
+
+// Full name: test_crate::A
+struct A {}
+
+// Full name: test_crate::MyIterator::<A>
+trait MyIterator::<A>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized::<A>
+    fn method<'_0> = method::<A><'_0_0>
+    vtable: test_crate::MyIterator::{vtable}::<A><String>
+}
+
+// Full name: test_crate::B
+struct B {}
+
+// Full name: test_crate::MyIterator::<B>
+trait MyIterator::<B>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized::<B>
+    fn method<'_0> = method::<B><'_0_0>
+    vtable: test_crate::MyIterator::{vtable}::<B><u8>
+}
+
+// Full name: test_crate::MyIterator::method
+fn method<'_0>(@1: &'_0 (A))
+{
+    let @0: (); // return
+    let self@1: &'_ (A); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::MyIterator::method
+fn method<'_0>(@1: &'_0 (B))
+{
+    let @0: (); // return
+    let self@1: &'_ (B); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::MyIterator::method::<A>
+fn method::<A><'_0>(@1: &'_0 (A))
+{
+    let @0: (); // return
+    let self@1: &'_ (A); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::MyIterator::method::<B>
+fn method::<B><'_0>(@1: &'_0 (B))
+{
+    let @0: (); // return
+    let self@1: &'_ (B); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+fn test_crate::{impl MyIterator::<A>}::<A><'_0>(@1: &'_0 (A))
+{
+    let @0: (); // return
+    let self@1: &'_ (A); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl MyIterator::<A>}
+impl MyIterator::<A> {
+    parent_clause0 = MetaSized::<A>
+    fn method<'_0> = test_crate::{impl MyIterator::<A>}::<A><'_0_0>
+    vtable: {impl MyIterator::<A>}::{vtable}
+}
+
+fn test_crate::{impl MyIterator::<B>}::<B><'_0>(@1: &'_0 (B))
+{
+    let @0: (); // return
+    let self@1: &'_ (B); // arg #1
+
+    @0 := ()
+    @0 := ()
+    return
+}
+
+// Full name: test_crate::{impl MyIterator::<B>}
+impl MyIterator::<B> {
+    parent_clause0 = MetaSized::<B>
+    fn method<'_0> = test_crate::{impl MyIterator::<B>}::<B><'_0_0>
+    vtable: {impl MyIterator::<B>}::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let @0: (); // return
+    let @1: (); // anonymous local
+    let @2: &'_ (A); // anonymous local
+    let @3: A; // anonymous local
+    let @4: (); // anonymous local
+    let @5: &'_ (B); // anonymous local
+    let @6: B; // anonymous local
+
+    @0 := ()
+    storage_live(@1)
+    storage_live(@2)
+    storage_live(@3)
+    @3 := A {  }
+    @2 := &@3
+    @1 := test_crate::{impl MyIterator::<A>}::<A><'_>(move (@2))
+    storage_dead(@2)
+    storage_dead(@3)
+    storage_dead(@1)
+    storage_live(@4)
+    storage_live(@5)
+    storage_live(@6)
+    @6 := B {  }
+    @5 := &@6
+    @4 := test_crate::{impl MyIterator::<B>}::<B><'_>(move (@5))
+    storage_dead(@5)
+    storage_dead(@6)
+    storage_dead(@4)
+    @0 := ()
+    return
+}
+
+
+

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.rs
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--mono --start-from=crate::main
 trait MyIterator {
     type Item;
@@ -26,6 +25,9 @@ struct B;
 impl MyIterator for B {
     type Item = u8;
 }
+
+// TODO(dyn): test the vtable too
+// fn test_dyn(_: &dyn MyIterator) {}
 
 fn main() {
     A.method();


### PR DESCRIPTION
This excludes methods with predicates from monomorphized traits. This is irrelevant outside of `dyn` since methods are never indirected in monomorphized code; figuring out dyn + monomorphization will haveto solve this on top of the other challenges.