### PR TITLE
Fix version detection

### DIFF
--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -158,12 +158,9 @@ and gcrate_of_json
       of_json_ctx -> json -> ('body gexpr_body option, string) result)
     (js : json) : ('body gcrate, string) result =
   match js with
-  | `Assoc
-      [
-        ("charon_version", charon_version);
-        ("translated", translated);
-        ("has_errors", _);
-      ] ->
+  | `Assoc [ ("charon_version", charon_version); ("translated", translated) ]
+  | `Assoc [ ("charon_version", charon_version); ("translated", translated); _ ]
+    ->
       (* Ensure the version is the one we support. *)
       let* charon_version = string_of_json () charon_version in
       if

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -15,6 +15,7 @@ pub struct CrateData {
     pub charon_version: CharonVersion,
     pub translated: TranslatedCrate,
     #[serde_state(stateless)]
+    #[charon::opaque] // Don't change, this would break version detection for old charon-ml
     /// If there were errors, this contains only a partial description of the input crate.
     pub has_errors: bool,
 }


### PR DESCRIPTION
I didn't realize that the OCaml side was less robust than the Rust side when I exposed the `has_errors` field >< There now exist some pairs of versions of charon/charon-ml that don't have a nice error message on version mismatches. Hopefully this keeps the number of such pairs low.