### PR TITLE
Add `ConstExprKind::FnPtr`, rename `FnPtr->FnDef`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.148"
+let supported_charon_version = "0.1.149"

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -135,7 +135,7 @@ and constant_expr_to_string (env : 'a fmt_env) (cv : constant_expr) : string =
   | CTraitConst (trait_ref, const_name) ->
       let trait_ref = trait_ref_to_string env trait_ref in
       trait_ref ^ const_name
-  | CFnPtr fn_ptr -> fn_ptr_to_string env fn_ptr
+  | CFnDef fn_ptr -> fn_ptr_to_string env fn_ptr
   | CRawMemory bytes ->
       "RawMemory([" ^ String.concat ", " (List.map string_of_int bytes) ^ "])"
   | COpaque reason -> "Opaque(" ^ reason ^ ")"

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -198,7 +198,7 @@ and constant_expr_kind =
           Remark: trait constants can not be used in types, they are necessarily
           values. *)
   | CVar of const_generic_var_id de_bruijn_var  (** A const generic var *)
-  | CFnPtr of fn_ptr  (** Function pointer *)
+  | CFnDef of fn_ptr  (** Function definition -- this is a ZST constant *)
   | CRawMemory of int list
       (** Raw memory value obtained from constant evaluation. Used when a more
           structured representation isn't possible (e.g. for unions) or just

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -565,9 +565,9 @@ and constant_expr_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Var", var) ] ->
         let* var = de_bruijn_var_of_json const_generic_var_id_of_json ctx var in
         Ok (CVar var)
-    | `Assoc [ ("FnPtr", fn_ptr) ] ->
-        let* fn_ptr = fn_ptr_of_json ctx fn_ptr in
-        Ok (CFnPtr fn_ptr)
+    | `Assoc [ ("FnDef", fn_def) ] ->
+        let* fn_def = fn_ptr_of_json ctx fn_def in
+        Ok (CFnDef fn_def)
     | `Assoc [ ("RawMemory", raw_memory) ] ->
         let* raw_memory = list_of_json int_of_json ctx raw_memory in
         Ok (CRawMemory raw_memory)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.148"
+version = "0.1.149"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -562,7 +562,12 @@ pub enum ConstantExprKind {
     Ptr(RefKind, Box<ConstantExpr>),
     /// A const generic var
     Var(ConstGenericDbVar),
-    /// Function pointer
+    /// Function definition -- this is a ZST constant
+    FnDef(FnPtr),
+    /// A function pointer to a function item; this is an actual pointer to that function item.
+    ///
+    /// We eliminate this case in a micro-pass.
+    #[charon::opaque]
     FnPtr(FnPtr),
     /// A pointer with no provenance (e.g. 0 for the null pointer)
     ///

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -546,7 +546,7 @@ impl BodyTransCtx<'_, '_, '_> {
                         let fn_ptr: FnPtr = fn_ptr_bound.clone().erase();
                         let src_ty = TyKind::FnDef(fn_ptr_bound).into_ty();
                         operand = Operand::Const(Box::new(ConstantExpr {
-                            kind: ConstantExprKind::FnPtr(fn_ptr),
+                            kind: ConstantExprKind::FnDef(fn_ptr),
                             ty: src_ty.clone(),
                         }));
                         CastKind::FnPtr(src_ty, tgt_ty)

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -134,7 +134,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     Err(err) => ConstantExprKind::Opaque(err.msg),
                 }
             }
-            hax::ConstantExprKind::FnDef(item) | hax::ConstantExprKind::FnPtr(item) => {
+            hax::ConstantExprKind::FnDef(item) => {
+                let fn_ptr = self
+                    .translate_fn_ptr(span, item, TransItemSourceKind::Fun)?
+                    .erase();
+                ConstantExprKind::FnDef(fn_ptr)
+            }
+            hax::ConstantExprKind::FnPtr(item) => {
                 let fn_ptr = self
                     .translate_fn_ptr(span, item, TransItemSourceKind::Fun)?
                     .erase();
@@ -176,6 +182,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             | ConstantExprKind::Ref(_)
             | ConstantExprKind::Ptr(..)
             | ConstantExprKind::FnPtr { .. }
+            | ConstantExprKind::FnDef { .. }
             | ConstantExprKind::Opaque(_)
             | ConstantExprKind::PtrNoProvenance(..) => {
                 raise_error!(self, span, "Unexpected constant generic: {:?}", kind)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -43,7 +43,7 @@ fn dynify<T: TyVisitable>(mut x: T, new_self: Option<Ty>, for_method: bool) -> T
                         .into_ty()
                 } else {
                     self.new_self.clone().expect(
-                        "Found unexpected `Self` 
+                        "Found unexpected `Self`
                         type when constructing vtable",
                     )
                 })
@@ -614,7 +614,7 @@ impl ItemTransCtx<'_, '_> {
                 let shim_ref = self
                     .translate_fn_ptr(span, &item_ref, TransItemSourceKind::VTableMethod)?
                     .erase();
-                ConstantExprKind::FnPtr(shim_ref)
+                ConstantExprKind::FnDef(shim_ref)
             }
             hax::ImplAssocItemValue::DefaultedFn { .. } => ConstantExprKind::Opaque(
                 "shim for default methods \
@@ -763,7 +763,7 @@ impl ItemTransCtx<'_, '_> {
         let drop_shim =
             self.translate_item(span, impl_def.this(), TransItemSourceKind::VTableDropShim)?;
 
-        mk_field(ConstantExprKind::FnPtr(drop_shim));
+        mk_field(ConstantExprKind::FnDef(drop_shim));
 
         for item in items {
             self.add_method_to_vtable_value(span, impl_def, item, &mut mk_field)?;

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1166,8 +1166,11 @@ impl<C: AstFormatter> FmtWithCtx<C> for ConstantExprKind {
                 RefKind::Shared => write!(f, "&raw const {}", cv.with_ctx(ctx)),
             },
             ConstantExprKind::Var(id) => write!(f, "{}", id.with_ctx(ctx)),
-            ConstantExprKind::FnPtr(fp) => {
+            ConstantExprKind::FnDef(fp) => {
                 write!(f, "{}", fp.with_ctx(ctx))
+            }
+            ConstantExprKind::FnPtr(fp) => {
+                write!(f, "fnptr({})", fp.with_ctx(ctx))
             }
             ConstantExprKind::PtrNoProvenance(v) => write!(f, "no-provenance {v}"),
             ConstantExprKind::RawMemory(bytes) => write!(f, "RawMemory({bytes:?})"),


### PR DESCRIPTION
That naming was horrendous 🫠 Now a `FnDef` is a proper `FnDef`, and `FnPtr` is a proper `FnPtr`.

I unfortunately couldn't get a simple example where a hax `FnPtr` gets generated. I can only say confidently that it occurs in this code:
```rust
let _: Vec<u8> = vec![0u8].into_iter().filter(|_| true).collect();
```
However this code still doesn't compile because somewhere inside it does a function call on a `const` operand, which hax crashes on. Ideally we should probably change `FnOperand` to just be `Static(FunDeclRef) | Dynamic(Operand)`, but trying to do that change also brought errors because of #917 (now fixed). I'll give it another try later :p

(the eurydice PR is fine i just closed one by accident and had to change it so CI ran w the wrong one)

ci: use https://github.com/AeneasVerif/aeneas/pull/660
ci: use https://github.com/AeneasVerif/eurydice/pull/361