### PR TITLE
fix double translation

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -187,6 +187,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                 let span = self.def_span(item_source.def_id());
                 raise_error!(self, span, "Failed to translate item {id:?}.")
             }
+            // Add to avoid the double translation of the same item
+            self.processed.insert(item_source.clone());
         }
         let item = self.translated.get_item(id);
         Ok(item.unwrap())


### PR DESCRIPTION
A small bug: there is chance when `get_or_translate` is called ahead of the usual translation, the usual translation loop will still translate and trigger a double translation.

This bug is not triggered here but will easily happen in, e.g., the next coming PR.