### PR TITLE
Make const-eval bytes more semantically precise

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.152"
+let supported_charon_version = "0.1.153"

--- a/charon-ml/src/PrintExpressions.ml
+++ b/charon-ml/src/PrintExpressions.ml
@@ -127,6 +127,19 @@ and binop_to_string (binop : binop) : string =
   | Cmp -> "cmp"
   | Offset -> "offset"
 
+and provenance_to_string (env : 'a fmt_env) (pv : provenance) : string =
+  match pv with
+  | Global gref -> "prov_global(" ^ global_decl_ref_to_string env gref ^ ")"
+  | Function fn_ref -> "prov_fn(" ^ fun_decl_ref_to_string env fn_ref ^ ")"
+  | Unknown -> "prov_unknown"
+
+and byte_to_string (env : 'a fmt_env) (cv : byte) : string =
+  match cv with
+  | Uninit -> "uninit"
+  | Value b -> string_of_int b
+  | Provenance (p, i) ->
+      provenance_to_string env p ^ "[" ^ string_of_int i ^ "]"
+
 and constant_expr_to_string (env : 'a fmt_env) (cv : constant_expr) : string =
   match cv.kind with
   | CLiteral lit ->
@@ -137,7 +150,9 @@ and constant_expr_to_string (env : 'a fmt_env) (cv : constant_expr) : string =
       trait_ref ^ const_name
   | CFnDef fn_ptr -> fn_ptr_to_string env fn_ptr
   | CRawMemory bytes ->
-      "RawMemory([" ^ String.concat ", " (List.map string_of_int bytes) ^ "])"
+      "RawMemory(["
+      ^ String.concat ", " (List.map (byte_to_string env) bytes)
+      ^ "])"
   | COpaque reason -> "Opaque(" ^ reason ^ ")"
 
 and operand_to_string (env : 'a fmt_env) (op : operand) : string =

--- a/charon-ml/src/generated/Generated_Expressions.ml
+++ b/charon-ml/src/generated/Generated_Expressions.ml
@@ -120,6 +120,17 @@ and borrow_kind =
           <https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/mir/enum.MutBorrowKind.html#variant.ClosureCapture>.
       *)
 
+(** A byte, in the MiniRust sense: it can either be uninitialized, a concrete u8
+    value, or part of a pointer with provenance (e.g. to a global or a function)
+*)
+and byte =
+  | Uninit  (** An uninitialized byte *)
+  | Value of int  (** A concrete byte value *)
+  | Provenance of provenance * int
+      (** A byte that is part of a pointer with provenance. The u8 is the offset
+          within the pointer. Note that we do not have an actual value for this
+          pointer byte, unlike MiniRust, as that is non-deterministic. *)
+
 (** For all the variants: the first type gives the source type, the second one
     gives the destination type. *)
 and cast_kind =
@@ -199,7 +210,7 @@ and constant_expr_kind =
           values. *)
   | CVar of const_generic_var_id de_bruijn_var  (** A const generic var *)
   | CFnDef of fn_ptr  (** Function definition -- this is a ZST constant *)
-  | CRawMemory of int list
+  | CRawMemory of byte list
       (** Raw memory value obtained from constant evaluation. Used when a more
           structured representation isn't possible (e.g. for unions) or just
           isn't implemented yet. *)
@@ -291,6 +302,11 @@ and projection_elem =
           - [from]
           - [to]
           - [from_end] *)
+
+and provenance =
+  | Global of global_decl_ref
+  | Function of fun_decl_ref
+  | Unknown
 
 (** TODO: we could factor out [Rvalue] and function calls (for LLBC, not ULLBC).
     We can also factor out the unops, binops with the function calls. TODO: move

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.152"
+version = "0.1.153"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -150,7 +150,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     .erase();
                 ConstantExprKind::FnPtr(fn_ptr)
             }
-            hax::ConstantExprKind::Memory(bytes) => ConstantExprKind::RawMemory(bytes.clone()),
+            hax::ConstantExprKind::Memory(bytes) => {
+                ConstantExprKind::RawMemory(bytes.iter().map(|b| Byte::Value(*b)).collect())
+            }
             hax::ConstantExprKind::Todo(msg) => {
                 register_error!(self, span, "Unsupported constant: {:?}", msg);
                 ConstantExprKind::Opaque(msg.into())

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -50,6 +50,7 @@ fn make_ocaml_ident(name: &str) -> String {
             | "end"
             | "include"
             | "to"
+            | "function"
     ) {
         name += "_";
     }


### PR DESCRIPTION
The last of my `ConstantExprKind` PRs :) 
I tried hard to find an example where this occurs and crashes hax, but I couldn't, again I wonder if it's a matter of MIR settings? I know that in my Charon fork I run into union constants (notably [here](https://doc.rust-lang.org/src/core/array/mod.rs.html#151)), but somehow hax/Charon compiles this into an aggregate assignment.

I still think it's a nice thing to have for clients (and I would need it..), but if you'd rather not add this I understand.
