### PR TITLE
Use `serde_state` instead of global mutable state

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.151"
+let supported_charon_version = "0.1.152"

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -176,7 +176,12 @@ and gcrate_of_json
       of_json_ctx -> json -> ('body gexpr_body option, string) result)
     (js : json) : ('body gcrate, string) result =
   match js with
-  | `Assoc [ ("charon_version", charon_version); ("translated", translated) ] ->
+  | `Assoc
+      [
+        ("charon_version", charon_version);
+        ("translated", translated);
+        ("has_errors", _);
+      ] ->
       (* Ensure the version is the one we support. *)
       let* charon_version = string_of_json () charon_version in
       if

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -42,12 +42,13 @@ let hash_consed_val_of_json (map : 'a HashConsId.Map.t ref)
     (js : json) : ('a, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("hash_cons_id", `Int id); ("value", json) ] ->
+    | `Assoc [ ("Untagged", json) ] -> of_json ctx json
+    | `Assoc [ ("HashConsedValue", `List [ `Int id; json ]) ] ->
         let* v = of_json ctx json in
         let id = HashConsId.of_int id in
         map := HashConsId.Map.add id v !map;
         Ok v
-    | `Assoc [ ("hash_cons_id", `Int id) ] -> begin
+    | `Assoc [ ("Deduplicated", `Int id) ] -> begin
         let id = HashConsId.of_int id in
         match HashConsId.Map.find_opt id !map with
         | Some v -> Ok v
@@ -56,7 +57,7 @@ let hash_consed_val_of_json (map : 'a HashConsId.Map.t ref)
               "Hash-consing key not found; there is a serialization mismatch \
                between Rust and OCaml"
       end
-    | json -> of_json ctx json)
+    | _ -> Error "")
 
 let path_buf_of_json = string_of_json
 

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.151"
+version = "0.1.152"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -252,9 +252,9 @@ dependencies = [
  "reqwest",
  "rustc_version",
  "serde",
- "serde-map-to-array",
  "serde_json",
  "serde_stacker",
+ "serde_state",
  "snapbox",
  "stacker",
  "strip-ansi-escapes",
@@ -1978,27 +1978,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-map-to-array"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14b52efc56c711e0dbae3f26e0cc233f5dac336c1bf0b07e1b7dc2dca3b2cc7"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2055,6 +2056,25 @@ checksum = "69c8defe6c780725cce4ec6ad3bd91e321baf6fa4e255df1f31e345d507ef01a"
 dependencies = [
  "serde",
  "stacker",
+]
+
+[[package]]
+name = "serde_state"
+version = "1.0.0"
+source = "git+https://github.com/Nadrieril/serde_state?branch=main#5a7882d9e88af931705d03b3205e22b0bc3e5bf5"
+dependencies = [
+ "serde",
+ "serde_state_derive",
+]
+
+[[package]]
+name = "serde_state_derive"
+version = "1.0.0"
+source = "git+https://github.com/Nadrieril/serde_state?branch=main#5a7882d9e88af931705d03b3205e22b0bc3e5bf5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.151"
+version = "0.1.152"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",
@@ -42,6 +42,8 @@ harness = false
 [dependencies]
 hax = { package = "hax-frontend-exporter", git = "https://github.com/AeneasVerif/hax", branch = "main", optional = true }
 # hax = { package = "hax-frontend-exporter", path = "../../hax/frontend/exporter", optional = true }
+serde_state = { git = "https://github.com/Nadrieril/serde_state", branch = "main" }
+# serde_state = { path = "../../../forks/serde_state/serde_state" }
 macros = { path = "./macros" }
 
 annotate-snippets = { git = "https://github.com/rust-lang/annotate-snippets-rs", rev = "74964e91d845e39fb549c4028452beffa7c6562b", version = "0.11.5" }
@@ -70,7 +72,6 @@ petgraph = "0.8.0"
 reqwest = { version = "0.12.8", optional = true }
 rustc_version = "0.4"
 serde_json = { version = "1.0.91", features = ["unbounded_depth"] }
-serde-map-to-array = { version = "1.1.1", features = ["std"] }
 serde_stacker = "0.1.11"
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 stacker = "0.1"

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -4,9 +4,11 @@ use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 use std::vec::Vec;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Place {
     pub kind: PlaceKind,
     pub ty: Ty,
@@ -20,8 +22,8 @@ pub struct Place {
     EnumIsA,
     EnumAsGetters,
     EnumToGetters,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
@@ -53,8 +55,8 @@ pub enum PlaceKind {
     EnumAsGetters,
     EnumToGetters,
     VariantName,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
@@ -101,8 +103,8 @@ pub enum ProjectionElem {
     Clone,
     EnumIsA,
     EnumAsGetters,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
@@ -156,13 +158,23 @@ pub enum BorrowKind {
 
 /// Unary operation
 #[derive(
-    Debug, PartialEq, Eq, Clone, EnumIsA, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 #[charon::rename("Unop")]
 pub enum UnOp {
     Not,
     /// This can overflow, for `-i::MIN`.
     #[drive(skip)]
+    #[serde_state(stateless)]
     Neg(OverflowMode),
     /// Casts are rvalues in MIR, but we treat them as unops.
     Cast(CastKind),
@@ -170,7 +182,16 @@ pub enum UnOp {
 
 /// Nullary operation
 #[derive(
-    Debug, PartialEq, Eq, Clone, EnumIsA, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 #[charon::rename("Nullop")]
 pub enum NullOp {
@@ -185,7 +206,16 @@ pub enum NullOp {
 /// For all the variants: the first type gives the source type, the second one gives
 /// the destination type.
 #[derive(
-    Debug, PartialEq, Eq, Clone, EnumIsA, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 #[charon::variants_prefix("Cast")]
 pub enum CastKind {
@@ -217,7 +247,16 @@ pub enum CastKind {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, Clone, EnumIsA, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 #[charon::variants_prefix("Meta")]
 pub enum UnsizingMetadata {
@@ -241,9 +280,20 @@ pub enum OverflowMode {
 
 /// Binary operations.
 #[derive(
-    Debug, PartialEq, Eq, Copy, Clone, EnumIsA, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    EnumIsA,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 #[charon::rename("Binop")]
+#[serde_state(stateless)]
 pub enum BinOp {
     BitXor,
     BitAnd,
@@ -293,11 +343,12 @@ pub enum BinOp {
     EnumToGetters,
     EnumAsGetters,
     VariantName,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
+#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub enum Operand {
     Copy(Place),
     Move(Place),
@@ -316,12 +367,13 @@ pub enum Operand {
     EnumIsA,
     EnumAsGetters,
     VariantName,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
 #[charon::variants_prefix("F")]
+#[serde_state(stateless)]
 pub enum FunId {
     /// A "regular" function (function local to the crate, external function
     /// not treated as a primitive one).
@@ -408,7 +460,7 @@ pub struct BuiltinIndexOp {
 }
 
 /// Reference to a function declaration or builtin function.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct MaybeBuiltinFunDeclRef {
     pub id: FunId,
     pub generics: BoxedArgs,
@@ -416,7 +468,7 @@ pub struct MaybeBuiltinFunDeclRef {
 }
 
 /// Reference to a trait method.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct TraitMethodRef {
     pub trait_ref: TraitRef,
     pub name: TraitItemName,
@@ -427,7 +479,16 @@ pub struct TraitMethodRef {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, EnumAsGetters, Serialize, Deserialize, Drive, DriveMut, Hash,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    EnumAsGetters,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+    Hash,
 )]
 pub enum FnPtrKind {
     #[charon::rename("FunId")]
@@ -450,7 +511,7 @@ impl From<FunDeclId> for FnPtrKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, Hash)]
 pub struct FnPtr {
     pub kind: Box<FnPtrKind>,
     pub generics: BoxedArgs,
@@ -498,13 +559,14 @@ impl From<FunDeclRef> for FnPtr {
     VariantName,
     EnumIsA,
     EnumAsGetters,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
 #[charon::variants_prefix("C")]
 pub enum ConstantExprKind {
+    #[serde_state(stateless)]
     Literal(Literal),
     /// In most situations:
     /// Enumeration with one variant with no fields, structure with
@@ -586,7 +648,8 @@ pub enum ConstantExprKind {
     Opaque(String),
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct ConstantExpr {
     pub kind: ConstantExprKind,
     pub ty: Ty,
@@ -597,7 +660,15 @@ pub struct ConstantExpr {
 /// TODO: move the aggregate kind to operands
 /// TODO: we should prefix the type variants with "R" or "Rv", this would avoid collisions
 #[derive(
-    Debug, Clone, EnumToGetters, EnumAsGetters, EnumIsA, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    Clone,
+    EnumToGetters,
+    EnumAsGetters,
+    EnumIsA,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub enum Rvalue {
     /// Lifts an operand as an rvalue.
@@ -607,6 +678,7 @@ pub enum Rvalue {
     #[charon::rename("RvRef")]
     Ref {
         place: Place,
+        #[serde_state(stateless)]
         kind: BorrowKind,
         ptr_metadata: Operand,
     },
@@ -689,7 +761,7 @@ pub enum Rvalue {
 /// initialization, `ls` is initialized to `⊥`, then this `⊥` is expanded to
 /// `Cons (⊥, ⊥)` upon the first assignment, at which point we can initialize
 /// the field 0, etc.).
-#[derive(Debug, Clone, VariantIndexArity, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, VariantIndexArity, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::variants_prefix("Aggregated")]
 pub enum AggregateKind {
     /// A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -6,10 +6,11 @@ use crate::ullbc_ast;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::EnumAsGetters;
 use macros::{EnumIsA, EnumToGetters};
-use serde::{Deserialize, Serialize};
+use serde_state::DeserializeState;
+use serde_state::SerializeState;
 
 /// A variable
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Local {
     /// Unique index identifying the variable
     pub index: LocalId,
@@ -27,7 +28,7 @@ pub type Var = Local;
 pub type VarId = LocalId;
 
 /// The local variables of a body.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Default, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Locals {
     /// The number of local variables used for the input arguments.
     #[drive(skip)]
@@ -43,7 +44,7 @@ pub struct Locals {
 /// An expression body.
 /// TODO: arg_count should be stored in GFunDecl below. But then,
 ///       the print is obfuscated and Aeneas may need some refactoring.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("GexprBody")]
 pub struct GExprBody<T> {
     pub span: Span,
@@ -59,7 +60,15 @@ pub struct GExprBody<T> {
 
 /// The body of a function.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, Drive, DriveMut, EnumIsA, EnumAsGetters, EnumToGetters,
+    Debug,
+    Clone,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+    EnumIsA,
+    EnumAsGetters,
+    EnumToGetters,
 )]
 pub enum Body {
     /// Body represented as a CFG. This is what ullbc is made of, and what we get after translating MIR.
@@ -79,6 +88,7 @@ pub enum Body {
     Missing,
     /// We encountered an error while translating this body.
     #[drive(skip)]
+    #[serde_state(stateless)]
     Error(Error),
 }
 
@@ -103,7 +113,7 @@ pub enum Body {
 ///     fn test(...) { ... } // regular
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut, PartialEq, Eq)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, PartialEq, Eq)]
 #[charon::variants_suffix("Item")]
 pub enum ItemSource {
     /// This item stands on its own.
@@ -152,7 +162,7 @@ pub enum ItemSource {
 }
 
 /// A function definition
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct FunDecl {
     #[drive(skip)]
     pub def_id: FunDeclId,
@@ -173,14 +183,14 @@ pub struct FunDecl {
 }
 
 /// Reference to a function declaration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct FunDeclRef {
     pub id: FunDeclId,
     /// Generic arguments passed to the function.
     pub generics: BoxedArgs,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum GlobalKind {
     /// A static.
     Static,
@@ -194,7 +204,7 @@ pub enum GlobalKind {
 }
 
 /// A global variable definition (constant or static).
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct GlobalDecl {
     #[drive(skip)]
     pub def_id: GlobalDeclId,
@@ -213,7 +223,7 @@ pub struct GlobalDecl {
 }
 
 /// Reference to a global declaration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
 pub struct GlobalDeclRef {
     pub id: GlobalDeclId,
     pub generics: BoxedArgs,
@@ -223,8 +233,8 @@ pub struct GlobalDeclRef {
     Debug,
     Clone,
     Copy,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
     PartialEq,
@@ -234,6 +244,7 @@ pub struct GlobalDeclRef {
     Ord,
 )]
 #[drive(skip)]
+#[serde_state(stateless)]
 pub struct TraitItemName(pub ustr::Ustr);
 
 /// A trait **declaration**.
@@ -269,7 +280,7 @@ pub struct TraitItemName(pub ustr::Ustr);
 /// Of course, this forbids other useful use cases such as visitors implemented
 /// by means of traits.
 #[allow(clippy::type_complexity)]
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitDecl {
     #[drive(skip)]
     pub def_id: TraitDeclId,
@@ -309,7 +320,7 @@ pub struct TraitDecl {
 }
 
 /// An associated constant in a trait.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitAssocConst {
     pub name: TraitItemName,
     pub ty: Ty,
@@ -317,7 +328,7 @@ pub struct TraitAssocConst {
 }
 
 /// An associated type in a trait.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitAssocTy {
     pub name: TraitItemName,
     pub default: Option<Ty>,
@@ -326,7 +337,7 @@ pub struct TraitAssocTy {
 }
 
 /// A trait method.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitMethod {
     pub name: TraitItemName,
     /// Each method declaration is represented by a function item. That function contains the
@@ -345,7 +356,7 @@ pub struct TraitMethod {
 ///   fn baz(...) { ... }
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitImpl {
     #[drive(skip)]
     pub def_id: TraitImplId,
@@ -369,7 +380,7 @@ pub struct TraitImpl {
 }
 
 /// The value of a trait associated type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitAssocTyImpl {
     pub value: Ty,
     /// The `Vec` corresponds to the same `Vector` in `TraitAssocTy`. In the same way, this is
@@ -381,7 +392,7 @@ pub struct TraitAssocTyImpl {
 /// A function operand is used in function calls.
 /// It either designates a top-level function, or a place in case
 /// we are using function pointers stored in local variables.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::variants_prefix("FnOp")]
 pub enum FnOperand {
     /// Regular case: call to a top-level function, trait method, etc.
@@ -390,14 +401,14 @@ pub enum FnOperand {
     Dynamic(Operand),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Call {
     pub func: FnOperand,
     pub args: Vec<Operand>,
     pub dest: Place,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct CopyNonOverlapping {
     pub src: Operand,
     pub dst: Operand,
@@ -408,7 +419,7 @@ pub struct CopyNonOverlapping {
 /// control-flow. The two kinds of abort are:
 /// - Panic (may unwind or not depending on compilation setting);
 /// - Undefined behavior:
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum AbortKind {
     /// A built-in panicking function.
     Panic(Option<Name>),
@@ -421,7 +432,7 @@ pub enum AbortKind {
 /// A `Drop` statement/terminator can mean two things, depending on what MIR phase we retrieved
 /// from rustc: it could be a real drop, or it could be a "conditional drop", which is where drop
 /// may happen depending on whether the borrow-checker determines a drop is needed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, Copy, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum DropKind {
     /// A real drop. This calls `<T as Destruct>::drop_in_place(&raw mut place)` and marks the
     /// place as moved-out-of. Use `--desugar-drops` to transform all such drops to an actual
@@ -454,7 +465,7 @@ pub enum DropKind {
 /// instance) to this. We then eliminate them in [crate::transform::resugar::reconstruct_fallible_operations],
 /// because they're implicit in the semantics of our array accesses etc. Finally we introduce new asserts in
 /// [crate::transform::resugar::reconstruct_asserts].
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("Assertion")]
 pub struct Assert {
     pub cond: Operand,

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -10,13 +10,21 @@ pub use super::llbc_ast_utils::*;
 pub use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
-use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 
 generate_index_type!(StatementId);
 
 /// A raw statement: a statement without meta data.
 #[derive(
-    Debug, Clone, EnumIsA, EnumToGetters, EnumAsGetters, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    Clone,
+    EnumIsA,
+    EnumToGetters,
+    EnumAsGetters,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub enum StatementKind {
     /// Assigns an `Rvalue` to a `Place`. e.g. `let y = x;` could become
@@ -71,7 +79,7 @@ pub enum StatementKind {
     Error(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Statement {
     pub span: Span,
     /// Integer uniquely identifying this statement among the statmeents in the current body. To
@@ -85,7 +93,8 @@ pub struct Statement {
     pub comments_before: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Block {
     pub span: Span,
     pub statements: Vec<Statement>,
@@ -97,8 +106,8 @@ pub struct Block {
     EnumIsA,
     EnumToGetters,
     EnumAsGetters,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
     VariantName,

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -5,6 +5,7 @@ use crate::names::Name;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters};
 use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 use std::path::PathBuf;
 
 generate_index_type!(FileId);
@@ -53,10 +54,13 @@ pub struct SpanData {
     Hash,
     Serialize,
     Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
 #[drive(skip)]
+#[serde_state(stateless)]
 pub struct Span {
     /// The source code span.
     ///
@@ -203,8 +207,10 @@ pub enum ItemOpacity {
 }
 
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[serde_state(stateless)]
 pub struct ItemMeta {
+    #[serde_state(stateful)]
     pub name: Name,
     pub span: Span,
     /// The source code that corresponds to this item.

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -2,16 +2,26 @@
 use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA};
-use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 
 generate_index_type!(Disambiguator);
 
 /// See the comments for [Name]
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut, EnumIsA, EnumAsGetters,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+    EnumIsA,
+    EnumAsGetters,
 )]
 #[charon::variants_prefix("Pe")]
 pub enum PathElem {
+    #[serde_state(stateless)]
     Ident(#[drive(skip)] String, Disambiguator),
     Impl(ImplElem),
     /// This item was obtained by instantiating its parent with the given args. The binder binds
@@ -30,7 +40,7 @@ pub enum PathElem {
 ///   impl<T> PartialEq for List<T> { ...}
 ///   ```
 /// We distinguish the two.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::variants_prefix("ImplElem")]
 pub enum ImplElem {
     Ty(Binder<Ty>),
@@ -72,7 +82,9 @@ pub enum ImplElem {
 /// name clashes anyway. Still, we might want to be more precise in the future.
 ///
 /// Also note that the first path element in the name is always the crate name.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut,
+)]
 #[serde(transparent)]
 pub struct Name {
     pub name: Vec<PathElem>,

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -8,6 +8,7 @@ use std::{
 use derive_generic_visitor::{Drive, DriveMut};
 use index_vec::Idx;
 use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 
 use crate::{ast::*, impl_from_enum};
 
@@ -78,14 +79,14 @@ impl DeBruijnId {
     Hash,
     PartialOrd,
     Ord,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
 pub enum DeBruijnVar<Id> {
     /// A variable attached to the nth binder, counting from the innermost.
-    Bound(DeBruijnId, Id),
+    Bound(#[serde_state(stateless)] DeBruijnId, Id),
     /// A variable attached to the outermost binder (the one on the item). As explained above, This
     /// is not used in charon internals, only as a micro-pass before exporting the crate data.
     Free(Id),
@@ -137,7 +138,7 @@ pub struct ConstGenericParam {
 
 /// A trait predicate in a signature, of the form `Type: Trait<Args>`. This functions like a
 /// variable binder, to which variables of the form `TraitRefKind::Clause` can refer to.
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitParam {
     /// Index identifying the clause among other clauses bound at the same level.
     pub clause_id: TraitClauseId,

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -3,7 +3,7 @@
 pub use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
-use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 
 // Block identifier. Similar to rust's `BasicBlock`.
 generate_index_type!(BlockId, "Block");
@@ -17,7 +17,15 @@ pub type ExprBody = GExprBody<BodyContents>;
 
 /// A raw statement: a statement without meta data.
 #[derive(
-    Debug, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize, Deserialize, Drive, DriveMut,
+    Debug,
+    Clone,
+    EnumIsA,
+    EnumAsGetters,
+    VariantName,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub enum StatementKind {
     Assign(Place, Rvalue),
@@ -46,7 +54,7 @@ pub enum StatementKind {
     Error(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Statement {
     pub span: Span,
     pub kind: StatementKind,
@@ -63,8 +71,8 @@ pub struct Statement {
     EnumAsGetters,
     VariantName,
     VariantIndexArity,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
 )]
@@ -79,7 +87,9 @@ pub enum SwitchTargets {
 }
 
 /// A raw terminator: a terminator without meta data.
-#[derive(Debug, Clone, EnumIsA, EnumAsGetters, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug, Clone, EnumIsA, EnumAsGetters, SerializeState, DeserializeState, Drive, DriveMut,
+)]
 pub enum TerminatorKind {
     Goto {
         target: BlockId,
@@ -112,7 +122,7 @@ pub enum TerminatorKind {
     UnwindResume,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Terminator {
     pub span: Span,
     pub kind: TerminatorKind,
@@ -122,7 +132,7 @@ pub struct Terminator {
     pub comments_before: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("Block")]
 pub struct BlockData {
     pub statements: Vec<Statement>,

--- a/charon/src/ast/values.rs
+++ b/charon/src/ast/values.rs
@@ -5,6 +5,7 @@ use core::hash::Hash;
 use derive_generic_visitor::{Drive, DriveMut};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 
 // We need to manipulate a lot of indices for the types, variables, definitions,
 // etc. In order not to confuse them, we define an index type for every one of
@@ -27,6 +28,8 @@ generate_index_type!(LocalId, "");
     EnumAsGetters,
     Serialize,
     Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
     Hash,
@@ -34,6 +37,7 @@ generate_index_type!(LocalId, "");
     Ord,
 )]
 #[charon::variants_prefix("V")]
+#[serde_state(stateless)]
 pub enum Literal {
     Scalar(ScalarValue),
     Float(FloatValue),

--- a/charon/src/bin/generate-ml/templates/GAstOfJson.ml
+++ b/charon/src/bin/generate-ml/templates/GAstOfJson.ml
@@ -43,18 +43,22 @@ let hash_consed_val_of_json (map : 'a HashConsId.Map.t ref)
     (js : json) : ('a, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("hash_cons_id", `Int id); ("value", json) ] ->
+    | `Assoc [ ("Untagged", json) ] -> of_json ctx json
+    | `Assoc [ ("HashConsedValue", `List [ `Int id; json ]) ] ->
         let* v = of_json ctx json in
         let id = HashConsId.of_int id in
         map := HashConsId.Map.add id v !map;
         Ok v
-    | `Assoc [ ("hash_cons_id", `Int id) ] -> begin
+    | `Assoc [ ("Deduplicated", `Int id) ] -> begin
         let id = HashConsId.of_int id in
         match HashConsId.Map.find_opt id !map with
         | Some v -> Ok v
-        | None -> Error "Hash-consing key not found; there is a serialization mismatch between Rust and OCaml"
+        | None ->
+            Error
+              "Hash-consing key not found; there is a serialization mismatch \
+               between Rust and OCaml"
       end
-    | json -> of_json ctx json)
+    | _ -> Error "")
 
 let path_buf_of_json = string_of_json
 

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -1,28 +1,76 @@
 use crate::ast::*;
 use crate::transform::TransformCtx;
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_state::{DeserializeState, SerializeState};
 use std::fs::File;
 use std::path::Path;
 
 /// The data of a generic crate. We serialize this to pass it to `charon-ml`, so this must be as
 /// stable as possible. This is used for both ULLBC and LLBC.
-#[derive(Serialize, Deserialize)]
-#[serde(rename = "Crate")]
+#[derive(SerializeState, DeserializeState)]
 pub struct CrateData {
     /// The version of charon currently being used. `charon-ml` inspects this and errors if it is
     /// trying to read an incompatible version (for now we compare versions for equality).
-    #[serde(deserialize_with = "ensure_version")]
-    pub charon_version: String,
+    #[serde_state(stateless)]
+    pub charon_version: CharonVersion,
     pub translated: TranslatedCrate,
-    #[serde(skip)]
+    #[serde_state(stateless)]
     /// If there were errors, this contains only a partial description of the input crate.
     pub has_errors: bool,
+}
+
+impl Serialize for CrateData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.translated.options.no_dedup_serialized_ast {
+            self.serialize_state(&(), serializer)
+        } else {
+            let state = HashConsDedupSerializer::default();
+            self.serialize_state(&state, serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CrateData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Always provide the state, just in case.
+        let state = HashConsDedupSerializer::default();
+        Self::deserialize_state(&state, deserializer)
+    }
+}
+
+#[derive(Serialize)]
+pub struct CharonVersion(pub String);
+
+impl<'de> Deserialize<'de> for CharonVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let version = String::deserialize(deserializer)?;
+        if version != crate::VERSION {
+            return Err(D::Error::custom(format!(
+                "Incompatible version of charon: \
+                this program supports llbc emitted by charon v{} \
+                but attempted to read a file emitted by charon v{}",
+                crate::VERSION,
+                version,
+            )));
+        }
+        Ok(CharonVersion(version))
+    }
 }
 
 impl CrateData {
     pub fn new(ctx: TransformCtx) -> Self {
         CrateData {
-            charon_version: crate::VERSION.to_owned(),
+            charon_version: CharonVersion(crate::VERSION.to_owned()),
             has_errors: ctx.has_errors(),
             translated: ctx.translated,
         }
@@ -49,11 +97,7 @@ impl CrateData {
             return Err(());
         };
         // Write to the file.
-        let res = if self.translated.options.no_dedup_serialized_ast {
-            serde_json::to_writer(&outfile, self)
-        } else {
-            with_dedup_serialization(|| serde_json::to_writer(&outfile, self))
-        };
+        let res = serde_json::to_writer(&outfile, self);
         match res {
             Ok(()) => {}
             Err(err) => {
@@ -75,19 +119,4 @@ impl CrateData {
         }
         Ok(())
     }
-}
-
-fn ensure_version<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
-    use serde::de::Error;
-    let version = String::deserialize(d)?;
-    if version != crate::VERSION {
-        return Err(D::Error::custom(format!(
-            "Incompatible version of charon: \
-            this program supports llbc emitted by charon v{} \
-            but attempted to read a file emitted by charon v{}",
-            crate::VERSION,
-            version,
-        )));
-    }
-    Ok(version)
 }

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -43,5 +43,25 @@ macro_rules! generate_index_type {
                 f.write_str(self.index().to_string().as_str())
             }
         }
+
+        impl<State: ?Sized> serde_state::SerializeState<State> for $name {
+            fn serialize_state<S: serde::ser::Serializer>(
+                &self,
+                _state: &State,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error> {
+                use serde::Serialize;
+                self.index().serialize(serializer)
+            }
+        }
+        impl<'de, State: ?Sized> serde_state::DeserializeState<'de, State> for $name {
+            fn deserialize_state<D: serde::de::Deserializer<'de>>(
+                _state: &State,
+                deserializer: D,
+            ) -> Result<Self, D::Error> {
+                use serde::Deserialize;
+                usize::deserialize(deserializer).map(Self::from_usize)
+            }
+        }
     };
 }

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -3,11 +3,10 @@ use crate::formatter::FmtCtx;
 use crate::pretty::FmtWithCtx;
 use derive_generic_visitor::*;
 use macros::EnumIsA;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 /// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, EnumIsA, Deserialize, Drive, DriveMut)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, EnumIsA, Drive, DriveMut)]
 pub enum GenericsSource {
     /// A top-level item.
     Item(ItemId),

--- a/charon/tests/ptr-metadata.json
+++ b/charon/tests/ptr-metadata.json
@@ -21,8 +21,10 @@
   "test_crate::GenericInLastField": "None",
   "test_crate::GenericWithUnsize": {
     "InheritFrom": {
-      "TypeVar": {
-        "Free": 0
+      "Untagged": {
+        "TypeVar": {
+          "Free": 0
+        }
       }
     }
   },


### PR DESCRIPTION
The implementation of deduplicated deserialization has a fundamental concurrency issue: we need to keep a mapping from `HashConsId` to deserialized value and we currently do that in a mutable global value. The issue then is that deserializing two different llbc files in parallel will cause collisions and incorrect deserializations.

To solve this, I developped https://github.com/Nadrieril/serde_state, which provides a (de)serialization infrastructure based on serde but that threads a state throughout. This PR replaces the heart of the (de)serialization impls in Charon with this new library.