### PR TITLE
Change representation of array and slice types

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.160"
+let supported_charon_version = "0.1.161"

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -172,9 +172,7 @@ let rec type_id_to_string (env : 'a fmt_env) (id : type_id) : string =
   | TBuiltin aty -> (
       match aty with
       | TBox -> "alloc::boxed::Box"
-      | TStr -> "str"
-      | TArray -> "@Array"
-      | TSlice -> "@Slice")
+      | TStr -> "str")
 
 and type_decl_id_to_string env def_id =
   (* We don't want the printing functions to crash if the crate is partial *)
@@ -305,6 +303,9 @@ and ty_to_string (env : 'a fmt_env) (ty : ty) : string =
         | r :: _ -> " + " ^ r
       in
       "dyn (" ^ String.concat " + " clauses ^ reg_str ^ ")"
+  | TArray (ty, len) ->
+      "[" ^ ty_to_string env ty ^ "; " ^ const_generic_to_string env len ^ "]"
+  | TSlice ty -> "[" ^ ty_to_string env ty ^ "]"
   | TPtrMetadata ty -> "PtrMetadata(" ^ ty_to_string env ty ^ ")"
   | TError msg -> "type_error (\"" ^ msg ^ "\")"
 

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -109,18 +109,9 @@ let ty_as_builtin_adt (ty : ty) : builtin_ty * generic_args =
   | None -> raise (Failure "Unreachable")
 
 let ty_as_opt_array (ty : ty) : (ty * const_generic) option =
-  match ty_as_builtin_adt_opt ty with
-  | None -> None
-  | Some (id, generics) -> (
-      match (id, generics) with
-      | ( TArray,
-          {
-            types = [ ty ];
-            const_generics = [ n ];
-            regions = [];
-            trait_refs = [];
-          } ) -> Some (ty, n)
-      | _ -> None)
+  match ty with
+  | TArray (ty, len) -> Some (ty, len)
+  | _ -> None
 
 let ty_is_array (ty : ty) : bool = Option.is_some (ty_as_opt_array ty)
 
@@ -130,14 +121,9 @@ let ty_as_array (ty : ty) : ty * const_generic =
   | None -> raise (Failure "Unreachable")
 
 let ty_as_opt_slice (ty : ty) : ty option =
-  match ty_as_builtin_adt_opt ty with
-  | None -> None
-  | Some (id, generics) -> (
-      match (id, generics) with
-      | ( TSlice,
-          { types = [ ty ]; const_generics = []; regions = []; trait_refs = [] }
-        ) -> Some ty
-      | _ -> None)
+  match ty with
+  | TSlice ty -> Some ty
+  | _ -> None
 
 let ty_is_slice (ty : ty) : bool = Option.is_some (ty_as_opt_slice ty)
 

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -305,8 +305,6 @@ and builtin_ty_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Box" -> Ok TBox
-    | `String "Array" -> Ok TArray
-    | `String "Slice" -> Ok TSlice
     | `String "Str" -> Ok TStr
     | _ -> Error "")
 
@@ -2146,6 +2144,13 @@ and ty_kind_of_json (ctx : of_json_ctx) (js : json) : (ty_kind, string) result =
     | `Assoc [ ("PtrMetadata", ptr_metadata) ] ->
         let* ptr_metadata = ty_of_json ctx ptr_metadata in
         Ok (TPtrMetadata ptr_metadata)
+    | `Assoc [ ("Array", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = ty_of_json ctx x_0 in
+        let* x_1 = const_generic_of_json ctx x_1 in
+        Ok (TArray (x_0, x_1))
+    | `Assoc [ ("Slice", slice) ] ->
+        let* slice = ty_of_json ctx slice in
+        Ok (TSlice slice)
     | `Assoc [ ("Error", error) ] ->
         let* error = string_of_json ctx error in
         Ok (TError error)

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -304,8 +304,6 @@ and builtin_index_op = {
     modular. TODO: move to builtins.rs? *)
 and builtin_ty =
   | TBox  (** Boxes are de facto a primitive type. *)
-  | TArray  (** Primitive type *)
-  | TSlice  (** Primitive type *)
   | TStr  (** Primitive type *)
 
 (** A const generic variable in a signature or binder. *)
@@ -626,6 +624,8 @@ and ty_kind =
   | TPtrMetadata of ty
       (** As a marker of taking out metadata from a given type The internal type
           is assumed to be a type variable *)
+  | TArray of ty * const_generic  (** An array type [[T; N]] *)
+  | TSlice of ty  (** A slice type [[T]] *)
   | TError of string  (** A type that could not be computed or was incorrect. *)
 
 (** Reference to a type declaration or builtin type. *)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.160"
+version = "0.1.161"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.160"
+version = "0.1.161"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/builtins.rs
+++ b/charon/src/ast/builtins.rs
@@ -17,8 +17,6 @@ impl BuiltinTy {
         let name: &[_] = match self {
             BuiltinTy::Box => &["alloc", "boxed", "Box"],
             BuiltinTy::Str => &["Str"],
-            BuiltinTy::Array => &["Array"],
-            BuiltinTy::Slice => &["Slice"],
         };
         Name::from_path(name)
     }

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -73,7 +73,9 @@ impl Place {
                 tref.generics.types[0].clone()
             }
             Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(..)
-            | FnPtr(..) | FnDef(..) | PtrMetadata(..) | Error(..) => panic!("internal type error"),
+            | FnPtr(..) | FnDef(..) | PtrMetadata(..) | Array(..) | Slice(_) | Error(..) => {
+                panic!("internal type error")
+            }
         };
         Place {
             ty: proj_ty,
@@ -160,7 +162,8 @@ impl ProjectionElem {
                         tref.generics.types[0].clone()
                     }
                     Adt(..) | TypeVar(_) | Literal(_) | Never | TraitType(..) | DynTrait(..)
-                    | FnPtr(..) | FnDef(..) | PtrMetadata(..) | Error(..) => {
+                    | Array(..) | Slice(..) | FnPtr(..) | FnDef(..) | PtrMetadata(..)
+                    | Error(..) => {
                         // Type error
                         return Err(());
                     }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -890,6 +890,10 @@ pub enum TyKind {
     /// As a marker of taking out metadata from a given type
     /// The internal type is assumed to be a type variable
     PtrMetadata(Ty),
+    /// An array type `[T; N]`
+    Array(Ty, ConstGeneric),
+    /// A slice type `[T]`
+    Slice(Ty),
     /// A type that could not be computed or was incorrect.
     #[drive(skip)]
     Error(String),
@@ -926,10 +930,6 @@ pub enum TyKind {
 pub enum BuiltinTy {
     /// Boxes are de facto a primitive type.
     Box,
-    /// Primitive type
-    Array,
-    /// Primitive type
-    Slice,
     /// Primitive type
     Str,
 }

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -139,14 +139,17 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 TyKind::Adt(tref)
             }
             hax::TyKind::Array(item_ref) => {
-                let args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;
-                let tref = TypeDeclRef::new(TypeId::Builtin(BuiltinTy::Array), args);
-                TyKind::Adt(tref)
+                let mut args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;
+                assert!(args.types.elem_count() == 1 && args.const_generics.elem_count() == 1);
+                TyKind::Array(
+                    args.types.pop().unwrap(),
+                    args.const_generics.pop().unwrap(),
+                )
             }
             hax::TyKind::Slice(item_ref) => {
-                let args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;
-                let tref = TypeDeclRef::new(TypeId::Builtin(BuiltinTy::Slice), args);
-                TyKind::Adt(tref)
+                let mut args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;
+                assert!(args.types.elem_count() == 1);
+                TyKind::Slice(args.types.pop().unwrap())
             }
             hax::TyKind::Tuple(item_ref) => {
                 let args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -145,6 +145,26 @@ impl Pattern {
                     TypeId::Tuple => false,
                 }
             }
+            TyKind::Array(ty, len) => {
+                let type_name = Name::from_path(&["Array"]);
+                let args = GenericArgs {
+                    regions: [].into(),
+                    types: [ty.clone()].into(),
+                    const_generics: [len.clone()].into(),
+                    trait_refs: [].into(),
+                };
+                self.matches_with_generics(ctx, &type_name, Some(&args))
+            }
+            TyKind::Slice(ty) => {
+                let type_name = Name::from_path(&["Slice"]);
+                let args = GenericArgs {
+                    regions: [].into(),
+                    types: [ty.clone()].into(),
+                    const_generics: [].into(),
+                    trait_refs: [].into(),
+                };
+                self.matches_with_generics(ctx, &type_name, Some(&args))
+            }
             TyKind::TypeVar(..)
             | TyKind::Literal(..)
             | TyKind::Never

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1434,9 +1434,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                         match ty_ref.id {
                             TypeId::Tuple => write!(f, "({})", ops_s),
                             TypeId::Builtin(BuiltinTy::Box) => write!(f, "Box({})", ops_s),
-                            TypeId::Builtin(
-                                BuiltinTy::Array | BuiltinTy::Slice | BuiltinTy::Str,
-                            ) => {
+                            TypeId::Builtin(BuiltinTy::Str) => {
                                 write!(f, "[{}]", ops_s)
                             }
                             TypeId::Adt(ty_id) => {
@@ -2010,6 +2008,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
                     RefKind::Mut => write!(f, "mut")?,
                 }
                 write!(f, " {}", ty.with_ctx(ctx))
+            }
+            TyKind::Array(ty, len) => {
+                write!(f, "[{}; {}]", ty.with_ctx(ctx), len.with_ctx(ctx))
+            }
+            TyKind::Slice(ty) => {
+                write!(f, "[{}]", ty.with_ctx(ctx))
             }
             TyKind::TraitType(trait_ref, name) => {
                 write!(f, "{}::{name}", trait_ref.with_ctx(ctx),)

--- a/charon/src/transform/normalize/partial_monomorphization.rs
+++ b/charon/src/transform/normalize/partial_monomorphization.rs
@@ -333,7 +333,10 @@ impl<'a> PartialMonomorphizer<'a> {
     fn is_infected(&self, ty: &Ty) -> bool {
         match ty.kind() {
             TyKind::Ref(_, _, RefKind::Mut) => true,
-            TyKind::Ref(_, ty, _) | TyKind::RawPtr(ty, _) => self.is_infected(ty),
+            TyKind::Ref(_, ty, _)
+            | TyKind::RawPtr(ty, _)
+            | TyKind::Array(ty, _)
+            | TyKind::Slice(ty) => self.is_infected(ty),
             TyKind::Adt(tref) => {
                 let ty_infected =
                     matches!(&tref.id, TypeId::Adt(id) if self.infected_types.contains(id));

--- a/charon/src/transform/simplify_output/index_to_function_calls.rs
+++ b/charon/src/transform/simplify_output/index_to_function_calls.rs
@@ -31,31 +31,34 @@ impl<'a, 'b> IndexVisitor<'a, 'b> {
         let Some((subplace, pe @ (Index { .. } | Subslice { .. }))) = place.as_projection() else {
             return;
         };
-        let tref = subplace.ty.as_adt().unwrap();
-        let builtin_ty = tref.id.as_builtin().unwrap();
+
+        let (ty, len) = match subplace.ty.kind() {
+            TyKind::Array(ty, len) => (ty.clone(), Some(len.clone())),
+            TyKind::Slice(ty) => (ty.clone(), None),
+            _ => unreachable!("Indexing can only be done on arrays or slices"),
+        };
 
         // The built-in function to call.
         let indexing_function = {
             let builtin_fun = BuiltinFunId::Index(BuiltinIndexOp {
-                is_array: matches!(builtin_ty, BuiltinTy::Array),
+                is_array: subplace.ty.kind().is_array(),
                 mutability: RefKind::mutable(mut_access),
-                is_range: matches!(pe, Subslice { .. }),
+                is_range: pe.is_subslice(),
             });
             // Same generics as the array/slice type, except for the extra lifetime.
-            let mut generics = tref.generics.clone();
-            generics.regions = [Region::Erased].into();
+            let generics = GenericArgs {
+                types: [ty.clone()].into(),
+                const_generics: len.map_or_else(|| [].into(), |l| [l].into()),
+                regions: [Region::Erased].into(),
+                trait_refs: [].into(),
+            };
             FnOperand::Regular(FnPtr::new(FnPtrKind::mk_builtin(builtin_fun), generics))
         };
 
-        let elem_ty = tref.generics.types[0].clone();
         let output_inner_ty = if matches!(pe, Index { .. }) {
-            elem_ty
+            ty
         } else {
-            TyKind::Adt(TypeDeclRef {
-                id: TypeId::Builtin(BuiltinTy::Slice),
-                generics: Box::new(GenericArgs::new_for_builtin(vec![elem_ty].into())),
-            })
-            .into_ty()
+            TyKind::Slice(ty).into_ty()
         };
         let output_ty = {
             TyKind::Ref(

--- a/charon/src/transform/simplify_output/simplify_constants.rs
+++ b/charon/src/transform/simplify_output/simplify_constants.rs
@@ -72,9 +72,7 @@ fn transform_constant_expr(
             // return unsize::<&[T; N], &[T]>(array_ref);
             let bval = transform_constant_expr(ctx, bval);
             let bval_ty = bval.ty().clone();
-            let adt = bval_ty.as_adt().expect("Non-adt slice sub-constant");
-            assert_eq!(adt.id, TypeId::Builtin(BuiltinTy::Array));
-            let len = adt.generics.const_generics[0].clone();
+            let (_, len) = bval_ty.as_array().expect("Non-adt slice sub-constant");
 
             let array_place = ctx.rval_to_place(Rvalue::Use(bval), bval_ty.clone());
 
@@ -84,7 +82,7 @@ fn transform_constant_expr(
                 UnOp::Cast(CastKind::Unsize(
                     array_ref.ty.clone(),
                     val.ty.clone(),
-                    UnsizingMetadata::Length(len),
+                    UnsizingMetadata::Length(len.clone()),
                 )),
                 Operand::Move(array_ref),
             )
@@ -141,15 +139,16 @@ fn transform_constant_expr(
                 UIntTy::Usize,
                 fields.len() as u128,
             )));
-            let mut tref = val.ty.kind().as_adt().unwrap().clone();
-            let ty = tref.generics.types.pop().unwrap();
-            match tref.id.as_builtin().unwrap() {
-                BuiltinTy::Array => {}
-                BuiltinTy::Slice => val_ty = Ty::mk_array(ty.clone(), len.clone()),
-                _ => {
-                    unreachable!("Unpexected builtin type in array/slice constant")
+            let ty = match val.ty.kind() {
+                TyKind::Array(ty, _) => ty.clone(),
+                TyKind::Slice(ty) => {
+                    val_ty = Ty::mk_array(ty.clone(), len.clone());
+                    ty.clone()
                 }
-            }
+                _ => {
+                    unreachable!("Unpexected type in array/slice constant")
+                }
+            };
             Rvalue::Aggregate(AggregateKind::Array(ty, len), fields)
         }
         ConstantExprKind::FnPtr(fptr) => {

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -23,26 +23,26 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: core::array::{impl Index<I, Clause2_Output> for Array<T, N>}::index
-pub fn {impl Index<I, Clause2_Output> for Array<T, N>}::index<'_0, T, I, Clause2_Output, const N : usize>(@1: &'_0 (Array<T, N>), @2: I) -> &'_0 (Clause2_Output)
+// Full name: core::array::{impl Index<I, Clause2_Output> for [T; N]}::index
+pub fn {impl Index<I, Clause2_Output> for [T; N]}::index<'_0, T, I, Clause2_Output, const N : usize>(@1: &'_0 ([T; N]), @2: I) -> &'_0 (Clause2_Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<Slice<T>, I, Clause2_Output>,
+    [@TraitClause2]: Index<[T], I, Clause2_Output>,
 = <opaque>
 
-// Full name: core::array::{impl Index<I, Clause2_Output> for Array<T, N>}
-impl<T, I, Clause2_Output, const N : usize> Index<I, Clause2_Output> for Array<T, N>
+// Full name: core::array::{impl Index<I, Clause2_Output> for [T; N]}
+impl<T, I, Clause2_Output, const N : usize> Index<I, Clause2_Output> for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<Slice<T>, I, Clause2_Output>,
+    [@TraitClause2]: Index<[T], I, Clause2_Output>,
 {
-    parent_clause0 = {built_in impl MetaSized for Array<T, N>}
+    parent_clause0 = {built_in impl MetaSized for [T; N]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause2
-    fn index<'_0_1> = {impl Index<I, Clause2_Output> for Array<T, N>}::index<'_0_1, T, I, Clause2_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I, Clause2_Output> for Array<T, N>}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I, Clause2_Output> for [T; N]}::index<'_0_1, T, I, Clause2_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I, Clause2_Output> for [T; N]}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::ops::index::IndexMut
@@ -56,26 +56,26 @@ pub trait IndexMut<Self, Idx, Self_Clause1_Output>
     vtable: core::ops::index::IndexMut::{vtable}<Idx, Self_Clause1_Output>
 }
 
-// Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::index_mut
-pub fn {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::index_mut<'_0, T, I, Clause2_Clause1_Output, const N : usize>(@1: &'_0 mut (Array<T, N>), @2: I) -> &'_0 mut (Clause2_Clause1_Output)
+// Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut
+pub fn {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut<'_0, T, I, Clause2_Clause1_Output, const N : usize>(@1: &'_0 mut ([T; N]), @2: I) -> &'_0 mut (Clause2_Clause1_Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IndexMut<Slice<T>, I, Clause2_Clause1_Output>,
+    [@TraitClause2]: IndexMut<[T], I, Clause2_Clause1_Output>,
 = <opaque>
 
-// Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}
-impl<T, I, Clause2_Clause1_Output, const N : usize> IndexMut<I, Clause2_Clause1_Output> for Array<T, N>
+// Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}
+impl<T, I, Clause2_Clause1_Output, const N : usize> IndexMut<I, Clause2_Clause1_Output> for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IndexMut<Slice<T>, I, Clause2_Clause1_Output>,
+    [@TraitClause2]: IndexMut<[T], I, Clause2_Clause1_Output>,
 {
-    parent_clause0 = {built_in impl MetaSized for Array<T, N>}
-    parent_clause1 = {impl Index<I, Clause2_Output> for Array<T, N>}<T, I, Clause2_Clause1_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause1]
+    parent_clause0 = {built_in impl MetaSized for [T; N]}
+    parent_clause1 = {impl Index<I, Clause2_Output> for [T; N]}<T, I, Clause2_Clause1_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2::parent_clause1]
     parent_clause2 = @TraitClause1::parent_clause0
-    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::index_mut<'_0_1, T, I, Clause2_Clause1_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut<'_0_1, T, I, Clause2_Clause1_Output, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::marker::Destruct
@@ -143,48 +143,48 @@ pub trait SliceIndex<Self, T, Self_Output>
     vtable: core::slice::index::SliceIndex::{vtable}<T, Self_Output>
 }
 
-// Full name: core::slice::index::{impl Index<I, Clause2_Output> for Slice<T>}::index
-pub fn {impl Index<I, Clause2_Output> for Slice<T>}::index<'_0, T, I, Clause2_Output>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (Clause2_Output)
+// Full name: core::slice::index::{impl Index<I, Clause2_Output> for [T]}::index
+pub fn {impl Index<I, Clause2_Output> for [T]}::index<'_0, T, I, Clause2_Output>(@1: &'_0 ([T]), @2: I) -> &'_0 (Clause2_Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>, Clause2_Output>,
+    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
 = <opaque>
 
-// Full name: core::slice::index::{impl Index<I, Clause2_Output> for Slice<T>}
-impl<T, I, Clause2_Output> Index<I, Clause2_Output> for Slice<T>
+// Full name: core::slice::index::{impl Index<I, Clause2_Output> for [T]}
+impl<T, I, Clause2_Output> Index<I, Clause2_Output> for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>, Clause2_Output>,
+    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause3
-    fn index<'_0_1> = {impl Index<I, Clause2_Output> for Slice<T>}::index<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I, Clause2_Output> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I, Clause2_Output> for [T]}::index<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I, Clause2_Output> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
-// Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut
-pub fn {impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut<'_0, T, I, Clause2_Output>(@1: &'_0 mut (Slice<T>), @2: I) -> &'_0 mut (Clause2_Output)
+// Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for [T]}::index_mut
+pub fn {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_0, T, I, Clause2_Output>(@1: &'_0 mut ([T]), @2: I) -> &'_0 mut (Clause2_Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>, Clause2_Output>,
+    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
 = <opaque>
 
-// Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for Slice<T>}
-impl<T, I, Clause2_Output> IndexMut<I, Clause2_Output> for Slice<T>
+// Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for [T]}
+impl<T, I, Clause2_Output> IndexMut<I, Clause2_Output> for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>, Clause2_Output>,
+    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
-    parent_clause1 = {impl Index<I, Clause2_Output> for Slice<T>}<T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
+    parent_clause0 = {built_in impl MetaSized for [T]}
+    parent_clause1 = {impl Index<I, Clause2_Output> for [T]}<T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
     parent_clause2 = @TraitClause1::parent_clause0
-    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl IndexMut<I, Clause2_Output> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl IndexMut<I, Clause2_Output> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
@@ -223,63 +223,63 @@ where
     [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> Option<&'_0 (Slice<T>)>[{built_in impl Sized for &'_0 (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get
+pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> Option<&'_0 ([T])>[{built_in impl Sized for &'_0 ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (Slice<T>)>[{built_in impl Sized for &'_0 mut (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
+pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> Option<&'_0 mut ([T])>[{built_in impl Sized for &'_0 mut ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const Slice<T>) -> *const Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut Slice<T>) -> *mut Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index
+pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
+pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
-impl<T> SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}
+impl<T> SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
     parent_clause1 = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
-    parent_clause3 = {built_in impl MetaSized for Slice<T>}
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    parent_clause2 = {built_in impl MetaSized for [T]}
+    parent_clause3 = {built_in impl MetaSized for [T]}
+    fn get<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
 }
 
-// Full name: core::slice::{Slice<T>}::len
+// Full name: core::slice::{[T]}::len
 #[lang_item("slice_len_fn")]
-pub fn len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
+pub fn len<'_0, T>(@1: &'_0 ([T])) -> usize
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -294,21 +294,21 @@ fn UNIT_METADATA()
 
 const UNIT_METADATA: () = @Fun0()
 
-// Full name: test_crate::<array>::{impl Destruct for Array<T, N>}::drop_in_place
-unsafe fn {impl Destruct for Array<T, N>}::drop_in_place<T, const N : usize>(@1: *mut Array<T, N>)
+// Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
+unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(@1: *mut [T; N])
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: (); // return
-    let @1: *mut Array<T, N>; // arg #1
-    let @2: &'0 mut (Array<T, N>); // anonymous local
-    let @3: *mut Array<T, N>; // anonymous local
-    let @4: *mut Slice<T>; // anonymous local
+    let @1: *mut [T; N]; // arg #1
+    let @2: &'0 mut ([T; N]); // anonymous local
+    let @3: *mut [T; N]; // anonymous local
+    let @4: *mut [T]; // anonymous local
     let @5: usize; // anonymous local
     let @6: usize; // anonymous local
     let @7: *mut T; // anonymous local
     let @8: bool; // anonymous local
-    let @9: &'_ mut (Slice<T>); // anonymous local
+    let @9: &'_ mut ([T]); // anonymous local
     let @10: &'_ mut (T); // anonymous local
 
     storage_live(@2)
@@ -321,7 +321,7 @@ where
     @0 := ()
     @2 := &mut *(@1)
     @3 := &raw mut *(@2)
-    @4 := unsize_cast<*mut Array<T, N>, *mut Slice<T>, N>(move (@3))
+    @4 := unsize_cast<*mut [T; N], *mut [T], N>(move (@3))
     @5 := copy (@4.metadata)
     @6 := const (0 : usize)
     loop {
@@ -342,12 +342,12 @@ where
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct for Array<T, N>}
-impl<T, const N : usize> Destruct for Array<T, N>
+// Full name: test_crate::<array>::{impl Destruct for [T; N]}
+impl<T, const N : usize> Destruct for [T; N]
 where
     [@TraitClause0]: Sized<T>,
 {
-    fn drop_in_place = {impl Destruct for Array<T, N>}::drop_in_place<T, N>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[@TraitClause0]
     non-dyn-compatible
 }
 
@@ -373,13 +373,13 @@ pub fn incr<'_0>(@1: &'_0 mut (u32))
 }
 
 // Full name: test_crate::array_to_shared_slice_
-pub fn array_to_shared_slice_<'_0, T>(@1: &'_0 (Array<T, 32 : usize>)) -> &'_0 (Slice<T>)
+pub fn array_to_shared_slice_<'_0, T>(@1: &'_0 ([T; 32 : usize])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 (Slice<T>); // return
-    let s@1: &'1 (Array<T, 32 : usize>); // arg #1
-    let @2: &'1 (Array<T, 32 : usize>); // anonymous local
+    let @0: &'0 ([T]); // return
+    let s@1: &'1 ([T; 32 : usize]); // arg #1
+    let @2: &'1 ([T; 32 : usize]); // anonymous local
 
     storage_live(@2)
     @2 := &*(s@1)
@@ -389,14 +389,14 @@ where
 }
 
 // Full name: test_crate::array_to_mut_slice_
-pub fn array_to_mut_slice_<'_0, T>(@1: &'_0 mut (Array<T, 32 : usize>)) -> &'_0 mut (Slice<T>)
+pub fn array_to_mut_slice_<'_0, T>(@1: &'_0 mut ([T; 32 : usize])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 mut (Slice<T>); // return
-    let s@1: &'1 mut (Array<T, 32 : usize>); // arg #1
-    let @2: &'0 mut (Slice<T>); // anonymous local
-    let @3: &'1 mut (Array<T, 32 : usize>); // anonymous local
+    let @0: &'0 mut ([T]); // return
+    let s@1: &'1 mut ([T; 32 : usize]); // arg #1
+    let @2: &'0 mut ([T]); // anonymous local
+    let @3: &'1 mut ([T; 32 : usize]); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
@@ -409,14 +409,14 @@ where
 }
 
 // Full name: test_crate::array_len
-pub fn array_len<T>(@1: Array<T, 32 : usize>) -> usize
+pub fn array_len<T>(@1: [T; 32 : usize]) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: usize; // return
-    let s@1: Array<T, 32 : usize>; // arg #1
-    let @2: &'0 (Slice<T>); // anonymous local
-    let @3: &'1 (Array<T, 32 : usize>); // anonymous local
+    let s@1: [T; 32 : usize]; // arg #1
+    let @2: &'0 ([T]); // anonymous local
+    let @3: &'1 ([T; 32 : usize]); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
@@ -425,19 +425,19 @@ where
     storage_dead(@3)
     @0 := len<'_, T>[@TraitClause0](move (@2))
     storage_dead(@2)
-    conditional_drop[{impl Destruct for Array<T, N>}<T, 32 : usize>[@TraitClause0]] s@1
+    conditional_drop[{impl Destruct for [T; N]}<T, 32 : usize>[@TraitClause0]] s@1
     return
 }
 
 // Full name: test_crate::shared_array_len
-pub fn shared_array_len<'_0, T>(@1: &'_0 (Array<T, 32 : usize>)) -> usize
+pub fn shared_array_len<'_0, T>(@1: &'_0 ([T; 32 : usize])) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: usize; // return
-    let s@1: &'0 (Array<T, 32 : usize>); // arg #1
-    let @2: &'1 (Slice<T>); // anonymous local
-    let @3: &'0 (Array<T, 32 : usize>); // anonymous local
+    let s@1: &'0 ([T; 32 : usize]); // arg #1
+    let @2: &'1 ([T]); // anonymous local
+    let @3: &'0 ([T; 32 : usize]); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
@@ -450,13 +450,13 @@ where
 }
 
 // Full name: test_crate::shared_slice_len
-pub fn shared_slice_len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
+pub fn shared_slice_len<'_0, T>(@1: &'_0 ([T])) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: usize; // return
-    let s@1: &'0 (Slice<T>); // arg #1
-    let @2: &'0 (Slice<T>); // anonymous local
+    let s@1: &'0 ([T]); // arg #1
+    let @2: &'0 ([T]); // anonymous local
 
     storage_live(@2)
     @2 := &*(s@1) with_metadata(copy (s@1.metadata))
@@ -466,16 +466,16 @@ where
 }
 
 // Full name: test_crate::index_array_shared
-pub fn index_array_shared<'_0, T>(@1: &'_0 (Array<T, 32 : usize>), @2: usize) -> &'_0 (T)
+pub fn index_array_shared<'_0, T>(@1: &'_0 ([T; 32 : usize]), @2: usize) -> &'_0 (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 (T); // return
-    let s@1: &'1 (Array<T, 32 : usize>); // arg #1
+    let s@1: &'1 ([T; 32 : usize]); // arg #1
     let i@2: usize; // arg #2
     let @3: &'0 (T); // anonymous local
     let @4: usize; // anonymous local
-    let @5: &'_ (Array<T, 32 : usize>); // anonymous local
+    let @5: &'_ ([T; 32 : usize]); // anonymous local
     let @6: &'_ (T); // anonymous local
 
     storage_live(@3)
@@ -493,13 +493,13 @@ where
 }
 
 // Full name: test_crate::index_array_u32
-pub fn index_array_u32(@1: Array<u32, 32 : usize>, @2: usize) -> u32
+pub fn index_array_u32(@1: [u32; 32 : usize], @2: usize) -> u32
 {
     let @0: u32; // return
-    let s@1: Array<u32, 32 : usize>; // arg #1
+    let s@1: [u32; 32 : usize]; // arg #1
     let i@2: usize; // arg #2
     let @3: usize; // anonymous local
-    let @4: &'_ (Array<u32, 32 : usize>); // anonymous local
+    let @4: &'_ ([u32; 32 : usize]); // anonymous local
     let @5: &'_ (u32); // anonymous local
 
     storage_live(@3)
@@ -514,12 +514,12 @@ pub fn index_array_u32(@1: Array<u32, 32 : usize>, @2: usize) -> u32
 }
 
 // Full name: test_crate::index_array_copy
-pub fn index_array_copy<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> u32
+pub fn index_array_copy<'_0>(@1: &'_0 ([u32; 32 : usize])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 (Array<u32, 32 : usize>); // arg #1
+    let x@1: &'0 ([u32; 32 : usize]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Array<u32, 32 : usize>); // anonymous local
+    let @3: &'_ ([u32; 32 : usize]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -534,17 +534,17 @@ pub fn index_array_copy<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> u32
 }
 
 // Full name: test_crate::index_mut_array
-pub fn index_mut_array<'_0, T>(@1: &'_0 mut (Array<T, 32 : usize>), @2: usize) -> &'_0 mut (T)
+pub fn index_mut_array<'_0, T>(@1: &'_0 mut ([T; 32 : usize]), @2: usize) -> &'_0 mut (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 mut (T); // return
-    let s@1: &'1 mut (Array<T, 32 : usize>); // arg #1
+    let s@1: &'1 mut ([T; 32 : usize]); // arg #1
     let i@2: usize; // arg #2
     let @3: &'0 mut (T); // anonymous local
     let @4: &'0 mut (T); // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ mut (Array<T, 32 : usize>); // anonymous local
+    let @6: &'_ mut ([T; 32 : usize]); // anonymous local
     let @7: &'_ mut (T); // anonymous local
 
     storage_live(@3)
@@ -565,16 +565,16 @@ where
 }
 
 // Full name: test_crate::index_slice
-pub fn index_slice<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> &'_0 (T)
+pub fn index_slice<'_0, T>(@1: &'_0 ([T]), @2: usize) -> &'_0 (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 (T); // return
-    let s@1: &'1 (Slice<T>); // arg #1
+    let s@1: &'1 ([T]); // arg #1
     let i@2: usize; // arg #2
     let @3: &'0 (T); // anonymous local
     let @4: usize; // anonymous local
-    let @5: &'_ (Slice<T>); // anonymous local
+    let @5: &'_ ([T]); // anonymous local
     let @6: &'_ (T); // anonymous local
 
     storage_live(@3)
@@ -592,17 +592,17 @@ where
 }
 
 // Full name: test_crate::index_mut_slice
-pub fn index_mut_slice<'_0, T>(@1: &'_0 mut (Slice<T>), @2: usize) -> &'_0 mut (T)
+pub fn index_mut_slice<'_0, T>(@1: &'_0 mut ([T]), @2: usize) -> &'_0 mut (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 mut (T); // return
-    let s@1: &'1 mut (Slice<T>); // arg #1
+    let s@1: &'1 mut ([T]); // arg #1
     let i@2: usize; // arg #2
     let @3: &'0 mut (T); // anonymous local
     let @4: &'0 mut (T); // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ mut (Slice<T>); // anonymous local
+    let @6: &'_ mut ([T]); // anonymous local
     let @7: &'_ mut (T); // anonymous local
 
     storage_live(@3)
@@ -623,15 +623,15 @@ where
 }
 
 // Full name: test_crate::slice_subslice_shared_
-pub fn slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
+pub fn slice_subslice_shared_<'_0>(@1: &'_0 ([u32]), @2: usize, @3: usize) -> &'_0 ([u32])
 {
-    let @0: &'0 (Slice<u32>); // return
-    let x@1: &'0 (Slice<u32>); // arg #1
+    let @0: &'0 ([u32]); // return
+    let x@1: &'0 ([u32]); // arg #1
     let y@2: usize; // arg #2
     let z@3: usize; // arg #3
-    let @4: &'0 (Slice<u32>); // anonymous local
-    let @5: &'0 (Slice<u32>); // anonymous local
-    let @6: &'0 (Slice<u32>); // anonymous local
+    let @4: &'0 ([u32]); // anonymous local
+    let @5: &'0 ([u32]); // anonymous local
+    let @6: &'0 ([u32]); // anonymous local
     let @7: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @8: usize; // anonymous local
     let @9: usize; // anonymous local
@@ -648,7 +648,7 @@ pub fn slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3: usize) 
     @7 := Range { start: move (@8), end: move (@9) }
     storage_dead(@9)
     storage_dead(@8)
-    @5 := {impl Index<I, Clause2_Output> for Slice<T>}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]](move (@6), move (@7))
+    @5 := {impl Index<I, Clause2_Output> for [T]}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]](move (@6), move (@7))
     storage_dead(@7)
     storage_dead(@6)
     @4 := &*(@5) with_metadata(copy (@5.metadata))
@@ -659,16 +659,16 @@ pub fn slice_subslice_shared_<'_0>(@1: &'_0 (Slice<u32>), @2: usize, @3: usize) 
 }
 
 // Full name: test_crate::slice_subslice_mut_
-pub fn slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
+pub fn slice_subslice_mut_<'_0>(@1: &'_0 mut ([u32]), @2: usize, @3: usize) -> &'_0 mut ([u32])
 {
-    let @0: &'0 mut (Slice<u32>); // return
-    let x@1: &'0 mut (Slice<u32>); // arg #1
+    let @0: &'0 mut ([u32]); // return
+    let x@1: &'0 mut ([u32]); // arg #1
     let y@2: usize; // arg #2
     let z@3: usize; // arg #3
-    let @4: &'0 mut (Slice<u32>); // anonymous local
-    let @5: &'0 mut (Slice<u32>); // anonymous local
-    let @6: &'0 mut (Slice<u32>); // anonymous local
-    let @7: &'0 mut (Slice<u32>); // anonymous local
+    let @4: &'0 mut ([u32]); // anonymous local
+    let @5: &'0 mut ([u32]); // anonymous local
+    let @6: &'0 mut ([u32]); // anonymous local
+    let @7: &'0 mut ([u32]); // anonymous local
     let @8: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @9: usize; // anonymous local
     let @10: usize; // anonymous local
@@ -686,7 +686,7 @@ pub fn slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3: usize)
     @8 := Range { start: move (@9), end: move (@10) }
     storage_dead(@10)
     storage_dead(@9)
-    @6 := {impl IndexMut<I, Clause2_Output> for Slice<T>}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]](move (@7), move (@8))
+    @6 := {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]](move (@7), move (@8))
     storage_dead(@8)
     storage_dead(@7)
     @5 := &mut *(@6) with_metadata(copy (@6.metadata))
@@ -699,11 +699,11 @@ pub fn slice_subslice_mut_<'_0>(@1: &'_0 mut (Slice<u32>), @2: usize, @3: usize)
 }
 
 // Full name: test_crate::array_to_slice_shared_
-pub fn array_to_slice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> &'_0 (Slice<u32>)
+pub fn array_to_slice_shared_<'_0>(@1: &'_0 ([u32; 32 : usize])) -> &'_0 ([u32])
 {
-    let @0: &'0 (Slice<u32>); // return
-    let x@1: &'1 (Array<u32, 32 : usize>); // arg #1
-    let @2: &'1 (Array<u32, 32 : usize>); // anonymous local
+    let @0: &'0 ([u32]); // return
+    let x@1: &'1 ([u32; 32 : usize]); // arg #1
+    let @2: &'1 ([u32; 32 : usize]); // anonymous local
 
     storage_live(@2)
     @2 := &*(x@1)
@@ -713,12 +713,12 @@ pub fn array_to_slice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> &'_0 (S
 }
 
 // Full name: test_crate::array_to_slice_mut_
-pub fn array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>)) -> &'_0 mut (Slice<u32>)
+pub fn array_to_slice_mut_<'_0>(@1: &'_0 mut ([u32; 32 : usize])) -> &'_0 mut ([u32])
 {
-    let @0: &'0 mut (Slice<u32>); // return
-    let x@1: &'1 mut (Array<u32, 32 : usize>); // arg #1
-    let @2: &'0 mut (Slice<u32>); // anonymous local
-    let @3: &'1 mut (Array<u32, 32 : usize>); // anonymous local
+    let @0: &'0 mut ([u32]); // return
+    let x@1: &'1 mut ([u32; 32 : usize]); // arg #1
+    let @2: &'0 mut ([u32]); // anonymous local
+    let @3: &'1 mut ([u32; 32 : usize]); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
@@ -731,15 +731,15 @@ pub fn array_to_slice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>)) -> &'_0 m
 }
 
 // Full name: test_crate::array_subslice_shared_
-pub fn array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
+pub fn array_subslice_shared_<'_0>(@1: &'_0 ([u32; 32 : usize]), @2: usize, @3: usize) -> &'_0 ([u32])
 {
-    let @0: &'0 (Slice<u32>); // return
-    let x@1: &'1 (Array<u32, 32 : usize>); // arg #1
+    let @0: &'0 ([u32]); // return
+    let x@1: &'1 ([u32; 32 : usize]); // arg #1
     let y@2: usize; // arg #2
     let z@3: usize; // arg #3
-    let @4: &'0 (Slice<u32>); // anonymous local
-    let @5: &'0 (Slice<u32>); // anonymous local
-    let @6: &'1 (Array<u32, 32 : usize>); // anonymous local
+    let @4: &'0 ([u32]); // anonymous local
+    let @5: &'0 ([u32]); // anonymous local
+    let @6: &'1 ([u32; 32 : usize]); // anonymous local
     let @7: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @8: usize; // anonymous local
     let @9: usize; // anonymous local
@@ -756,7 +756,7 @@ pub fn array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize,
     @7 := Range { start: move (@8), end: move (@9) }
     storage_dead(@9)
     storage_dead(@8)
-    @5 := {impl Index<I, Clause2_Output> for Array<T, N>}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>, 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I, Clause2_Output> for Slice<T>}<u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
+    @5 := {impl Index<I, Clause2_Output> for [T; N]}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32], 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I, Clause2_Output> for [T]}<u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
     storage_dead(@7)
     storage_dead(@6)
     @4 := &*(@5) with_metadata(copy (@5.metadata))
@@ -767,16 +767,16 @@ pub fn array_subslice_shared_<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize,
 }
 
 // Full name: test_crate::array_subslice_mut_
-pub fn array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 mut (Slice<u32>)
+pub fn array_subslice_mut_<'_0>(@1: &'_0 mut ([u32; 32 : usize]), @2: usize, @3: usize) -> &'_0 mut ([u32])
 {
-    let @0: &'0 mut (Slice<u32>); // return
-    let x@1: &'1 mut (Array<u32, 32 : usize>); // arg #1
+    let @0: &'0 mut ([u32]); // return
+    let x@1: &'1 mut ([u32; 32 : usize]); // arg #1
     let y@2: usize; // arg #2
     let z@3: usize; // arg #3
-    let @4: &'0 mut (Slice<u32>); // anonymous local
-    let @5: &'0 mut (Slice<u32>); // anonymous local
-    let @6: &'0 mut (Slice<u32>); // anonymous local
-    let @7: &'1 mut (Array<u32, 32 : usize>); // anonymous local
+    let @4: &'0 mut ([u32]); // anonymous local
+    let @5: &'0 mut ([u32]); // anonymous local
+    let @6: &'0 mut ([u32]); // anonymous local
+    let @7: &'1 mut ([u32; 32 : usize]); // anonymous local
     let @8: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @9: usize; // anonymous local
     let @10: usize; // anonymous local
@@ -794,7 +794,7 @@ pub fn array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize
     @8 := Range { start: move (@9), end: move (@10) }
     storage_dead(@10)
     storage_dead(@9)
-    @6 := {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>, 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl IndexMut<I, Clause2_Output> for Slice<T>}<u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@7), move (@8))
+    @6 := {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32], 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl IndexMut<I, Clause2_Output> for [T]}<u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@7), move (@8))
     storage_dead(@8)
     storage_dead(@7)
     @5 := &mut *(@6) with_metadata(copy (@6.metadata))
@@ -807,15 +807,15 @@ pub fn array_subslice_mut_<'_0>(@1: &'_0 mut (Array<u32, 32 : usize>), @2: usize
 }
 
 // Full name: test_crate::index_slice_0
-pub fn index_slice_0<'_0, T>(@1: &'_0 (Slice<T>)) -> &'_0 (T)
+pub fn index_slice_0<'_0, T>(@1: &'_0 ([T])) -> &'_0 (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 (T); // return
-    let s@1: &'1 (Slice<T>); // arg #1
+    let s@1: &'1 ([T]); // arg #1
     let @2: &'0 (T); // anonymous local
     let @3: usize; // anonymous local
-    let @4: &'_ (Slice<T>); // anonymous local
+    let @4: &'_ ([T]); // anonymous local
     let @5: &'_ (T); // anonymous local
 
     storage_live(@2)
@@ -833,15 +833,15 @@ where
 }
 
 // Full name: test_crate::index_array_0
-pub fn index_array_0<'_0, T>(@1: &'_0 (Array<T, 32 : usize>)) -> &'_0 (T)
+pub fn index_array_0<'_0, T>(@1: &'_0 ([T; 32 : usize])) -> &'_0 (T)
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: &'0 (T); // return
-    let s@1: &'1 (Array<T, 32 : usize>); // arg #1
+    let s@1: &'1 ([T; 32 : usize]); // arg #1
     let @2: &'0 (T); // anonymous local
     let @3: usize; // anonymous local
-    let @4: &'_ (Array<T, 32 : usize>); // anonymous local
+    let @4: &'_ ([T; 32 : usize]); // anonymous local
     let @5: &'_ (T); // anonymous local
 
     storage_live(@2)
@@ -859,17 +859,17 @@ where
 }
 
 // Full name: test_crate::index_index_array
-pub fn index_index_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: usize, @3: usize) -> u32
+pub fn index_index_array(@1: [[u32; 32 : usize]; 32 : usize], @2: usize, @3: usize) -> u32
 {
     let @0: u32; // return
-    let s@1: Array<Array<u32, 32 : usize>, 32 : usize>; // arg #1
+    let s@1: [[u32; 32 : usize]; 32 : usize]; // arg #1
     let i@2: usize; // arg #2
     let j@3: usize; // arg #3
     let @4: usize; // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ (Array<Array<u32, 32 : usize>, 32 : usize>); // anonymous local
-    let @7: &'_ (Array<u32, 32 : usize>); // anonymous local
-    let @8: &'_ (Array<u32, 32 : usize>); // anonymous local
+    let @6: &'_ ([[u32; 32 : usize]; 32 : usize]); // anonymous local
+    let @7: &'_ ([u32; 32 : usize]); // anonymous local
+    let @8: &'_ ([u32; 32 : usize]); // anonymous local
     let @9: &'_ (u32); // anonymous local
 
     storage_live(@4)
@@ -879,7 +879,7 @@ pub fn index_index_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: usiz
     storage_live(@6)
     @6 := &s@1
     storage_live(@7)
-    @7 := @ArrayIndexShared<'_, Array<u32, 32 : usize>, 32 : usize>(move (@6), copy (@4))
+    @7 := @ArrayIndexShared<'_, [u32; 32 : usize], 32 : usize>(move (@6), copy (@4))
     storage_live(@8)
     @8 := &*(@7)
     storage_live(@9)
@@ -891,17 +891,17 @@ pub fn index_index_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: usiz
 }
 
 // Full name: test_crate::update_update_array
-pub fn update_update_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: usize, @3: usize)
+pub fn update_update_array(@1: [[u32; 32 : usize]; 32 : usize], @2: usize, @3: usize)
 {
     let @0: (); // return
-    let s@1: Array<Array<u32, 32 : usize>, 32 : usize>; // arg #1
+    let s@1: [[u32; 32 : usize]; 32 : usize]; // arg #1
     let i@2: usize; // arg #2
     let j@3: usize; // arg #3
     let @4: usize; // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ mut (Array<Array<u32, 32 : usize>, 32 : usize>); // anonymous local
-    let @7: &'_ mut (Array<u32, 32 : usize>); // anonymous local
-    let @8: &'_ mut (Array<u32, 32 : usize>); // anonymous local
+    let @6: &'_ mut ([[u32; 32 : usize]; 32 : usize]); // anonymous local
+    let @7: &'_ mut ([u32; 32 : usize]); // anonymous local
+    let @8: &'_ mut ([u32; 32 : usize]); // anonymous local
     let @9: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -912,7 +912,7 @@ pub fn update_update_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: us
     storage_live(@6)
     @6 := &mut s@1
     storage_live(@7)
-    @7 := @ArrayIndexMut<'_, Array<u32, 32 : usize>, 32 : usize>(move (@6), copy (@4))
+    @7 := @ArrayIndexMut<'_, [u32; 32 : usize], 32 : usize>(move (@6), copy (@4))
     storage_live(@8)
     @8 := &mut *(@7)
     storage_live(@9)
@@ -925,15 +925,15 @@ pub fn update_update_array(@1: Array<Array<u32, 32 : usize>, 32 : usize>, @2: us
 }
 
 // Full name: test_crate::incr_array_self
-pub fn incr_array_self<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>))
+pub fn incr_array_self<'_0>(@1: &'_0 mut ([u32; 2 : usize]))
 {
     let @0: (); // return
-    let s@1: &'0 mut (Array<u32, 2 : usize>); // arg #1
+    let s@1: &'0 mut ([u32; 2 : usize]); // arg #1
     let @2: usize; // anonymous local
     let @3: u32; // anonymous local
-    let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @4: &'_ ([u32; 2 : usize]); // anonymous local
     let @5: &'_ (u32); // anonymous local
-    let @6: &'_ mut (Array<u32, 2 : usize>); // anonymous local
+    let @6: &'_ mut ([u32; 2 : usize]); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
     storage_live(@3)
@@ -956,15 +956,15 @@ pub fn incr_array_self<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>))
 }
 
 // Full name: test_crate::incr_slice_self
-pub fn incr_slice_self<'_0>(@1: &'_0 mut (Slice<u32>))
+pub fn incr_slice_self<'_0>(@1: &'_0 mut ([u32]))
 {
     let @0: (); // return
-    let s@1: &'0 mut (Slice<u32>); // arg #1
+    let s@1: &'0 mut ([u32]); // arg #1
     let @2: usize; // anonymous local
     let @3: u32; // anonymous local
-    let @4: &'_ (Slice<u32>); // anonymous local
+    let @4: &'_ ([u32]); // anonymous local
     let @5: &'_ (u32); // anonymous local
-    let @6: &'_ mut (Slice<u32>); // anonymous local
+    let @6: &'_ mut ([u32]); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
     storage_live(@3)
@@ -987,11 +987,11 @@ pub fn incr_slice_self<'_0>(@1: &'_0 mut (Slice<u32>))
 }
 
 // Full name: test_crate::array_local_deep_copy
-pub fn array_local_deep_copy<'_0>(@1: &'_0 (Array<u32, 32 : usize>))
+pub fn array_local_deep_copy<'_0>(@1: &'_0 ([u32; 32 : usize]))
 {
     let @0: (); // return
-    let x@1: &'0 (Array<u32, 32 : usize>); // arg #1
-    let _y@2: Array<u32, 32 : usize>; // local
+    let x@1: &'0 ([u32; 32 : usize]); // arg #1
+    let _y@2: [u32; 32 : usize]; // local
 
     @0 := ()
     storage_live(_y@2)
@@ -1002,10 +1002,10 @@ pub fn array_local_deep_copy<'_0>(@1: &'_0 (Array<u32, 32 : usize>))
 }
 
 // Full name: test_crate::take_array
-pub fn take_array(@1: Array<u32, 2 : usize>)
+pub fn take_array(@1: [u32; 2 : usize])
 {
     let @0: (); // return
-    let @1: Array<u32, 2 : usize>; // arg #1
+    let @1: [u32; 2 : usize]; // arg #1
 
     @0 := ()
     @0 := ()
@@ -1013,10 +1013,10 @@ pub fn take_array(@1: Array<u32, 2 : usize>)
 }
 
 // Full name: test_crate::take_array_borrow
-pub fn take_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>))
+pub fn take_array_borrow<'_0>(@1: &'_0 ([u32; 2 : usize]))
 {
     let @0: (); // return
-    let @1: &'0 (Array<u32, 2 : usize>); // arg #1
+    let @1: &'0 ([u32; 2 : usize]); // arg #1
 
     @0 := ()
     @0 := ()
@@ -1024,10 +1024,10 @@ pub fn take_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>))
 }
 
 // Full name: test_crate::take_slice
-pub fn take_slice<'_0>(@1: &'_0 (Slice<u32>))
+pub fn take_slice<'_0>(@1: &'_0 ([u32]))
 {
     let @0: (); // return
-    let @1: &'0 (Slice<u32>); // arg #1
+    let @1: &'0 ([u32]); // arg #1
 
     @0 := ()
     @0 := ()
@@ -1035,10 +1035,10 @@ pub fn take_slice<'_0>(@1: &'_0 (Slice<u32>))
 }
 
 // Full name: test_crate::take_mut_slice
-pub fn take_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>))
+pub fn take_mut_slice<'_0>(@1: &'_0 mut ([u32]))
 {
     let @0: (); // return
-    let @1: &'0 mut (Slice<u32>); // arg #1
+    let @1: &'0 mut ([u32]); // arg #1
 
     @0 := ()
     @0 := ()
@@ -1046,9 +1046,9 @@ pub fn take_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>))
 }
 
 // Full name: test_crate::const_array
-pub fn const_array() -> Array<u32, 2 : usize>
+pub fn const_array() -> [u32; 2 : usize]
 {
-    let @0: Array<u32, 2 : usize>; // return
+    let @0: [u32; 2 : usize]; // return
 
     @0 := @ArrayRepeat<'_, u32, 2 : usize>(const (0 : u32))
     return
@@ -1058,12 +1058,12 @@ pub fn const_array() -> Array<u32, 2 : usize>
 pub fn const_slice()
 {
     let @0: (); // return
-    let @1: &'0 (Slice<u32>); // anonymous local
-    let @2: &'1 (Array<u32, 2 : usize>); // anonymous local
-    let @3: &'1 (Array<u32, 2 : usize>); // anonymous local
-    let @4: &'1 (Array<u32, 2 : usize>); // anonymous local
-    let @5: &'_ (Array<u32, 2 : usize>); // anonymous local
-    let @6: Array<u32, 2 : usize>; // anonymous local
+    let @1: &'0 ([u32]); // anonymous local
+    let @2: &'1 ([u32; 2 : usize]); // anonymous local
+    let @3: &'1 ([u32; 2 : usize]); // anonymous local
+    let @4: &'1 ([u32; 2 : usize]); // anonymous local
+    let @5: &'_ ([u32; 2 : usize]); // anonymous local
+    let @6: [u32; 2 : usize]; // anonymous local
 
     storage_live(@5)
     storage_live(@6)
@@ -1089,22 +1089,22 @@ pub fn const_slice()
 pub fn take_all()
 {
     let @0: (); // return
-    let x@1: Array<u32, 2 : usize>; // local
+    let x@1: [u32; 2 : usize]; // local
     let @2: (); // anonymous local
-    let @3: Array<u32, 2 : usize>; // anonymous local
+    let @3: [u32; 2 : usize]; // anonymous local
     let @4: (); // anonymous local
-    let @5: Array<u32, 2 : usize>; // anonymous local
+    let @5: [u32; 2 : usize]; // anonymous local
     let @6: (); // anonymous local
-    let @7: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @8: &'0 (Array<u32, 2 : usize>); // anonymous local
+    let @7: &'0 ([u32; 2 : usize]); // anonymous local
+    let @8: &'0 ([u32; 2 : usize]); // anonymous local
     let @9: (); // anonymous local
-    let @10: &'1 (Slice<u32>); // anonymous local
-    let @11: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @12: &'0 (Array<u32, 2 : usize>); // anonymous local
+    let @10: &'1 ([u32]); // anonymous local
+    let @11: &'0 ([u32; 2 : usize]); // anonymous local
+    let @12: &'0 ([u32; 2 : usize]); // anonymous local
     let @13: (); // anonymous local
-    let @14: &'2 mut (Slice<u32>); // anonymous local
-    let @15: &'3 mut (Array<u32, 2 : usize>); // anonymous local
-    let @16: &'3 mut (Array<u32, 2 : usize>); // anonymous local
+    let @14: &'2 mut ([u32]); // anonymous local
+    let @15: &'3 mut ([u32; 2 : usize]); // anonymous local
+    let @16: &'3 mut ([u32; 2 : usize]); // anonymous local
 
     @0 := ()
     storage_live(x@1)
@@ -1165,12 +1165,12 @@ pub fn take_all()
 }
 
 // Full name: test_crate::index_array
-pub fn index_array(@1: Array<u32, 2 : usize>) -> u32
+pub fn index_array(@1: [u32; 2 : usize]) -> u32
 {
     let @0: u32; // return
-    let x@1: Array<u32, 2 : usize>; // arg #1
+    let x@1: [u32; 2 : usize]; // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @3: &'_ ([u32; 2 : usize]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -1185,12 +1185,12 @@ pub fn index_array(@1: Array<u32, 2 : usize>) -> u32
 }
 
 // Full name: test_crate::index_array_borrow
-pub fn index_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>)) -> u32
+pub fn index_array_borrow<'_0>(@1: &'_0 ([u32; 2 : usize])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 (Array<u32, 2 : usize>); // arg #1
+    let x@1: &'0 ([u32; 2 : usize]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @3: &'_ ([u32; 2 : usize]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -1205,12 +1205,12 @@ pub fn index_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>)) -> u32
 }
 
 // Full name: test_crate::index_slice_u32_0
-pub fn index_slice_u32_0<'_0>(@1: &'_0 (Slice<u32>)) -> u32
+pub fn index_slice_u32_0<'_0>(@1: &'_0 ([u32])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 (Slice<u32>); // arg #1
+    let x@1: &'0 ([u32]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Slice<u32>); // anonymous local
+    let @3: &'_ ([u32]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -1225,12 +1225,12 @@ pub fn index_slice_u32_0<'_0>(@1: &'_0 (Slice<u32>)) -> u32
 }
 
 // Full name: test_crate::index_mut_slice_u32_0
-pub fn index_mut_slice_u32_0<'_0>(@1: &'_0 mut (Slice<u32>)) -> u32
+pub fn index_mut_slice_u32_0<'_0>(@1: &'_0 mut ([u32])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 mut (Slice<u32>); // arg #1
+    let x@1: &'0 mut ([u32]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Slice<u32>); // anonymous local
+    let @3: &'_ ([u32]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -1248,31 +1248,31 @@ pub fn index_mut_slice_u32_0<'_0>(@1: &'_0 mut (Slice<u32>)) -> u32
 pub fn index_all() -> u32
 {
     let @0: u32; // return
-    let x@1: Array<u32, 2 : usize>; // local
+    let x@1: [u32; 2 : usize]; // local
     let @2: bool; // anonymous local
-    let _y@3: Array<u32, 2 : usize>; // local
-    let _z@4: Array<u32, 1 : usize>; // local
+    let _y@3: [u32; 2 : usize]; // local
+    let _z@4: [u32; 1 : usize]; // local
     let @5: u32; // anonymous local
     let @6: u32; // anonymous local
     let @7: u32; // anonymous local
     let @8: u32; // anonymous local
-    let @9: Array<u32, 2 : usize>; // anonymous local
+    let @9: [u32; 2 : usize]; // anonymous local
     let @10: u32; // anonymous local
-    let @11: Array<u32, 2 : usize>; // anonymous local
+    let @11: [u32; 2 : usize]; // anonymous local
     let @12: u32; // anonymous local
     let @13: u32; // anonymous local
-    let @14: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @15: &'0 (Array<u32, 2 : usize>); // anonymous local
+    let @14: &'0 ([u32; 2 : usize]); // anonymous local
+    let @15: &'0 ([u32; 2 : usize]); // anonymous local
     let @16: u32; // anonymous local
     let @17: u32; // anonymous local
-    let @18: &'1 (Slice<u32>); // anonymous local
-    let @19: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @20: &'0 (Array<u32, 2 : usize>); // anonymous local
+    let @18: &'1 ([u32]); // anonymous local
+    let @19: &'0 ([u32; 2 : usize]); // anonymous local
+    let @20: &'0 ([u32; 2 : usize]); // anonymous local
     let @21: u32; // anonymous local
     let @22: u32; // anonymous local
-    let @23: &'2 mut (Slice<u32>); // anonymous local
-    let @24: &'3 mut (Array<u32, 2 : usize>); // anonymous local
-    let @25: &'3 mut (Array<u32, 2 : usize>); // anonymous local
+    let @23: &'2 mut ([u32]); // anonymous local
+    let @24: &'3 mut ([u32; 2 : usize]); // anonymous local
+    let @25: &'3 mut ([u32; 2 : usize]); // anonymous local
     let @26: u32; // anonymous local
 
     storage_live(@12)
@@ -1357,12 +1357,12 @@ pub fn index_all() -> u32
 }
 
 // Full name: test_crate::update_array
-pub fn update_array(@1: Array<u32, 2 : usize>)
+pub fn update_array(@1: [u32; 2 : usize])
 {
     let @0: (); // return
-    let x@1: Array<u32, 2 : usize>; // arg #1
+    let x@1: [u32; 2 : usize]; // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ mut (Array<u32, 2 : usize>); // anonymous local
+    let @3: &'_ mut ([u32; 2 : usize]); // anonymous local
     let @4: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -1379,12 +1379,12 @@ pub fn update_array(@1: Array<u32, 2 : usize>)
 }
 
 // Full name: test_crate::update_array_mut_borrow
-pub fn update_array_mut_borrow<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>))
+pub fn update_array_mut_borrow<'_0>(@1: &'_0 mut ([u32; 2 : usize]))
 {
     let @0: (); // return
-    let x@1: &'0 mut (Array<u32, 2 : usize>); // arg #1
+    let x@1: &'0 mut ([u32; 2 : usize]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ mut (Array<u32, 2 : usize>); // anonymous local
+    let @3: &'_ mut ([u32; 2 : usize]); // anonymous local
     let @4: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -1401,12 +1401,12 @@ pub fn update_array_mut_borrow<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>))
 }
 
 // Full name: test_crate::update_mut_slice
-pub fn update_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>))
+pub fn update_mut_slice<'_0>(@1: &'_0 mut ([u32]))
 {
     let @0: (); // return
-    let x@1: &'0 mut (Slice<u32>); // arg #1
+    let x@1: &'0 mut ([u32]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ mut (Slice<u32>); // anonymous local
+    let @3: &'_ mut ([u32]); // anonymous local
     let @4: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -1426,18 +1426,18 @@ pub fn update_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>))
 pub fn update_all()
 {
     let @0: (); // return
-    let x@1: Array<u32, 2 : usize>; // local
+    let x@1: [u32; 2 : usize]; // local
     let @2: (); // anonymous local
-    let @3: Array<u32, 2 : usize>; // anonymous local
+    let @3: [u32; 2 : usize]; // anonymous local
     let @4: (); // anonymous local
-    let @5: Array<u32, 2 : usize>; // anonymous local
+    let @5: [u32; 2 : usize]; // anonymous local
     let @6: (); // anonymous local
-    let @7: &'0 mut (Array<u32, 2 : usize>); // anonymous local
-    let @8: &'0 mut (Array<u32, 2 : usize>); // anonymous local
+    let @7: &'0 mut ([u32; 2 : usize]); // anonymous local
+    let @8: &'0 mut ([u32; 2 : usize]); // anonymous local
     let @9: (); // anonymous local
-    let @10: &'1 mut (Slice<u32>); // anonymous local
-    let @11: &'0 mut (Array<u32, 2 : usize>); // anonymous local
-    let @12: &'0 mut (Array<u32, 2 : usize>); // anonymous local
+    let @10: &'1 mut ([u32]); // anonymous local
+    let @11: &'0 mut ([u32; 2 : usize]); // anonymous local
+    let @12: &'0 mut ([u32; 2 : usize]); // anonymous local
 
     @0 := ()
     storage_live(x@1)
@@ -1484,12 +1484,12 @@ pub fn update_all()
 pub fn range_all()
 {
     let @0: (); // return
-    let x@1: Array<u32, 4 : usize>; // local
+    let x@1: [u32; 4 : usize]; // local
     let @2: (); // anonymous local
-    let @3: &'0 mut (Slice<u32>); // anonymous local
-    let @4: &'0 mut (Slice<u32>); // anonymous local
-    let @5: &'0 mut (Slice<u32>); // anonymous local
-    let @6: &'1 mut (Array<u32, 4 : usize>); // anonymous local
+    let @3: &'0 mut ([u32]); // anonymous local
+    let @4: &'0 mut ([u32]); // anonymous local
+    let @5: &'0 mut ([u32]); // anonymous local
+    let @6: &'1 mut ([u32; 4 : usize]); // anonymous local
     let @7: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
 
     @0 := ()
@@ -1504,7 +1504,7 @@ pub fn range_all()
     @6 := &mut x@1
     storage_live(@7)
     @7 := Range { start: const (1 : usize), end: const (3 : usize) }
-    @5 := {impl IndexMut<I, Clause2_Clause1_Output> for Array<T, N>}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>, 4 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl IndexMut<I, Clause2_Output> for Slice<T>}<u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
+    @5 := {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32], 4 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl IndexMut<I, Clause2_Output> for [T]}<u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
     storage_dead(@7)
     storage_dead(@6)
     @4 := &mut *(@5) with_metadata(copy (@5.metadata))
@@ -1520,13 +1520,13 @@ pub fn range_all()
 }
 
 // Full name: test_crate::deref_array_borrow
-pub fn deref_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>)) -> u32
+pub fn deref_array_borrow<'_0>(@1: &'_0 ([u32; 2 : usize])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 (Array<u32, 2 : usize>); // arg #1
-    let x@2: Array<u32, 2 : usize>; // local
+    let x@1: &'0 ([u32; 2 : usize]); // arg #1
+    let x@2: [u32; 2 : usize]; // local
     let @3: usize; // anonymous local
-    let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @4: &'_ ([u32; 2 : usize]); // anonymous local
     let @5: &'_ (u32); // anonymous local
 
     storage_live(x@2)
@@ -1544,13 +1544,13 @@ pub fn deref_array_borrow<'_0>(@1: &'_0 (Array<u32, 2 : usize>)) -> u32
 }
 
 // Full name: test_crate::deref_array_mut_borrow
-pub fn deref_array_mut_borrow<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>)) -> u32
+pub fn deref_array_mut_borrow<'_0>(@1: &'_0 mut ([u32; 2 : usize])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 mut (Array<u32, 2 : usize>); // arg #1
-    let x@2: Array<u32, 2 : usize>; // local
+    let x@1: &'0 mut ([u32; 2 : usize]); // arg #1
+    let x@2: [u32; 2 : usize]; // local
     let @3: usize; // anonymous local
-    let @4: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let @4: &'_ ([u32; 2 : usize]); // anonymous local
     let @5: &'_ (u32); // anonymous local
 
     storage_live(x@2)
@@ -1568,10 +1568,10 @@ pub fn deref_array_mut_borrow<'_0>(@1: &'_0 mut (Array<u32, 2 : usize>)) -> u32
 }
 
 // Full name: test_crate::take_array_t
-pub fn take_array_t(@1: Array<AB, 2 : usize>)
+pub fn take_array_t(@1: [AB; 2 : usize])
 {
     let @0: (); // return
-    let @1: Array<AB, 2 : usize>; // arg #1
+    let @1: [AB; 2 : usize]; // arg #1
 
     @0 := ()
     @0 := ()
@@ -1582,11 +1582,11 @@ pub fn take_array_t(@1: Array<AB, 2 : usize>)
 pub fn non_copyable_array()
 {
     let @0: (); // return
-    let x@1: Array<AB, 2 : usize>; // local
+    let x@1: [AB; 2 : usize]; // local
     let @2: AB; // anonymous local
     let @3: AB; // anonymous local
     let @4: (); // anonymous local
-    let @5: Array<AB, 2 : usize>; // anonymous local
+    let @5: [AB; 2 : usize]; // anonymous local
 
     @0 := ()
     storage_live(x@1)
@@ -1613,21 +1613,21 @@ pub fn non_copyable_array()
 }
 
 // Full name: test_crate::sum
-pub fn sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
+pub fn sum<'_0>(@1: &'_0 ([u32])) -> u32
 {
     let @0: u32; // return
-    let s@1: &'0 (Slice<u32>); // arg #1
+    let s@1: &'0 ([u32]); // arg #1
     let sum@2: u32; // local
     let i@3: usize; // local
     let @4: bool; // anonymous local
     let @5: usize; // anonymous local
     let @6: usize; // anonymous local
-    let @7: &'0 (Slice<u32>); // anonymous local
+    let @7: &'0 ([u32]); // anonymous local
     let @8: u32; // anonymous local
     let @9: usize; // anonymous local
     let @10: u32; // anonymous local
     let @11: usize; // anonymous local
-    let @12: &'_ (Slice<u32>); // anonymous local
+    let @12: &'_ ([u32]); // anonymous local
     let @13: &'_ (u32); // anonymous local
 
     storage_live(@10)
@@ -1679,22 +1679,22 @@ pub fn sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
 }
 
 // Full name: test_crate::sum2
-pub fn sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u32
+pub fn sum2<'_0, '_1>(@1: &'_0 ([u32]), @2: &'_1 ([u32])) -> u32
 {
     let @0: u32; // return
-    let s@1: &'0 (Slice<u32>); // arg #1
-    let s2@2: &'0 (Slice<u32>); // arg #2
+    let s@1: &'0 ([u32]); // arg #1
+    let s2@2: &'0 ([u32]); // arg #2
     let sum@3: u32; // local
     let @4: bool; // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'0 (Slice<u32>); // anonymous local
+    let @6: &'0 ([u32]); // anonymous local
     let @7: usize; // anonymous local
-    let @8: &'0 (Slice<u32>); // anonymous local
+    let @8: &'0 ([u32]); // anonymous local
     let i@9: usize; // local
     let @10: bool; // anonymous local
     let @11: usize; // anonymous local
     let @12: usize; // anonymous local
-    let @13: &'0 (Slice<u32>); // anonymous local
+    let @13: &'0 ([u32]); // anonymous local
     let @14: u32; // anonymous local
     let @15: u32; // anonymous local
     let @16: usize; // anonymous local
@@ -1703,9 +1703,9 @@ pub fn sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u32
     let @19: u32; // anonymous local
     let @20: u32; // anonymous local
     let @21: usize; // anonymous local
-    let @22: &'_ (Slice<u32>); // anonymous local
+    let @22: &'_ ([u32]); // anonymous local
     let @23: &'_ (u32); // anonymous local
-    let @24: &'_ (Slice<u32>); // anonymous local
+    let @24: &'_ ([u32]); // anonymous local
     let @25: &'_ (u32); // anonymous local
 
     storage_live(@19)
@@ -1796,12 +1796,12 @@ pub fn sum2<'_0, '_1>(@1: &'_0 (Slice<u32>), @2: &'_1 (Slice<u32>)) -> u32
 pub fn f0()
 {
     let @0: (); // return
-    let s@1: &'0 mut (Slice<u32>); // local
-    let @2: &'1 mut (Array<u32, 2 : usize>); // anonymous local
-    let @3: &'1 mut (Array<u32, 2 : usize>); // anonymous local
-    let @4: Array<u32, 2 : usize>; // anonymous local
+    let s@1: &'0 mut ([u32]); // local
+    let @2: &'1 mut ([u32; 2 : usize]); // anonymous local
+    let @3: &'1 mut ([u32; 2 : usize]); // anonymous local
+    let @4: [u32; 2 : usize]; // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ mut (Slice<u32>); // anonymous local
+    let @6: &'_ mut ([u32]); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -1833,9 +1833,9 @@ pub fn f0()
 pub fn f1()
 {
     let @0: (); // return
-    let s@1: Array<u32, 2 : usize>; // local
+    let s@1: [u32; 2 : usize]; // local
     let @2: usize; // anonymous local
-    let @3: &'_ mut (Array<u32, 2 : usize>); // anonymous local
+    let @3: &'_ mut ([u32; 2 : usize]); // anonymous local
     let @4: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -1866,15 +1866,15 @@ pub fn f2(@1: u32)
 }
 
 // Full name: test_crate::f4
-pub fn f4<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 (Slice<u32>)
+pub fn f4<'_0>(@1: &'_0 ([u32; 32 : usize]), @2: usize, @3: usize) -> &'_0 ([u32])
 {
-    let @0: &'0 (Slice<u32>); // return
-    let x@1: &'1 (Array<u32, 32 : usize>); // arg #1
+    let @0: &'0 ([u32]); // return
+    let x@1: &'1 ([u32; 32 : usize]); // arg #1
     let y@2: usize; // arg #2
     let z@3: usize; // arg #3
-    let @4: &'0 (Slice<u32>); // anonymous local
-    let @5: &'0 (Slice<u32>); // anonymous local
-    let @6: &'1 (Array<u32, 32 : usize>); // anonymous local
+    let @4: &'0 ([u32]); // anonymous local
+    let @5: &'0 ([u32]); // anonymous local
+    let @6: &'1 ([u32; 32 : usize]); // anonymous local
     let @7: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @8: usize; // anonymous local
     let @9: usize; // anonymous local
@@ -1891,7 +1891,7 @@ pub fn f4<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 
     @7 := Range { start: move (@8), end: move (@9) }
     storage_dead(@9)
     storage_dead(@8)
-    @5 := {impl Index<I, Clause2_Output> for Array<T, N>}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>, 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I, Clause2_Output> for Slice<T>}<u32, Range<usize>[{built_in impl Sized for usize}], Slice<u32>>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>, Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
+    @5 := {impl Index<I, Clause2_Output> for [T; N]}::index<'_, u32, Range<usize>[{built_in impl Sized for usize}], [u32], 32 : usize>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I, Clause2_Output> for [T]}<u32, Range<usize>[{built_in impl Sized for usize}], [u32]>[{built_in impl Sized for u32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}<u32>[{built_in impl Sized for u32}]]](move (@6), move (@7))
     storage_dead(@7)
     storage_dead(@6)
     @4 := &*(@5) with_metadata(copy (@5.metadata))
@@ -1905,19 +1905,19 @@ pub fn f4<'_0>(@1: &'_0 (Array<u32, 32 : usize>), @2: usize, @3: usize) -> &'_0 
 pub fn f3() -> u32
 {
     let @0: u32; // return
-    let a@1: Array<u32, 2 : usize>; // local
+    let a@1: [u32; 2 : usize]; // local
     let @2: (); // anonymous local
     let @3: u32; // anonymous local
     let @4: usize; // anonymous local
-    let b@5: Array<u32, 32 : usize>; // local
-    let @6: &'0 (Slice<u32>); // anonymous local
-    let @7: &'1 (Array<u32, 2 : usize>); // anonymous local
-    let @8: &'1 (Array<u32, 2 : usize>); // anonymous local
-    let @9: &'0 (Slice<u32>); // anonymous local
-    let @10: &'0 (Slice<u32>); // anonymous local
-    let @11: &'2 (Array<u32, 32 : usize>); // anonymous local
-    let @12: &'2 (Array<u32, 32 : usize>); // anonymous local
-    let @13: &'_ (Array<u32, 2 : usize>); // anonymous local
+    let b@5: [u32; 32 : usize]; // local
+    let @6: &'0 ([u32]); // anonymous local
+    let @7: &'1 ([u32; 2 : usize]); // anonymous local
+    let @8: &'1 ([u32; 2 : usize]); // anonymous local
+    let @9: &'0 ([u32]); // anonymous local
+    let @10: &'0 ([u32]); // anonymous local
+    let @11: &'2 ([u32; 32 : usize]); // anonymous local
+    let @12: &'2 ([u32; 32 : usize]); // anonymous local
+    let @13: &'_ ([u32; 2 : usize]); // anonymous local
     let @14: &'_ (u32); // anonymous local
 
     storage_live(a@1)
@@ -1977,12 +1977,12 @@ pub fn SZ() -> usize
 pub const SZ: usize = SZ()
 
 // Full name: test_crate::f5
-pub fn f5<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> u32
+pub fn f5<'_0>(@1: &'_0 ([u32; 32 : usize])) -> u32
 {
     let @0: u32; // return
-    let x@1: &'0 (Array<u32, 32 : usize>); // arg #1
+    let x@1: &'0 ([u32; 32 : usize]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Array<u32, 32 : usize>); // anonymous local
+    let @3: &'_ ([u32; 32 : usize]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)
@@ -2000,17 +2000,17 @@ pub fn f5<'_0>(@1: &'_0 (Array<u32, 32 : usize>)) -> u32
 pub fn ite()
 {
     let @0: (); // return
-    let x@1: Array<u32, 2 : usize>; // local
+    let x@1: [u32; 2 : usize]; // local
     let @2: bool; // anonymous local
-    let y@3: Array<u32, 2 : usize>; // local
+    let y@3: [u32; 2 : usize]; // local
     let @4: u32; // anonymous local
-    let @5: &'0 mut (Slice<u32>); // anonymous local
-    let @6: &'1 mut (Array<u32, 2 : usize>); // anonymous local
-    let @7: &'1 mut (Array<u32, 2 : usize>); // anonymous local
+    let @5: &'0 mut ([u32]); // anonymous local
+    let @6: &'1 mut ([u32; 2 : usize]); // anonymous local
+    let @7: &'1 mut ([u32; 2 : usize]); // anonymous local
     let @8: u32; // anonymous local
-    let @9: &'0 mut (Slice<u32>); // anonymous local
-    let @10: &'1 mut (Array<u32, 2 : usize>); // anonymous local
-    let @11: &'1 mut (Array<u32, 2 : usize>); // anonymous local
+    let @9: &'0 mut ([u32]); // anonymous local
+    let @10: &'1 mut ([u32; 2 : usize]); // anonymous local
+    let @11: &'1 mut ([u32; 2 : usize]); // anonymous local
 
     @0 := ()
     storage_live(x@1)
@@ -2055,19 +2055,19 @@ pub fn ite()
 }
 
 // Full name: test_crate::zero_slice
-pub fn zero_slice<'_0>(@1: &'_0 mut (Slice<u8>))
+pub fn zero_slice<'_0>(@1: &'_0 mut ([u8]))
 {
     let @0: (); // return
-    let a@1: &'0 mut (Slice<u8>); // arg #1
+    let a@1: &'0 mut ([u8]); // arg #1
     let i@2: usize; // local
     let len@3: usize; // local
-    let @4: &'1 (Slice<u8>); // anonymous local
+    let @4: &'1 ([u8]); // anonymous local
     let @5: bool; // anonymous local
     let @6: usize; // anonymous local
     let @7: usize; // anonymous local
     let @8: usize; // anonymous local
     let @9: usize; // anonymous local
-    let @10: &'_ mut (Slice<u8>); // anonymous local
+    let @10: &'_ mut ([u8]); // anonymous local
     let @11: &'_ mut (u8); // anonymous local
 
     storage_live(@9)
@@ -2115,12 +2115,12 @@ pub fn zero_slice<'_0>(@1: &'_0 mut (Slice<u8>))
 }
 
 // Full name: test_crate::iter_mut_slice
-pub fn iter_mut_slice<'_0>(@1: &'_0 mut (Slice<u8>))
+pub fn iter_mut_slice<'_0>(@1: &'_0 mut ([u8]))
 {
     let @0: (); // return
-    let a@1: &'0 mut (Slice<u8>); // arg #1
+    let a@1: &'0 mut ([u8]); // arg #1
     let len@2: usize; // local
-    let @3: &'1 (Slice<u8>); // anonymous local
+    let @3: &'1 ([u8]); // anonymous local
     let i@4: usize; // local
     let @5: bool; // anonymous local
     let @6: usize; // anonymous local
@@ -2164,21 +2164,21 @@ pub fn iter_mut_slice<'_0>(@1: &'_0 mut (Slice<u8>))
 }
 
 // Full name: test_crate::sum_mut_slice
-pub fn sum_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>)) -> u32
+pub fn sum_mut_slice<'_0>(@1: &'_0 mut ([u32])) -> u32
 {
     let @0: u32; // return
-    let a@1: &'0 mut (Slice<u32>); // arg #1
+    let a@1: &'0 mut ([u32]); // arg #1
     let i@2: usize; // local
     let s@3: u32; // local
     let @4: bool; // anonymous local
     let @5: usize; // anonymous local
     let @6: usize; // anonymous local
-    let @7: &'1 (Slice<u32>); // anonymous local
+    let @7: &'1 ([u32]); // anonymous local
     let @8: u32; // anonymous local
     let @9: usize; // anonymous local
     let @10: u32; // anonymous local
     let @11: usize; // anonymous local
-    let @12: &'_ (Slice<u32>); // anonymous local
+    let @12: &'_ ([u32]); // anonymous local
     let @13: &'_ (u32); // anonymous local
 
     storage_live(@10)
@@ -2230,12 +2230,12 @@ pub fn sum_mut_slice<'_0>(@1: &'_0 mut (Slice<u32>)) -> u32
 }
 
 // Full name: test_crate::slice_pattern_1
-fn slice_pattern_1(@1: Array<(), 1 : usize>)
+fn slice_pattern_1(@1: [(); 1 : usize])
 {
     let @0: (); // return
-    let x@1: Array<(), 1 : usize>; // arg #1
+    let x@1: [(); 1 : usize]; // arg #1
     let _named@2: (); // local
-    let @3: &'_ (Array<(), 1 : usize>); // anonymous local
+    let @3: &'_ ([(); 1 : usize]); // anonymous local
     let @4: &'_ (()); // anonymous local
 
     @0 := ()
@@ -2251,20 +2251,20 @@ fn slice_pattern_1(@1: Array<(), 1 : usize>)
 }
 
 // Full name: test_crate::slice_pattern_2
-fn slice_pattern_2<'_0, T>(@1: Array<&'_0 mut (T), 3 : usize>)
+fn slice_pattern_2<'_0, T>(@1: [&'_0 mut (T); 3 : usize])
 where
     [@TraitClause0]: Sized<T>,
 {
     let @0: (); // return
-    let x@1: Array<&'0 mut (T), 3 : usize>; // arg #1
+    let x@1: [&'0 mut (T); 3 : usize]; // arg #1
     let _a@2: &'0 mut (T); // local
     let _b@3: &'0 mut (T); // local
     let _c@4: &'0 mut (T); // local
-    let @5: &'_ mut (Array<&'0 mut (T), 3 : usize>); // anonymous local
+    let @5: &'_ mut ([&'0 mut (T); 3 : usize]); // anonymous local
     let @6: &'_ mut (&'0 mut (T)); // anonymous local
-    let @7: &'_ mut (Array<&'0 mut (T), 3 : usize>); // anonymous local
+    let @7: &'_ mut ([&'0 mut (T); 3 : usize]); // anonymous local
     let @8: &'_ mut (&'0 mut (T)); // anonymous local
-    let @9: &'_ mut (Array<&'0 mut (T), 3 : usize>); // anonymous local
+    let @9: &'_ mut ([&'0 mut (T); 3 : usize]); // anonymous local
     let @10: &'_ mut (&'0 mut (T)); // anonymous local
 
     @0 := ()
@@ -2294,12 +2294,12 @@ where
 }
 
 // Full name: test_crate::slice_pattern_3
-fn slice_pattern_3<'_0>(@1: &'_0 (Array<(), 1 : usize>))
+fn slice_pattern_3<'_0>(@1: &'_0 ([(); 1 : usize]))
 {
     let @0: (); // return
-    let x@1: &'0 (Array<(), 1 : usize>); // arg #1
+    let x@1: &'0 ([(); 1 : usize]); // arg #1
     let _named@2: &'1 (()); // local
-    let @3: &'_ (Array<(), 1 : usize>); // anonymous local
+    let @3: &'_ ([(); 1 : usize]); // anonymous local
     let @4: &'_ (()); // anonymous local
 
     @0 := ()
@@ -2315,16 +2315,16 @@ fn slice_pattern_3<'_0>(@1: &'_0 (Array<(), 1 : usize>))
 }
 
 // Full name: test_crate::slice_pattern_4
-fn slice_pattern_4<'_0>(@1: &'_0 (Slice<()>))
+fn slice_pattern_4<'_0>(@1: &'_0 ([()]))
 {
     let @0: (); // return
-    let x@1: &'0 (Slice<()>); // arg #1
+    let x@1: &'0 ([()]); // arg #1
     let @2: usize; // anonymous local
     let @3: usize; // anonymous local
     let @4: usize; // anonymous local
     let @5: bool; // anonymous local
     let _named@6: &'1 (()); // local
-    let @7: &'_ (Slice<()>); // anonymous local
+    let @7: &'_ ([()]); // anonymous local
     let @8: &'_ (()); // anonymous local
 
     storage_live(@2)

--- a/charon/tests/ui/arrays_const_generics.out
+++ b/charon/tests/ui/arrays_const_generics.out
@@ -11,13 +11,13 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::index_array_generic
-pub fn index_array_generic<const N : usize>(@1: Array<u32, N>, @2: usize) -> u32
+pub fn index_array_generic<const N : usize>(@1: [u32; N], @2: usize) -> u32
 {
     let @0: u32; // return
-    let s@1: Array<u32, N>; // arg #1
+    let s@1: [u32; N]; // arg #1
     let i@2: usize; // arg #2
     let @3: usize; // anonymous local
-    let @4: &'_ (Array<u32, N>); // anonymous local
+    let @4: &'_ ([u32; N]); // anonymous local
     let @5: &'_ (u32); // anonymous local
 
     storage_live(@3)
@@ -32,12 +32,12 @@ pub fn index_array_generic<const N : usize>(@1: Array<u32, N>, @2: usize) -> u32
 }
 
 // Full name: test_crate::index_array_generic_call
-pub fn index_array_generic_call<const N : usize>(@1: Array<u32, N>, @2: usize) -> u32
+pub fn index_array_generic_call<const N : usize>(@1: [u32; N], @2: usize) -> u32
 {
     let @0: u32; // return
-    let s@1: Array<u32, N>; // arg #1
+    let s@1: [u32; N]; // arg #1
     let i@2: usize; // arg #2
-    let @3: Array<u32, N>; // anonymous local
+    let @3: [u32; N]; // anonymous local
     let @4: usize; // anonymous local
 
     storage_live(@3)
@@ -60,9 +60,9 @@ pub fn const_gen_ret<const N : usize>() -> usize
 }
 
 // Full name: test_crate::init_array_variable_len
-pub fn init_array_variable_len<const LEN : usize>() -> Array<u8, LEN>
+pub fn init_array_variable_len<const LEN : usize>() -> [u8; LEN]
 {
-    let @0: Array<u8, LEN>; // return
+    let @0: [u8; LEN]; // return
 
     @0 := @ArrayRepeat<'_, u8, LEN>(const (0 : u8))
     return

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -27,7 +27,7 @@ struct V<T, const N : usize>
 where
     [@TraitClause0]: Sized<T>,
 {
-  x: Array<T, N>,
+  x: [T; N],
 }
 
 fn test_crate::{V<T, N>[@TraitClause0]}::LEN<T, const N : usize>() -> usize
@@ -53,8 +53,8 @@ trait HasLen<Self>
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl HasLen for Array<(), N>}::LEN
-fn {impl HasLen for Array<(), N>}::LEN<const N : usize>() -> usize
+// Full name: test_crate::{impl HasLen for [(); N]}::LEN
+fn {impl HasLen for [(); N]}::LEN<const N : usize>() -> usize
 {
     let @0: usize; // return
 
@@ -62,18 +62,18 @@ fn {impl HasLen for Array<(), N>}::LEN<const N : usize>() -> usize
     return
 }
 
-// Full name: test_crate::{impl HasLen for Array<(), N>}::LEN
-const {impl HasLen for Array<(), N>}::LEN<const N : usize>: usize = {impl HasLen for Array<(), N>}::LEN()
+// Full name: test_crate::{impl HasLen for [(); N]}::LEN
+const {impl HasLen for [(); N]}::LEN<const N : usize>: usize = {impl HasLen for [(); N]}::LEN()
 
-// Full name: test_crate::{impl HasLen for Array<(), N>}
-impl<const N : usize> HasLen for Array<(), N> {
-    parent_clause0 = {built_in impl MetaSized for Array<(), N>}
-    const LEN = {impl HasLen for Array<(), N>}::LEN<N>
+// Full name: test_crate::{impl HasLen for [(); N]}
+impl<const N : usize> HasLen for [(); N] {
+    parent_clause0 = {built_in impl MetaSized for [(); N]}
+    const LEN = {impl HasLen for [(); N]}::LEN<N>
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl HasLen for Array<bool, N>}::LEN
-fn {impl HasLen for Array<bool, N>}::LEN<const N : usize>() -> usize
+// Full name: test_crate::{impl HasLen for [bool; N]}::LEN
+fn {impl HasLen for [bool; N]}::LEN<const N : usize>() -> usize
 {
     let @0: usize; // return
     let @1: usize; // anonymous local
@@ -84,13 +84,13 @@ fn {impl HasLen for Array<bool, N>}::LEN<const N : usize>() -> usize
     return
 }
 
-// Full name: test_crate::{impl HasLen for Array<bool, N>}::LEN
-const {impl HasLen for Array<bool, N>}::LEN<const N : usize>: usize = {impl HasLen for Array<bool, N>}::LEN()
+// Full name: test_crate::{impl HasLen for [bool; N]}::LEN
+const {impl HasLen for [bool; N]}::LEN<const N : usize>: usize = {impl HasLen for [bool; N]}::LEN()
 
-// Full name: test_crate::{impl HasLen for Array<bool, N>}
-impl<const N : usize> HasLen for Array<bool, N> {
-    parent_clause0 = {built_in impl MetaSized for Array<bool, N>}
-    const LEN = {impl HasLen for Array<bool, N>}::LEN<N>
+// Full name: test_crate::{impl HasLen for [bool; N]}
+impl<const N : usize> HasLen for [bool; N] {
+    parent_clause0 = {built_in impl MetaSized for [bool; N]}
+    const LEN = {impl HasLen for [bool; N]}::LEN<N>
     non-dyn-compatible
 }
 
@@ -155,18 +155,18 @@ where
     [@TraitClause0]: HasDefaultLen<Self, M>,
  = test_crate::HasDefaultLen::LEN()
 
-// Full name: test_crate::{impl HasDefaultLen<N> for Array<(), N>}
-impl<const N : usize> HasDefaultLen<N> for Array<(), N> {
-    parent_clause0 = {built_in impl MetaSized for Array<(), N>}
-    const LEN = test_crate::HasDefaultLen::LEN<Array<(), N>, N>[{impl HasDefaultLen<N> for Array<(), N>}<N>]
+// Full name: test_crate::{impl HasDefaultLen<N> for [(); N]}
+impl<const N : usize> HasDefaultLen<N> for [(); N] {
+    parent_clause0 = {built_in impl MetaSized for [(); N]}
+    const LEN = test_crate::HasDefaultLen::LEN<[(); N], N>[{impl HasDefaultLen<N> for [(); N]}<N>]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl HasDefaultLen<N> for Array<bool, N>}::LEN
-pub const {impl HasDefaultLen<N> for Array<bool, N>}::LEN<const N : usize>: usize = {impl HasDefaultLen<N> for Array<bool, N>}::LEN()
+// Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}::LEN
+pub const {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>: usize = {impl HasDefaultLen<N> for [bool; N]}::LEN()
 
-// Full name: test_crate::{impl HasDefaultLen<N> for Array<bool, N>}::LEN
-pub fn {impl HasDefaultLen<N> for Array<bool, N>}::LEN<const N : usize>() -> usize
+// Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}::LEN
+pub fn {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>() -> usize
 {
     let @0: usize; // return
     let @1: bool; // anonymous local
@@ -176,16 +176,16 @@ pub fn {impl HasDefaultLen<N> for Array<bool, N>}::LEN<const N : usize>() -> usi
     if move (@1) {
         @0 := const (N)
     } else {
-        @0 := copy ({impl HasDefaultLen<N> for Array<bool, N>}::LEN<N>)
+        @0 := copy ({impl HasDefaultLen<N> for [bool; N]}::LEN<N>)
     }
     storage_dead(@1)
     return
 }
 
-// Full name: test_crate::{impl HasDefaultLen<N> for Array<bool, N>}
-impl<const N : usize> HasDefaultLen<N> for Array<bool, N> {
-    parent_clause0 = {built_in impl MetaSized for Array<bool, N>}
-    const LEN = {impl HasDefaultLen<N> for Array<bool, N>}::LEN<N>
+// Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}
+impl<const N : usize> HasDefaultLen<N> for [bool; N] {
+    parent_clause0 = {built_in impl MetaSized for [bool; N]}
+    const LEN = {impl HasDefaultLen<N> for [bool; N]}::LEN<N>
     non-dyn-compatible
 }
 
@@ -218,11 +218,11 @@ where
     [@TraitClause0]: AlsoHasLen<Self>,
  = ALSO_LEN()
 
-// Full name: test_crate::{impl AlsoHasLen for Array<(), N>}
-impl<const N : usize> AlsoHasLen for Array<(), N> {
-    parent_clause0 = {built_in impl MetaSized for Array<(), N>}
-    parent_clause1 = {impl HasLen for Array<(), N>}<N>
-    const ALSO_LEN = ALSO_LEN<Array<(), N>>[{impl AlsoHasLen for Array<(), N>}<N>]
+// Full name: test_crate::{impl AlsoHasLen for [(); N]}
+impl<const N : usize> AlsoHasLen for [(); N] {
+    parent_clause0 = {built_in impl MetaSized for [(); N]}
+    parent_clause1 = {impl HasLen for [(); N]}<N>
+    const ALSO_LEN = ALSO_LEN<[(); N]>[{impl AlsoHasLen for [(); N]}<N>]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -44,8 +44,8 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
 
-// Full name: core::array::{Array<T, N>}::map
-pub fn map<T, F, U, const N : usize>(@1: Array<T, N>, @2: F) -> Array<U, N>
+// Full name: core::array::{[T; N]}::map
+pub fn map<T, F, U, const N : usize>(@1: [T; N], @2: F) -> [U; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -2003,11 +2003,11 @@ impl FnMut<(i32), i32> for test_crate::test_array_map::closure {
 }
 
 // Full name: test_crate::test_array_map
-pub fn test_array_map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
+pub fn test_array_map(@1: [i32; 256 : usize]) -> [i32; 256 : usize]
 {
-    let @0: Array<i32, 256 : usize>; // return
-    let x@1: Array<i32, 256 : usize>; // arg #1
-    let @2: Array<i32, 256 : usize>; // anonymous local
+    let @0: [i32; 256 : usize]; // return
+    let x@1: [i32; 256 : usize]; // arg #1
+    let @2: [i32; 256 : usize]; // anonymous local
     let @3: test_crate::test_array_map::closure; // anonymous local
 
     storage_live(@2)

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -46,7 +46,7 @@ pub trait FnMut<Self, Args>
 }
 
 // Full name: core::array::from_fn
-pub fn from_fn<T, F, const N : usize>(@1: F) -> Array<T, N>
+pub fn from_fn<T, F, const N : usize>(@1: F) -> [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -192,12 +192,12 @@ where
 }
 
 // Full name: test_crate::test
-fn test<T, const K : usize>() -> Array<T, 1 : usize>
+fn test<T, const K : usize>() -> [T; 1 : usize]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Ops<T, K>,
 {
-    let @0: Array<T, 1 : usize>; // return
+    let @0: [T; 1 : usize]; // return
     let @1: closure<T, K>[@TraitClause0, @TraitClause1]; // anonymous local
 
     storage_live(@1)

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -71,9 +71,9 @@ pub enum AssertKind {
   Match,
 }
 
-// Full name: core::slice::{Slice<T>}::len
+// Full name: core::slice::{[T]}::len
 #[lang_item("slice_len_fn")]
-pub fn len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
+pub fn len<'_0, T>(@1: &'_0 ([T])) -> usize
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -100,10 +100,10 @@ fn function_call(@1: u32)
 }
 
 // Full name: test_crate::sum
-pub fn sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
+pub fn sum<'_0>(@1: &'_0 ([u32])) -> u32
 {
     let @0: u32; // return
-    let s@1: &'0 (Slice<u32>); // arg #1
+    let s@1: &'0 ([u32]); // arg #1
     let sum@2: u32; // local
     let i@3: usize; // local
     let @4: (); // anonymous local
@@ -113,7 +113,7 @@ pub fn sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
     let @8: bool; // anonymous local
     let @9: usize; // anonymous local
     let @10: usize; // anonymous local
-    let @11: &'0 (Slice<u32>); // anonymous local
+    let @11: &'0 ([u32]); // anonymous local
     let @12: u32; // anonymous local
     let @13: usize; // anonymous local
     let @14: u32; // anonymous local
@@ -127,7 +127,7 @@ pub fn sum<'_0>(@1: &'_0 (Slice<u32>)) -> u32
     let @22: u32; // anonymous local
     let @23: u32; // anonymous local
     let @24: u32; // anonymous local
-    let @25: &'_ (Slice<u32>); // anonymous local
+    let @25: &'_ ([u32]); // anonymous local
     let @26: &'_ (u32); // anonymous local
 
     storage_live(@7)
@@ -326,7 +326,7 @@ fn foo()
     let @12: Bar; // anonymous local
     let @13: u32; // anonymous local
     let @14: u32; // anonymous local
-    let a@15: Array<u32, 10 : usize>; // local
+    let a@15: [u32; 10 : usize]; // local
     let @16: (&'0 (u32), &'0 (u32)); // anonymous local
     let @17: &'0 (u32); // anonymous local
     let @18: usize; // anonymous local
@@ -346,7 +346,7 @@ fn foo()
     let @32: &'0 (u32); // anonymous local
     let @33: &'_ (u32); // anonymous local
     let @34: u32; // anonymous local
-    let @35: &'_ (Array<u32, 10 : usize>); // anonymous local
+    let @35: &'_ ([u32; 10 : usize]); // anonymous local
     let @36: &'_ (u32); // anonymous local
 
     storage_live(@32)

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -415,7 +415,7 @@ pub struct V<T, const N : usize>
 where
     [@TraitClause0]: Sized<T>,
 {
-  x: Array<T, N>,
+  x: [T; N],
 }
 
 // Full name: test_crate::{V<T, N>[@TraitClause0]}::LEN

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -426,7 +426,7 @@ where
     T : 'a,
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -437,14 +437,14 @@ where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for Chunks<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ (Slice<T>)}
-    type Item = &'a (Slice<T>)
+    parent_clause1 = {built_in impl Sized for &'_ ([T])}
+    type Item = &'a ([T])
     fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
     vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
-// Full name: core::slice::{Slice<T>}::chunks
-pub fn chunks<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> Chunks<'_0, T>[@TraitClause0]
+// Full name: core::slice::{[T]}::chunks
+pub fn chunks<'_0, T>(@1: &'_0 ([T]), @2: usize) -> Chunks<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -460,10 +460,10 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::f1
-fn f1<'_0>(@1: &'_0 (Slice<u8>)) -> usize
+fn f1<'_0>(@1: &'_0 ([u8])) -> usize
 {
     let @0: usize; // return
-    let a@1: &'0 (Slice<u8>); // arg #1
+    let a@1: &'0 ([u8]); // arg #1
     let sampled@2: usize; // local
     let @3: bool; // anonymous local
     let @4: u8; // anonymous local
@@ -473,9 +473,9 @@ fn f1<'_0>(@1: &'_0 (Slice<u8>)) -> usize
     let @8: usize; // anonymous local
     let @9: usize; // anonymous local
     let @10: usize; // anonymous local
-    let @11: &'_ (Slice<u8>); // anonymous local
+    let @11: &'_ ([u8]); // anonymous local
     let @12: &'_ (u8); // anonymous local
-    let @13: &'_ (Slice<u8>); // anonymous local
+    let @13: &'_ ([u8]); // anonymous local
     let @14: &'_ (u8); // anonymous local
 
     storage_live(@9)
@@ -540,20 +540,20 @@ fn FIELD_MODULUS() -> i16
 const FIELD_MODULUS: i16 = FIELD_MODULUS()
 
 // Full name: test_crate::f2
-fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
+fn f2<'_0, '_1>(@1: &'_0 ([u8]), @2: &'_1 mut ([i16])) -> usize
 {
     let @0: usize; // return
-    let a@1: &'0 (Slice<u8>); // arg #1
-    let result@2: &'1 mut (Slice<i16>); // arg #2
+    let a@1: &'0 ([u8]); // arg #1
+    let result@2: &'1 mut ([i16]); // arg #2
     let sampled@3: usize; // local
     let @4: Chunks<'2, u8>[{built_in impl Sized for u8}]; // anonymous local
     let @5: Chunks<'2, u8>[{built_in impl Sized for u8}]; // anonymous local
-    let @6: &'0 (Slice<u8>); // anonymous local
+    let @6: &'0 ([u8]); // anonymous local
     let iter@7: Chunks<'2, u8>[{built_in impl Sized for u8}]; // local
-    let @8: Option<&'0 (Slice<u8>)>[{built_in impl Sized for &'0 (Slice<u8>)}]; // anonymous local
+    let @8: Option<&'0 ([u8])>[{built_in impl Sized for &'0 ([u8])}]; // anonymous local
     let @9: &'5 mut (Chunks<'2, u8>[{built_in impl Sized for u8}]); // anonymous local
     let @10: &'5 mut (Chunks<'2, u8>[{built_in impl Sized for u8}]); // anonymous local
-    let bytes@11: &'0 (Slice<u8>); // local
+    let bytes@11: &'0 ([u8]); // local
     let b1@12: i16; // local
     let @13: u8; // anonymous local
     let @14: usize; // anonymous local
@@ -587,15 +587,15 @@ fn f2<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 mut (Slice<i16>)) -> usize
     let @42: i16; // anonymous local
     let @43: usize; // anonymous local
     let @44: usize; // anonymous local
-    let @45: &'_ mut (Slice<i16>); // anonymous local
+    let @45: &'_ mut ([i16]); // anonymous local
     let @46: &'_ mut (i16); // anonymous local
-    let @47: &'_ mut (Slice<i16>); // anonymous local
+    let @47: &'_ mut ([i16]); // anonymous local
     let @48: &'_ mut (i16); // anonymous local
-    let @49: &'_ (Slice<u8>); // anonymous local
+    let @49: &'_ ([u8]); // anonymous local
     let @50: &'_ (u8); // anonymous local
-    let @51: &'_ (Slice<u8>); // anonymous local
+    let @51: &'_ ([u8]); // anonymous local
     let @52: &'_ (u8); // anonymous local
-    let @53: &'_ (Slice<u8>); // anonymous local
+    let @53: &'_ ([u8]); // anonymous local
     let @54: &'_ (u8); // anonymous local
 
     storage_live(@37)

--- a/charon/tests/ui/control-flow/issue-507-cfg.out
+++ b/charon/tests/ui/control-flow/issue-507-cfg.out
@@ -52,10 +52,10 @@ fn f0()
 }
 
 // Full name: test_crate::f1
-fn f1<'_0>(@1: &'_0 (Array<u8, 1 : usize>))
+fn f1<'_0>(@1: &'_0 ([u8; 1 : usize]))
 {
     let @0: (); // return
-    let serialized@1: &'0 (Array<u8, 1 : usize>); // arg #1
+    let serialized@1: &'0 ([u8; 1 : usize]); // arg #1
     let previous_true_hints_seen@2: usize; // local
     let i@3: i32; // local
     let @4: bool; // anonymous local

--- a/charon/tests/ui/cross_compile_big_endian.out
+++ b/charon/tests/ui/cross_compile_big_endian.out
@@ -8,7 +8,7 @@ pub fn MAX() -> usize
 pub const MAX: usize = MAX()
 
 // Full name: core::num::{u128}::to_ne_bytes
-pub fn to_ne_bytes(@1: u128) -> Array<u8, 16 : usize>
+pub fn to_ne_bytes(@1: u128) -> [u8; 16 : usize]
 = <opaque>
 
 fn UNIT_METADATA()
@@ -22,16 +22,16 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::S
-fn S() -> Array<u8, 16 : usize>
+fn S() -> [u8; 16 : usize]
 {
-    let @0: Array<u8, 16 : usize>; // return
+    let @0: [u8; 16 : usize]; // return
 
     @0 := to_ne_bytes(const (24197857199965561741520400062332047378 : u128))
     return
 }
 
 // Full name: test_crate::S
-const S: Array<u8, 16 : usize> = S()
+const S: [u8; 16 : usize] = S()
 
 // Full name: test_crate::HasBEDiscr
 enum HasBEDiscr {

--- a/charon/tests/ui/foreign-type-alias.out
+++ b/charon/tests/ui/foreign-type-alias.out
@@ -97,43 +97,43 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
 
-// Full name: alloc::slice::{impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
-pub fn {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(@1: &'_0 (Vec<T>[@TraitClause0, @TraitClause1])) -> &'_0 (Slice<T>)
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
+pub fn {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(@1: &'_0 (Vec<T>[@TraitClause0, @TraitClause1])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
 = <opaque>
 
-// Full name: alloc::slice::{impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}
+impl<T, A> Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
 {
     parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl MetaSized for Slice<T>}
-    fn borrow<'_0_1> = {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
+    parent_clause1 = {built_in impl MetaSized for [T]}
+    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
+    vtable: {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
 }
 
-// Full name: alloc::slice::{impl ToOwned for Slice<T>}::to_owned
-pub fn {impl ToOwned for Slice<T>}::to_owned<'_0, T>(@1: &'_0 (Slice<T>)) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+// Full name: alloc::slice::{impl ToOwned for [T]}::to_owned
+pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(@1: &'_0 ([T])) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
 = <opaque>
 
-// Full name: alloc::slice::{impl ToOwned for Slice<T>}
-impl<T> ToOwned for Slice<T>
+// Full name: alloc::slice::{impl ToOwned for [T]}
+impl<T> ToOwned for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = {built_in impl Sized for Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}
-    parent_clause2 = {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
+    parent_clause2 = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
     type Owned = Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
-    fn to_owned<'_0_1> = {impl ToOwned for Slice<T>}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
+    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
@@ -159,12 +159,12 @@ where
 pub type Generic2<'a, T>
 where
     [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>, = Cow<'a, Slice<T>>[{built_in impl MetaSized for Slice<T>}, {impl ToOwned for Slice<T>}<T>[@TraitClause0, @TraitClause1]]
+    [@TraitClause1]: Clone<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[@TraitClause0, @TraitClause1]]
 
 // Full name: type_alias::GenericWithoutBound
 pub type GenericWithoutBound<'a, T>
 where
-    [@TraitClause0]: Sized<T>, = Cow<'a, Slice<T>>[{built_in impl MetaSized for Slice<T>}, UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
+    [@TraitClause0]: Sized<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
 
 
 

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -127,7 +127,7 @@ pub opaque type Arguments<'a>
 pub opaque type Argument<'a>
 
 // Full name: core::fmt::{Arguments<'a>}::new
-pub unsafe fn new<'a, const N : usize, const M : usize>(@1: &'a (Array<u8, N>), @2: &'a (Array<Argument<'a>, M>)) -> Arguments<'a>
+pub unsafe fn new<'a, const N : usize, const M : usize>(@1: &'a ([u8; N]), @2: &'a ([Argument<'a>; M])) -> Arguments<'a>
 = <opaque>
 
 // Full name: core::result::Result
@@ -492,25 +492,25 @@ where
     vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
-// Full name: core::slice::iter::{impl IntoIterator for &'a (Slice<T>)}::into_iter
-pub fn {impl IntoIterator for &'a (Slice<T>)}::into_iter<'a, T>(@1: &'a (Slice<T>)) -> Iter<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl IntoIterator for &'a ([T])}::into_iter
+pub fn {impl IntoIterator for &'a ([T])}::into_iter<'a, T>(@1: &'a ([T])) -> Iter<'a, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::iter::{impl IntoIterator for &'a (Slice<T>)}
-impl<'a, T> IntoIterator for &'a (Slice<T>)
+// Full name: core::slice::iter::{impl IntoIterator for &'a ([T])}
+impl<'a, T> IntoIterator for &'a ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for &'_ (Slice<T>)}
+    parent_clause0 = {built_in impl MetaSized for &'_ ([T])}
     parent_clause1 = {built_in impl Sized for &'_ (T)}
     parent_clause2 = {built_in impl Sized for Iter<'_, T>[@TraitClause0]}
     parent_clause3 = {impl Iterator for Iter<'a, T>[@TraitClause0]}<'_, T>[@TraitClause0]
     type Item = &'a (T)
     type IntoIter = Iter<'a, T>[@TraitClause0]
-    fn into_iter = {impl IntoIterator for &'a (Slice<T>)}::into_iter<'a, T>[@TraitClause0]
-    vtable: {impl IntoIterator for &'a (Slice<T>)}::{vtable}<'a, T>[@TraitClause0]
+    fn into_iter = {impl IntoIterator for &'a ([T])}::into_iter<'a, T>[@TraitClause0]
+    vtable: {impl IntoIterator for &'a ([T])}::{vtable}<'a, T>[@TraitClause0]
 }
 
 // Full name: std::io::stdio::_eprint
@@ -528,15 +528,15 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::debug_slice
-fn debug_slice<'_0, T>(@1: &'_0 (Slice<T>))
+fn debug_slice<'_0, T>(@1: &'_0 ([T]))
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Debug<T>,
 {
     let @0: (); // return
-    let slice@1: &'0 (Slice<T>); // arg #1
+    let slice@1: &'0 ([T]); // arg #1
     let @2: Iter<'1, T>[@TraitClause0]; // anonymous local
-    let @3: &'0 (Slice<T>); // anonymous local
+    let @3: &'0 ([T]); // anonymous local
     let iter@4: Iter<'1, T>[@TraitClause0]; // local
     let @5: Option<&'2 (T)>[{built_in impl Sized for &'2 (T)}]; // anonymous local
     let @6: &'5 mut (Iter<'1, T>[@TraitClause0]); // anonymous local
@@ -546,21 +546,21 @@ where
     let @10: Arguments<'6>; // anonymous local
     let args@11: (&'7 (&'2 (T))); // local
     let @12: &'7 (&'2 (T)); // anonymous local
-    let args@13: Array<Argument<'8>, 1 : usize>; // local
+    let args@13: [Argument<'8>; 1 : usize]; // local
     let @14: Argument<'8>; // anonymous local
     let @15: &'7 (&'2 (T)); // anonymous local
-    let @16: &'9 (Array<u8, 7 : usize>); // anonymous local
-    let @17: &'9 (Array<u8, 7 : usize>); // anonymous local
-    let @18: &'10 (Array<Argument<'8>, 1 : usize>); // anonymous local
-    let @19: &'10 (Array<Argument<'8>, 1 : usize>); // anonymous local
-    let @20: Array<u8, 7 : usize>; // anonymous local
-    let @21: &'9 (Array<u8, 7 : usize>); // anonymous local
+    let @16: &'9 ([u8; 7 : usize]); // anonymous local
+    let @17: &'9 ([u8; 7 : usize]); // anonymous local
+    let @18: &'10 ([Argument<'8>; 1 : usize]); // anonymous local
+    let @19: &'10 ([Argument<'8>; 1 : usize]); // anonymous local
+    let @20: [u8; 7 : usize]; // anonymous local
+    let @21: &'9 ([u8; 7 : usize]); // anonymous local
 
     @0 := ()
     storage_live(@2)
     storage_live(@3)
     @3 := copy (slice@1)
-    @2 := {impl IntoIterator for &'a (Slice<T>)}::into_iter<'11, T>[@TraitClause0](move (@3))
+    @2 := {impl IntoIterator for &'a ([T])}::into_iter<'11, T>[@TraitClause0](move (@3))
     storage_dead(@3)
     storage_live(iter@4)
     iter@4 := move (@2)
@@ -636,12 +636,12 @@ fn main()
 {
     let @0: (); // return
     let @1: (); // anonymous local
-    let @2: &'0 (Slice<i32>); // anonymous local
-    let @3: &'1 (Array<i32, 3 : usize>); // anonymous local
-    let @4: &'1 (Array<i32, 3 : usize>); // anonymous local
-    let @5: &'1 (Array<i32, 3 : usize>); // anonymous local
-    let @6: &'_ (Array<i32, 3 : usize>); // anonymous local
-    let @7: Array<i32, 3 : usize>; // anonymous local
+    let @2: &'0 ([i32]); // anonymous local
+    let @3: &'1 ([i32; 3 : usize]); // anonymous local
+    let @4: &'1 ([i32; 3 : usize]); // anonymous local
+    let @5: &'1 ([i32; 3 : usize]); // anonymous local
+    let @6: &'_ ([i32; 3 : usize]); // anonymous local
+    let @7: [i32; 3 : usize]; // anonymous local
 
     storage_live(@6)
     storage_live(@7)

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -176,9 +176,9 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
 
-// Full name: alloc::slice::{Slice<T>}::into_vec
+// Full name: alloc::slice::{[T]}::into_vec
 #[lang_item("slice_into_vec")]
-pub fn into_vec<T, A>(@1: alloc::boxed::Box<Slice<T>>[{built_in impl MetaSized for Slice<T>}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(@1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
@@ -224,11 +224,11 @@ fn foo()
 {
     let @0: (); // return
     let _v@1: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let @2: alloc::boxed::Box<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]; // anonymous local
-    let @3: alloc::boxed::Box<Array<i32, 1 : usize>>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}]; // anonymous local
-    let @4: alloc::boxed::Box<Array<i32, 1 : usize>>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}]; // anonymous local
+    let @2: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
+    let @3: alloc::boxed::Box<[i32; 1 : usize]>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let @4: alloc::boxed::Box<[i32; 1 : usize]>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _v2@5: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let @6: Array<i32, 1 : usize>; // anonymous local
+    let @6: [i32; 1 : usize]; // anonymous local
 
     @0 := ()
     storage_live(_v@1)
@@ -237,11 +237,11 @@ fn foo()
     storage_live(@6)
     @6 := [const (1 : i32)]
     storage_live(@4)
-    @4 := @BoxNew<Array<i32, 1 : usize>>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}](move (@6))
+    @4 := @BoxNew<[i32; 1 : usize]>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}](move (@6))
     @3 := move (@4)
-    @2 := unsize_cast<alloc::boxed::Box<Array<i32, 1 : usize>>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}], alloc::boxed::Box<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}], 1 : usize>(move (@3))
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Array<i32, 1 : usize>, Global>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}]] @3
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Array<i32, 1 : usize>, Global>[{built_in impl MetaSized for Array<i32, 1 : usize>}, {built_in impl Sized for Global}]] @4
+    @2 := unsize_cast<alloc::boxed::Box<[i32; 1 : usize]>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1 : usize>(move (@3))
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[i32; 1 : usize], Global>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}]] @3
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[i32; 1 : usize], Global>[{built_in impl MetaSized for [i32; 1 : usize]}, {built_in impl Sized for Global}]] @4
     storage_dead(@4)
     storage_dead(@3)
     _v@1 := into_vec<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}](move (@2))
@@ -264,11 +264,11 @@ pub fn bar()
 {
     let @0: (); // return
     let @1: Vec<Foo>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}]; // anonymous local
-    let @2: alloc::boxed::Box<Slice<Foo>>[{built_in impl MetaSized for Slice<Foo>}, {built_in impl Sized for Global}]; // anonymous local
-    let @3: alloc::boxed::Box<Array<Foo, 1 : usize>>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}]; // anonymous local
-    let @4: alloc::boxed::Box<Array<Foo, 1 : usize>>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}]; // anonymous local
+    let @2: alloc::boxed::Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}]; // anonymous local
+    let @3: alloc::boxed::Box<[Foo; 1 : usize]>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let @4: alloc::boxed::Box<[Foo; 1 : usize]>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}]; // anonymous local
     let @5: Foo; // anonymous local
-    let @6: Array<Foo, 1 : usize>; // anonymous local
+    let @6: [Foo; 1 : usize]; // anonymous local
 
     @0 := ()
     storage_live(@1)
@@ -277,14 +277,14 @@ pub fn bar()
     storage_live(@6)
     @6 := [move (@5)]
     storage_live(@4)
-    @4 := @BoxNew<Array<Foo, 1 : usize>>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}](move (@6))
+    @4 := @BoxNew<[Foo; 1 : usize]>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}](move (@6))
     storage_live(@5)
     @5 := Foo {  }
     storage_dead(@5)
     @3 := move (@4)
-    @2 := unsize_cast<alloc::boxed::Box<Array<Foo, 1 : usize>>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}], alloc::boxed::Box<Slice<Foo>>[{built_in impl MetaSized for Slice<Foo>}, {built_in impl Sized for Global}], 1 : usize>(move (@3))
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Array<Foo, 1 : usize>, Global>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}]] @3
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Array<Foo, 1 : usize>, Global>[{built_in impl MetaSized for Array<Foo, 1 : usize>}, {built_in impl Sized for Global}]] @4
+    @2 := unsize_cast<alloc::boxed::Box<[Foo; 1 : usize]>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}], 1 : usize>(move (@3))
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[Foo; 1 : usize], Global>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}]] @3
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[Foo; 1 : usize], Global>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}]] @4
     storage_dead(@4)
     storage_dead(@3)
     @1 := into_vec<Foo, Global>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}](move (@2))

--- a/charon/tests/ui/issue-393-shallowinitbox.out
+++ b/charon/tests/ui/issue-393-shallowinitbox.out
@@ -1,3 +1,224 @@
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: Sized<T>
+            got: {built_in impl Sized for [u8; 1 : usize]}: Sized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<missing(@TypeBound(1, 0))>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitRef
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
+         charon_lib::ast::types::GenericArgs
+         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: Sized<T>
+            got: {built_in impl Sized for [u8; 1 : usize]}: Sized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<missing(@TypeBound(1, 0))>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitRef
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
+         charon_lib::ast::types::GenericArgs
+         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after translation:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8]}: MetaSized<[u8]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::ullbc_ast::TerminatorKind
+         charon_lib::ast::ullbc_ast::Terminator
+         charon_lib::ast::ullbc_ast::BlockData
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>
+         charon_lib::ast::gast::GExprBody<charon_lib::ids::index_vec::IndexVec<charon_lib::ast::ullbc_ast::BlockId, charon_lib::ast::ullbc_ast::BlockData>>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:54:9
+
 error: Could not reconstruct `Box` initialization; branching during `Box` initialization is not supported.
  --> tests/ui/issue-393-shallowinitbox.rs:2:1
   |
@@ -7,4 +228,188 @@ error: Could not reconstruct `Box` initialization; branching during `Box` initia
 5 | | }
   | |_^
 
-ERROR Charon failed to translate this code (1 errors)
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: Sized<T>
+            got: {built_in impl Sized for [u8; 1 : usize]}: Sized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<missing(@TypeBound(1, 0))>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitRef
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
+         charon_lib::ast::types::GenericArgs
+         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: Sized<T>
+            got: {built_in impl Sized for [u8; 1 : usize]}: Sized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<missing(@TypeBound(1, 0))>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitRef
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
+         charon_lib::ast::types::GenericArgs
+         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::expressions::ConstantExprKind
+         charon_lib::ast::expressions::ConstantExpr
+         alloc::boxed::Box<charon_lib::ast::expressions::ConstantExpr>
+         charon_lib::ast::expressions::Operand
+         alloc::vec::Vec<charon_lib::ast::expressions::Operand>
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:13
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::llbc_ast::Switch
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: [@TraitClause0]: MetaSized<T>
+            got: {built_in impl MetaSized for [u8; 1 : usize]}: MetaSized<[u8; 1 : usize]>
+       Visitor stack:
+         charon_lib::ast::types::TraitImplRef
+         charon_lib::ast::types::TraitRefKind
+         charon_lib::ast::types::TraitRefContents
+         charon_lib::ast::hash_cons::HashConsed<charon_lib::ast::types::TraitRefContents>
+         charon_lib::ast::types::TraitRef
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: 
+ --> /rustc/library/alloc/src/macros.rs:53:45
+
+ERROR Charon failed to translate this code (17 errors)

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -77,24 +77,24 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
-// Full name: core::array::{impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from
-pub fn {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> Result<Array<T, N>, TryFromSliceError>[{built_in impl Sized for Array<T, N>}, {built_in impl Sized for TryFromSliceError}]
+// Full name: core::array::{impl TryFrom<&'_0 ([T])> for [T; N]}::try_from
+pub fn {impl TryFrom<&'_0 ([T])> for [T; N]}::try_from<'_0, T, const N : usize>(@1: &'_0 ([T])) -> Result<[T; N], TryFromSliceError>[{built_in impl Sized for [T; N]}, {built_in impl Sized for TryFromSliceError}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
 = <opaque>
 
-// Full name: core::array::{impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}
-impl<'_0, T, const N : usize> TryFrom<&'_0 (Slice<T>)> for Array<T, N>
+// Full name: core::array::{impl TryFrom<&'_0 ([T])> for [T; N]}
+impl<'_0, T, const N : usize> TryFrom<&'_0 ([T])> for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
 {
-    parent_clause0 = {built_in impl Sized for Array<T, N>}
-    parent_clause1 = {built_in impl Sized for &'_ (Slice<T>)}
+    parent_clause0 = {built_in impl Sized for [T; N]}
+    parent_clause1 = {built_in impl Sized for &'_ ([T])}
     parent_clause2 = {built_in impl Sized for TryFromSliceError}
     type Error = TryFromSliceError
-    fn try_from = {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
+    fn try_from = {impl TryFrom<&'_0 ([T])> for [T; N]}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
@@ -204,22 +204,22 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::trait_error
-pub fn trait_error<'_0>(@1: &'_0 (Slice<u8>))
+pub fn trait_error<'_0>(@1: &'_0 ([u8]))
 {
     let @0: (); // return
-    let s@1: &'0 (Slice<u8>); // arg #1
-    let _array@2: Array<u8, 4 : usize>; // local
-    let @3: Result<Array<u8, 4 : usize>, TryFromSliceError>[{built_in impl Sized for Array<u8, 4 : usize>}, {built_in impl Sized for TryFromSliceError}]; // anonymous local
-    let @4: &'0 (Slice<u8>); // anonymous local
+    let s@1: &'0 ([u8]); // arg #1
+    let _array@2: [u8; 4 : usize]; // local
+    let @3: Result<[u8; 4 : usize], TryFromSliceError>[{built_in impl Sized for [u8; 4 : usize]}, {built_in impl Sized for TryFromSliceError}]; // anonymous local
+    let @4: &'0 ([u8]); // anonymous local
 
     @0 := ()
     storage_live(_array@2)
     storage_live(@3)
     storage_live(@4)
     @4 := &*(s@1) with_metadata(copy (s@1.metadata))
-    @3 := {impl TryInto<U> for T}::try_into<&'0 (Slice<u8>), Array<u8, 4 : usize>>[{built_in impl Sized for &'0 (Slice<u8>)}, {built_in impl Sized for Array<u8, 4 : usize>}, {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}<'0, u8, 4 : usize>[{built_in impl Sized for u8}, {impl Copy for u8}]](move (@4))
+    @3 := {impl TryInto<U> for T}::try_into<&'0 ([u8]), [u8; 4 : usize]>[{built_in impl Sized for &'0 ([u8])}, {built_in impl Sized for [u8; 4 : usize]}, {impl TryFrom<&'_0 ([T])> for [T; N]}<'4, u8, 4 : usize>[{built_in impl Sized for u8}, {impl Copy for u8}]](move (@4))
     storage_dead(@4)
-    _array@2 := unwrap<Array<u8, 4 : usize>, TryFromSliceError>[{built_in impl Sized for Array<u8, 4 : usize>}, {built_in impl Sized for TryFromSliceError}, {impl Debug for TryFromSliceError}](move (@3))
+    _array@2 := unwrap<[u8; 4 : usize], TryFromSliceError>[{built_in impl Sized for [u8; 4 : usize]}, {built_in impl Sized for TryFromSliceError}, {impl Debug for TryFromSliceError}](move (@3))
     storage_dead(@3)
     @0 := ()
     storage_dead(_array@2)

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -77,24 +77,24 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
-// Full name: core::array::{impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from
-pub fn {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from<'_0, T, const N : usize>(@1: &'_0 (Slice<T>)) -> Result<Array<T, N>, TryFromSliceError>[{built_in impl Sized for Array<T, N>}, {built_in impl Sized for TryFromSliceError}]
+// Full name: core::array::{impl TryFrom<&'_0 ([T])> for [T; N]}::try_from
+pub fn {impl TryFrom<&'_0 ([T])> for [T; N]}::try_from<'_0, T, const N : usize>(@1: &'_0 ([T])) -> Result<[T; N], TryFromSliceError>[{built_in impl Sized for [T; N]}, {built_in impl Sized for TryFromSliceError}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
 = <opaque>
 
-// Full name: core::array::{impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}
-impl<'_0, T, const N : usize> TryFrom<&'_0 (Slice<T>)> for Array<T, N>
+// Full name: core::array::{impl TryFrom<&'_0 ([T])> for [T; N]}
+impl<'_0, T, const N : usize> TryFrom<&'_0 ([T])> for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
 {
-    parent_clause0 = {built_in impl Sized for Array<T, N>}
-    parent_clause1 = {built_in impl Sized for &'_ (Slice<T>)}
+    parent_clause0 = {built_in impl Sized for [T; N]}
+    parent_clause1 = {built_in impl Sized for &'_ ([T])}
     parent_clause2 = {built_in impl Sized for TryFromSliceError}
     type Error = TryFromSliceError
-    fn try_from = {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
+    fn try_from = {impl TryFrom<&'_0 ([T])> for [T; N]}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
@@ -204,22 +204,22 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::trait_error
-fn trait_error<'_0>(@1: &'_0 (Slice<u8>))
+fn trait_error<'_0>(@1: &'_0 ([u8]))
 {
     let @0: (); // return
-    let s@1: &'0 (Slice<u8>); // arg #1
-    let _array@2: Array<u8, 4 : usize>; // local
-    let @3: Result<Array<u8, 4 : usize>, TryFromSliceError>[{built_in impl Sized for Array<u8, 4 : usize>}, {built_in impl Sized for TryFromSliceError}]; // anonymous local
-    let @4: &'0 (Slice<u8>); // anonymous local
+    let s@1: &'0 ([u8]); // arg #1
+    let _array@2: [u8; 4 : usize]; // local
+    let @3: Result<[u8; 4 : usize], TryFromSliceError>[{built_in impl Sized for [u8; 4 : usize]}, {built_in impl Sized for TryFromSliceError}]; // anonymous local
+    let @4: &'0 ([u8]); // anonymous local
 
     @0 := ()
     storage_live(_array@2)
     storage_live(@3)
     storage_live(@4)
     @4 := &*(s@1) with_metadata(copy (s@1.metadata))
-    @3 := {impl TryInto<U> for T}::try_into<&'0 (Slice<u8>), Array<u8, 4 : usize>>[{built_in impl Sized for &'0 (Slice<u8>)}, {built_in impl Sized for Array<u8, 4 : usize>}, {impl TryFrom<&'_0 (Slice<T>)> for Array<T, N>}<'0, u8, 4 : usize>[{built_in impl Sized for u8}, {impl Copy for u8}]](move (@4))
+    @3 := {impl TryInto<U> for T}::try_into<&'0 ([u8]), [u8; 4 : usize]>[{built_in impl Sized for &'0 ([u8])}, {built_in impl Sized for [u8; 4 : usize]}, {impl TryFrom<&'_0 ([T])> for [T; N]}<'4, u8, 4 : usize>[{built_in impl Sized for u8}, {impl Copy for u8}]](move (@4))
     storage_dead(@4)
-    _array@2 := unwrap<Array<u8, 4 : usize>, TryFromSliceError>[{built_in impl Sized for Array<u8, 4 : usize>}, {built_in impl Sized for TryFromSliceError}, {impl Debug for TryFromSliceError}](move (@3))
+    _array@2 := unwrap<[u8; 4 : usize], TryFromSliceError>[{built_in impl Sized for [u8; 4 : usize]}, {built_in impl Sized for TryFromSliceError}, {impl Debug for TryFromSliceError}](move (@3))
     storage_dead(@3)
     @0 := ()
     storage_dead(_array@2)

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -45,7 +45,7 @@ pub trait FnMut<Self, Args>
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
 }
 
-pub fn core::array::{Array<T, N>}::map<T, F, U, const N : usize>(@1: Array<T, N>, @2: F) -> Array<U, N>
+pub fn core::array::{[T; N]}::map<T, F, U, const N : usize>(@1: [T; N], @2: F) -> [U; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -548,7 +548,7 @@ pub enum AssertKind {
 }
 
 #[lang_item("slice_len_fn")]
-pub fn core::slice::{Slice<T>}::len<'_0, T>(@1: &'_0 (Slice<T>)) -> usize
+pub fn core::slice::{[T]}::len<'_0, T>(@1: &'_0 ([T])) -> usize
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -626,37 +626,37 @@ impl FnMut<(i32)> for closure {
     non-dyn-compatible
 }
 
-pub fn test_crate::map(@1: Array<i32, 256 : usize>) -> Array<i32, 256 : usize>
+pub fn test_crate::map(@1: [i32; 256 : usize]) -> [i32; 256 : usize]
 {
-    let @0: Array<i32, 256 : usize>; // return
-    let x@1: Array<i32, 256 : usize>; // arg #1
-    let @2: Array<i32, 256 : usize>; // anonymous local
+    let @0: [i32; 256 : usize]; // return
+    let x@1: [i32; 256 : usize]; // arg #1
+    let @2: [i32; 256 : usize]; // anonymous local
     let @3: closure; // anonymous local
 
     storage_live(@2)
     @2 := copy (x@1)
     storage_live(@3)
     @3 := closure {  }
-    @0 := core::array::{Array<T, N>}::map<i32, closure, i32, 256 : usize>[{built_in impl Sized for i32}, {built_in impl Sized for closure}, {built_in impl Sized for i32}, {impl FnMut<(i32)> for closure}](move (@2), move (@3))
+    @0 := core::array::{[T; N]}::map<i32, closure, i32, 256 : usize>[{built_in impl Sized for i32}, {built_in impl Sized for closure}, {built_in impl Sized for i32}, {impl FnMut<(i32)> for closure}](move (@2), move (@3))
     storage_dead(@3)
     storage_dead(@2)
     return
 }
 
 // Full name: test_crate::array
-pub fn array<const LEN : usize>() -> Array<u8, LEN>
+pub fn array<const LEN : usize>() -> [u8; LEN]
 {
-    let @0: Array<u8, LEN>; // return
+    let @0: [u8; LEN]; // return
 
     @0 := @ArrayRepeat<'_, u8, LEN>(const (0 : u8))
     return
 }
 
 // Full name: test_crate::cbd
-fn cbd(@1: Array<u8, 33 : usize>)
+fn cbd(@1: [u8; 33 : usize])
 {
     let @0: (); // return
-    let prf_input@1: Array<u8, 33 : usize>; // arg #1
+    let prf_input@1: [u8; 33 : usize]; // arg #1
     let @2: Range<u8>[{built_in impl Sized for u8}]; // anonymous local
     let @3: Range<u8>[{built_in impl Sized for u8}]; // anonymous local
     let iter@4: Range<u8>[{built_in impl Sized for u8}]; // local
@@ -666,7 +666,7 @@ fn cbd(@1: Array<u8, 33 : usize>)
     let i@8: u8; // local
     let @9: u8; // anonymous local
     let @10: usize; // anonymous local
-    let @11: &'_ mut (Array<u8, 33 : usize>); // anonymous local
+    let @11: &'_ mut ([u8; 33 : usize]); // anonymous local
     let @12: &'_ mut (u8); // anonymous local
 
     @0 := ()
@@ -719,19 +719,19 @@ fn cbd(@1: Array<u8, 33 : usize>)
 }
 
 // Full name: test_crate::select
-fn select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
+fn select<'_0, '_1>(@1: &'_0 ([u8]), @2: &'_1 ([u8]))
 {
     let @0: (); // return
-    let lhs@1: &'0 (Slice<u8>); // arg #1
-    let rhs@2: &'0 (Slice<u8>); // arg #2
+    let lhs@1: &'0 ([u8]); // arg #1
+    let rhs@2: &'0 ([u8]); // arg #2
     let @3: bool; // anonymous local
     let @4: (&'1 (usize), &'1 (usize)); // anonymous local
     let @5: &'1 (usize); // anonymous local
     let @6: usize; // anonymous local
-    let @7: &'0 (Slice<u8>); // anonymous local
+    let @7: &'0 ([u8]); // anonymous local
     let @8: &'1 (usize); // anonymous local
     let @9: usize; // anonymous local
-    let @10: &'0 (Slice<u8>); // anonymous local
+    let @10: &'0 ([u8]); // anonymous local
     let left_val@11: &'1 (usize); // local
     let right_val@12: &'1 (usize); // local
     let @13: bool; // anonymous local
@@ -754,14 +754,14 @@ fn select<'_0, '_1>(@1: &'_0 (Slice<u8>), @2: &'_1 (Slice<u8>))
         storage_live(@6)
         storage_live(@7)
         @7 := &*(lhs@1) with_metadata(copy (lhs@1.metadata))
-        @6 := core::slice::{Slice<T>}::len<'_, u8>[{built_in impl Sized for u8}](move (@7))
+        @6 := core::slice::{[T]}::len<'_, u8>[{built_in impl Sized for u8}](move (@7))
         storage_dead(@7)
         @5 := &@6
         storage_live(@8)
         storage_live(@9)
         storage_live(@10)
         @10 := &*(rhs@2) with_metadata(copy (rhs@2.metadata))
-        @9 := core::slice::{Slice<T>}::len<'_, u8>[{built_in impl Sized for u8}](move (@10))
+        @9 := core::slice::{[T]}::len<'_, u8>[{built_in impl Sized for u8}](move (@10))
         storage_dead(@10)
         @8 := &@9
         @4 := (move (@5), move (@8))

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -481,7 +481,7 @@ pub trait Iterator<Self>
     fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), Self::Item)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (Self::Item)>, @TraitClause4_1::parent_clause1::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flatten<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 (Array<Self::Item, N>))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, N>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 ([Self::Item; N]))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, N>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn fuse<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[Self, @TraitClause0_1]
     fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (Self::Item))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_1, Self>[Self, @TraitClause0_1]
@@ -665,7 +665,7 @@ where
 = <opaque>
 
 // Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk<'_0, T, const N : usize, const N : usize>(@1: &'_0 mut (IntoIter<T, N>[@TraitClause0])) -> Result<Array<T, N>, IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for Array<T, N>}, {built_in impl Sized for IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]}]
+pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk<'_0, T, const N : usize, const N : usize>(@1: &'_0 mut (IntoIter<T, N>[@TraitClause0])) -> Result<[T; N], IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [T; N]}, {built_in impl Sized for IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
@@ -888,7 +888,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 (Array<T, N>))>,
+    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 ([T; N]))>,
     for<'_0_1> @TraitClause4::parent_clause1::Output = R,
 = <opaque>
 
@@ -1452,7 +1452,7 @@ where
     fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), T)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::scan<T, St, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (T)>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flat_map<T, U, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flatten<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flatten<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 (Array<T, N>))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_windows<T, F, R, N, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 ([T; N]))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_windows<T, F, R, N, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn fuse<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::fuse<T, N>[@TraitClause0, @TraitClause0_1]
     fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (T))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::inspect<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn by_ref<'_0_1, [@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::by_ref<'_0_1, T, N>[@TraitClause0, @TraitClause0_1]
@@ -1506,25 +1506,25 @@ where
     vtable: {impl Iterator for IntoIter<T, N>[@TraitClause0]}::{vtable}<T, N>[@TraitClause0]
 }
 
-// Full name: core::array::iter::{impl IntoIterator for Array<T, N>}::into_iter
-pub fn {impl IntoIterator for Array<T, N>}::into_iter<T, const N : usize>(@1: Array<T, N>) -> IntoIter<T, N>[@TraitClause0]
+// Full name: core::array::iter::{impl IntoIterator for [T; N]}::into_iter
+pub fn {impl IntoIterator for [T; N]}::into_iter<T, const N : usize>(@1: [T; N]) -> IntoIter<T, N>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::array::iter::{impl IntoIterator for Array<T, N>}
-impl<T, const N : usize> IntoIterator for Array<T, N>
+// Full name: core::array::iter::{impl IntoIterator for [T; N]}
+impl<T, const N : usize> IntoIterator for [T; N]
 where
     [@TraitClause0]: Sized<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for Array<T, N>}
+    parent_clause0 = {built_in impl MetaSized for [T; N]}
     parent_clause1 = @TraitClause0
     parent_clause2 = {built_in impl Sized for IntoIter<T, N>[@TraitClause0]}
     parent_clause3 = {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]
     type Item = T
     type IntoIter = IntoIter<T, N>[@TraitClause0]
-    fn into_iter = {impl IntoIterator for Array<T, N>}::into_iter<T, N>[@TraitClause0]
-    vtable: {impl IntoIterator for Array<T, N>}::{vtable}<T, N>[@TraitClause0]
+    fn into_iter = {impl IntoIterator for [T; N]}::into_iter<T, N>[@TraitClause0]
+    vtable: {impl IntoIterator for [T; N]}::{vtable}<T, N>[@TraitClause0]
 }
 
 #[lang_item("clone_fn")]
@@ -1835,7 +1835,7 @@ where
     [@TraitClause0]: Iterator<Self>,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> Result<Array<@TraitClause0::Item, N>, IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]>[{built_in impl Sized for Array<@TraitClause0::Item, N>}, {built_in impl Sized for IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]}]
+pub fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(@1: &'_0 mut (Self)) -> Result<[@TraitClause0::Item; N], IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]>[{built_in impl Sized for [@TraitClause0::Item; N]}, {built_in impl Sized for IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]}]
 where
     [@TraitClause0]: Iterator<Self>,
     [@TraitClause1]: Sized<Self>,
@@ -2035,7 +2035,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 (Array<@TraitClause0::Item, N>))>,
+    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 ([@TraitClause0::Item; N]))>,
     for<'_0_1> @TraitClause4::parent_clause1::Output = R,
 = <opaque>
 
@@ -2580,7 +2580,7 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (Iter<'a, T>[@TraitClause0])) -> Result<Array<&'a (T), N>, IntoIter<&'a (T), N>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for Array<&'a (T), N>}, {built_in impl Sized for IntoIter<&'a (T), N>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
+pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (Iter<'a, T>[@TraitClause0])) -> Result<[&'a (T); N], IntoIter<&'a (T), N>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [&'a (T); N]}, {built_in impl Sized for IntoIter<&'a (T), N>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
@@ -2803,7 +2803,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 (Array<&'a (T), N>))>,
+    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 ([&'a (T); N]))>,
     for<'_0_1> @TraitClause4::parent_clause1::Output = R,
 = <opaque>
 
@@ -3367,7 +3367,7 @@ where
     fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), &'a (T))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a (T))>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn flatten<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a (T)>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 (Array<&'a (T), N>))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 ([&'a (T); N]))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn fuse<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
     fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (T)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
@@ -3429,13 +3429,13 @@ where
     T : 'a,
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Result<Array<&'a (Slice<T>), N>, IntoIter<&'a (Slice<T>), N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for Array<&'a (Slice<T>), N>}, {built_in impl Sized for IntoIter<&'a (Slice<T>), N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0])) -> Result<[&'a ([T]); N], IntoIter<&'a ([T]), N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [&'a ([T]); N]}, {built_in impl Sized for IntoIter<&'a ([T]), N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
@@ -3454,7 +3454,7 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::last
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::last<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::last<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -3466,7 +3466,7 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: usize) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: usize) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -3485,7 +3485,7 @@ where
     [@TraitClause1]: Sized<U>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = &'a (Slice<T>),
+    @TraitClause3::Item = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::zip
@@ -3498,11 +3498,11 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>(@1: Chunks<'a, T>[@TraitClause0], @2: &'a (Slice<T>)) -> Intersperse<Chunks<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>(@1: Chunks<'a, T>[@TraitClause0], @2: &'a ([T])) -> Intersperse<Chunks<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<&'a (Slice<T>)>,
+    [@TraitClause2]: Clone<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with
@@ -3512,7 +3512,7 @@ where
     [@TraitClause1]: Sized<G>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = &'a (Slice<T>),
+    @TraitClause3::parent_clause1::Output = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::map
@@ -3523,7 +3523,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = B,
 = <opaque>
 
@@ -3533,7 +3533,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = (),
 = <opaque>
 
@@ -3544,7 +3544,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3555,7 +3555,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -3580,7 +3580,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3590,7 +3590,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3601,7 +3601,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<P>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<P, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -3627,7 +3627,7 @@ where
     [@TraitClause2]: Sized<B>,
     [@TraitClause3]: Sized<F>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut (St), &'a (Slice<T>))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut (St), &'a ([T]))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
 = <opaque>
 
@@ -3639,7 +3639,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]))>,
     @TraitClause5::parent_clause1::Output = U,
 = <opaque>
 
@@ -3648,7 +3648,7 @@ pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten<'a, T>(@1: Chun
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<&'a (Slice<T>)>,
+    [@TraitClause2]: IntoIterator<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows
@@ -3658,7 +3658,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 (Array<&'a (Slice<T>), N>))>,
+    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 ([&'a ([T]); N]))>,
     for<'_0_1> @TraitClause4::parent_clause1::Output = R,
 = <opaque>
 
@@ -3675,7 +3675,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = (),
 = <opaque>
 
@@ -3692,7 +3692,7 @@ pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect<'a, T, B>(@1: C
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, &'a (Slice<T>)>,
+    [@TraitClause2]: FromIterator<B, &'a ([T])>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -3702,7 +3702,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Try<&'a (Slice<T>)>,
+    [@TraitClause3]: Try<&'a ([T])>,
     [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
     [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
 = <opaque>
@@ -3712,7 +3712,7 @@ pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into<'a, '_1, T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, &'a (Slice<T>)>,
+    [@TraitClause2]: Extend<E, &'a ([T])>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -3724,8 +3724,8 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, &'a (Slice<T>)>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: Extend<B, &'a ([T])>,
+    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3749,7 +3749,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<P, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3761,7 +3761,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<R>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, &'a (Slice<T>))>,
+    [@TraitClause5]: FnMut<F, (B, &'a ([T]))>,
     [@TraitClause6]: Try<R>,
     @TraitClause5::parent_clause1::Output = R,
     @TraitClause6::Output = B,
@@ -3774,7 +3774,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     [@TraitClause5]: Try<R>,
     @TraitClause4::parent_clause1::Output = R,
     @TraitClause5::Output = (),
@@ -3787,18 +3787,18 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (B, &'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (B, &'a ([T]))>,
     @TraitClause4::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>), &'a (Slice<T>))>,
-    @TraitClause3::parent_clause1::Output = &'a (Slice<T>),
+    [@TraitClause3]: FnMut<F, (&'a ([T]), &'a ([T]))>,
+    @TraitClause3::parent_clause1::Output = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce
@@ -3809,9 +3809,9 @@ where
     [@TraitClause2]: Sized<impl FnMut(Self::Item, Self::Item) -> R>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a (Slice<T>), &'a (Slice<T>))>,
-    @TraitClause4::Output = &'a (Slice<T>),
+    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
+    [@TraitClause6]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a ([T]), &'a ([T]))>,
+    @TraitClause4::Output = &'a ([T]),
     @TraitClause6::parent_clause1::Output = R,
 = <opaque>
 
@@ -3821,7 +3821,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3831,17 +3831,17 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::find
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: P) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: P) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3852,7 +3852,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -3864,8 +3864,8 @@ where
     [@TraitClause2]: Sized<impl FnMut(&Self::Item) -> R>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
+    [@TraitClause6]: for<'_0_1> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_1 (&'a ([T])))>,
     @TraitClause4::Output = bool,
     for<'_0_1> @TraitClause6::parent_clause1::Output = R,
 = <opaque>
@@ -3876,7 +3876,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<P, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -3885,7 +3885,7 @@ pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition<'a, '_1, T, P
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause2]: FnMut<P, (&'a ([T]))>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: ExactSizeIterator<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause5]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>,
@@ -3893,62 +3893,62 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a (Slice<T>)>,
+    [@TraitClause2]: Ord<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>(@1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a (Slice<T>)>,
+    [@TraitClause2]: Ord<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Ord<B>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Ord<B>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>(@1: Chunks<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
 = <opaque>
 
@@ -4024,7 +4024,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<S>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, &'a (Slice<T>)>,
+    [@TraitClause3]: Sum<S, &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::product
@@ -4033,7 +4033,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, &'a (Slice<T>)>,
+    [@TraitClause3]: Product<P, &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp
@@ -4042,9 +4042,9 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<&'a (Slice<T>)>,
+    [@TraitClause3]: Ord<&'a ([T])>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    @TraitClause2::Item = &'a (Slice<T>),
+    @TraitClause2::Item = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by
@@ -4055,7 +4055,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = Ordering,
 = <opaque>
 
@@ -4065,7 +4065,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4077,7 +4077,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
@@ -4087,7 +4087,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialEq<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4099,7 +4099,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4109,7 +4109,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialEq<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4119,7 +4119,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4129,7 +4129,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4139,7 +4139,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4149,7 +4149,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4158,7 +4158,7 @@ pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted<'a, T>(@1: Ch
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<&'a (Slice<T>), &'a (Slice<T>)>,
+    [@TraitClause2]: PartialOrd<&'a ([T]), &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by
@@ -4167,7 +4167,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4178,13 +4178,13 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<K>,
     [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     [@TraitClause5]: PartialOrd<K, K>,
     @TraitClause4::parent_clause1::Output = K,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: usize) -> &'a (Slice<T>)
+pub unsafe fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (Chunks<'a, T>[@TraitClause0]), @2: usize) -> &'a ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -4195,8 +4195,8 @@ where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for Chunks<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ (Slice<T>)}
-    type Item = &'a (Slice<T>)
+    parent_clause1 = {built_in impl Sized for &'_ ([T])}
+    type Item = &'a ([T])
     fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
     fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk<'a, '_0_1, T, N>[@TraitClause0, @TraitClause0_1]
     fn size_hint<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::size_hint<'a, '_0_1, T>[@TraitClause0]
@@ -4205,74 +4205,74 @@ where
     fn advance_by<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::advance_by<'a, '_0_1, T>[@TraitClause0]
     fn nth<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth<'a, '_0_1, T>[@TraitClause0]
     fn step_by<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::step_by<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a (Slice<T>)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a ([T])> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a (Slice<T>)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn intersperse<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a ([T])> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn enumerate<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::enumerate<'a, T>[@TraitClause0, @TraitClause0_1]
     fn peekable<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::peekable<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn skip<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip<'a, T>[@TraitClause0, @TraitClause0_1]
     fn take<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), &'a (Slice<T>))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 (Array<&'a (Slice<T>), N>))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), &'a ([T]))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a ([T]))>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn flatten<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 ([&'a ([T]); N]))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn fuse<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a (Slice<T>)>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a (Slice<T>)>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a (Slice<T>)>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a (Slice<T>)>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a ([T])>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a ([T])>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a ([T])>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a ([T])>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
     fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 (T))>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut (T), for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a (Slice<T>))>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>), &'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = &'a (Slice<T>)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a (Slice<T>), &'a (Slice<T>))>, @TraitClause3_1::Output = &'a (Slice<T>), @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, impl FnMut(&Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a (Slice<T>)>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_2 (&'a (Slice<T>)))>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, impl FnMut(&Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a (Slice<T>))>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a ([T]))>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a ([T]))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]), &'a ([T]))>, @TraitClause2_1::parent_clause1::Output = &'a ([T])> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_reduce<'_0_1, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a ([T]), &'a ([T]))>, @TraitClause3_1::Output = &'a ([T]), @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn try_find<'_0_1, R, impl FnMut(&Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a ([T])>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_2 (&'a ([T])))>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, impl FnMut(&Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a ([T]))>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn max<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn min<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn rev<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rev<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
     fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause9_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
     fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a (T)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a (T)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn cycle<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cycle<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
     fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::array_chunks<'a, T, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a (Slice<T>)>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a (Slice<T>)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a (Slice<T>), &'a (Slice<T>)>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a ([T])>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a ([T])> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn is_sorted<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a ([T]), &'a ([T])>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn __iterator_get_unchecked<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[@TraitClause0]
     vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
@@ -4285,13 +4285,13 @@ where
     T : 'a,
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0])) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0])) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0])) -> Result<Array<&'a (Slice<T>), N>, IntoIter<&'a (Slice<T>), N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for Array<&'a (Slice<T>), N>}, {built_in impl Sized for IntoIter<&'a (Slice<T>), N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0])) -> Result<[&'a ([T]); N], IntoIter<&'a ([T]), N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [&'a ([T]); N]}, {built_in impl Sized for IntoIter<&'a ([T]), N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
@@ -4310,7 +4310,7 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -4322,7 +4322,7 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> Option<&'a (Slice<T>)>[{built_in impl Sized for &'_ (Slice<T>)}]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> Option<&'a ([T])>[{built_in impl Sized for &'_ ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -4341,7 +4341,7 @@ where
     [@TraitClause1]: Sized<U>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = &'a (Slice<T>),
+    @TraitClause3::Item = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::zip
@@ -4354,11 +4354,11 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0], @2: &'a (Slice<T>)) -> Intersperse<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0], @2: &'a ([T])) -> Intersperse<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<&'a (Slice<T>)>,
+    [@TraitClause2]: Clone<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with
@@ -4368,7 +4368,7 @@ where
     [@TraitClause1]: Sized<G>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = &'a (Slice<T>),
+    @TraitClause3::parent_clause1::Output = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map
@@ -4379,7 +4379,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = B,
 = <opaque>
 
@@ -4389,7 +4389,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = (),
 = <opaque>
 
@@ -4400,7 +4400,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4411,7 +4411,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -4436,7 +4436,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4446,7 +4446,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4457,7 +4457,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<P>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<P, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -4483,7 +4483,7 @@ where
     [@TraitClause2]: Sized<B>,
     [@TraitClause3]: Sized<F>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut (St), &'a (Slice<T>))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut (St), &'a ([T]))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
 = <opaque>
 
@@ -4495,7 +4495,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]))>,
     @TraitClause5::parent_clause1::Output = U,
 = <opaque>
 
@@ -4504,7 +4504,7 @@ pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten<'a, T>(@1:
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<&'a (Slice<T>)>,
+    [@TraitClause2]: IntoIterator<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows
@@ -4514,7 +4514,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 (Array<&'a (Slice<T>), N>))>,
+    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 ([&'a ([T]); N]))>,
     for<'_0_1> @TraitClause4::parent_clause1::Output = R,
 = <opaque>
 
@@ -4531,7 +4531,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = (),
 = <opaque>
 
@@ -4548,7 +4548,7 @@ pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect<'a, T, B>(
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, &'a (Slice<T>)>,
+    [@TraitClause2]: FromIterator<B, &'a ([T])>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4558,7 +4558,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Try<&'a (Slice<T>)>,
+    [@TraitClause3]: Try<&'a ([T])>,
     [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
     [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
 = <opaque>
@@ -4568,7 +4568,7 @@ pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into<'a, '
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, &'a (Slice<T>)>,
+    [@TraitClause2]: Extend<E, &'a ([T])>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4580,8 +4580,8 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, &'a (Slice<T>)>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: Extend<B, &'a ([T])>,
+    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4605,7 +4605,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<P, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4617,7 +4617,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<R>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, &'a (Slice<T>))>,
+    [@TraitClause5]: FnMut<F, (B, &'a ([T]))>,
     [@TraitClause6]: Try<R>,
     @TraitClause5::parent_clause1::Output = R,
     @TraitClause6::Output = B,
@@ -4630,7 +4630,7 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<R>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     [@TraitClause5]: Try<R>,
     @TraitClause4::parent_clause1::Output = R,
     @TraitClause5::Output = (),
@@ -4643,18 +4643,18 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (B, &'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (B, &'a ([T]))>,
     @TraitClause4::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>), &'a (Slice<T>))>,
-    @TraitClause3::parent_clause1::Output = &'a (Slice<T>),
+    [@TraitClause3]: FnMut<F, (&'a ([T]), &'a ([T]))>,
+    @TraitClause3::parent_clause1::Output = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce
@@ -4665,9 +4665,9 @@ where
     [@TraitClause2]: Sized<impl FnMut(Self::Item, Self::Item) -> R>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a (Slice<T>), &'a (Slice<T>))>,
-    @TraitClause4::Output = &'a (Slice<T>),
+    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
+    [@TraitClause6]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a ([T]), &'a ([T]))>,
+    @TraitClause4::Output = &'a ([T]),
     @TraitClause6::parent_clause1::Output = R,
 = <opaque>
 
@@ -4677,7 +4677,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4687,17 +4687,17 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<F, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: P) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: P) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4708,7 +4708,7 @@ where
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
 = <opaque>
 
@@ -4720,8 +4720,8 @@ where
     [@TraitClause2]: Sized<impl FnMut(&Self::Item) -> R>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
+    [@TraitClause6]: for<'_0_1> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_1 (&'a ([T])))>,
     @TraitClause4::Output = bool,
     for<'_0_1> @TraitClause6::parent_clause1::Output = R,
 = <opaque>
@@ -4732,7 +4732,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause3]: FnMut<P, (&'a ([T]))>,
     @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4741,7 +4741,7 @@ pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition<'a, '_1,
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (&'a (Slice<T>))>,
+    [@TraitClause2]: FnMut<P, (&'a ([T]))>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: ExactSizeIterator<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause5]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>,
@@ -4749,62 +4749,62 @@ where
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a (Slice<T>)>,
+    [@TraitClause2]: Ord<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>(@1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a (Slice<T>)>,
+    [@TraitClause2]: Ord<&'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Ord<B>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<B>,
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Ord<B>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)))>,
+    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 (&'a ([T])))>,
     for<'_0_1> @TraitClause5::parent_clause1::Output = B,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>(@1: ChunksExact<'a, T>[@TraitClause0], @2: F) -> Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
 = <opaque>
 
@@ -4880,7 +4880,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<S>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, &'a (Slice<T>)>,
+    [@TraitClause3]: Sum<S, &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product
@@ -4889,7 +4889,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<P>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, &'a (Slice<T>)>,
+    [@TraitClause3]: Product<P, &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp
@@ -4898,9 +4898,9 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<&'a (Slice<T>)>,
+    [@TraitClause3]: Ord<&'a ([T])>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    @TraitClause2::Item = &'a (Slice<T>),
+    @TraitClause2::Item = &'a ([T]),
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by
@@ -4911,7 +4911,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = Ordering,
 = <opaque>
 
@@ -4921,7 +4921,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4933,7 +4933,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
@@ -4943,7 +4943,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialEq<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4955,7 +4955,7 @@ where
     [@TraitClause2]: Sized<F>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
     [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a (Slice<T>), @TraitClause4::Item)>,
+    [@TraitClause5]: FnMut<F, (&'a ([T]), @TraitClause4::Item)>,
     @TraitClause5::parent_clause1::Output = bool,
 = <opaque>
 
@@ -4965,7 +4965,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialEq<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4975,7 +4975,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4985,7 +4985,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -4995,7 +4995,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -5005,7 +5005,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a (Slice<T>), @TraitClause2::Item>,
+    [@TraitClause3]: PartialOrd<&'a ([T]), @TraitClause2::Item>,
     [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
 = <opaque>
 
@@ -5014,7 +5014,7 @@ pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted<'a, T>(@
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<&'a (Slice<T>), &'a (Slice<T>)>,
+    [@TraitClause2]: PartialOrd<&'a ([T]), &'a ([T])>,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by
@@ -5023,7 +5023,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a (Slice<T>)), &'_1_1 (&'a (Slice<T>)))>,
+    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 (&'a ([T])), &'_1_1 (&'a ([T])))>,
     for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
 = <opaque>
 
@@ -5034,13 +5034,13 @@ where
     [@TraitClause1]: Sized<F>,
     [@TraitClause2]: Sized<K>,
     [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a (Slice<T>))>,
+    [@TraitClause4]: FnMut<F, (&'a ([T]))>,
     [@TraitClause5]: PartialOrd<K, K>,
     @TraitClause4::parent_clause1::Output = K,
 = <opaque>
 
 // Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> &'a (Slice<T>)
+pub unsafe fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(@1: &'_1 mut (ChunksExact<'a, T>[@TraitClause0]), @2: usize) -> &'a ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -5051,8 +5051,8 @@ where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for ChunksExact<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ (Slice<T>)}
-    type Item = &'a (Slice<T>)
+    parent_clause1 = {built_in impl Sized for &'_ ([T])}
+    type Item = &'a ([T])
     fn next<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
     fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk<'a, '_0_1, T, N>[@TraitClause0, @TraitClause0_1]
     fn size_hint<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::size_hint<'a, '_0_1, T>[@TraitClause0]
@@ -5061,93 +5061,93 @@ where
     fn advance_by<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::advance_by<'a, '_0_1, T>[@TraitClause0]
     fn nth<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth<'a, '_0_1, T>[@TraitClause0]
     fn step_by<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::step_by<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a (Slice<T>)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a ([T])> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a (Slice<T>)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn intersperse<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a ([T])> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn enumerate<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::enumerate<'a, T>[@TraitClause0, @TraitClause0_1]
     fn peekable<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::peekable<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn skip<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip<'a, T>[@TraitClause0, @TraitClause0_1]
     fn take<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), &'a (Slice<T>))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 (Array<&'a (Slice<T>), N>))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut (St), &'a ([T]))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a ([T]))>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn flatten<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 ([&'a ([T]); N]))>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn fuse<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn by_ref<'_0_1, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a (Slice<T>)>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a (Slice<T>)>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a (Slice<T>)>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a (Slice<T>)>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a ([T])>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a ([T])>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a ([T])>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a ([T])>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
     fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 (T))>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut (T), for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a (Slice<T>))>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>), &'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = &'a (Slice<T>)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a (Slice<T>), &'a (Slice<T>))>, @TraitClause3_1::Output = &'a (Slice<T>), @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, impl FnMut(&Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a (Slice<T>)>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_2 (&'a (Slice<T>)))>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, impl FnMut(&Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a (Slice<T>))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a (Slice<T>))>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a ([T]))>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a ([T]))>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]), &'a ([T]))>, @TraitClause2_1::parent_clause1::Output = &'a ([T])> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn try_reduce<'_0_1, R, impl FnMut(Self::Item, Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(Self::Item, Self::Item) -> R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<impl FnMut(Self::Item, Self::Item) -> R, (&'a ([T]), &'a ([T]))>, @TraitClause3_1::Output = &'a ([T]), @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, impl FnMut(Self::Item, Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn try_find<'_0_1, R, impl FnMut(&Self::Item) -> R, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<impl FnMut(&Self::Item) -> R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a ([T])>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<impl FnMut(&Self::Item) -> R, (&'_0_2 (&'a ([T])))>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, impl FnMut(&Self::Item) -> R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
+    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a ([T]))>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a ([T]))>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn max<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn min<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 (&'a ([T])))>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
     fn rev<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rev<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
     fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause9_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
     fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a (T)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a (T)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
     fn cycle<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cycle<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
     fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::array_chunks<'a, T, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a (Slice<T>)>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a (Slice<T>)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a (Slice<T>), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a (Slice<T>), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a (Slice<T>), &'a (Slice<T>)>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a (Slice<T>)), &'_1_2 (&'a (Slice<T>)))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a (Slice<T>))>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a ([T])>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a ([T])> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a ([T]), @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
+    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a ([T]), @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
+    fn is_sorted<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a ([T]), &'a ([T])>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
+    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 (&'a ([T])), &'_1_2 (&'a ([T])))>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a ([T]))>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
     fn __iterator_get_unchecked<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[@TraitClause0]
     vtable: {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
-// Full name: core::slice::{Slice<T>}::iter
+// Full name: core::slice::{[T]}::iter
 #[lang_item("slice_iter")]
-pub fn iter<'_0, T>(@1: &'_0 (Slice<T>)) -> Iter<'_0, T>[@TraitClause0]
+pub fn iter<'_0, T>(@1: &'_0 ([T])) -> Iter<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::{Slice<T>}::chunks
-pub fn chunks<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> Chunks<'_0, T>[@TraitClause0]
+// Full name: core::slice::{[T]}::chunks
+pub fn chunks<'_0, T>(@1: &'_0 ([T]), @2: usize) -> Chunks<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::{Slice<T>}::chunks_exact
-pub fn chunks_exact<'_0, T>(@1: &'_0 (Slice<T>), @2: usize) -> ChunksExact<'_0, T>[@TraitClause0]
+// Full name: core::slice::{[T]}::chunks_exact
+pub fn chunks_exact<'_0, T>(@1: &'_0 ([T]), @2: usize) -> ChunksExact<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -5166,11 +5166,11 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let a@1: Array<i32, 7 : usize>; // local
+    let a@1: [i32; 7 : usize]; // local
     let i@2: i32; // local
     let @3: IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]; // anonymous local
     let @4: IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]; // anonymous local
-    let @5: Array<i32, 7 : usize>; // anonymous local
+    let @5: [i32; 7 : usize]; // anonymous local
     let iter@6: IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]; // local
     let @7: Option<i32>[{built_in impl Sized for i32}]; // anonymous local
     let @8: &'0 mut (IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]); // anonymous local
@@ -5180,8 +5180,8 @@ fn main()
     let @12: i32; // anonymous local
     let @13: Iter<'1, i32>[{built_in impl Sized for i32}]; // anonymous local
     let @14: Iter<'1, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let @15: &'2 (Slice<i32>); // anonymous local
-    let @16: &'3 (Array<i32, 7 : usize>); // anonymous local
+    let @15: &'2 ([i32]); // anonymous local
+    let @16: &'3 ([i32; 7 : usize]); // anonymous local
     let iter@17: Iter<'1, i32>[{built_in impl Sized for i32}]; // local
     let @18: Option<&'4 (i32)>[{built_in impl Sized for &'4 (i32)}]; // anonymous local
     let @19: &'7 mut (Iter<'1, i32>[{built_in impl Sized for i32}]); // anonymous local
@@ -5192,19 +5192,19 @@ fn main()
     let @24: &'4 (i32); // anonymous local
     let @25: Chunks<'9, i32>[{built_in impl Sized for i32}]; // anonymous local
     let @26: Chunks<'9, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let @27: &'2 (Slice<i32>); // anonymous local
-    let @28: &'3 (Array<i32, 7 : usize>); // anonymous local
+    let @27: &'2 ([i32]); // anonymous local
+    let @28: &'3 ([i32; 7 : usize]); // anonymous local
     let iter@29: Chunks<'9, i32>[{built_in impl Sized for i32}]; // local
-    let @30: Option<&'2 (Slice<i32>)>[{built_in impl Sized for &'2 (Slice<i32>)}]; // anonymous local
+    let @30: Option<&'2 ([i32])>[{built_in impl Sized for &'2 ([i32])}]; // anonymous local
     let @31: &'12 mut (Chunks<'9, i32>[{built_in impl Sized for i32}]); // anonymous local
     let @32: &'12 mut (Chunks<'9, i32>[{built_in impl Sized for i32}]); // anonymous local
     let @33: i32; // anonymous local
     let @34: ChunksExact<'13, i32>[{built_in impl Sized for i32}]; // anonymous local
     let @35: ChunksExact<'13, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let @36: &'2 (Slice<i32>); // anonymous local
-    let @37: &'3 (Array<i32, 7 : usize>); // anonymous local
+    let @36: &'2 ([i32]); // anonymous local
+    let @37: &'3 ([i32; 7 : usize]); // anonymous local
     let iter@38: ChunksExact<'13, i32>[{built_in impl Sized for i32}]; // local
-    let @39: Option<&'2 (Slice<i32>)>[{built_in impl Sized for &'2 (Slice<i32>)}]; // anonymous local
+    let @39: Option<&'2 ([i32])>[{built_in impl Sized for &'2 ([i32])}]; // anonymous local
     let @40: &'14 mut (ChunksExact<'13, i32>[{built_in impl Sized for i32}]); // anonymous local
     let @41: &'14 mut (ChunksExact<'13, i32>[{built_in impl Sized for i32}]); // anonymous local
     let @42: i32; // anonymous local
@@ -5237,7 +5237,7 @@ fn main()
     storage_live(@4)
     storage_live(@5)
     @5 := copy (a@1)
-    @4 := {impl IntoIterator for Array<T, N>}::into_iter<i32, 7 : usize>[{built_in impl Sized for i32}](move (@5))
+    @4 := {impl IntoIterator for [T; N]}::into_iter<i32, 7 : usize>[{built_in impl Sized for i32}](move (@5))
     storage_dead(@5)
     @3 := {impl IntoIterator for I}::into_iter<IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]}, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<i32, 7 : usize>[{built_in impl Sized for i32}]](move (@4))
     storage_dead(@4)

--- a/charon/tests/ui/loops.out
+++ b/charon/tests/ui/loops.out
@@ -734,59 +734,59 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::get
-pub fn {impl SliceIndex<Slice<T>> for usize}::get<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> Option<&'_0 (T)>[{built_in impl Sized for &'_0 (T)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get
+pub fn {impl SliceIndex<[T]> for usize}::get<'_0, T>(@1: usize, @2: &'_0 ([T])) -> Option<&'_0 (T)>[{built_in impl Sized for &'_0 (T)}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::get_mut
-pub fn {impl SliceIndex<Slice<T>> for usize}::get_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (T)>[{built_in impl Sized for &'_0 mut (T)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_mut
+pub fn {impl SliceIndex<[T]> for usize}::get_mut<'_0, T>(@1: usize, @2: &'_0 mut ([T])) -> Option<&'_0 mut (T)>[{built_in impl Sized for &'_0 mut (T)}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>> for usize}::get_unchecked<T>(@1: usize, @2: *const Slice<T>) -> *const T
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T]> for usize}::get_unchecked<T>(@1: usize, @2: *const [T]) -> *const T
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>> for usize}::get_unchecked_mut<T>(@1: usize, @2: *mut Slice<T>) -> *mut T
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T]> for usize}::get_unchecked_mut<T>(@1: usize, @2: *mut [T]) -> *mut T
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::index
-pub fn {impl SliceIndex<Slice<T>> for usize}::index<'_0, T>(@1: usize, @2: &'_0 (Slice<T>)) -> &'_0 (T)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::index
+pub fn {impl SliceIndex<[T]> for usize}::index<'_0, T>(@1: usize, @2: &'_0 ([T])) -> &'_0 (T)
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}::index_mut
-pub fn {impl SliceIndex<Slice<T>> for usize}::index_mut<'_0, T>(@1: usize, @2: &'_0 mut (Slice<T>)) -> &'_0 mut (T)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::index_mut
+pub fn {impl SliceIndex<[T]> for usize}::index_mut<'_0, T>(@1: usize, @2: &'_0 mut ([T])) -> &'_0 mut (T)
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for usize}
-impl<T> SliceIndex<Slice<T>> for usize
+// Full name: core::slice::index::{impl SliceIndex<[T]> for usize}
+impl<T> SliceIndex<[T]> for usize
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for usize}
     parent_clause1 = {impl Sealed for usize}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
+    parent_clause2 = {built_in impl MetaSized for [T]}
     parent_clause3 = @TraitClause0::parent_clause0
     type Output = T
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>> for usize}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>> for usize}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>> for usize}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for usize}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>> for usize}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>> for usize}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>> for usize}::{vtable}<T>[@TraitClause0]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for usize}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for usize}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for usize}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for usize}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T]> for usize}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: alloc::alloc::Global
@@ -812,7 +812,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: SliceIndex<I, Slice<T>>,
+    [@TraitClause3]: SliceIndex<I, [T]>,
 = <opaque>
 
 // Full name: alloc::vec::{impl Index<I> for Vec<T>[@TraitClause0, @TraitClause2]}
@@ -821,7 +821,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: SliceIndex<I, Slice<T>>,
+    [@TraitClause3]: SliceIndex<I, [T]>,
 {
     parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause2]}
     parent_clause1 = @TraitClause1::parent_clause0
@@ -837,7 +837,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: SliceIndex<I, Slice<T>>,
+    [@TraitClause3]: SliceIndex<I, [T]>,
 = <opaque>
 
 // Full name: alloc::vec::{impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}
@@ -846,7 +846,7 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
     [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: SliceIndex<I, Slice<T>>,
+    [@TraitClause3]: SliceIndex<I, [T]>,
 {
     parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause2]}
     parent_clause1 = {impl Index<I> for Vec<T>[@TraitClause0, @TraitClause2]}<T, I, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
@@ -1853,10 +1853,10 @@ pub fn test_crate::sum(@1: u32) -> u32
 }
 
 // Full name: test_crate::sum_array
-pub fn sum_array<const N : usize>(@1: Array<u32, N>) -> u32
+pub fn sum_array<const N : usize>(@1: [u32; N]) -> u32
 {
     let @0: u32; // return
-    let a@1: Array<u32, N>; // arg #1
+    let a@1: [u32; N]; // arg #1
     let i@2: usize; // local
     let s@3: u32; // local
     let @4: bool; // anonymous local
@@ -1865,7 +1865,7 @@ pub fn sum_array<const N : usize>(@1: Array<u32, N>) -> u32
     let @7: usize; // anonymous local
     let @8: u32; // anonymous local
     let @9: usize; // anonymous local
-    let @10: &'_ (Array<u32, N>); // anonymous local
+    let @10: &'_ ([u32; N]); // anonymous local
     let @11: &'_ (u32); // anonymous local
 
     storage_live(@8)
@@ -1949,7 +1949,7 @@ pub fn clear<'_0>(@1: &'_0 mut (Vec<u32>[{built_in impl Sized for u32}, {built_i
         @8 := &mut *(v@1)
         storage_live(@9)
         @9 := copy (i@2)
-        @7 := {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut<'_, u32, usize, Global>[{built_in impl Sized for u32}, {built_in impl Sized for usize}, {built_in impl Sized for Global}, {impl SliceIndex<Slice<T>> for usize}<u32>[{built_in impl Sized for u32}]](move (@8), move (@9))
+        @7 := {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut<'_, u32, usize, Global>[{built_in impl Sized for u32}, {built_in impl Sized for usize}, {built_in impl Sized for Global}, {impl SliceIndex<[T]> for usize}<u32>[{built_in impl Sized for u32}]](move (@8), move (@9))
         storage_dead(@9)
         storage_dead(@8)
         *(@7) := const (0 : u32)

--- a/charon/tests/ui/ml-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-mono-name-matcher-tests.out
@@ -60,33 +60,33 @@ pub trait Sized::<&'_ (Str)>
     non-dyn-compatible
 }
 
-// Full name: core::marker::MetaSized::<&'_ (Slice<bool>)>
+// Full name: core::marker::MetaSized::<&'_ ([bool])>
 #[lang_item("meta_sized")]
-pub trait MetaSized::<&'_ (Slice<bool>)>
+pub trait MetaSized::<&'_ ([bool])>
 
-// Full name: core::marker::Sized::<&'_ (Slice<bool>)>
+// Full name: core::marker::Sized::<&'_ ([bool])>
 #[lang_item("sized")]
-pub trait Sized::<&'_ (Slice<bool>)>
+pub trait Sized::<&'_ ([bool])>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized::<&'_ (Slice<bool>)>
+    parent_clause0 : [@TraitClause0]: MetaSized::<&'_ ([bool])>
     non-dyn-compatible
 }
 
-// Full name: core::marker::MetaSized::<&'_ mut (Slice<bool>)>
+// Full name: core::marker::MetaSized::<&'_ mut ([bool])>
 #[lang_item("meta_sized")]
-pub trait MetaSized::<&'_ mut (Slice<bool>)>
+pub trait MetaSized::<&'_ mut ([bool])>
 
-// Full name: core::marker::Sized::<&'_ mut (Slice<bool>)>
+// Full name: core::marker::Sized::<&'_ mut ([bool])>
 #[lang_item("sized")]
-pub trait Sized::<&'_ mut (Slice<bool>)>
+pub trait Sized::<&'_ mut ([bool])>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized::<&'_ mut (Slice<bool>)>
+    parent_clause0 : [@TraitClause0]: MetaSized::<&'_ mut ([bool])>
     non-dyn-compatible
 }
 
-// Full name: core::marker::MetaSized::<Slice<bool>>
+// Full name: core::marker::MetaSized::<[bool]>
 #[lang_item("meta_sized")]
-pub trait MetaSized::<Slice<bool>>
+pub trait MetaSized::<[bool]>
 
 // Full name: core::marker::Destruct::<i32>
 #[lang_item("destruct")]
@@ -118,17 +118,17 @@ pub struct RangeFrom::<usize> {
   start: usize,
 }
 
-// Full name: core::ops::index::Index::<Slice<bool>, RangeFrom::<usize>>
+// Full name: core::ops::index::Index::<[bool], RangeFrom::<usize>>
 #[lang_item("index")]
-pub trait Index::<Slice<bool>, RangeFrom::<usize>>
+pub trait Index::<[bool], RangeFrom::<usize>>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized::<Slice<bool>>
+    parent_clause0 : [@TraitClause0]: MetaSized::<[bool]>
     parent_clause1 : [@TraitClause1]: MetaSized::<RangeFrom::<usize>>
-    fn index<'_0_1> = core::ops::index::Index::index::<Slice<bool>, RangeFrom::<usize>><'_0_1>
-    vtable: core::ops::index::Index::{vtable}::<Slice<bool>, RangeFrom::<usize>><Slice<bool>>
+    fn index<'_0_1> = core::ops::index::Index::index::<[bool], RangeFrom::<usize>><'_0_1>
+    vtable: core::ops::index::Index::{vtable}::<[bool], RangeFrom::<usize>><[bool]>
 }
 
-pub fn core::ops::index::Index::index::<Slice<bool>, RangeFrom::<usize>><'_0>(@1: &'_0 (Slice<bool>), @2: RangeFrom::<usize>) -> &'_0 (Slice<bool>)
+pub fn core::ops::index::Index::index::<[bool], RangeFrom::<usize>><'_0>(@1: &'_0 ([bool]), @2: RangeFrom::<usize>) -> &'_0 ([bool])
 = <opaque>
 
 // Full name: core::option::Option::<i32>
@@ -138,34 +138,34 @@ pub enum Option::<i32> {
   Some(i32),
 }
 
-// Full name: core::option::Option::<&'_ (Slice<bool>)>
+// Full name: core::option::Option::<&'_ ([bool])>
 #[lang_item("Option")]
-pub enum Option::<&'_ (Slice<bool>)> {
+pub enum Option::<&'_ ([bool])> {
   None,
-  Some(&'_ (Slice<bool>)),
+  Some(&'_ ([bool])),
 }
 
-// Full name: core::option::Option::<&'_ mut (Slice<bool>)>
+// Full name: core::option::Option::<&'_ mut ([bool])>
 #[lang_item("Option")]
-pub enum Option::<&'_ mut (Slice<bool>)> {
+pub enum Option::<&'_ mut ([bool])> {
   None,
-  Some(&'_ mut (Slice<bool>)),
+  Some(&'_ mut ([bool])),
 }
 
 // Full name: core::option::{Option::<i32>}::is_some::<i32>
 pub fn is_some::<i32><'_0>(@1: &'_0 (Option::<i32>)) -> bool
 = <opaque>
 
-// Full name: core::slice::index::{impl Index::<Slice<bool>, RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>>
-pub fn {impl Index::<Slice<bool>, RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_0>(@1: &'_0 (Slice<bool>), @2: RangeFrom::<usize>) -> &'_0 (Slice<bool>)
+// Full name: core::slice::index::{impl Index::<[bool], RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>>
+pub fn {impl Index::<[bool], RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_0>(@1: &'_0 ([bool]), @2: RangeFrom::<usize>) -> &'_0 ([bool])
 = <opaque>
 
-// Full name: core::slice::index::{impl Index::<Slice<bool>, RangeFrom::<usize>>}::<bool, RangeFrom::<usize>>
-impl Index::<Slice<bool>, RangeFrom::<usize>> {
-    parent_clause0 = {built_in impl MetaSized::<Slice<bool>>}
+// Full name: core::slice::index::{impl Index::<[bool], RangeFrom::<usize>>}::<bool, RangeFrom::<usize>>
+impl Index::<[bool], RangeFrom::<usize>> {
+    parent_clause0 = {built_in impl MetaSized::<[bool]>}
     parent_clause1 = {built_in impl MetaSized::<RangeFrom::<usize>>}
-    fn index<'_0_1> = {impl Index::<Slice<bool>, RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_0_1>
-    vtable: {impl Index::<Slice<bool>, RangeFrom::<usize>>}::{vtable}::<bool, RangeFrom::<usize>>
+    fn index<'_0_1> = {impl Index::<[bool], RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_0_1>
+    vtable: {impl Index::<[bool], RangeFrom::<usize>>}::{vtable}::<bool, RangeFrom::<usize>>
 }
 
 // Full name: core::slice::index::private_slice_index::Sealed::<RangeFrom::<usize>>
@@ -181,76 +181,76 @@ impl Sealed::<RangeFrom::<usize>> {
     vtable: {impl Sealed::<RangeFrom::<usize>>}::{vtable}
 }
 
-// Full name: core::slice::index::SliceIndex::<RangeFrom::<usize>, Slice<bool>>
+// Full name: core::slice::index::SliceIndex::<RangeFrom::<usize>, [bool]>
 #[lang_item("SliceIndex")]
-pub trait SliceIndex::<RangeFrom::<usize>, Slice<bool>>
+pub trait SliceIndex::<RangeFrom::<usize>, [bool]>
 {
     parent_clause0 : [@TraitClause0]: MetaSized::<RangeFrom::<usize>>
     parent_clause1 : [@TraitClause1]: Sealed::<RangeFrom::<usize>>
-    parent_clause2 : [@TraitClause2]: MetaSized::<Slice<bool>>
-    fn get<'_0_1> = core::slice::index::SliceIndex::get::<RangeFrom::<usize>, Slice<bool>><'_0_1>
-    fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut::<RangeFrom::<usize>, Slice<bool>><'_0_1>
-    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked::<RangeFrom::<usize>, Slice<bool>>
-    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut::<RangeFrom::<usize>, Slice<bool>>
-    fn index<'_0_1> = core::slice::index::SliceIndex::index::<RangeFrom::<usize>, Slice<bool>><'_0_1>
-    fn index_mut<'_0_1> = core::slice::index::SliceIndex::index_mut::<RangeFrom::<usize>, Slice<bool>><'_0_1>
-    vtable: core::slice::index::SliceIndex::{vtable}::<RangeFrom::<usize>, Slice<bool>><Slice<bool>>
+    parent_clause2 : [@TraitClause2]: MetaSized::<[bool]>
+    fn get<'_0_1> = core::slice::index::SliceIndex::get::<RangeFrom::<usize>, [bool]><'_0_1>
+    fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut::<RangeFrom::<usize>, [bool]><'_0_1>
+    fn get_unchecked = core::slice::index::SliceIndex::get_unchecked::<RangeFrom::<usize>, [bool]>
+    fn get_unchecked_mut = core::slice::index::SliceIndex::get_unchecked_mut::<RangeFrom::<usize>, [bool]>
+    fn index<'_0_1> = core::slice::index::SliceIndex::index::<RangeFrom::<usize>, [bool]><'_0_1>
+    fn index_mut<'_0_1> = core::slice::index::SliceIndex::index_mut::<RangeFrom::<usize>, [bool]><'_0_1>
+    vtable: core::slice::index::SliceIndex::{vtable}::<RangeFrom::<usize>, [bool]><[bool]>
 }
 
-pub fn core::slice::index::SliceIndex::get::<RangeFrom::<usize>, Slice<bool>><'_0>(@1: RangeFrom::<usize>, @2: &'_0 (Slice<bool>)) -> Option::<&'_ (Slice<bool>)>
+pub fn core::slice::index::SliceIndex::get::<RangeFrom::<usize>, [bool]><'_0>(@1: RangeFrom::<usize>, @2: &'_0 ([bool])) -> Option::<&'_ ([bool])>
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::get_mut::<RangeFrom::<usize>, Slice<bool>><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut (Slice<bool>)) -> Option::<&'_ mut (Slice<bool>)>
+pub fn core::slice::index::SliceIndex::get_mut::<RangeFrom::<usize>, [bool]><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut ([bool])) -> Option::<&'_ mut ([bool])>
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked::<RangeFrom::<usize>, Slice<bool>>(@1: RangeFrom::<usize>, @2: *const Slice<bool>) -> *const Slice<bool>
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked::<RangeFrom::<usize>, [bool]>(@1: RangeFrom::<usize>, @2: *const [bool]) -> *const [bool]
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut::<RangeFrom::<usize>, Slice<bool>>(@1: RangeFrom::<usize>, @2: *mut Slice<bool>) -> *mut Slice<bool>
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut::<RangeFrom::<usize>, [bool]>(@1: RangeFrom::<usize>, @2: *mut [bool]) -> *mut [bool]
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index::<RangeFrom::<usize>, Slice<bool>><'_0>(@1: RangeFrom::<usize>, @2: &'_0 (Slice<bool>)) -> &'_0 (Slice<bool>)
+pub fn core::slice::index::SliceIndex::index::<RangeFrom::<usize>, [bool]><'_0>(@1: RangeFrom::<usize>, @2: &'_0 ([bool])) -> &'_0 ([bool])
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index_mut::<RangeFrom::<usize>, Slice<bool>><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut (Slice<bool>)) -> &'_0 mut (Slice<bool>)
+pub fn core::slice::index::SliceIndex::index_mut::<RangeFrom::<usize>, [bool]><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut ([bool])) -> &'_0 mut ([bool])
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get::<bool>
-pub fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 (Slice<bool>)) -> Option::<&'_ (Slice<bool>)>
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get::<bool>
+pub fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 ([bool])) -> Option::<&'_ ([bool])>
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_mut::<bool>
-pub fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_mut::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut (Slice<bool>)) -> Option::<&'_ mut (Slice<bool>)>
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_mut::<bool>
+pub fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_mut::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut ([bool])) -> Option::<&'_ mut ([bool])>
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked::<bool>
-pub unsafe fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked::<bool>(@1: RangeFrom::<usize>, @2: *const Slice<bool>) -> *const Slice<bool>
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked::<bool>
+pub unsafe fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked::<bool>(@1: RangeFrom::<usize>, @2: *const [bool]) -> *const [bool]
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked_mut::<bool>
-pub unsafe fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked_mut::<bool>(@1: RangeFrom::<usize>, @2: *mut Slice<bool>) -> *mut Slice<bool>
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked_mut::<bool>
+pub unsafe fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked_mut::<bool>(@1: RangeFrom::<usize>, @2: *mut [bool]) -> *mut [bool]
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index::<bool>
-pub fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 (Slice<bool>)) -> &'_0 (Slice<bool>)
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index::<bool>
+pub fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 ([bool])) -> &'_0 ([bool])
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index_mut::<bool>
-pub fn {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index_mut::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut (Slice<bool>)) -> &'_0 mut (Slice<bool>)
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index_mut::<bool>
+pub fn {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index_mut::<bool><'_0>(@1: RangeFrom::<usize>, @2: &'_0 mut ([bool])) -> &'_0 mut ([bool])
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::<bool>
-impl SliceIndex::<RangeFrom::<usize>, Slice<bool>> {
+// Full name: core::slice::index::{impl SliceIndex::<RangeFrom::<usize>, [bool]>}::<bool>
+impl SliceIndex::<RangeFrom::<usize>, [bool]> {
     parent_clause0 = {built_in impl MetaSized::<RangeFrom::<usize>>}
     parent_clause1 = {impl Sealed::<RangeFrom::<usize>>}
-    parent_clause2 = {built_in impl MetaSized::<Slice<bool>>}
-    fn get<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get::<bool><'_0_1>
-    fn get_mut<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_mut::<bool><'_0_1>
-    fn get_unchecked = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked::<bool>
-    fn get_unchecked_mut = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::get_unchecked_mut::<bool>
-    fn index<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index::<bool><'_0_1>
-    fn index_mut<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::index_mut::<bool><'_0_1>
-    vtable: {impl SliceIndex::<RangeFrom::<usize>, Slice<bool>>}::{vtable}::<bool>
+    parent_clause2 = {built_in impl MetaSized::<[bool]>}
+    fn get<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get::<bool><'_0_1>
+    fn get_mut<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_mut::<bool><'_0_1>
+    fn get_unchecked = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked::<bool>
+    fn get_unchecked_mut = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::get_unchecked_mut::<bool>
+    fn index<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index::<bool><'_0_1>
+    fn index_mut<'_0_1> = {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::index_mut::<bool><'_0_1>
+    vtable: {impl SliceIndex::<RangeFrom::<usize>, [bool]>}::{vtable}::<bool>
 }
 
 fn UNIT_METADATA()
@@ -279,19 +279,19 @@ fn foo()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'0 (Option::<i32>); // anonymous local
-    let slice@3: &'1 (Slice<bool>); // local
-    let @4: &'2 (Array<bool, 1 : usize>); // anonymous local
-    let @5: &'2 (Array<bool, 1 : usize>); // anonymous local
-    let @6: &'1 (Slice<bool>); // anonymous local
-    let @7: &'1 (Slice<bool>); // anonymous local
-    let @8: &'1 (Slice<bool>); // anonymous local
+    let slice@3: &'1 ([bool]); // local
+    let @4: &'2 ([bool; 1 : usize]); // anonymous local
+    let @5: &'2 ([bool; 1 : usize]); // anonymous local
+    let @6: &'1 ([bool]); // anonymous local
+    let @7: &'1 ([bool]); // anonymous local
+    let @8: &'1 ([bool]); // anonymous local
     let @9: RangeFrom::<usize>; // anonymous local
-    let @10: &'2 (Array<bool, 1 : usize>); // anonymous local
+    let @10: &'2 ([bool; 1 : usize]); // anonymous local
     let @11: &'0 (Option::<i32>); // anonymous local
     let @12: &'_ (Option::<i32>); // anonymous local
     let @13: Option::<i32>; // anonymous local
-    let @14: &'_ (Array<bool, 1 : usize>); // anonymous local
-    let @15: Array<bool, 1 : usize>; // anonymous local
+    let @14: &'_ ([bool; 1 : usize]); // anonymous local
+    let @15: [bool; 1 : usize]; // anonymous local
 
     storage_live(@12)
     storage_live(@13)
@@ -326,7 +326,7 @@ fn foo()
     @8 := &*(slice@3) with_metadata(copy (slice@3.metadata))
     storage_live(@9)
     @9 := RangeFrom::<usize> { start: const (1 : usize) }
-    @7 := {impl Index::<Slice<bool>, RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_>(move (@8), move (@9))
+    @7 := {impl Index::<[bool], RangeFrom::<usize>>}::index::<bool, RangeFrom::<usize>><'_>(move (@8), move (@9))
     storage_dead(@9)
     storage_dead(@8)
     @6 := &*(@7) with_metadata(copy (@7.metadata))

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -91,27 +91,27 @@ pub trait SliceIndex<Self, T>
     vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}::index
-pub fn {impl Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
+// Full name: core::slice::index::{impl Index<I> for [T]}::index
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(@1: &'_0 ([T]), @2: I) -> &'_0 (@TraitClause2::Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 = <opaque>
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}
-impl<T, I> Index<I> for Slice<T>
+// Full name: core::slice::index::{impl Index<I> for [T]}
+impl<T, I> Index<I> for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
-    fn index<'_0_1> = {impl Index<I> for Slice<T>}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I> for [T]}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}
@@ -150,59 +150,59 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> Option<&'_0 (Slice<T>)>[{built_in impl Sized for &'_0 (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get
+pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> Option<&'_0 ([T])>[{built_in impl Sized for &'_0 ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (Slice<T>)>[{built_in impl Sized for &'_0 mut (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut
+pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> Option<&'_0 mut ([T])>[{built_in impl Sized for &'_0 mut ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: *const Slice<T>) -> *const Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: *mut Slice<T>) -> *mut Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index
+pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut
+pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: RangeFrom<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}
-impl<T> SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}
+impl<T> SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for RangeFrom<usize>[{built_in impl Sized for usize}]}
     parent_clause1 = {impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
-    parent_clause3 = {built_in impl MetaSized for Slice<T>}
-    type Output = Slice<T>
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    parent_clause2 = {built_in impl MetaSized for [T]}
+    parent_clause3 = {built_in impl MetaSized for [T]}
+    type Output = [T]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
 }
 
 // Full name: alloc::alloc::Global
@@ -300,19 +300,19 @@ fn foo()
     let @0: (); // return
     let @1: bool; // anonymous local
     let @2: &'0 (Option<i32>[{built_in impl Sized for i32}]); // anonymous local
-    let slice@3: &'1 (Slice<bool>); // local
-    let @4: &'2 (Array<bool, 1 : usize>); // anonymous local
-    let @5: &'2 (Array<bool, 1 : usize>); // anonymous local
-    let @6: &'1 (Slice<bool>); // anonymous local
-    let @7: &'1 (Slice<bool>); // anonymous local
-    let @8: &'1 (Slice<bool>); // anonymous local
+    let slice@3: &'1 ([bool]); // local
+    let @4: &'2 ([bool; 1 : usize]); // anonymous local
+    let @5: &'2 ([bool; 1 : usize]); // anonymous local
+    let @6: &'1 ([bool]); // anonymous local
+    let @7: &'1 ([bool]); // anonymous local
+    let @8: &'1 ([bool]); // anonymous local
     let @9: RangeFrom<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let @10: &'2 (Array<bool, 1 : usize>); // anonymous local
+    let @10: &'2 ([bool; 1 : usize]); // anonymous local
     let @11: &'0 (Option<i32>[{built_in impl Sized for i32}]); // anonymous local
     let @12: &'_ (Option<i32>[{built_in impl Sized for i32}]); // anonymous local
     let @13: Option<i32>[{built_in impl Sized for i32}]; // anonymous local
-    let @14: &'_ (Array<bool, 1 : usize>); // anonymous local
-    let @15: Array<bool, 1 : usize>; // anonymous local
+    let @14: &'_ ([bool; 1 : usize]); // anonymous local
+    let @15: [bool; 1 : usize]; // anonymous local
 
     storage_live(@12)
     storage_live(@13)
@@ -347,7 +347,7 @@ fn foo()
     @8 := &*(slice@3) with_metadata(copy (slice@3.metadata))
     storage_live(@9)
     @9 := RangeFrom { start: const (1 : usize) }
-    @7 := {impl Index<I> for Slice<T>}::index<'_, bool, RangeFrom<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for bool}, {built_in impl Sized for RangeFrom<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>> for RangeFrom<usize>[{built_in impl Sized for usize}]}<bool>[{built_in impl Sized for bool}]](move (@8), move (@9))
+    @7 := {impl Index<I> for [T]}::index<'_, bool, RangeFrom<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for bool}, {built_in impl Sized for RangeFrom<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}<bool>[{built_in impl Sized for bool}]](move (@8), move (@9))
     storage_dead(@9)
     storage_dead(@8)
     @6 := &*(@7) with_metadata(copy (@7.metadata))

--- a/charon/tests/ui/monomorphization/fn_ptr_generics.out
+++ b/charon/tests/ui/monomorphization/fn_ptr_generics.out
@@ -33,11 +33,11 @@ const UNIT_METADATA: () = @Fun0()
 fn init_option()
 {
     let @0: (); // return
-    let a@1: Array<Option::<u8>, 6 : usize>; // local
+    let a@1: [Option::<u8>; 6 : usize]; // local
     let @2: Option::<u8>; // anonymous local
     let b@3: Option::<u8>; // local
     let @4: usize; // anonymous local
-    let @5: &'_ (Array<Option::<u8>, 6 : usize>); // anonymous local
+    let @5: &'_ ([Option::<u8>; 6 : usize]); // anonymous local
     let @6: &'_ (Option::<u8>); // anonymous local
 
     @0 := ()

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -632,21 +632,21 @@ struct ArrayWrapper<T, const N : usize>
 where
     [@TraitClause0]: Sized<T>,
 {
-  Array<T, N>,
+  [T; N],
 }
 
 struct test_crate::ArrayWrapper::<&_ mut (_), 1 : usize><'_0, T0>
 where
     [@TraitClause0]: core::marker::Sized::<&_ mut (_)><'_0, T0>,
 {
-  Array<&'_0 mut (T0), 1 : usize>,
+  [&'_0 mut (T0); 1 : usize],
 }
 
 struct test_crate::ArrayWrapper::<&_ mut (_), 2 : usize><'_0, T0>
 where
     [@TraitClause0]: core::marker::Sized::<&_ mut (_)><'_0, T0>,
 {
-  Array<&'_0 mut (T0), 2 : usize>,
+  [&'_0 mut (T0); 2 : usize],
 }
 
 // Full name: test_crate::use_const_generic

--- a/charon/tests/ui/opacity.out
+++ b/charon/tests/ui/opacity.out
@@ -130,7 +130,7 @@ fn foo()
     let @1: bool; // anonymous local
     let @2: &'0 (Option<i32>[{built_in impl Sized for i32}]); // anonymous local
     let @3: u64; // anonymous local
-    let @4: &'1 (Slice<i32>); // anonymous local
+    let @4: &'1 ([i32]); // anonymous local
     let @5: &'2 (i32); // anonymous local
     let @6: &'2 (i32); // anonymous local
     let @7: &'2 (i32); // anonymous local

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -112,7 +112,7 @@ where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>
 
-pub fn core::hash::Hasher::write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn core::hash::Hasher::write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>
@@ -257,7 +257,7 @@ pub fn {impl Hasher for DefaultHasher}::finish<'_0>(@1: &'_0 (DefaultHasher)) ->
 = <opaque>
 
 // Full name: std::hash::random::{impl Hasher for DefaultHasher}::write
-pub fn {impl Hasher for DefaultHasher}::write<'_0, '_1>(@1: &'_0 mut (DefaultHasher), @2: &'_1 (Slice<u8>))
+pub fn {impl Hasher for DefaultHasher}::write<'_0, '_1>(@1: &'_0 mut (DefaultHasher), @2: &'_1 ([u8]))
 = <opaque>
 
 // Full name: std::hash::random::{impl Hasher for DefaultHasher}

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -160,7 +160,7 @@ fn precondition_check(@1: *const (), @2: isize, @3: usize)
     let @28: usize; // anonymous local
     let @29: usize; // anonymous local
     let @30: *const Str; // anonymous local
-    let @31: &'3 (Slice<u8>); // anonymous local
+    let @31: &'3 ([u8]); // anonymous local
 
     storage_live(msg@5)
     storage_live(@6)
@@ -239,7 +239,7 @@ fn precondition_check(@1: *const (), @2: isize, @3: usize)
     storage_live(@28)
     storage_live(@29)
     storage_live(@31)
-    @31 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @31 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @29 := copy (@31.metadata)
     storage_dead(@31)
     @28 := move (@29) wrap.<< const (1 : i32)
@@ -280,8 +280,8 @@ where
     return
 }
 
-// Full name: core::slice::{Slice<T>}::as_ptr
-pub fn as_ptr<'_0, T>(@1: &'_0 (Slice<T>)) -> *const T
+// Full name: core::slice::{[T]}::as_ptr
+pub fn as_ptr<'_0, T>(@1: &'_0 ([T])) -> *const T
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -300,10 +300,10 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let s@1: Array<i32, 2 : usize>; // local
+    let s@1: [i32; 2 : usize]; // local
     let ptr@2: *const i32; // local
-    let @3: &'0 (Slice<i32>); // anonymous local
-    let @4: &'1 (Array<i32, 2 : usize>); // anonymous local
+    let @3: &'0 ([i32]); // anonymous local
+    let @4: &'1 ([i32; 2 : usize]); // anonymous local
     let @5: bool; // anonymous local
     let @6: i32; // anonymous local
     let @7: *const i32; // anonymous local

--- a/charon/tests/ui/ptr_no_provenance.out
+++ b/charon/tests/ui/ptr_no_provenance.out
@@ -206,7 +206,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -274,7 +274,7 @@ fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(@1: usiz
     let @10: usize; // anonymous local
     let @11: usize; // anonymous local
     let @12: *const Str; // anonymous local
-    let @13: &'3 (Slice<u8>); // anonymous local
+    let @13: &'3 ([u8]); // anonymous local
 
     storage_live(msg@2)
     storage_live(@3)
@@ -301,7 +301,7 @@ fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(@1: usiz
             storage_live(@10)
             storage_live(@11)
             storage_live(@13)
-            @13 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: Alignment::new_unchecked requires a power of two\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+            @13 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: Alignment::new_unchecked requires a power of two\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
             @11 := copy (@13.metadata)
             storage_dead(@13)
             @10 := move (@11) wrap.<< const (1 : i32)
@@ -449,7 +449,7 @@ fn core::alloc::layout::{Layout}::from_size_align_unchecked::precondition_check(
     let @11: usize; // anonymous local
     let @12: usize; // anonymous local
     let @13: *const Str; // anonymous local
-    let @14: &'3 (Slice<u8>); // anonymous local
+    let @14: &'3 ([u8]); // anonymous local
 
     storage_live(msg@4)
     storage_live(@5)
@@ -473,7 +473,7 @@ fn core::alloc::layout::{Layout}::from_size_align_unchecked::precondition_check(
         storage_live(@11)
         storage_live(@12)
         storage_live(@14)
-        @14 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: Layout::from_size_align_unchecked requires that align is a power of 2 and the rounded-up allocation size does not exceed isize::MAX\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+        @14 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: Layout::from_size_align_unchecked requires that align is a power of 2 and the rounded-up allocation size does not exceed isize::MAX\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
         @12 := copy (@14.metadata)
         storage_dead(@14)
         @11 := move (@12) wrap.<< const (1 : i32)
@@ -533,7 +533,7 @@ pub trait Allocator<Self>
     vtable: core::alloc::Allocator::{vtable}
 }
 
-pub fn core::alloc::Allocator::allocate<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn core::alloc::Allocator::allocate<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 = <method_without_default_body>
@@ -573,7 +573,7 @@ pub fn is_aligned_to<T>(@1: *const T, @2: usize) -> bool
     let @14: usize; // anonymous local
     let @15: usize; // anonymous local
     let @16: *const Str; // anonymous local
-    let @17: &'3 (Slice<u8>); // anonymous local
+    let @17: &'3 ([u8]); // anonymous local
 
     storage_live(@7)
     @7 := ctpop<usize>[{built_in impl Sized for usize}, {impl Copy for usize}](copy (align@2))
@@ -598,7 +598,7 @@ pub fn is_aligned_to<T>(@1: *const T, @2: usize) -> bool
             storage_live(@14)
             storage_live(@15)
             storage_live(@17)
-            @17 := transmute<&'1 (Str), &'3 (Slice<u8>)>(const ("is_aligned_to: align is not a power-of-two"))
+            @17 := transmute<&'1 (Str), &'3 ([u8])>(const ("is_aligned_to: align is not a power-of-two"))
             @15 := copy (@17.metadata)
             storage_dead(@17)
             @14 := move (@15) wrap.<< const (1 : i32)
@@ -651,7 +651,7 @@ fn core::ptr::write_bytes::precondition_check(@1: *const (), @2: usize, @3: bool
     let @15: usize; // anonymous local
     let @16: usize; // anonymous local
     let @17: *const Str; // anonymous local
-    let @18: &'3 (Slice<u8>); // anonymous local
+    let @18: &'3 ([u8]); // anonymous local
 
     storage_live(msg@5)
     storage_live(@6)
@@ -697,7 +697,7 @@ fn core::ptr::write_bytes::precondition_check(@1: *const (), @2: usize, @3: bool
     storage_live(@15)
     storage_live(@16)
     storage_live(@18)
-    @18 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: ptr::write_bytes requires that the destination pointer is aligned and non-null\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @18 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: ptr::write_bytes requires that the destination pointer is aligned and non-null\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @16 := copy (@18.metadata)
     storage_dead(@18)
     @15 := move (@16) wrap.<< const (1 : i32)
@@ -919,29 +919,29 @@ where
     undefined_behavior
 }
 
-pub fn core::alloc::Allocator::allocate_zeroed<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn core::alloc::Allocator::allocate_zeroed<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Self); // arg #1
     let layout@2: Layout; // arg #2
-    let @3: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@4: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let ptr@5: NonNull<Slice<u8>>; // local
+    let @3: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@4: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let ptr@5: NonNull<[u8]>; // local
     let @6: (); // anonymous local
     let self@7: *mut u8; // local
     let self@8: NonNull<u8>; // local
     let count@9: usize; // local
-    let v@10: NonNull<Slice<u8>>; // local
+    let v@10: NonNull<[u8]>; // local
     let @11: *const u8; // anonymous local
-    let @12: *mut Slice<u8>; // anonymous local
+    let @12: *mut [u8]; // anonymous local
     let @13: (); // anonymous local
     let @14: *const (); // anonymous local
     let @15: bool; // anonymous local
     let @16: bool; // anonymous local
     let @17: AllocError; // anonymous local
-    let @18: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @18: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(ptr@5)
     storage_live(@6)
@@ -975,11 +975,11 @@ where
     storage_live(self@7)
     storage_live(self@8)
     storage_live(@11)
-    @12 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (ptr@5))
-    @11 := cast<*mut Slice<u8>, *const u8>(copy (@12))
+    @12 := transmute<NonNull<[u8]>, *mut [u8]>(copy (ptr@5))
+    @11 := cast<*mut [u8], *const u8>(copy (@12))
     self@8 := NonNull { pointer: copy (@11) }
     storage_dead(@11)
-    self@7 := cast<*mut Slice<u8>, *mut u8>(copy (@12))
+    self@7 := cast<*mut [u8], *mut u8>(copy (@12))
     storage_dead(self@8)
     storage_live(count@9)
     count@9 := copy (@12.metadata)
@@ -987,7 +987,7 @@ where
     @16 := ub_checks<bool>
     if copy (@16) {
         storage_live(@14)
-        @14 := cast<*mut Slice<u8>, *const ()>(copy (@12))
+        @14 := cast<*mut [u8], *const ()>(copy (@12))
         storage_live(@15)
         @15 := copy (count@9) == const (0 : usize)
         @13 := core::ptr::write_bytes::precondition_check(move (@14), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), move (@15))
@@ -1029,7 +1029,7 @@ pub fn from_str<'a>(@1: &'static (Str)) -> Arguments<'a>
     let @6: usize; // anonymous local
     let @7: usize; // anonymous local
     let @8: *const Str; // anonymous local
-    let @9: &'3 (Slice<u8>); // anonymous local
+    let @9: &'3 ([u8]); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
@@ -1044,7 +1044,7 @@ pub fn from_str<'a>(@1: &'static (Str)) -> Arguments<'a>
     storage_live(@6)
     storage_live(@7)
     storage_live(@9)
-    @9 := transmute<&'1 (Str), &'3 (Slice<u8>)>(copy (s@1))
+    @9 := transmute<&'1 (Str), &'3 ([u8])>(copy (s@1))
     @7 := copy (@9.metadata)
     storage_dead(@9)
     @6 := move (@7) wrap.<< const (1 : i32)
@@ -1182,7 +1182,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(@1: *const (), @2: *mut ()
     let @26: usize; // anonymous local
     let @27: usize; // anonymous local
     let @28: *const Str; // anonymous local
-    let @29: &'3 (Slice<u8>); // anonymous local
+    let @29: &'3 ([u8]); // anonymous local
 
     storage_live(zero_size@7)
     storage_live(ptr@12)
@@ -1398,7 +1398,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(@1: *const (), @2: *mut ()
     storage_live(@26)
     storage_live(@27)
     storage_live(@29)
-    @29 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @29 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @27 := copy (@29.metadata)
     storage_dead(@29)
     @26 := move (@27) wrap.<< const (1 : i32)
@@ -1413,30 +1413,30 @@ fn core::ptr::copy_nonoverlapping::precondition_check(@1: *const (), @2: *mut ()
     @14 := panic_nounwind_fmt<'_>(move (@15), const (false))
 }
 
-pub unsafe fn core::alloc::Allocator::grow<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::grow<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Self); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
     let new_layout@4: Layout; // arg #4
-    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@6: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let new_ptr@7: NonNull<Slice<u8>>; // local
+    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@6: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let new_ptr@7: NonNull<[u8]>; // local
     let src@8: *const u8; // local
     let dst@9: *mut u8; // local
     let count@10: usize; // local
     let @11: (); // anonymous local
-    let v@12: NonNull<Slice<u8>>; // local
-    let @13: *mut Slice<u8>; // anonymous local
+    let v@12: NonNull<[u8]>; // local
+    let @13: *mut [u8]; // anonymous local
     let @14: (); // anonymous local
     let @15: *const (); // anonymous local
     let @16: *mut (); // anonymous local
     let @17: bool; // anonymous local
     let @18: AllocError; // anonymous local
-    let @19: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @19: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(new_ptr@7)
     storage_live(@11)
@@ -1470,8 +1470,8 @@ where
     storage_live(src@8)
     src@8 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
     storage_live(dst@9)
-    @13 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@7))
-    dst@9 := cast<*mut Slice<u8>, *mut u8>(copy (@13))
+    @13 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@7))
+    dst@9 := cast<*mut [u8], *mut u8>(copy (@13))
     storage_live(count@10)
     count@10 := copy ((old_layout@3).size)
     storage_live(@17)
@@ -1480,7 +1480,7 @@ where
         storage_live(@15)
         @15 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
         storage_live(@16)
-        @16 := cast<*mut Slice<u8>, *mut ()>(copy (@13))
+        @16 := cast<*mut [u8], *mut ()>(copy (@13))
         @14 := core::ptr::copy_nonoverlapping::precondition_check(move (@15), move (@16), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (count@10))
         storage_dead(@16)
         storage_dead(@15)
@@ -1496,30 +1496,30 @@ where
     return
 }
 
-pub unsafe fn core::alloc::Allocator::grow_zeroed<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::grow_zeroed<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Self); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
     let new_layout@4: Layout; // arg #4
-    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@6: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let new_ptr@7: NonNull<Slice<u8>>; // local
+    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@6: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let new_ptr@7: NonNull<[u8]>; // local
     let src@8: *const u8; // local
     let dst@9: *mut u8; // local
     let count@10: usize; // local
     let @11: (); // anonymous local
-    let v@12: NonNull<Slice<u8>>; // local
-    let @13: *mut Slice<u8>; // anonymous local
+    let v@12: NonNull<[u8]>; // local
+    let @13: *mut [u8]; // anonymous local
     let @14: (); // anonymous local
     let @15: *const (); // anonymous local
     let @16: *mut (); // anonymous local
     let @17: bool; // anonymous local
     let @18: AllocError; // anonymous local
-    let @19: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @19: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(new_ptr@7)
     storage_live(@11)
@@ -1553,8 +1553,8 @@ where
     storage_live(src@8)
     src@8 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
     storage_live(dst@9)
-    @13 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@7))
-    dst@9 := cast<*mut Slice<u8>, *mut u8>(copy (@13))
+    @13 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@7))
+    dst@9 := cast<*mut [u8], *mut u8>(copy (@13))
     storage_live(count@10)
     count@10 := copy ((old_layout@3).size)
     storage_live(@17)
@@ -1563,7 +1563,7 @@ where
         storage_live(@15)
         @15 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
         storage_live(@16)
-        @16 := cast<*mut Slice<u8>, *mut ()>(copy (@13))
+        @16 := cast<*mut [u8], *mut ()>(copy (@13))
         @14 := core::ptr::copy_nonoverlapping::precondition_check(move (@15), move (@16), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (count@10))
         storage_dead(@16)
         storage_dead(@15)
@@ -1579,30 +1579,30 @@ where
     return
 }
 
-pub unsafe fn core::alloc::Allocator::shrink<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::shrink<'_0, Self>(@1: &'_0 (Self), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Self); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
     let new_layout@4: Layout; // arg #4
-    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@6: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let new_ptr@7: NonNull<Slice<u8>>; // local
+    let @5: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@6: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let new_ptr@7: NonNull<[u8]>; // local
     let src@8: *const u8; // local
     let dst@9: *mut u8; // local
     let count@10: usize; // local
     let @11: (); // anonymous local
-    let v@12: NonNull<Slice<u8>>; // local
-    let @13: *mut Slice<u8>; // anonymous local
+    let v@12: NonNull<[u8]>; // local
+    let @13: *mut [u8]; // anonymous local
     let @14: (); // anonymous local
     let @15: *const (); // anonymous local
     let @16: *mut (); // anonymous local
     let @17: bool; // anonymous local
     let @18: AllocError; // anonymous local
-    let @19: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @19: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(new_ptr@7)
     storage_live(@11)
@@ -1636,8 +1636,8 @@ where
     storage_live(src@8)
     src@8 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
     storage_live(dst@9)
-    @13 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@7))
-    dst@9 := cast<*mut Slice<u8>, *mut u8>(copy (@13))
+    @13 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@7))
+    dst@9 := cast<*mut [u8], *mut u8>(copy (@13))
     storage_live(count@10)
     count@10 := copy ((new_layout@4).size)
     storage_live(@17)
@@ -1646,7 +1646,7 @@ where
         storage_live(@15)
         @15 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
         storage_live(@16)
-        @16 := cast<*mut Slice<u8>, *mut ()>(copy (@13))
+        @16 := cast<*mut [u8], *mut ()>(copy (@13))
         @14 := core::ptr::copy_nonoverlapping::precondition_check(move (@15), move (@16), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (count@10))
         storage_dead(@16)
         storage_dead(@15)
@@ -1818,7 +1818,7 @@ fn core::ptr::non_null::{NonNull<T>}::new_unchecked::precondition_check(@1: *mut
     let @10: usize; // anonymous local
     let @11: usize; // anonymous local
     let @12: *const Str; // anonymous local
-    let @13: &'3 (Slice<u8>); // anonymous local
+    let @13: &'3 ([u8]); // anonymous local
 
     storage_live(msg@2)
     storage_live(@3)
@@ -1849,7 +1849,7 @@ fn core::ptr::non_null::{NonNull<T>}::new_unchecked::precondition_check(@1: *mut
     storage_live(@10)
     storage_live(@11)
     storage_live(@13)
-    @13 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @13 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @11 := copy (@13.metadata)
     storage_dead(@13)
     @10 := move (@11) wrap.<< const (1 : i32)
@@ -1878,7 +1878,7 @@ fn core::hint::assert_unchecked::precondition_check(@1: bool)
     let @9: usize; // anonymous local
     let @10: usize; // anonymous local
     let @11: *const Str; // anonymous local
-    let @12: &'3 (Slice<u8>); // anonymous local
+    let @12: &'3 ([u8]); // anonymous local
 
     storage_live(msg@2)
     storage_live(@3)
@@ -1900,7 +1900,7 @@ fn core::hint::assert_unchecked::precondition_check(@1: bool)
         storage_live(@9)
         storage_live(@10)
         storage_live(@12)
-        @12 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: hint::assert_unchecked must never be called when the condition is false\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+        @12 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: hint::assert_unchecked must never be called when the condition is false\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
         @10 := copy (@12.metadata)
         storage_dead(@12)
         @9 := move (@10) wrap.<< const (1 : i32)
@@ -1942,29 +1942,29 @@ unsafe fn __rust_no_alloc_shim_is_unstable_v2()
 pub struct Global {}
 
 // Full name: alloc::alloc::{Global}::alloc_impl
-fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let layout@2: Layout; // arg #2
     let zeroed@3: bool; // arg #3
     let size@4: usize; // local
-    let @5: NonNull<Slice<u8>>; // anonymous local
+    let @5: NonNull<[u8]>; // anonymous local
     let data@6: NonNull<u8>; // local
     let raw_ptr@7: *mut u8; // local
     let @8: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<u8>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<u8>}]; // anonymous local
     let self@9: Result<NonNull<u8>, AllocError>[{built_in impl Sized for NonNull<u8>}, {built_in impl Sized for AllocError}]; // local
     let self@10: Option<NonNull<u8>>[{built_in impl Sized for NonNull<u8>}]; // local
     let ptr@11: NonNull<u8>; // local
-    let @12: NonNull<Slice<u8>>; // anonymous local
+    let @12: NonNull<[u8]>; // anonymous local
     let @13: NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]; // anonymous local
     let @14: Alignment; // anonymous local
     let @15: *const u8; // anonymous local
-    let ptr@16: *mut Slice<u8>; // local
+    let ptr@16: *mut [u8]; // local
     let data@17: *mut u8; // local
     let @18: (); // anonymous local
     let @19: *mut (); // anonymous local
-    let @20: *const Slice<u8>; // anonymous local
+    let @20: *const [u8]; // anonymous local
     let @21: bool; // anonymous local
     let @22: (); // anonymous local
     let @23: usize; // anonymous local
@@ -1980,17 +1980,17 @@ fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<Sl
     let @33: bool; // anonymous local
     let v@34: NonNull<u8>; // local
     let v@35: NonNull<u8>; // local
-    let ptr@36: *mut Slice<u8>; // local
+    let ptr@36: *mut [u8]; // local
     let data@37: *mut u8; // local
     let @38: (); // anonymous local
     let @39: *mut (); // anonymous local
-    let @40: *const Slice<u8>; // anonymous local
+    let @40: *const [u8]; // anonymous local
     let @41: bool; // anonymous local
     let @42: Option<NonNull<u8>>[{built_in impl Sized for NonNull<u8>}]; // anonymous local
     let @43: AllocError; // anonymous local
     let @44: Result<NonNull<u8>, AllocError>[{built_in impl Sized for NonNull<u8>}, {built_in impl Sized for AllocError}]; // anonymous local
     let @45: AllocError; // anonymous local
-    let @46: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @46: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(size@4)
     storage_live(raw_ptr@7)
@@ -2079,7 +2079,7 @@ fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<Sl
                         storage_dead(@39)
                     } else {
                     }
-                    @40 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@36))
+                    @40 := cast<*mut [u8], *const [u8]>(copy (ptr@36))
                     @12 := NonNull { pointer: copy (@40) }
                     storage_dead(@41)
                     storage_dead(@40)
@@ -2138,7 +2138,7 @@ fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<Sl
         storage_dead(@19)
     } else {
     }
-    @20 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@16))
+    @20 := cast<*mut [u8], *const [u8]>(copy (ptr@16))
     @5 := NonNull { pointer: copy (@20) }
     storage_dead(@21)
     storage_dead(@20)
@@ -2150,9 +2150,9 @@ fn alloc_impl<'_0>(@1: &'_0 (Global), @2: Layout, @3: bool) -> Result<NonNull<Sl
 }
 
 // Full name: alloc::alloc::{Global}::grow_impl
-unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout, @5: bool) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout, @5: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
@@ -2177,10 +2177,10 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
     let self@22: *mut u8; // local
     let self@23: *mut u8; // local
     let count@24: usize; // local
-    let @25: NonNull<Slice<u8>>; // anonymous local
-    let @26: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@27: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let new_ptr@28: NonNull<Slice<u8>>; // local
+    let @25: NonNull<[u8]>; // anonymous local
+    let @26: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@27: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let new_ptr@28: NonNull<[u8]>; // local
     let src@29: *const u8; // local
     let ptr@30: *mut u8; // local
     let dst@31: *mut u8; // local
@@ -2199,24 +2199,24 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
     let @44: (); // anonymous local
     let @45: *const (); // anonymous local
     let @46: bool; // anonymous local
-    let ptr@47: *mut Slice<u8>; // local
+    let ptr@47: *mut [u8]; // local
     let data@48: *mut u8; // local
     let @49: (); // anonymous local
     let @50: *mut (); // anonymous local
-    let @51: *const Slice<u8>; // anonymous local
-    let v@52: NonNull<Slice<u8>>; // local
-    let @53: *mut Slice<u8>; // anonymous local
+    let @51: *const [u8]; // anonymous local
+    let v@52: NonNull<[u8]>; // local
+    let @53: *mut [u8]; // anonymous local
     let @54: (); // anonymous local
     let @55: *const (); // anonymous local
     let @56: *mut (); // anonymous local
     let @57: bool; // anonymous local
     let @58: AllocError; // anonymous local
-    let @59: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @59: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let @60: Option<NonNull<u8>>[{built_in impl Sized for NonNull<u8>}]; // anonymous local
     let @61: AllocError; // anonymous local
     let @62: Result<NonNull<u8>, AllocError>[{built_in impl Sized for NonNull<u8>}, {built_in impl Sized for AllocError}]; // anonymous local
     let @63: AllocError; // anonymous local
-    let @64: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @64: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(old_size@6)
     storage_live(@8)
@@ -2283,15 +2283,15 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
                 ptr@30 := transmute<NonNull<u8>, *mut u8>(copy (ptr@2))
                 src@29 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
                 storage_live(dst@31)
-                @53 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@28))
-                dst@31 := cast<*mut Slice<u8>, *mut u8>(copy (@53))
+                @53 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@28))
+                dst@31 := cast<*mut [u8], *mut u8>(copy (@53))
                 storage_live(@57)
                 @57 := ub_checks<bool>
                 if copy (@57) {
                     storage_live(@55)
                     @55 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
                     storage_live(@56)
-                    @56 := cast<*mut Slice<u8>, *mut ()>(copy (@53))
+                    @56 := cast<*mut [u8], *mut ()>(copy (@53))
                     @54 := core::ptr::copy_nonoverlapping::precondition_check(move (@55), move (@56), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (old_size@6))
                     storage_dead(@56)
                     storage_dead(@55)
@@ -2405,7 +2405,7 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
                             storage_dead(@50)
                         } else {
                         }
-                        @51 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@47))
+                        @51 := cast<*mut [u8], *const [u8]>(copy (ptr@47))
                         @25 := NonNull { pointer: copy (@51) }
                         storage_dead(@51)
                         storage_dead(ptr@47)
@@ -2547,7 +2547,7 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
                 storage_dead(@50)
             } else {
             }
-            @51 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@47))
+            @51 := cast<*mut [u8], *const [u8]>(copy (ptr@47))
             @25 := NonNull { pointer: copy (@51) }
             storage_dead(@51)
             storage_dead(ptr@47)
@@ -2561,9 +2561,9 @@ unsafe fn grow_impl<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Lay
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::allocate
-pub fn {impl Allocator for Global}::allocate<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn {impl Allocator for Global}::allocate<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let layout@2: Layout; // arg #2
 
@@ -2572,9 +2572,9 @@ pub fn {impl Allocator for Global}::allocate<'_0>(@1: &'_0 (Global), @2: Layout)
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::allocate_zeroed
-pub fn {impl Allocator for Global}::allocate_zeroed<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn {impl Allocator for Global}::allocate_zeroed<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let layout@2: Layout; // arg #2
 
@@ -2618,9 +2618,9 @@ pub unsafe fn {impl Allocator for Global}::deallocate<'_0>(@1: &'_0 (Global), @2
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::grow
-pub unsafe fn {impl Allocator for Global}::grow<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::grow<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
@@ -2631,9 +2631,9 @@ pub unsafe fn {impl Allocator for Global}::grow<'_0>(@1: &'_0 (Global), @2: NonN
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::grow_zeroed
-pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
@@ -2644,16 +2644,16 @@ pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(@1: &'_0 (Global), @
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::shrink
-pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: NonNull<u8>, @3: Layout, @4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
-    let @0: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // return
+    let @0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self@1: &'0 (Global); // arg #1
     let ptr@2: NonNull<u8>; // arg #2
     let old_layout@3: Layout; // arg #3
     let new_layout@4: Layout; // arg #4
     let new_size@5: usize; // local
     let @6: (); // anonymous local
-    let @7: NonNull<Slice<u8>>; // anonymous local
+    let @7: NonNull<[u8]>; // anonymous local
     let data@8: NonNull<u8>; // local
     let @9: bool; // anonymous local
     let @10: usize; // anonymous local
@@ -2669,10 +2669,10 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
     let self@20: Option<NonNull<u8>>[{built_in impl Sized for NonNull<u8>}]; // local
     let ptr@21: *mut u8; // local
     let ptr@22: NonNull<u8>; // local
-    let @23: NonNull<Slice<u8>>; // anonymous local
-    let @24: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
-    let self@25: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // local
-    let new_ptr@26: NonNull<Slice<u8>>; // local
+    let @23: NonNull<[u8]>; // anonymous local
+    let @24: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
+    let self@25: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // local
+    let new_ptr@26: NonNull<[u8]>; // local
     let src@27: *const u8; // local
     let ptr@28: *mut u8; // local
     let dst@29: *mut u8; // local
@@ -2685,11 +2685,11 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
     let @36: NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]; // anonymous local
     let @37: Alignment; // anonymous local
     let @38: *const u8; // anonymous local
-    let ptr@39: *mut Slice<u8>; // local
+    let ptr@39: *mut [u8]; // local
     let data@40: *mut u8; // local
     let @41: (); // anonymous local
     let @42: *mut (); // anonymous local
-    let @43: *const Slice<u8>; // anonymous local
+    let @43: *const [u8]; // anonymous local
     let @44: bool; // anonymous local
     let @45: AlignmentEnum; // anonymous local
     let @46: (); // anonymous local
@@ -2701,13 +2701,13 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
     let @52: *mut (); // anonymous local
     let v@53: NonNull<u8>; // local
     let v@54: NonNull<u8>; // local
-    let ptr@55: *mut Slice<u8>; // local
+    let ptr@55: *mut [u8]; // local
     let data@56: *mut u8; // local
     let @57: (); // anonymous local
     let @58: *mut (); // anonymous local
-    let @59: *const Slice<u8>; // anonymous local
-    let v@60: NonNull<Slice<u8>>; // local
-    let @61: *mut Slice<u8>; // anonymous local
+    let @59: *const [u8]; // anonymous local
+    let v@60: NonNull<[u8]>; // local
+    let @61: *mut [u8]; // anonymous local
     let @62: (); // anonymous local
     let @63: *const (); // anonymous local
     let @64: *mut (); // anonymous local
@@ -2715,14 +2715,14 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
     let @66: usize; // anonymous local
     let @67: AllocError; // anonymous local
     let @68: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
-    let @69: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<Slice<u8>>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<Slice<u8>>}]; // anonymous local
+    let @69: ControlFlow<Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}], NonNull<[u8]>>[{built_in impl Sized for Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]}, {built_in impl Sized for NonNull<[u8]>}]; // anonymous local
     let @70: Option<NonNull<u8>>[{built_in impl Sized for NonNull<u8>}]; // anonymous local
     let @71: AllocError; // anonymous local
-    let @72: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @72: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let @73: AllocError; // anonymous local
     let @74: Result<NonNull<u8>, AllocError>[{built_in impl Sized for NonNull<u8>}, {built_in impl Sized for AllocError}]; // anonymous local
     let @75: AllocError; // anonymous local
-    let @76: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let @76: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
 
     storage_live(new_size@5)
     storage_live(@6)
@@ -2883,7 +2883,7 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
                                     storage_dead(@58)
                                 } else {
                                 }
-                                @59 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@55))
+                                @59 := cast<*mut [u8], *const [u8]>(copy (ptr@55))
                                 @23 := NonNull { pointer: copy (@59) }
                                 storage_dead(@59)
                                 storage_dead(ptr@55)
@@ -2932,7 +2932,7 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
                                     storage_dead(@58)
                                 } else {
                                 }
-                                @59 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@55))
+                                @59 := cast<*mut [u8], *const [u8]>(copy (ptr@55))
                                 @23 := NonNull { pointer: copy (@59) }
                                 storage_dead(@59)
                                 storage_dead(ptr@55)
@@ -2975,15 +2975,15 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
                                 ptr@28 := transmute<NonNull<u8>, *mut u8>(copy (ptr@2))
                                 src@27 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
                                 storage_live(dst@29)
-                                @61 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@26))
-                                dst@29 := cast<*mut Slice<u8>, *mut u8>(copy (@61))
+                                @61 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@26))
+                                dst@29 := cast<*mut [u8], *mut u8>(copy (@61))
                                 storage_live(@65)
                                 @65 := ub_checks<bool>
                                 if copy (@65) {
                                     storage_live(@63)
                                     @63 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
                                     storage_live(@64)
-                                    @64 := cast<*mut Slice<u8>, *mut ()>(copy (@61))
+                                    @64 := cast<*mut [u8], *mut ()>(copy (@61))
                                     @62 := core::ptr::copy_nonoverlapping::precondition_check(move (@63), move (@64), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (new_size@5))
                                     storage_dead(@64)
                                     storage_dead(@63)
@@ -3035,15 +3035,15 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
                                 ptr@28 := transmute<NonNull<u8>, *mut u8>(copy (ptr@2))
                                 src@27 := transmute<NonNull<u8>, *const u8>(copy (ptr@2))
                                 storage_live(dst@29)
-                                @61 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (new_ptr@26))
-                                dst@29 := cast<*mut Slice<u8>, *mut u8>(copy (@61))
+                                @61 := transmute<NonNull<[u8]>, *mut [u8]>(copy (new_ptr@26))
+                                dst@29 := cast<*mut [u8], *mut u8>(copy (@61))
                                 storage_live(@65)
                                 @65 := ub_checks<bool>
                                 if copy (@65) {
                                     storage_live(@63)
                                     @63 := transmute<NonNull<u8>, *const ()>(copy (ptr@2))
                                     storage_live(@64)
-                                    @64 := cast<*mut Slice<u8>, *mut ()>(copy (@61))
+                                    @64 := cast<*mut [u8], *mut ()>(copy (@61))
                                     @62 := core::ptr::copy_nonoverlapping::precondition_check(move (@63), move (@64), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::SIZE), const ({impl SizedTypeProperties for T}<u8>[{built_in impl Sized for u8}]::ALIGN), copy (new_size@5))
                                     storage_dead(@64)
                                     storage_dead(@63)
@@ -3126,7 +3126,7 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(@1: &'_0 (Global), @2: No
         storage_dead(@42)
     } else {
     }
-    @43 := cast<*mut Slice<u8>, *const Slice<u8>>(copy (ptr@39))
+    @43 := cast<*mut [u8], *const [u8]>(copy (ptr@39))
     @7 := NonNull { pointer: copy (@43) }
     storage_dead(@44)
     storage_dead(@43)
@@ -3208,13 +3208,13 @@ unsafe fn exchange_malloc(@1: usize, @2: usize) -> *mut u8
     let size@1: usize; // arg #1
     let align@2: usize; // arg #2
     let layout@3: Layout; // local
-    let @4: Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]; // anonymous local
-    let ptr@5: NonNull<Slice<u8>>; // local
+    let @4: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
+    let ptr@5: NonNull<[u8]>; // local
     let @6: !; // anonymous local
     let @7: bool; // anonymous local
     let @8: (); // anonymous local
     let @9: Alignment; // anonymous local
-    let @10: *mut Slice<u8>; // anonymous local
+    let @10: *mut [u8]; // anonymous local
     let @11: &'_ (Global); // anonymous local
     let @12: Global; // anonymous local
 
@@ -3248,8 +3248,8 @@ unsafe fn exchange_malloc(@1: usize, @2: usize) -> *mut u8
     }
     ptr@5 := copy ((@4 as variant Result::Ok).0)
     storage_live(@10)
-    @10 := transmute<NonNull<Slice<u8>>, *mut Slice<u8>>(copy (ptr@5))
-    @0 := cast<*mut Slice<u8>, *mut u8>(copy (@10))
+    @10 := transmute<NonNull<[u8]>, *mut [u8]>(copy (ptr@5))
+    @0 := cast<*mut [u8], *mut u8>(copy (@10))
     storage_dead(@10)
     storage_dead(@4)
     return

--- a/charon/tests/ui/remove-dynamic-checks.out
+++ b/charon/tests/ui/remove-dynamic-checks.out
@@ -605,10 +605,10 @@ fn shr_i32_manual_cast(@1: i32, @2: i32) -> i32
 }
 
 // Full name: test_crate::index_slice_ignore_value
-fn index_slice_ignore_value<'_0>(@1: &'_0 (Slice<u32>))
+fn index_slice_ignore_value<'_0>(@1: &'_0 ([u32]))
 {
     let @0: (); // return
-    let x@1: &'0 (Slice<u32>); // arg #1
+    let x@1: &'0 ([u32]); // arg #1
     let @2: usize; // anonymous local
 
     @0 := ()
@@ -819,14 +819,14 @@ fn div_signed_with_constant() -> i32
 }
 
 // Full name: test_crate::div_unsigned_to_slice
-fn div_unsigned_to_slice<'_0>(@1: &'_0 mut (Slice<u32>), @2: u32)
+fn div_unsigned_to_slice<'_0>(@1: &'_0 mut ([u32]), @2: u32)
 {
     let @0: (); // return
-    let result@1: &'0 mut (Slice<u32>); // arg #1
+    let result@1: &'0 mut ([u32]); // arg #1
     let x@2: u32; // arg #2
     let @3: u32; // anonymous local
     let @4: usize; // anonymous local
-    let @5: &'_ mut (Slice<u32>); // anonymous local
+    let @5: &'_ mut ([u32]); // anonymous local
     let @6: &'_ mut (u32); // anonymous local
 
     @0 := ()
@@ -846,14 +846,14 @@ fn div_unsigned_to_slice<'_0>(@1: &'_0 mut (Slice<u32>), @2: u32)
 }
 
 // Full name: test_crate::div_signed_to_slice
-fn div_signed_to_slice<'_0>(@1: &'_0 mut (Slice<i32>), @2: i32)
+fn div_signed_to_slice<'_0>(@1: &'_0 mut ([i32]), @2: i32)
 {
     let @0: (); // return
-    let result@1: &'0 mut (Slice<i32>); // arg #1
+    let result@1: &'0 mut ([i32]); // arg #1
     let x@2: i32; // arg #2
     let @3: i32; // anonymous local
     let @4: usize; // anonymous local
-    let @5: &'_ mut (Slice<i32>); // anonymous local
+    let @5: &'_ mut ([i32]); // anonymous local
     let @6: &'_ mut (i32); // anonymous local
 
     @0 := ()
@@ -873,15 +873,15 @@ fn div_signed_to_slice<'_0>(@1: &'_0 mut (Slice<i32>), @2: i32)
 }
 
 // Full name: test_crate::add_to_slice
-fn add_to_slice<'_0>(@1: &'_0 mut (Slice<u32>), @2: u32)
+fn add_to_slice<'_0>(@1: &'_0 mut ([u32]), @2: u32)
 {
     let @0: (); // return
-    let result@1: &'0 mut (Slice<u32>); // arg #1
+    let result@1: &'0 mut ([u32]); // arg #1
     let x@2: u32; // arg #2
     let @3: u32; // anonymous local
     let @4: u32; // anonymous local
     let @5: usize; // anonymous local
-    let @6: &'_ mut (Slice<u32>); // anonymous local
+    let @6: &'_ mut ([u32]); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
     storage_live(@4)
@@ -903,10 +903,10 @@ fn add_to_slice<'_0>(@1: &'_0 mut (Slice<u32>), @2: u32)
 }
 
 // Full name: test_crate::add_to_slice2
-fn add_to_slice2<'_0>(@1: &'_0 mut (Slice<u8>), @2: usize, @3: u8)
+fn add_to_slice2<'_0>(@1: &'_0 mut ([u8]), @2: usize, @3: u8)
 {
     let @0: (); // return
-    let result@1: &'0 mut (Slice<u8>); // arg #1
+    let result@1: &'0 mut ([u8]); // arg #1
     let i@2: usize; // arg #2
     let x@3: u8; // arg #3
     let @4: u8; // anonymous local
@@ -914,7 +914,7 @@ fn add_to_slice2<'_0>(@1: &'_0 mut (Slice<u8>), @2: usize, @3: u8)
     let @6: usize; // anonymous local
     let @7: usize; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'_ mut (Slice<u8>); // anonymous local
+    let @9: &'_ mut ([u8]); // anonymous local
     let @10: &'_ mut (u8); // anonymous local
 
     storage_live(@5)

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -97,8 +97,8 @@ where
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<T> for Slice<T>}::method
-fn {impl Trait<T> for Slice<T>}::method<T, U>()
+// Full name: test_crate::{impl Trait<T> for [T]}::method
+fn {impl Trait<T> for [T]}::method<T, U>()
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<U>,
@@ -110,19 +110,19 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<T> for Slice<T>}
-impl<T> Trait<T> for Slice<T>
+// Full name: test_crate::{impl Trait<T> for [T]}
+impl<T> Trait<T> for [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = @TraitClause0
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for Slice<T>}::method<T, U>[@TraitClause0, @TraitClause0_1]
+    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for [T]}::method<T, U>[@TraitClause0, @TraitClause0_1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<T> for &'_0 (Slice<T>)}::method
-fn {impl Trait<T> for &'_0 (Slice<T>)}::method<'_0, T, U>()
+// Full name: test_crate::{impl Trait<T> for &'_0 ([T])}::method
+fn {impl Trait<T> for &'_0 ([T])}::method<'_0, T, U>()
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<U>,
@@ -134,14 +134,14 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<T> for &'_0 (Slice<T>)}
-impl<'_0, T> Trait<T> for &'_0 (Slice<T>)
+// Full name: test_crate::{impl Trait<T> for &'_0 ([T])}
+impl<'_0, T> Trait<T> for &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for &'_ (Slice<T>)}
+    parent_clause0 = {built_in impl MetaSized for &'_ ([T])}
     parent_clause1 = @TraitClause0
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for &'_0 (Slice<T>)}::method<'_0, T, U>[@TraitClause0, @TraitClause0_1]
+    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for &'_0 ([T])}::method<'_0, T, U>[@TraitClause0, @TraitClause0_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -319,10 +319,10 @@ fn test_crate::ptr_casts::foo()
 fn ptr_casts()
 {
     let @0: (); // return
-    let array_ptr@1: *const Array<u32, 64 : usize>; // local
-    let @2: &'0 (Array<u32, 64 : usize>); // anonymous local
+    let array_ptr@1: *const [u32; 64 : usize]; // local
+    let @2: &'0 ([u32; 64 : usize]); // anonymous local
     let @3: *const u32; // anonymous local
-    let @4: *const Array<u32, 64 : usize>; // anonymous local
+    let @4: *const [u32; 64 : usize]; // anonymous local
     let x@5: u8; // local
     let x@6: *const u8; // local
     let @7: &'1 (u8); // anonymous local
@@ -335,9 +335,9 @@ fn ptr_casts()
     let @14: *const u8; // anonymous local
     let @15: *const u8; // anonymous local
     let @16: fn(); // anonymous local
-    let @17: &'0 (Array<u32, 64 : usize>); // anonymous local
-    let @18: &'_ (Array<u32, 64 : usize>); // anonymous local
-    let @19: Array<u32, 64 : usize>; // anonymous local
+    let @17: &'0 ([u32; 64 : usize]); // anonymous local
+    let @18: &'_ ([u32; 64 : usize]); // anonymous local
+    let @19: [u32; 64 : usize]; // anonymous local
 
     storage_live(@18)
     storage_live(@19)
@@ -354,7 +354,7 @@ fn ptr_casts()
     storage_live(@3)
     storage_live(@4)
     @4 := copy (array_ptr@1)
-    @3 := cast<*const Array<u32, 64 : usize>, *const u32>(move (@4))
+    @3 := cast<*const [u32; 64 : usize], *const u32>(move (@4))
     storage_dead(@4)
     storage_dead(@3)
     storage_live(x@5)
@@ -583,9 +583,9 @@ fn boxes()
 }
 
 // Full name: test_crate::STEAL
-fn STEAL() -> Array<(), 1 : usize>
+fn STEAL() -> [(); 1 : usize]
 {
-    let @0: Array<(), 1 : usize>; // return
+    let @0: [(); 1 : usize]; // return
     let @1: (); // anonymous local
 
     storage_live(@1)
@@ -596,27 +596,27 @@ fn STEAL() -> Array<(), 1 : usize>
 }
 
 // Full name: test_crate::STEAL
-static STEAL: Array<(), 1 : usize> = STEAL()
+static STEAL: [(); 1 : usize] = STEAL()
 
 // Full name: test_crate::transmute
-fn transmute(@1: Array<u32, 2 : usize>) -> u64
+fn transmute(@1: [u32; 2 : usize]) -> u64
 {
     let @0: u64; // return
-    let x@1: Array<u32, 2 : usize>; // arg #1
-    let @2: Array<u32, 2 : usize>; // anonymous local
+    let x@1: [u32; 2 : usize]; // arg #1
+    let @2: [u32; 2 : usize]; // anonymous local
 
     storage_live(@2)
     // When optimized, this becomes a built-in cast. Otherwise this is just a call to `transmute`.
     @2 := copy (x@1)
-    @0 := transmute<Array<u32, 2 : usize>, u64>(move (@2))
+    @0 := transmute<[u32; 2 : usize], u64>(move (@2))
     storage_dead(@2)
     return
 }
 
 // Full name: test_crate::STEAL2
-fn STEAL2() -> Array<(), 13 : usize>
+fn STEAL2() -> [(); 13 : usize]
 {
-    let @0: Array<(), 13 : usize>; // return
+    let @0: [(); 13 : usize]; // return
     let @1: (); // anonymous local
 
     storage_live(@1)
@@ -627,7 +627,7 @@ fn STEAL2() -> Array<(), 13 : usize>
 }
 
 // Full name: test_crate::STEAL2
-static STEAL2: Array<(), 13 : usize> = STEAL2()
+static STEAL2: [(); 13 : usize] = STEAL2()
 
 // Full name: test_crate::nullary_ops::Struct
 struct Struct<T>

--- a/charon/tests/ui/simple/array_index.out
+++ b/charon/tests/ui/simple/array_index.out
@@ -11,12 +11,12 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::first
-pub fn first(@1: Array<u32, 0 : usize>) -> u32
+pub fn first(@1: [u32; 0 : usize]) -> u32
 {
     let @0: u32; // return
-    let s@1: Array<u32, 0 : usize>; // arg #1
+    let s@1: [u32; 0 : usize]; // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Array<u32, 0 : usize>); // anonymous local
+    let @3: &'_ ([u32; 0 : usize]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)

--- a/charon/tests/ui/simple/box-new.out
+++ b/charon/tests/ui/simple/box-new.out
@@ -43,7 +43,7 @@ pub trait Allocator<Self>
     vtable: core::alloc::Allocator::{vtable}
 }
 
-pub fn core::alloc::Allocator::allocate<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn core::alloc::Allocator::allocate<'_0, Self>(@1: &'_0 (Self), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 = <opaque>
@@ -69,7 +69,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(@1: *mut Self)
 pub struct Global {}
 
 // Full name: alloc::alloc::{impl Allocator for Global}::allocate
-pub fn {impl Allocator for Global}::allocate<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<Slice<u8>>, AllocError>[{built_in impl Sized for NonNull<Slice<u8>>}, {built_in impl Sized for AllocError}]
+pub fn {impl Allocator for Global}::allocate<'_0>(@1: &'_0 (Global), @2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 = <opaque>
 
 // Full name: alloc::alloc::{impl Allocator for Global}::deallocate

--- a/charon/tests/ui/simple/builtin-drop-mono.out
+++ b/charon/tests/ui/simple/builtin-drop-mono.out
@@ -24,20 +24,20 @@ pub trait Sized::<Global>
     non-dyn-compatible
 }
 
-// Full name: core::marker::MetaSized::<Slice<String>>
+// Full name: core::marker::MetaSized::<[String]>
 #[lang_item("meta_sized")]
-pub trait MetaSized::<Slice<String>>
+pub trait MetaSized::<[String]>
 
 // Full name: alloc::string::String
 #[lang_item("String")]
 pub opaque type String
 
-// Full name: core::marker::Destruct::<Array<String, 4 : usize>>
+// Full name: core::marker::Destruct::<[String; 4 : usize]>
 #[lang_item("destruct")]
-pub trait Destruct::<Array<String, 4 : usize>>
+pub trait Destruct::<[String; 4 : usize]>
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<Array<String, 4 : usize>>
-    vtable: core::marker::Destruct::{vtable}::<Array<String, 4 : usize>>
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<[String; 4 : usize]>
+    vtable: core::marker::Destruct::{vtable}::<[String; 4 : usize]>
 }
 
 // Full name: core::marker::Destruct::<String>
@@ -48,12 +48,12 @@ pub trait Destruct::<String>
     vtable: core::marker::Destruct::{vtable}::<String>
 }
 
-// Full name: core::marker::Destruct::<Slice<String>>
+// Full name: core::marker::Destruct::<[String]>
 #[lang_item("destruct")]
-pub trait Destruct::<Slice<String>>
+pub trait Destruct::<[String]>
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<Slice<String>>
-    vtable: core::marker::Destruct::{vtable}::<Slice<String>>
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<[String]>
+    vtable: core::marker::Destruct::{vtable}::<[String]>
 }
 
 // Full name: alloc::alloc::Global
@@ -88,17 +88,17 @@ impl Destruct::<String> {
     non-dyn-compatible
 }
 
-// Full name: test_crate::<slice>::{impl Destruct::<Slice<String>>}::drop_in_place::<String>
-unsafe fn {impl Destruct::<Slice<String>>}::drop_in_place::<String>(@1: *mut Slice<String>)
+// Full name: test_crate::<slice>::{impl Destruct::<[String]>}::drop_in_place::<String>
+unsafe fn {impl Destruct::<[String]>}::drop_in_place::<String>(@1: *mut [String])
 {
     let @0: (); // return
-    let @1: *mut Slice<String>; // arg #1
-    let @2: &'0 mut (Slice<String>); // anonymous local
+    let @1: *mut [String]; // arg #1
+    let @2: &'0 mut ([String]); // anonymous local
     let @3: usize; // anonymous local
     let @4: usize; // anonymous local
     let @5: *mut String; // anonymous local
     let @6: bool; // anonymous local
-    let @7: &'_ mut (Slice<String>); // anonymous local
+    let @7: &'_ mut ([String]); // anonymous local
     let @8: &'_ mut (String); // anonymous local
 
     storage_live(@2)
@@ -128,9 +128,9 @@ unsafe fn {impl Destruct::<Slice<String>>}::drop_in_place::<String>(@1: *mut Sli
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct::<Slice<String>>}::<String>
-impl Destruct::<Slice<String>> {
-    fn drop_in_place = {impl Destruct::<Slice<String>>}::drop_in_place::<String>
+// Full name: test_crate::<slice>::{impl Destruct::<[String]>}::<String>
+impl Destruct::<[String]> {
+    fn drop_in_place = {impl Destruct::<[String]>}::drop_in_place::<String>
     non-dyn-compatible
 }
 
@@ -144,12 +144,12 @@ impl Destruct::<Global> {
     non-dyn-compatible
 }
 
-// Full name: core::marker::Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>
+// Full name: core::marker::Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>
 #[lang_item("destruct")]
-pub trait Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>
+pub trait Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>
-    vtable: core::marker::Destruct::{vtable}::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>
+    vtable: core::marker::Destruct::{vtable}::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>
 }
 
 // Full name: core::marker::Destruct::<(String, String)>
@@ -163,44 +163,44 @@ pub trait Destruct::<(String, String)>
 unsafe fn core::marker::Destruct::drop_in_place::<Global>(@1: *mut Global)
 = <missing>
 
-unsafe fn core::marker::Destruct::drop_in_place::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>(@1: *mut alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}])
+unsafe fn core::marker::Destruct::drop_in_place::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>(@1: *mut alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}])
 = <missing>
 
 unsafe fn core::marker::Destruct::drop_in_place::<String>(@1: *mut String)
 = <missing>
 
-unsafe fn core::marker::Destruct::drop_in_place::<Array<String, 4 : usize>>(@1: *mut Array<String, 4 : usize>)
+unsafe fn core::marker::Destruct::drop_in_place::<[String; 4 : usize]>(@1: *mut [String; 4 : usize])
 = <missing>
 
-unsafe fn core::marker::Destruct::drop_in_place::<Slice<String>>(@1: *mut Slice<String>)
+unsafe fn core::marker::Destruct::drop_in_place::<[String]>(@1: *mut [String])
 = <missing>
 
 unsafe fn core::marker::Destruct::drop_in_place::<(String, String)>(@1: *mut (String, String))
 = <missing>
 
-// Full name: alloc::boxed::Box::{impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<Slice<String>, Global>
-unsafe fn {impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<Slice<String>, Global>(@1: *mut alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}])
+// Full name: alloc::boxed::Box::{impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<[String], Global>
+unsafe fn {impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<[String], Global>(@1: *mut alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}])
 = <opaque>
 
-// Full name: alloc::boxed::Box::{impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>}::<Slice<String>, Global>
-impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]> {
-    fn drop_in_place = {impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<Slice<String>, Global>
+// Full name: alloc::boxed::Box::{impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>}::<[String], Global>
+impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]> {
+    fn drop_in_place = {impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>}::drop_in_place::<[String], Global>
     non-dyn-compatible
 }
 
-// Full name: test_crate::<array>::{impl Destruct::<Array<String, 4 : usize>>}::drop_in_place::<String, 4 : usize>
-unsafe fn {impl Destruct::<Array<String, 4 : usize>>}::drop_in_place::<String, 4 : usize>(@1: *mut Array<String, 4 : usize>)
+// Full name: test_crate::<array>::{impl Destruct::<[String; 4 : usize]>}::drop_in_place::<String, 4 : usize>
+unsafe fn {impl Destruct::<[String; 4 : usize]>}::drop_in_place::<String, 4 : usize>(@1: *mut [String; 4 : usize])
 {
     let @0: (); // return
-    let @1: *mut Array<String, 4 : usize>; // arg #1
-    let @2: &'0 mut (Array<String, 4 : usize>); // anonymous local
-    let @3: *mut Array<String, 4 : usize>; // anonymous local
-    let @4: *mut Slice<String>; // anonymous local
+    let @1: *mut [String; 4 : usize]; // arg #1
+    let @2: &'0 mut ([String; 4 : usize]); // anonymous local
+    let @3: *mut [String; 4 : usize]; // anonymous local
+    let @4: *mut [String]; // anonymous local
     let @5: usize; // anonymous local
     let @6: usize; // anonymous local
     let @7: *mut String; // anonymous local
     let @8: bool; // anonymous local
-    let @9: &'_ mut (Slice<String>); // anonymous local
+    let @9: &'_ mut ([String]); // anonymous local
     let @10: &'_ mut (String); // anonymous local
 
     storage_live(@2)
@@ -213,7 +213,7 @@ unsafe fn {impl Destruct::<Array<String, 4 : usize>>}::drop_in_place::<String, 4
     @0 := ()
     @2 := &mut *(@1)
     @3 := &raw mut *(@2)
-    @4 := unsize_cast<*mut Array<String, 4 : usize>, *mut Slice<String>, 4 : usize>(move (@3))
+    @4 := unsize_cast<*mut [String; 4 : usize], *mut [String], 4 : usize>(move (@3))
     @5 := copy (@4.metadata)
     @6 := const (0 : usize)
     loop {
@@ -234,9 +234,9 @@ unsafe fn {impl Destruct::<Array<String, 4 : usize>>}::drop_in_place::<String, 4
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct::<Array<String, 4 : usize>>}::<String, 4 : usize>
-impl Destruct::<Array<String, 4 : usize>> {
-    fn drop_in_place = {impl Destruct::<Array<String, 4 : usize>>}::drop_in_place::<String, 4 : usize>
+// Full name: test_crate::<array>::{impl Destruct::<[String; 4 : usize]>}::<String, 4 : usize>
+impl Destruct::<[String; 4 : usize]> {
+    fn drop_in_place = {impl Destruct::<[String; 4 : usize]>}::drop_in_place::<String, 4 : usize>
     non-dyn-compatible
 }
 
@@ -262,26 +262,26 @@ impl Destruct::<(String, String)> {
 }
 
 // Full name: test_crate::drop_array
-fn drop_array(@1: Array<String, 4 : usize>)
+fn drop_array(@1: [String; 4 : usize])
 {
     let @0: (); // return
-    let @1: Array<String, 4 : usize>; // arg #1
+    let @1: [String; 4 : usize]; // arg #1
 
     @0 := ()
     @0 := ()
-    drop[{impl Destruct::<Array<String, 4 : usize>>}::<String, 4 : usize>] @1
+    drop[{impl Destruct::<[String; 4 : usize]>}::<String, 4 : usize>] @1
     return
 }
 
 // Full name: test_crate::drop_slice
-fn drop_slice(@1: alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}])
+fn drop_slice(@1: alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}])
 {
     let @0: (); // return
-    let @1: alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]; // arg #1
+    let @1: alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]; // arg #1
 
     @0 := ()
     @0 := ()
-    drop[{impl Destruct::<alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized::<Slice<String>>}, {built_in impl Sized::<Global>}, {impl Destruct::<Slice<String>>}::<String>, {impl Destruct::<Global>}]>}::<Slice<String>, Global>] @1
+    drop[{impl Destruct::<alloc::boxed::Box<[String]>[{built_in impl MetaSized::<[String]>}, {built_in impl Sized::<Global>}, {impl Destruct::<[String]>}::<String>, {impl Destruct::<Global>}]>}::<[String], Global>] @1
     return
 }
 

--- a/charon/tests/ui/simple/builtin-drop.out
+++ b/charon/tests/ui/simple/builtin-drop.out
@@ -82,22 +82,22 @@ fn UNIT_METADATA()
 
 const UNIT_METADATA: () = @Fun0()
 
-// Full name: test_crate::<array>::{impl Destruct for Array<T, N>}::drop_in_place
-unsafe fn {impl Destruct for Array<T, N>}::drop_in_place<T, const N : usize>(@1: *mut Array<T, N>)
+// Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
+unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(@1: *mut [T; N])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
 {
     let @0: (); // return
-    let @1: *mut Array<T, N>; // arg #1
-    let @2: &'0 mut (Array<T, N>); // anonymous local
-    let @3: *mut Array<T, N>; // anonymous local
-    let @4: *mut Slice<T>; // anonymous local
+    let @1: *mut [T; N]; // arg #1
+    let @2: &'0 mut ([T; N]); // anonymous local
+    let @3: *mut [T; N]; // anonymous local
+    let @4: *mut [T]; // anonymous local
     let @5: usize; // anonymous local
     let @6: usize; // anonymous local
     let @7: *mut T; // anonymous local
     let @8: bool; // anonymous local
-    let @9: &'_ mut (Slice<T>); // anonymous local
+    let @9: &'_ mut ([T]); // anonymous local
     let @10: &'_ mut (T); // anonymous local
 
     storage_live(@2)
@@ -110,7 +110,7 @@ where
     @0 := ()
     @2 := &mut *(@1)
     @3 := &raw mut *(@2)
-    @4 := unsize_cast<*mut Array<T, N>, *mut Slice<T>, N>(move (@3))
+    @4 := unsize_cast<*mut [T; N], *mut [T], N>(move (@3))
     @5 := copy (@4.metadata)
     @6 := const (0 : usize)
     loop {
@@ -131,30 +131,30 @@ where
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct for Array<T, N>}
-impl<T, const N : usize> Destruct for Array<T, N>
+// Full name: test_crate::<array>::{impl Destruct for [T; N]}
+impl<T, const N : usize> Destruct for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
 {
-    fn drop_in_place = {impl Destruct for Array<T, N>}::drop_in_place<T, N>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for Slice<T>}::drop_in_place
-unsafe fn {impl Destruct for Slice<T>}::drop_in_place<T>(@1: *mut Slice<T>)
+// Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_in_place
+unsafe fn {impl Destruct for [T]}::drop_in_place<T>(@1: *mut [T])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
 {
     let @0: (); // return
-    let @1: *mut Slice<T>; // arg #1
-    let @2: &'0 mut (Slice<T>); // anonymous local
+    let @1: *mut [T]; // arg #1
+    let @2: &'0 mut ([T]); // anonymous local
     let @3: usize; // anonymous local
     let @4: usize; // anonymous local
     let @5: *mut T; // anonymous local
     let @6: bool; // anonymous local
-    let @7: &'_ mut (Slice<T>); // anonymous local
+    let @7: &'_ mut ([T]); // anonymous local
     let @8: &'_ mut (T); // anonymous local
 
     storage_live(@2)
@@ -184,13 +184,13 @@ where
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for Slice<T>}
-impl<T> Destruct for Slice<T>
+// Full name: test_crate::<slice>::{impl Destruct for [T]}
+impl<T> Destruct for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
 {
-    fn drop_in_place = {impl Destruct for Slice<T>}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for [T]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
@@ -225,26 +225,26 @@ where
 }
 
 // Full name: test_crate::drop_array
-fn drop_array(@1: Array<String, 4 : usize>)
+fn drop_array(@1: [String; 4 : usize])
 {
     let @0: (); // return
-    let @1: Array<String, 4 : usize>; // arg #1
+    let @1: [String; 4 : usize]; // arg #1
 
     @0 := ()
     @0 := ()
-    drop[{impl Destruct for Array<T, N>}<String, 4 : usize>[{built_in impl Sized for String}, {impl Destruct for String}]] @1
+    drop[{impl Destruct for [T; N]}<String, 4 : usize>[{built_in impl Sized for String}, {impl Destruct for String}]] @1
     return
 }
 
 // Full name: test_crate::drop_slice
-fn drop_slice(@1: alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized for Slice<String>}, {built_in impl Sized for Global}, {impl Destruct for Slice<T>}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}])
+fn drop_slice(@1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, {impl Destruct for [T]}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}])
 {
     let @0: (); // return
-    let @1: alloc::boxed::Box<Slice<String>>[{built_in impl MetaSized for Slice<String>}, {built_in impl Sized for Global}, {impl Destruct for Slice<T>}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]; // arg #1
+    let @1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, {impl Destruct for [T]}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]; // arg #1
 
     @0 := ()
     @0 := ()
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause3, @TraitClause4]}<Slice<String>, Global>[{built_in impl MetaSized for Slice<String>}, {built_in impl Sized for Global}, {impl Destruct for Slice<T>}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]] @1
+    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause3, @TraitClause4]}<[String], Global>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, {impl Destruct for [T]}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]] @1
     return
 }
 

--- a/charon/tests/ui/simple/const-subslice.out
+++ b/charon/tests/ui/simple/const-subslice.out
@@ -14,14 +14,14 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let y@1: &'0 (Slice<u8>); // local
+    let y@1: &'0 ([u8]); // local
     let z@2: *const u8; // local
-    let @3: *const Slice<u8>; // anonymous local
+    let @3: *const [u8]; // anonymous local
     let @4: usize; // anonymous local
     let @5: *const u8; // anonymous local
-    let @6: Array<u8, 3 : usize>; // anonymous local
-    let @7: &'_ (Array<u8, 3 : usize>); // anonymous local
-    let @8: &'0 (Slice<u8>); // anonymous local
+    let @6: [u8; 3 : usize]; // anonymous local
+    let @7: &'_ ([u8; 3 : usize]); // anonymous local
+    let @8: &'0 ([u8]); // anonymous local
 
     @0 := ()
     storage_live(y@1)
@@ -35,7 +35,7 @@ fn main()
     storage_live(z@2)
     storage_live(@3)
     @3 := &raw const *(y@1) with_metadata(copy (y@1.metadata))
-    z@2 := cast<*const Slice<u8>, *const u8>(move (@3))
+    z@2 := cast<*const [u8], *const u8>(move (@3))
     storage_dead(@3)
     storage_live(@4)
     storage_live(@5)

--- a/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
+++ b/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
@@ -52,7 +52,7 @@ struct KeccakState {}
 
 // Full name: test_crate::PortableHash
 struct PortableHash<const K : usize> {
-  shake128_state: Array<KeccakState, K>,
+  shake128_state: [KeccakState; K],
   make_non_trivial: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}],
 }
 

--- a/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
+++ b/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
@@ -55,20 +55,20 @@ where
     [@TraitClause0]: Convert<Self, T>,
 = <method_without_default_body>
 
-// Full name: test_crate::{impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}::method
-fn {impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}::method<'a>(@1: &'a (u32)) -> &'a (Array<u8, 4 : usize>)
+// Full name: test_crate::{impl Convert<&'a ([u8; 4 : usize])> for &'a (u32)}::method
+fn {impl Convert<&'a ([u8; 4 : usize])> for &'a (u32)}::method<'a>(@1: &'a (u32)) -> &'a ([u8; 4 : usize])
 {
-    let @0: &'0 (Array<u8, 4 : usize>); // return
+    let @0: &'0 ([u8; 4 : usize]); // return
     let self@1: &'1 (u32); // arg #1
-    let @2: &'0 (Array<u8, 4 : usize>); // anonymous local
-    let @3: *const Array<u8, 4 : usize>; // anonymous local
+    let @2: &'0 ([u8; 4 : usize]); // anonymous local
+    let @3: *const [u8; 4 : usize]; // anonymous local
     let @4: *const u32; // anonymous local
 
     storage_live(@2)
     storage_live(@3)
     storage_live(@4)
     @4 := &raw const *(self@1)
-    @3 := cast<u32, Array<u8, 4 : usize>>[{built_in impl Sized for Array<u8, 4 : usize>}](move (@4))
+    @3 := cast<u32, [u8; 4 : usize]>[{built_in impl Sized for [u8; 4 : usize]}](move (@4))
     storage_dead(@4)
     @2 := &*(@3)
     @0 := &*(@2)
@@ -77,11 +77,11 @@ fn {impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}::method<'a>(@1: &'a 
     return
 }
 
-// Full name: test_crate::{impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}
-impl<'a> Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32) {
+// Full name: test_crate::{impl Convert<&'a ([u8; 4 : usize])> for &'a (u32)}
+impl<'a> Convert<&'a ([u8; 4 : usize])> for &'a (u32) {
     parent_clause0 = {built_in impl Sized for &'_ (u32)}
-    parent_clause1 = {built_in impl Sized for &'_ (Array<u8, 4 : usize>)}
-    fn method = {impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}::method<'a>
+    parent_clause1 = {built_in impl Sized for &'_ ([u8; 4 : usize])}
+    fn method = {impl Convert<&'a ([u8; 4 : usize])> for &'a (u32)}::method<'a>
     non-dyn-compatible
 }
 
@@ -105,19 +105,19 @@ where
 }
 
 // Full name: test_crate::to_bytes_by_ref
-pub fn to_bytes_by_ref<'b>(@1: &'b (u32)) -> &'b (Array<u8, 4 : usize>)
+pub fn to_bytes_by_ref<'b>(@1: &'b (u32)) -> &'b ([u8; 4 : usize])
 {
-    let @0: &'0 (Array<u8, 4 : usize>); // return
-    let s@1: &'0 (u32); // arg #1
-    let @2: &'0 (Array<u8, 4 : usize>); // anonymous local
-    let @3: &'0 (u32); // anonymous local
+    let @0: &'0 ([u8; 4 : usize]); // return
+    let s@1: &'1 (u32); // arg #1
+    let @2: &'0 ([u8; 4 : usize]); // anonymous local
+    let @3: &'1 (u32); // anonymous local
 
     storage_live(@2)
     storage_live(@3)
     // Here `convert` is given generics `<&'_ u32, &'_ [u8; 4]>`, which loses the information
     // that the lifetime is the same by virtue of the trait impl.
     @3 := copy (s@1)
-    @2 := convert<&'0 (u32), &'0 (Array<u8, 4 : usize>)>[{built_in impl Sized for &'0 (u32)}, {built_in impl Sized for &'0 (Array<u8, 4 : usize>)}, {impl Convert<&'a (Array<u8, 4 : usize>)> for &'a (u32)}<'0>](move (@3))
+    @2 := convert<&'1 (u32), &'0 ([u8; 4 : usize])>[{built_in impl Sized for &'1 (u32)}, {built_in impl Sized for &'0 ([u8; 4 : usize])}, {impl Convert<&'a ([u8; 4 : usize])> for &'a (u32)}<'8>](move (@3))
     @0 := &*(@2)
     storage_dead(@3)
     storage_dead(@2)

--- a/charon/tests/ui/simple/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/simple/mem-discriminant-from-derive.out
@@ -135,7 +135,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>

--- a/charon/tests/ui/simple/pointee_metadata.out
+++ b/charon/tests/ui/simple/pointee_metadata.out
@@ -162,7 +162,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>
@@ -271,12 +271,12 @@ fn slice_metadata()
 {
     let @0: (); // return
     let @1: (*const (), usize); // anonymous local
-    let @2: *const Slice<u32>; // anonymous local
-    let @3: *const Array<u32, 2 : usize>; // anonymous local
-    let @4: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @5: &'0 (Array<u32, 2 : usize>); // anonymous local
-    let @6: &'_ (Array<u32, 2 : usize>); // anonymous local
-    let @7: Array<u32, 2 : usize>; // anonymous local
+    let @2: *const [u32]; // anonymous local
+    let @3: *const [u32; 2 : usize]; // anonymous local
+    let @4: &'0 ([u32; 2 : usize]); // anonymous local
+    let @5: &'0 ([u32; 2 : usize]); // anonymous local
+    let @6: &'_ ([u32; 2 : usize]); // anonymous local
+    let @7: [u32; 2 : usize]; // anonymous local
 
     storage_live(@6)
     storage_live(@7)
@@ -291,9 +291,9 @@ fn slice_metadata()
     @5 := move (@6)
     @4 := &*(@5)
     @3 := &raw const *(@4)
-    @2 := unsize_cast<*const Array<u32, 2 : usize>, *const Slice<u32>, 2 : usize>(move (@3))
+    @2 := unsize_cast<*const [u32; 2 : usize], *const [u32], 2 : usize>(move (@3))
     storage_dead(@3)
-    @1 := to_raw_parts<Slice<u32>>(move (@2))
+    @1 := to_raw_parts<[u32]>(move (@2))
     storage_dead(@2)
     storage_dead(@4)
     storage_dead(@1)

--- a/charon/tests/ui/simple/promoted-u32-slice.out
+++ b/charon/tests/ui/simple/promoted-u32-slice.out
@@ -11,14 +11,14 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::foo
-pub fn foo() -> &'static (Slice<u32>)
+pub fn foo() -> &'static ([u32])
 {
-    let @0: &'0 (Slice<u32>); // return
-    let @1: &'1 (Array<u32, 4 : usize>); // anonymous local
-    let @2: &'1 (Array<u32, 4 : usize>); // anonymous local
-    let @3: &'1 (Array<u32, 4 : usize>); // anonymous local
-    let @4: &'_ (Array<u32, 4 : usize>); // anonymous local
-    let @5: Array<u32, 4 : usize>; // anonymous local
+    let @0: &'0 ([u32]); // return
+    let @1: &'1 ([u32; 4 : usize]); // anonymous local
+    let @2: &'1 ([u32; 4 : usize]); // anonymous local
+    let @3: &'1 ([u32; 4 : usize]); // anonymous local
+    let @4: &'_ ([u32; 4 : usize]); // anonymous local
+    let @5: [u32; 4 : usize]; // anonymous local
 
     storage_live(@4)
     storage_live(@5)

--- a/charon/tests/ui/simple/ptr-from-raw-parts.out
+++ b/charon/tests/ui/simple/ptr-from-raw-parts.out
@@ -206,7 +206,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>
@@ -289,9 +289,9 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let a@1: Array<u32, 2 : usize>; // local
-    let @2: *const Slice<u32>; // anonymous local
-    let @3: *const Array<u32, 2 : usize>; // anonymous local
+    let a@1: [u32; 2 : usize]; // local
+    let @2: *const [u32]; // anonymous local
+    let @3: *const [u32; 2 : usize]; // anonymous local
 
     @0 := ()
     storage_live(a@1)
@@ -299,7 +299,7 @@ fn main()
     storage_live(@2)
     storage_live(@3)
     @3 := &raw const a@1
-    @2 := from_raw_parts<Slice<u32>, Array<u32, 2 : usize>>[{built_in impl Sized for Array<u32, 2 : usize>}, {impl#0}<Array<u32, 2 : usize>>[{built_in impl Pointee for Array<u32, 2 : usize> where Metadata  = ()}]](move (@3), const (2 : usize))
+    @2 := from_raw_parts<[u32], [u32; 2 : usize]>[{built_in impl Sized for [u32; 2 : usize]}, {impl#0}<[u32; 2 : usize]>[{built_in impl Pointee for [u32; 2 : usize] where Metadata  = ()}]](move (@3), const (2 : usize))
     storage_dead(@3)
     storage_dead(@2)
     @0 := ()

--- a/charon/tests/ui/simple/ptr_metadata.out
+++ b/charon/tests/ui/simple/ptr_metadata.out
@@ -206,7 +206,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>

--- a/charon/tests/ui/simple/slice_increment.out
+++ b/charon/tests/ui/simple/slice_increment.out
@@ -11,15 +11,15 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(@1: &'_0 mut (Slice<u32>))
+pub fn incr<'_0>(@1: &'_0 mut ([u32]))
 {
     let @0: (); // return
-    let s@1: &'0 mut (Slice<u32>); // arg #1
+    let s@1: &'0 mut ([u32]); // arg #1
     let @2: usize; // anonymous local
     let @3: u32; // anonymous local
-    let @4: &'_ (Slice<u32>); // anonymous local
+    let @4: &'_ ([u32]); // anonymous local
     let @5: &'_ (u32); // anonymous local
-    let @6: &'_ mut (Slice<u32>); // anonymous local
+    let @6: &'_ mut ([u32]); // anonymous local
     let @7: &'_ mut (u32); // anonymous local
 
     storage_live(@3)

--- a/charon/tests/ui/simple/slice_index.out
+++ b/charon/tests/ui/simple/slice_index.out
@@ -11,12 +11,12 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::first
-pub fn first<'_0>(@1: &'_0 (Slice<u32>)) -> u32
+pub fn first<'_0>(@1: &'_0 ([u32])) -> u32
 {
     let @0: u32; // return
-    let s@1: &'0 (Slice<u32>); // arg #1
+    let s@1: &'0 ([u32]); // arg #1
     let @2: usize; // anonymous local
-    let @3: &'_ (Slice<u32>); // anonymous local
+    let @3: &'_ ([u32]); // anonymous local
     let @4: &'_ (u32); // anonymous local
 
     storage_live(@2)

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -238,34 +238,34 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <method_without_default_body>
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}::index
-pub fn {impl Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
+// Full name: core::slice::index::{impl Index<I> for [T]}::index
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(@1: &'_0 ([T]), @2: I) -> &'_0 (@TraitClause2::Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 {
     let @0: &'0 (@TraitClause2::Output); // return
-    let self@1: &'1 (Slice<T>); // arg #1
+    let self@1: &'1 ([T]); // arg #1
     let index@2: I; // arg #2
 
     @0 := @TraitClause2::index<'_>(move (index@2), move (self@1))
     return
 }
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}
-impl<T, I> Index<I> for Slice<T>
+// Full name: core::slice::index::{impl Index<I> for [T]}
+impl<T, I> Index<I> for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
-    fn index<'_0_1> = {impl Index<I> for Slice<T>}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I> for [T]}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::slice_index_fail
@@ -400,28 +400,28 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <method_without_default_body>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> Option<&'_0 (Slice<T>)>[{built_in impl Sized for &'_0 (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> Option<&'_0 ([T])>[{built_in impl Sized for &'_0 ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // return
+    let @0: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'0 (Slice<T>); // anonymous local
-    let @10: *const Slice<T>; // anonymous local
-    let @11: *const Slice<T>; // anonymous local
+    let @9: &'0 ([T]); // anonymous local
+    let @10: *const [T]; // anonymous local
+    let @11: *const [T]; // anonymous local
     let @12: bool; // anonymous local
     let @13: usize; // anonymous local
     let @14: *const T; // anonymous local
     let @15: *const T; // anonymous local
-    let @16: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // anonymous local
+    let @16: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(rhs@5)
@@ -456,9 +456,9 @@ where
             @11 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@14)
             storage_live(@15)
-            @14 := cast<*const Slice<T>, *const T>(copy (@11))
+            @14 := cast<*const [T], *const T>(copy (@11))
             @15 := copy (@14) offset copy (rhs@5)
-            @10 := @PtrFromPartsShared<'_, Slice<T>>(copy (@15), copy (new_len@6))
+            @10 := @PtrFromPartsShared<'_, [T]>(copy (@15), copy (new_len@6))
             storage_dead(@15)
             storage_dead(@14)
             storage_dead(@11)
@@ -478,28 +478,28 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (Slice<T>)>[{built_in impl Sized for &'_0 mut (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> Option<&'_0 mut ([T])>[{built_in impl Sized for &'_0 mut ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // return
+    let @0: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'0 mut (Slice<T>); // anonymous local
-    let @10: *mut Slice<T>; // anonymous local
-    let ptr@11: *mut Slice<T>; // local
+    let @9: &'0 mut ([T]); // anonymous local
+    let @10: *mut [T]; // anonymous local
+    let ptr@11: *mut [T]; // local
     let @12: bool; // anonymous local
     let @13: usize; // anonymous local
     let @14: *mut T; // anonymous local
     let @15: *mut T; // anonymous local
-    let @16: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // anonymous local
+    let @16: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(rhs@5)
@@ -534,9 +534,9 @@ where
             ptr@11 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@14)
             storage_live(@15)
-            @14 := cast<*mut Slice<T>, *mut T>(copy (ptr@11))
+            @14 := cast<*mut [T], *mut T>(copy (ptr@11))
             @15 := copy (@14) offset copy (rhs@5)
-            @10 := @PtrFromPartsMut<'_, Slice<T>>(copy (@15), copy (new_len@6))
+            @10 := @PtrFromPartsMut<'_, [T]>(copy (@15), copy (new_len@6))
             storage_dead(@15)
             storage_dead(@14)
             storage_dead(ptr@11)
@@ -556,8 +556,8 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
-fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(@1: usize, @2: usize, @3: usize)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(@1: usize, @2: usize, @3: usize)
 {
     let @0: (); // return
     let start@1: usize; // arg #1
@@ -575,7 +575,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     let @13: usize; // anonymous local
     let @14: usize; // anonymous local
     let @15: *const Str; // anonymous local
-    let @16: &'3 (Slice<u8>); // anonymous local
+    let @16: &'3 ([u8]); // anonymous local
 
     storage_live(msg@6)
     storage_live(@7)
@@ -608,7 +608,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     storage_live(@13)
     storage_live(@14)
     storage_live(@16)
-    @16 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @16 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @14 := copy (@16.metadata)
     storage_dead(@16)
     @13 := move (@14) wrap.<< const (1 : i32)
@@ -623,14 +623,14 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     @7 := panic_nounwind_fmt<'_>(move (@8), const (false))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const Slice<T>) -> *const Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *const Slice<T>; // return
+    let @0: *const [T]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *const Slice<T>; // arg #2
+    let slice@2: *const [T]; // arg #2
     let @3: bool; // anonymous local
     let @4: (); // anonymous local
     let @5: usize; // anonymous local
@@ -654,7 +654,7 @@ where
         @6 := copy ((self@1).end)
         storage_live(@7)
         @7 := copy (slice@2.metadata)
-        @4 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(move (@5), move (@6), move (@7))
+        @4 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(move (@5), move (@6), move (@7))
         storage_dead(@7)
         storage_dead(@6)
         storage_dead(@5)
@@ -668,16 +668,16 @@ where
     storage_dead(@9)
     storage_live(@11)
     storage_live(@12)
-    @11 := cast<*const Slice<T>, *const T>(copy (slice@2))
+    @11 := cast<*const [T], *const T>(copy (slice@2))
     @12 := copy (@11) offset copy (offset@10)
-    @0 := @PtrFromPartsShared<'_, Slice<T>>(copy (@12), copy (new_len@8))
+    @0 := @PtrFromPartsShared<'_, [T]>(copy (@12), copy (new_len@8))
     storage_dead(@12)
     storage_dead(@11)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
-fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(@1: usize, @2: usize, @3: usize)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(@1: usize, @2: usize, @3: usize)
 {
     let @0: (); // return
     let start@1: usize; // arg #1
@@ -695,7 +695,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     let @13: usize; // anonymous local
     let @14: usize; // anonymous local
     let @15: *const Str; // anonymous local
-    let @16: &'3 (Slice<u8>); // anonymous local
+    let @16: &'3 ([u8]); // anonymous local
 
     storage_live(msg@6)
     storage_live(@7)
@@ -728,7 +728,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     storage_live(@13)
     storage_live(@14)
     storage_live(@16)
-    @16 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: slice::get_unchecked_mut requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @16 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: slice::get_unchecked_mut requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @14 := copy (@16.metadata)
     storage_dead(@16)
     @13 := move (@14) wrap.<< const (1 : i32)
@@ -743,14 +743,14 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     @7 := panic_nounwind_fmt<'_>(move (@8), const (false))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut Slice<T>) -> *mut Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *mut Slice<T>; // return
+    let @0: *mut [T]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *mut Slice<T>; // arg #2
+    let slice@2: *mut [T]; // arg #2
     let @3: bool; // anonymous local
     let @4: (); // anonymous local
     let @5: usize; // anonymous local
@@ -774,7 +774,7 @@ where
         @6 := copy ((self@1).end)
         storage_live(@7)
         @7 := copy (slice@2.metadata)
-        @4 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(move (@5), move (@6), move (@7))
+        @4 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(move (@5), move (@6), move (@7))
         storage_dead(@7)
         storage_dead(@6)
         storage_dead(@5)
@@ -788,30 +788,30 @@ where
     storage_dead(@9)
     storage_live(@11)
     storage_live(@12)
-    @11 := cast<*mut Slice<T>, *mut T>(copy (slice@2))
+    @11 := cast<*mut [T], *mut T>(copy (slice@2))
     @12 := copy (@11) offset copy (offset@10)
-    @0 := @PtrFromPartsMut<'_, Slice<T>>(copy (@12), copy (new_len@8))
+    @0 := @PtrFromPartsMut<'_, [T]>(copy (@12), copy (new_len@8))
     storage_dead(@12)
     storage_dead(@11)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 (Slice<T>); // return
+    let @0: &'0 ([T]); // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: *const Slice<T>; // anonymous local
-    let @10: *const Slice<T>; // anonymous local
+    let @9: *const [T]; // anonymous local
+    let @10: *const [T]; // anonymous local
     let @11: !; // anonymous local
     let @12: usize; // anonymous local
     let @13: bool; // anonymous local
@@ -848,9 +848,9 @@ where
             @10 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@15)
             storage_live(@16)
-            @15 := cast<*const Slice<T>, *const T>(copy (@10))
+            @15 := cast<*const [T], *const T>(copy (@10))
             @16 := copy (@15) offset copy (rhs@5)
-            @9 := @PtrFromPartsShared<'_, Slice<T>>(copy (@16), copy (new_len@6))
+            @9 := @PtrFromPartsShared<'_, [T]>(copy (@16), copy (new_len@6))
             storage_dead(@16)
             storage_dead(@15)
             storage_dead(@10)
@@ -869,22 +869,22 @@ where
     @11 := slice_index_fail(move (rhs@5), move (self@4), move (@12))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 mut (Slice<T>); // return
+    let @0: &'0 mut ([T]); // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: *mut Slice<T>; // anonymous local
-    let ptr@10: *mut Slice<T>; // local
+    let @9: *mut [T]; // anonymous local
+    let ptr@10: *mut [T]; // local
     let @11: !; // anonymous local
     let @12: usize; // anonymous local
     let @13: bool; // anonymous local
@@ -921,9 +921,9 @@ where
             ptr@10 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@15)
             storage_live(@16)
-            @15 := cast<*mut Slice<T>, *mut T>(copy (ptr@10))
+            @15 := cast<*mut [T], *mut T>(copy (ptr@10))
             @16 := copy (@15) offset copy (rhs@5)
-            @9 := @PtrFromPartsMut<'_, Slice<T>>(copy (@16), copy (new_len@6))
+            @9 := @PtrFromPartsMut<'_, [T]>(copy (@16), copy (new_len@6))
             storage_dead(@16)
             storage_dead(@15)
             storage_dead(ptr@10)
@@ -942,49 +942,49 @@ where
     @11 := slice_index_fail(move (rhs@5), move (self@4), move (@12))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
-impl<T> SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}
+impl<T> SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
     parent_clause1 = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
-    parent_clause3 = {built_in impl MetaSized for Slice<T>}
-    type Output = Slice<T>
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    parent_clause2 = {built_in impl MetaSized for [T]}
+    parent_clause3 = {built_in impl MetaSized for [T]}
+    type Output = [T]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> Option<&'_0 (Slice<T>)>[{built_in impl Sized for &'_0 (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> Option<&'_0 ([T])>[{built_in impl Sized for &'_0 ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // return
+    let @0: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let @3: bool; // anonymous local
     let self@4: usize; // local
     let exclusive_end@5: usize; // local
     let @6: bool; // anonymous local
     let @7: usize; // anonymous local
-    let @8: &'0 (Slice<T>); // anonymous local
-    let @9: *const Slice<T>; // anonymous local
-    let @10: *const Slice<T>; // anonymous local
+    let @8: &'0 ([T]); // anonymous local
+    let @9: *const [T]; // anonymous local
+    let @10: *const [T]; // anonymous local
     let @11: bool; // anonymous local
     let new_len@12: usize; // local
     let @13: *const T; // anonymous local
     let @14: *const T; // anonymous local
     let self@15: usize; // local
     let self@16: bool; // local
-    let @17: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // anonymous local
-    let @18: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // anonymous local
+    let @17: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // anonymous local
+    let @18: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(exclusive_end@5)
@@ -1030,9 +1030,9 @@ where
                 @10 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
                 storage_live(@13)
                 storage_live(@14)
-                @13 := cast<*const Slice<T>, *const T>(copy (@10))
+                @13 := cast<*const [T], *const T>(copy (@10))
                 @14 := copy (@13) offset copy (self@15)
-                @9 := @PtrFromPartsShared<'_, Slice<T>>(copy (@14), copy (new_len@12))
+                @9 := @PtrFromPartsShared<'_, [T]>(copy (@14), copy (new_len@12))
                 storage_dead(@14)
                 storage_dead(@13)
                 storage_dead(@10)
@@ -1053,30 +1053,30 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (Slice<T>)>[{built_in impl Sized for &'_0 mut (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> Option<&'_0 mut ([T])>[{built_in impl Sized for &'_0 mut ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // return
+    let @0: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let @3: bool; // anonymous local
     let self@4: usize; // local
     let exclusive_end@5: usize; // local
     let @6: bool; // anonymous local
     let @7: usize; // anonymous local
-    let @8: &'0 mut (Slice<T>); // anonymous local
-    let @9: *mut Slice<T>; // anonymous local
-    let ptr@10: *mut Slice<T>; // local
+    let @8: &'0 mut ([T]); // anonymous local
+    let @9: *mut [T]; // anonymous local
+    let ptr@10: *mut [T]; // local
     let @11: bool; // anonymous local
     let new_len@12: usize; // local
     let @13: *mut T; // anonymous local
     let @14: *mut T; // anonymous local
     let self@15: usize; // local
     let self@16: bool; // local
-    let @17: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // anonymous local
-    let @18: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // anonymous local
+    let @17: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // anonymous local
+    let @18: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(exclusive_end@5)
@@ -1122,9 +1122,9 @@ where
                 ptr@10 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
                 storage_live(@13)
                 storage_live(@14)
-                @13 := cast<*mut Slice<T>, *mut T>(copy (ptr@10))
+                @13 := cast<*mut [T], *mut T>(copy (ptr@10))
                 @14 := copy (@13) offset copy (self@15)
-                @9 := @PtrFromPartsMut<'_, Slice<T>>(copy (@14), copy (new_len@12))
+                @9 := @PtrFromPartsMut<'_, [T]>(copy (@14), copy (new_len@12))
                 storage_dead(@14)
                 storage_dead(@13)
                 storage_dead(ptr@10)
@@ -1145,14 +1145,14 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: *const Slice<T>) -> *const Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *const Slice<T>; // return
+    let @0: *const [T]; // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *const Slice<T>; // arg #2
+    let slice@2: *const [T]; // arg #2
     let exclusive_end@3: usize; // local
     let @4: bool; // anonymous local
     let @5: (); // anonymous local
@@ -1183,7 +1183,7 @@ where
     if move (@4) {
         storage_live(@6)
         @6 := copy (slice@2.metadata)
-        @5 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(copy (self@10), copy (exclusive_end@3), move (@6))
+        @5 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(copy (self@10), copy (exclusive_end@3), move (@6))
         storage_dead(@6)
     } else {
     }
@@ -1191,23 +1191,23 @@ where
     new_len@7 := copy (exclusive_end@3) ub.- copy (self@10)
     storage_live(@8)
     storage_live(@9)
-    @8 := cast<*const Slice<T>, *const T>(copy (slice@2))
+    @8 := cast<*const [T], *const T>(copy (slice@2))
     @9 := copy (@8) offset copy (self@10)
-    @0 := @PtrFromPartsShared<'_, Slice<T>>(copy (@9), copy (new_len@7))
+    @0 := @PtrFromPartsShared<'_, [T]>(copy (@9), copy (new_len@7))
     storage_dead(@9)
     storage_dead(@8)
     storage_dead(new_len@7)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: *mut Slice<T>) -> *mut Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *mut Slice<T>; // return
+    let @0: *mut [T]; // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *mut Slice<T>; // arg #2
+    let slice@2: *mut [T]; // arg #2
     let exclusive_end@3: usize; // local
     let @4: bool; // anonymous local
     let @5: (); // anonymous local
@@ -1238,7 +1238,7 @@ where
     if move (@4) {
         storage_live(@6)
         @6 := copy (slice@2.metadata)
-        @5 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(copy (self@10), copy (exclusive_end@3), move (@6))
+        @5 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(copy (self@10), copy (exclusive_end@3), move (@6))
         storage_dead(@6)
     } else {
     }
@@ -1246,23 +1246,23 @@ where
     new_len@7 := copy (exclusive_end@3) ub.- copy (self@10)
     storage_live(@8)
     storage_live(@9)
-    @8 := cast<*mut Slice<T>, *mut T>(copy (slice@2))
+    @8 := cast<*mut [T], *mut T>(copy (slice@2))
     @9 := copy (@8) offset copy (self@10)
-    @0 := @PtrFromPartsMut<'_, Slice<T>>(copy (@9), copy (new_len@7))
+    @0 := @PtrFromPartsMut<'_, [T]>(copy (@9), copy (new_len@7))
     storage_dead(@9)
     storage_dead(@8)
     storage_dead(new_len@7)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 (Slice<T>); // return
+    let @0: &'0 ([T]); // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let start@3: usize; // local
     let end@4: usize; // local
     let exhausted@5: bool; // local
@@ -1274,8 +1274,8 @@ where
     let self@11: usize; // local
     let rhs@12: usize; // local
     let new_len@13: usize; // local
-    let @14: *const Slice<T>; // anonymous local
-    let @15: *const Slice<T>; // anonymous local
+    let @14: *const [T]; // anonymous local
+    let @15: *const [T]; // anonymous local
     let @16: !; // anonymous local
     let @17: bool; // anonymous local
     let @18: usize; // anonymous local
@@ -1332,9 +1332,9 @@ where
             @15 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@19)
             storage_live(@20)
-            @19 := cast<*const Slice<T>, *const T>(copy (@15))
+            @19 := cast<*const [T], *const T>(copy (@15))
             @20 := copy (@19) offset copy (start@3)
-            @14 := @PtrFromPartsShared<'_, Slice<T>>(copy (@20), copy (new_len@13))
+            @14 := @PtrFromPartsShared<'_, [T]>(copy (@20), copy (new_len@13))
             storage_dead(@20)
             storage_dead(@19)
             storage_dead(@15)
@@ -1351,14 +1351,14 @@ where
     @16 := slice_index_fail(move (start@3), move (end@4), move (len@6))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: RangeInclusive<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 mut (Slice<T>); // return
+    let @0: &'0 mut ([T]); // return
     let self@1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let start@3: usize; // local
     let end@4: usize; // local
     let exhausted@5: bool; // local
@@ -1370,8 +1370,8 @@ where
     let self@11: usize; // local
     let rhs@12: usize; // local
     let new_len@13: usize; // local
-    let @14: *mut Slice<T>; // anonymous local
-    let ptr@15: *mut Slice<T>; // local
+    let @14: *mut [T]; // anonymous local
+    let ptr@15: *mut [T]; // local
     let @16: !; // anonymous local
     let @17: bool; // anonymous local
     let @18: usize; // anonymous local
@@ -1428,9 +1428,9 @@ where
             ptr@15 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@19)
             storage_live(@20)
-            @19 := cast<*mut Slice<T>, *mut T>(copy (ptr@15))
+            @19 := cast<*mut [T], *mut T>(copy (ptr@15))
             @20 := copy (@19) offset copy (start@3)
-            @14 := @PtrFromPartsMut<'_, Slice<T>>(copy (@20), copy (new_len@13))
+            @14 := @PtrFromPartsMut<'_, [T]>(copy (@20), copy (new_len@13))
             storage_dead(@20)
             storage_dead(@19)
             storage_dead(ptr@15)
@@ -1447,23 +1447,23 @@ where
     @16 := slice_index_fail(move (start@3), move (end@4), move (len@6))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}
-impl<T> SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}
+impl<T> SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for RangeInclusive<usize>[{built_in impl Sized for usize}]}
     parent_clause1 = {impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
-    parent_clause3 = {built_in impl MetaSized for Slice<T>}
-    type Output = Slice<T>
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    parent_clause2 = {built_in impl MetaSized for [T]}
+    parent_clause3 = {built_in impl MetaSized for [T]}
+    type Output = [T]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
 }
 
 fn UNIT_METADATA()
@@ -1477,13 +1477,13 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::slice_index_range
-pub fn slice_index_range<'_0>(@1: &'_0 (Slice<u8>)) -> &'_0 (Slice<u8>)
+pub fn slice_index_range<'_0>(@1: &'_0 ([u8])) -> &'_0 ([u8])
 {
-    let @0: &'0 (Slice<u8>); // return
-    let slice@1: &'0 (Slice<u8>); // arg #1
-    let @2: &'0 (Slice<u8>); // anonymous local
-    let @3: &'0 (Slice<u8>); // anonymous local
-    let @4: &'0 (Slice<u8>); // anonymous local
+    let @0: &'0 ([u8]); // return
+    let slice@1: &'0 ([u8]); // arg #1
+    let @2: &'0 ([u8]); // anonymous local
+    let @3: &'0 ([u8]); // anonymous local
+    let @4: &'0 ([u8]); // anonymous local
     let @5: RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
 
     storage_live(@2)
@@ -1492,7 +1492,7 @@ pub fn slice_index_range<'_0>(@1: &'_0 (Slice<u8>)) -> &'_0 (Slice<u8>)
     @4 := &*(slice@1) with_metadata(copy (slice@1.metadata))
     storage_live(@5)
     @5 := new<usize>[{built_in impl Sized for usize}](const (0 : usize), const (10 : usize))
-    @3 := {impl Index<I> for Slice<T>}::index<'_, u8, RangeInclusive<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for u8}, {built_in impl Sized for RangeInclusive<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>> for RangeInclusive<usize>[{built_in impl Sized for usize}]}<u8>[{built_in impl Sized for u8}]](move (@4), move (@5))
+    @3 := {impl Index<I> for [T]}::index<'_, u8, RangeInclusive<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for u8}, {built_in impl Sized for RangeInclusive<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}<u8>[{built_in impl Sized for u8}]](move (@4), move (@5))
     storage_dead(@5)
     storage_dead(@4)
     @2 := &*(@3) with_metadata(copy (@3.metadata))

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -24,27 +24,27 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: core::array::{impl Index<I> for Array<T, N>}::index
-pub fn {impl Index<I> for Array<T, N>}::index<'_0, T, I, const N : usize>(@1: &'_0 (Array<T, N>), @2: I) -> &'_0 (@TraitClause2::Output)
+// Full name: core::array::{impl Index<I> for [T; N]}::index
+pub fn {impl Index<I> for [T; N]}::index<'_0, T, I, const N : usize>(@1: &'_0 ([T; N]), @2: I) -> &'_0 (@TraitClause2::Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<Slice<T>, I>,
+    [@TraitClause2]: Index<[T], I>,
 = <opaque>
 
-// Full name: core::array::{impl Index<I> for Array<T, N>}
-impl<T, I, const N : usize> Index<I> for Array<T, N>
+// Full name: core::array::{impl Index<I> for [T; N]}
+impl<T, I, const N : usize> Index<I> for [T; N]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<Slice<T>, I>,
+    [@TraitClause2]: Index<[T], I>,
 {
-    parent_clause0 = {built_in impl MetaSized for Array<T, N>}
+    parent_clause0 = {built_in impl MetaSized for [T; N]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause2
     type Output = @TraitClause2::Output
-    fn index<'_0_1> = {impl Index<I> for Array<T, N>}::index<'_0_1, T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I> for Array<T, N>}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I> for [T; N]}::index<'_0_1, T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I> for [T; N]}::{vtable}<T, I, N>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::fmt::Arguments
@@ -166,34 +166,34 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <method_without_default_body>
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}::index
-pub fn {impl Index<I> for Slice<T>}::index<'_0, T, I>(@1: &'_0 (Slice<T>), @2: I) -> &'_0 (@TraitClause2::Output)
+// Full name: core::slice::index::{impl Index<I> for [T]}::index
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(@1: &'_0 ([T]), @2: I) -> &'_0 (@TraitClause2::Output)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 {
     let @0: &'0 (@TraitClause2::Output); // return
-    let self@1: &'1 (Slice<T>); // arg #1
+    let self@1: &'1 ([T]); // arg #1
     let index@2: I; // arg #2
 
     @0 := @TraitClause2::index<'_>(move (index@2), move (self@1))
     return
 }
 
-// Full name: core::slice::index::{impl Index<I> for Slice<T>}
-impl<T, I> Index<I> for Slice<T>
+// Full name: core::slice::index::{impl Index<I> for [T]}
+impl<T, I> Index<I> for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, Slice<T>>,
+    [@TraitClause2]: SliceIndex<I, [T]>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = @TraitClause1::parent_clause0
     parent_clause2 = @TraitClause2::parent_clause3
     type Output = @TraitClause2::Output
-    fn index<'_0_1> = {impl Index<I> for Slice<T>}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I> for Slice<T>}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn index<'_0_1> = {impl Index<I> for [T]}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    vtable: {impl Index<I> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
 }
 
 // Full name: core::slice::index::slice_index_fail
@@ -322,28 +322,28 @@ where
     [@TraitClause0]: SliceIndex<Self, T>,
 = <method_without_default_body>
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> Option<&'_0 (Slice<T>)>[{built_in impl Sized for &'_0 (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> Option<&'_0 ([T])>[{built_in impl Sized for &'_0 ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // return
+    let @0: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'0 (Slice<T>); // anonymous local
-    let @10: *const Slice<T>; // anonymous local
-    let @11: *const Slice<T>; // anonymous local
+    let @9: &'0 ([T]); // anonymous local
+    let @10: *const [T]; // anonymous local
+    let @11: *const [T]; // anonymous local
     let @12: bool; // anonymous local
     let @13: usize; // anonymous local
     let @14: *const T; // anonymous local
     let @15: *const T; // anonymous local
-    let @16: Option<&'0 (Slice<T>)>[{built_in impl Sized for &'0 (Slice<T>)}]; // anonymous local
+    let @16: Option<&'0 ([T])>[{built_in impl Sized for &'0 ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(rhs@5)
@@ -378,9 +378,9 @@ where
             @11 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@14)
             storage_live(@15)
-            @14 := cast<*const Slice<T>, *const T>(copy (@11))
+            @14 := cast<*const [T], *const T>(copy (@11))
             @15 := copy (@14) offset copy (rhs@5)
-            @10 := @PtrFromPartsShared<'_, Slice<T>>(copy (@15), copy (new_len@6))
+            @10 := @PtrFromPartsShared<'_, [T]>(copy (@15), copy (new_len@6))
             storage_dead(@15)
             storage_dead(@14)
             storage_dead(@11)
@@ -400,28 +400,28 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> Option<&'_0 mut (Slice<T>)>[{built_in impl Sized for &'_0 mut (Slice<T>)}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> Option<&'_0 mut ([T])>[{built_in impl Sized for &'_0 mut ([T])}]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // return
+    let @0: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'0 mut (Slice<T>); // anonymous local
-    let @10: *mut Slice<T>; // anonymous local
-    let ptr@11: *mut Slice<T>; // local
+    let @9: &'0 mut ([T]); // anonymous local
+    let @10: *mut [T]; // anonymous local
+    let ptr@11: *mut [T]; // local
     let @12: bool; // anonymous local
     let @13: usize; // anonymous local
     let @14: *mut T; // anonymous local
     let @15: *mut T; // anonymous local
-    let @16: Option<&'0 mut (Slice<T>)>[{built_in impl Sized for &'0 mut (Slice<T>)}]; // anonymous local
+    let @16: Option<&'0 mut ([T])>[{built_in impl Sized for &'0 mut ([T])}]; // anonymous local
 
     storage_live(self@4)
     storage_live(rhs@5)
@@ -456,9 +456,9 @@ where
             ptr@11 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@14)
             storage_live(@15)
-            @14 := cast<*mut Slice<T>, *mut T>(copy (ptr@11))
+            @14 := cast<*mut [T], *mut T>(copy (ptr@11))
             @15 := copy (@14) offset copy (rhs@5)
-            @10 := @PtrFromPartsMut<'_, Slice<T>>(copy (@15), copy (new_len@6))
+            @10 := @PtrFromPartsMut<'_, [T]>(copy (@15), copy (new_len@6))
             storage_dead(@15)
             storage_dead(@14)
             storage_dead(ptr@11)
@@ -478,8 +478,8 @@ where
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
-fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(@1: usize, @2: usize, @3: usize)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(@1: usize, @2: usize, @3: usize)
 {
     let @0: (); // return
     let start@1: usize; // arg #1
@@ -497,7 +497,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     let @13: usize; // anonymous local
     let @14: usize; // anonymous local
     let @15: *const Str; // anonymous local
-    let @16: &'3 (Slice<u8>); // anonymous local
+    let @16: &'3 ([u8]); // anonymous local
 
     storage_live(msg@6)
     storage_live(@7)
@@ -530,7 +530,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     storage_live(@13)
     storage_live(@14)
     storage_live(@16)
-    @16 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @16 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @14 := copy (@16.metadata)
     storage_dead(@16)
     @13 := move (@14) wrap.<< const (1 : i32)
@@ -545,14 +545,14 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     @7 := panic_nounwind_fmt<'_>(move (@8), const (false))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const Slice<T>) -> *const Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *const Slice<T>; // return
+    let @0: *const [T]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *const Slice<T>; // arg #2
+    let slice@2: *const [T]; // arg #2
     let @3: bool; // anonymous local
     let @4: (); // anonymous local
     let @5: usize; // anonymous local
@@ -576,7 +576,7 @@ where
         @6 := copy ((self@1).end)
         storage_live(@7)
         @7 := copy (slice@2.metadata)
-        @4 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(move (@5), move (@6), move (@7))
+        @4 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(move (@5), move (@6), move (@7))
         storage_dead(@7)
         storage_dead(@6)
         storage_dead(@5)
@@ -590,16 +590,16 @@ where
     storage_dead(@9)
     storage_live(@11)
     storage_live(@12)
-    @11 := cast<*const Slice<T>, *const T>(copy (slice@2))
+    @11 := cast<*const [T], *const T>(copy (slice@2))
     @12 := copy (@11) offset copy (offset@10)
-    @0 := @PtrFromPartsShared<'_, Slice<T>>(copy (@12), copy (new_len@8))
+    @0 := @PtrFromPartsShared<'_, [T]>(copy (@12), copy (new_len@8))
     storage_dead(@12)
     storage_dead(@11)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
-fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(@1: usize, @2: usize, @3: usize)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(@1: usize, @2: usize, @3: usize)
 {
     let @0: (); // return
     let start@1: usize; // arg #1
@@ -617,7 +617,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     let @13: usize; // anonymous local
     let @14: usize; // anonymous local
     let @15: *const Str; // anonymous local
-    let @16: &'3 (Slice<u8>); // anonymous local
+    let @16: &'3 ([u8]); // anonymous local
 
     storage_live(msg@6)
     storage_live(@7)
@@ -650,7 +650,7 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     storage_live(@13)
     storage_live(@14)
     storage_live(@16)
-    @16 := transmute<&'0 (Str), &'3 (Slice<u8>)>(const ("unsafe precondition(s) violated: slice::get_unchecked_mut requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
+    @16 := transmute<&'0 (Str), &'3 ([u8])>(const ("unsafe precondition(s) violated: slice::get_unchecked_mut requires that the range is within the slice\n\nThis indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety."))
     @14 := copy (@16.metadata)
     storage_dead(@16)
     @13 := move (@14) wrap.<< const (1 : i32)
@@ -665,14 +665,14 @@ fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
     @7 := panic_nounwind_fmt<'_>(move (@8), const (false))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut Slice<T>) -> *mut Slice<T>
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: *mut Slice<T>; // return
+    let @0: *mut [T]; // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: *mut Slice<T>; // arg #2
+    let slice@2: *mut [T]; // arg #2
     let @3: bool; // anonymous local
     let @4: (); // anonymous local
     let @5: usize; // anonymous local
@@ -696,7 +696,7 @@ where
         @6 := copy ((self@1).end)
         storage_live(@7)
         @7 := copy (slice@2.metadata)
-        @4 := {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(move (@5), move (@6), move (@7))
+        @4 := {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(move (@5), move (@6), move (@7))
         storage_dead(@7)
         storage_dead(@6)
         storage_dead(@5)
@@ -710,30 +710,30 @@ where
     storage_dead(@9)
     storage_live(@11)
     storage_live(@12)
-    @11 := cast<*mut Slice<T>, *mut T>(copy (slice@2))
+    @11 := cast<*mut [T], *mut T>(copy (slice@2))
     @12 := copy (@11) offset copy (offset@10)
-    @0 := @PtrFromPartsMut<'_, Slice<T>>(copy (@12), copy (new_len@8))
+    @0 := @PtrFromPartsMut<'_, [T]>(copy (@12), copy (new_len@8))
     storage_dead(@12)
     storage_dead(@11)
     return
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 (Slice<T>)) -> &'_0 (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 ([T])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 (Slice<T>); // return
+    let @0: &'0 ([T]); // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 (Slice<T>); // arg #2
+    let slice@2: &'0 ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: *const Slice<T>; // anonymous local
-    let @10: *const Slice<T>; // anonymous local
+    let @9: *const [T]; // anonymous local
+    let @10: *const [T]; // anonymous local
     let @11: !; // anonymous local
     let @12: usize; // anonymous local
     let @13: bool; // anonymous local
@@ -770,9 +770,9 @@ where
             @10 := &raw const *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@15)
             storage_live(@16)
-            @15 := cast<*const Slice<T>, *const T>(copy (@10))
+            @15 := cast<*const [T], *const T>(copy (@10))
             @16 := copy (@15) offset copy (rhs@5)
-            @9 := @PtrFromPartsShared<'_, Slice<T>>(copy (@16), copy (new_len@6))
+            @9 := @PtrFromPartsShared<'_, [T]>(copy (@16), copy (new_len@6))
             storage_dead(@16)
             storage_dead(@15)
             storage_dead(@10)
@@ -791,22 +791,22 @@ where
     @11 := slice_index_fail(move (rhs@5), move (self@4), move (@12))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut (Slice<T>)) -> &'_0 mut (Slice<T>)
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(@1: Range<usize>[{built_in impl Sized for usize}], @2: &'_0 mut ([T])) -> &'_0 mut ([T])
 where
     [@TraitClause0]: Sized<T>,
 {
-    let @0: &'0 mut (Slice<T>); // return
+    let @0: &'0 mut ([T]); // return
     let self@1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice@2: &'0 mut (Slice<T>); // arg #2
+    let slice@2: &'0 mut ([T]); // arg #2
     let @3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let self@4: usize; // local
     let rhs@5: usize; // local
     let new_len@6: usize; // local
     let @7: bool; // anonymous local
     let @8: usize; // anonymous local
-    let @9: *mut Slice<T>; // anonymous local
-    let ptr@10: *mut Slice<T>; // local
+    let @9: *mut [T]; // anonymous local
+    let ptr@10: *mut [T]; // local
     let @11: !; // anonymous local
     let @12: usize; // anonymous local
     let @13: bool; // anonymous local
@@ -843,9 +843,9 @@ where
             ptr@10 := &raw mut *(slice@2) with_metadata(copy (slice@2.metadata))
             storage_live(@15)
             storage_live(@16)
-            @15 := cast<*mut Slice<T>, *mut T>(copy (ptr@10))
+            @15 := cast<*mut [T], *mut T>(copy (ptr@10))
             @16 := copy (@15) offset copy (rhs@5)
-            @9 := @PtrFromPartsMut<'_, Slice<T>>(copy (@16), copy (new_len@6))
+            @9 := @PtrFromPartsMut<'_, [T]>(copy (@16), copy (new_len@6))
             storage_dead(@16)
             storage_dead(@15)
             storage_dead(ptr@10)
@@ -864,23 +864,23 @@ where
     @11 := slice_index_fail(move (rhs@5), move (self@4), move (@12))
 }
 
-// Full name: core::slice::index::{impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}
-impl<T> SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}
+impl<T> SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
     parent_clause1 = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for Slice<T>}
-    parent_clause3 = {built_in impl MetaSized for Slice<T>}
-    type Output = Slice<T>
-    fn get<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    parent_clause2 = {built_in impl MetaSized for [T]}
+    parent_clause3 = {built_in impl MetaSized for [T]}
+    type Output = [T]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
+    vtable: {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
 }
 
 fn UNIT_METADATA()
@@ -897,15 +897,15 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let array@1: Array<i32, 6 : usize>; // local
-    let slice@2: &'0 (Slice<i32>); // local
-    let @3: &'0 (Slice<i32>); // anonymous local
-    let @4: &'1 (Array<i32, 6 : usize>); // anonymous local
+    let array@1: [i32; 6 : usize]; // local
+    let slice@2: &'0 ([i32]); // local
+    let @3: &'0 ([i32]); // anonymous local
+    let @4: &'1 ([i32; 6 : usize]); // anonymous local
     let @5: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let @6: bool; // anonymous local
     let @7: i32; // anonymous local
     let @8: usize; // anonymous local
-    let @9: &'_ (Slice<i32>); // anonymous local
+    let @9: &'_ ([i32]); // anonymous local
     let @10: &'_ (i32); // anonymous local
 
     @0 := ()
@@ -917,7 +917,7 @@ fn main()
     @4 := &array@1
     storage_live(@5)
     @5 := Range { start: const (2 : usize), end: const (5 : usize) }
-    @3 := {impl Index<I> for Array<T, N>}::index<'_, i32, Range<usize>[{built_in impl Sized for usize}], 6 : usize>[{built_in impl Sized for i32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I> for Slice<T>}<i32, Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for i32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<Slice<T>> for Range<usize>[{built_in impl Sized for usize}]}<i32>[{built_in impl Sized for i32}]]](move (@4), move (@5))
+    @3 := {impl Index<I> for [T; N]}::index<'_, i32, Range<usize>[{built_in impl Sized for usize}], 6 : usize>[{built_in impl Sized for i32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Index<I> for [T]}<i32, Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for i32}, {built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}<i32>[{built_in impl Sized for i32}]]](move (@4), move (@5))
     storage_dead(@5)
     storage_dead(@4)
     slice@2 := &*(@3) with_metadata(copy (@3.metadata))

--- a/charon/tests/ui/start_from.out
+++ b/charon/tests/ui/start_from.out
@@ -82,7 +82,7 @@ where
     T : 'a,
 
 // Full name: core::slice::iter::{Iter<'a, T>[@TraitClause0]}::as_slice
-pub fn as_slice<'a, '_1, T>(@1: &'_1 (Iter<'a, T>[@TraitClause0])) -> &'a (Slice<T>)
+pub fn as_slice<'a, '_1, T>(@1: &'_1 (Iter<'a, T>[@TraitClause0])) -> &'a ([T])
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>

--- a/charon/tests/ui/stealing.out
+++ b/charon/tests/ui/stealing.out
@@ -11,9 +11,9 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = @Fun0()
 
 // Full name: test_crate::SLICE
-fn SLICE() -> Array<(), 4 : usize>
+fn SLICE() -> [(); 4 : usize]
 {
-    let @0: Array<(), 4 : usize>; // return
+    let @0: [(); 4 : usize]; // return
     let @1: (); // anonymous local
 
     storage_live(@1)
@@ -24,7 +24,7 @@ fn SLICE() -> Array<(), 4 : usize>
 }
 
 // Full name: test_crate::SLICE
-static SLICE: Array<(), 4 : usize> = SLICE()
+static SLICE: [(); 4 : usize] = SLICE()
 
 // Full name: test_crate::four
 fn four() -> usize
@@ -39,9 +39,9 @@ fn four() -> usize
 }
 
 // Full name: test_crate::BAR
-fn BAR() -> Array<(), 42 : usize>
+fn BAR() -> [(); 42 : usize]
 {
-    let @0: Array<(), 42 : usize>; // return
+    let @0: [(); 42 : usize]; // return
     let @1: (); // anonymous local
 
     storage_live(@1)
@@ -52,7 +52,7 @@ fn BAR() -> Array<(), 42 : usize>
 }
 
 // Full name: test_crate::BAR
-const BAR: Array<(), 42 : usize> = BAR()
+const BAR: [(); 42 : usize] = BAR()
 
 // Full name: test_crate::FOO
 fn FOO() -> usize

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -130,13 +130,13 @@ fn FOO() -> &'static (Str)
 static FOO: &'static (Str) = FOO()
 
 // Full name: test_crate::BAR
-fn BAR() -> &'static (Slice<u8>)
+fn BAR() -> &'static ([u8])
 {
-    let @0: &'0 (Slice<u8>); // return
-    let @1: &'1 (Array<u8, 5 : usize>); // anonymous local
-    let @2: &'1 (Array<u8, 5 : usize>); // anonymous local
-    let @3: Array<u8, 5 : usize>; // anonymous local
-    let @4: &'1 (Array<u8, 5 : usize>); // anonymous local
+    let @0: &'0 ([u8]); // return
+    let @1: &'1 ([u8; 5 : usize]); // anonymous local
+    let @2: &'1 ([u8; 5 : usize]); // anonymous local
+    let @3: [u8; 5 : usize]; // anonymous local
+    let @4: &'1 ([u8; 5 : usize]); // anonymous local
 
     storage_live(@1)
     storage_live(@2)
@@ -153,7 +153,7 @@ fn BAR() -> &'static (Slice<u8>)
 }
 
 // Full name: test_crate::BAR
-static BAR: &'static (Slice<u8>) = BAR()
+static BAR: &'static ([u8]) = BAR()
 
 // Full name: test_crate::main
 fn main()

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -807,7 +807,7 @@ where
     [@TraitClause0]: WithConstTy<Self, LEN>,
  = LEN2()
 
-pub fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(@1: &'_0 mut (@TraitClause0::W), @2: &'_1 (Array<u8, LEN>))
+pub fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(@1: &'_0 mut (@TraitClause0::W), @2: &'_1 ([u8; LEN]))
 where
     [@TraitClause0]: WithConstTy<Self, LEN>,
 = <method_without_default_body>
@@ -825,11 +825,11 @@ pub fn LEN1() -> usize
 pub const LEN1: usize = LEN1()
 
 // Full name: test_crate::{impl WithConstTy<32 : usize> for bool}::f
-pub fn {impl WithConstTy<32 : usize> for bool}::f<'_0, '_1>(@1: &'_0 mut (u64), @2: &'_1 (Array<u8, 32 : usize>))
+pub fn {impl WithConstTy<32 : usize> for bool}::f<'_0, '_1>(@1: &'_0 mut (u64), @2: &'_1 ([u8; 32 : usize]))
 {
     let @0: (); // return
     let @1: &'0 mut (u64); // arg #1
-    let @2: &'1 (Array<u8, 32 : usize>); // arg #2
+    let @2: &'1 ([u8; 32 : usize]); // arg #2
 
     @0 := ()
     @0 := ()
@@ -1235,8 +1235,8 @@ pub trait Trait<Self>
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait for Array<T, N>}::LEN
-pub fn {impl Trait for Array<T, N>}::LEN<T, const N : usize>() -> usize
+// Full name: test_crate::{impl Trait for [T; N]}::LEN
+pub fn {impl Trait for [T; N]}::LEN<T, const N : usize>() -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1246,19 +1246,19 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait for Array<T, N>}::LEN
-pub const {impl Trait for Array<T, N>}::LEN<T, const N : usize>: usize
+// Full name: test_crate::{impl Trait for [T; N]}::LEN
+pub const {impl Trait for [T; N]}::LEN<T, const N : usize>: usize
 where
     [@TraitClause0]: Sized<T>,
- = {impl Trait for Array<T, N>}::LEN()
+ = {impl Trait for [T; N]}::LEN()
 
-// Full name: test_crate::{impl Trait for Array<T, N>}
-impl<T, const N : usize> Trait for Array<T, N>
+// Full name: test_crate::{impl Trait for [T; N]}
+impl<T, const N : usize> Trait for [T; N]
 where
     [@TraitClause0]: Sized<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for Array<T, N>}
-    const LEN = {impl Trait for Array<T, N>}::LEN<T, N>[@TraitClause0]
+    parent_clause0 = {built_in impl MetaSized for [T; N]}
+    const LEN = {impl Trait for [T; N]}::LEN<T, N>[@TraitClause0]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -97,43 +97,43 @@ where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
 
-// Full name: alloc::slice::{impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
-pub fn {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(@1: &'_0 (Vec<T>[@TraitClause0, @TraitClause1])) -> &'_0 (Slice<T>)
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
+pub fn {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(@1: &'_0 (Vec<T>[@TraitClause0, @TraitClause1])) -> &'_0 ([T])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
 = <opaque>
 
-// Full name: alloc::slice::{impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}
+impl<T, A> Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
 {
     parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl MetaSized for Slice<T>}
-    fn borrow<'_0_1> = {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
+    parent_clause1 = {built_in impl MetaSized for [T]}
+    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
+    vtable: {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
 }
 
-// Full name: alloc::slice::{impl ToOwned for Slice<T>}::to_owned
-pub fn {impl ToOwned for Slice<T>}::to_owned<'_0, T>(@1: &'_0 (Slice<T>)) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+// Full name: alloc::slice::{impl ToOwned for [T]}::to_owned
+pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(@1: &'_0 ([T])) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
 = <opaque>
 
-// Full name: alloc::slice::{impl ToOwned for Slice<T>}
-impl<T> ToOwned for Slice<T>
+// Full name: alloc::slice::{impl ToOwned for [T]}
+impl<T> ToOwned for [T]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
 {
-    parent_clause0 = {built_in impl MetaSized for Slice<T>}
+    parent_clause0 = {built_in impl MetaSized for [T]}
     parent_clause1 = {built_in impl Sized for Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}
-    parent_clause2 = {impl Borrow<Slice<T>> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
+    parent_clause2 = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
     type Owned = Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
-    fn to_owned<'_0_1> = {impl ToOwned for Slice<T>}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
+    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
     non-dyn-compatible
 }
 
@@ -159,12 +159,12 @@ where
 pub type Generic2<'a, T>
 where
     [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>, = Cow<'a, Slice<T>>[{built_in impl MetaSized for Slice<T>}, {impl ToOwned for Slice<T>}<T>[@TraitClause0, @TraitClause1]]
+    [@TraitClause1]: Clone<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[@TraitClause0, @TraitClause1]]
 
 // Full name: test_crate::GenericWithoutBound
 pub type GenericWithoutBound<'a, T>
 where
-    [@TraitClause0]: Sized<T>, = Cow<'a, Slice<T>>[{built_in impl MetaSized for Slice<T>}, UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
+    [@TraitClause0]: Sized<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, UNKNOWN(Could not find a clause for `Binder { value: <[T] as std::borrow::ToOwned>, bound_vars: [] }` in the current context: `Unimplemented`)]
 
 
 

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -50,7 +50,7 @@ pub opaque type Arguments<'a>
 pub opaque type Argument<'a>
 
 // Full name: core::fmt::{Arguments<'a>}::new
-pub unsafe fn new<'a, const N : usize, const M : usize>(@1: &'a (Array<u8, N>), @2: &'a (Array<Argument<'a>, M>)) -> Arguments<'a>
+pub unsafe fn new<'a, const N : usize, const M : usize>(@1: &'a ([u8; N]), @2: &'a ([Argument<'a>; M])) -> Arguments<'a>
 = <opaque>
 
 // Full name: core::result::Result
@@ -166,15 +166,15 @@ where
     let args@3: (&'1 (U)); // local
     let @4: &'1 (U); // anonymous local
     let @5: U; // anonymous local
-    let args@6: Array<Argument<'2>, 1 : usize>; // local
+    let args@6: [Argument<'2>; 1 : usize]; // local
     let @7: Argument<'2>; // anonymous local
     let @8: &'1 (U); // anonymous local
-    let @9: &'3 (Array<u8, 4 : usize>); // anonymous local
-    let @10: &'3 (Array<u8, 4 : usize>); // anonymous local
-    let @11: &'4 (Array<Argument<'2>, 1 : usize>); // anonymous local
-    let @12: &'4 (Array<Argument<'2>, 1 : usize>); // anonymous local
-    let @13: Array<u8, 4 : usize>; // anonymous local
-    let @14: &'3 (Array<u8, 4 : usize>); // anonymous local
+    let @9: &'3 ([u8; 4 : usize]); // anonymous local
+    let @10: &'3 ([u8; 4 : usize]); // anonymous local
+    let @11: &'4 ([Argument<'2>; 1 : usize]); // anonymous local
+    let @12: &'4 ([Argument<'2>; 1 : usize]); // anonymous local
+    let @13: [u8; 4 : usize]; // anonymous local
+    let @14: &'3 ([u8; 4 : usize]); // anonymous local
 
     @0 := ()
     storage_live(@1)

--- a/charon/tests/ui/unions.out
+++ b/charon/tests/ui/unions.out
@@ -13,7 +13,7 @@ const UNIT_METADATA: () = @Fun0()
 // Full name: test_crate::Foo
 union Foo {
   one: u64,
-  two: Array<u32, 2 : usize>,
+  two: [u32; 2 : usize],
 }
 
 // Full name: test_crate::use_union
@@ -21,7 +21,7 @@ fn use_union()
 {
     let @0: (); // return
     let one@1: Foo; // local
-    let _two@2: Array<u32, 2 : usize>; // local
+    let _two@2: [u32; 2 : usize]; // local
 
     @0 := ()
     storage_live(one@1)

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -206,7 +206,7 @@ where
 = <opaque>
 
 // Full name: core::hash::Hasher::write
-pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 (Slice<u8>))
+pub fn write<'_0, '_1, Self>(@1: &'_0 mut (Self), @2: &'_1 ([u8]))
 where
     [@TraitClause0]: Hasher<Self>,
 = <opaque>
@@ -393,7 +393,7 @@ fn access_mutable_static()
 // Full name: test_crate::Foo
 union Foo {
   one: u64,
-  two: Array<u32, 2 : usize>,
+  two: [u32; 2 : usize],
 }
 
 // Full name: test_crate::access_union_field
@@ -401,7 +401,7 @@ fn access_union_field()
 {
     let @0: (); // return
     let one@1: Foo; // local
-    let _two@2: Array<u32, 2 : usize>; // local
+    let _two@2: [u32; 2 : usize]; // local
 
     @0 := ()
     storage_live(one@1)

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -177,16 +177,16 @@ const UNIT_METADATA: () = @Fun0()
 fn foo()
 {
     let @0: (); // return
-    let array@1: Array<i32, 2 : usize>; // local
-    let @2: &'0 (Slice<i32>); // anonymous local
-    let @3: &'1 (Array<i32, 2 : usize>); // anonymous local
-    let @4: &'1 (Array<i32, 2 : usize>); // anonymous local
-    let @5: alloc::boxed::Box<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]; // anonymous local
-    let @6: alloc::boxed::Box<Array<i32, 2 : usize>>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}]; // anonymous local
-    let @7: Array<i32, 2 : usize>; // anonymous local
-    let @8: Rc<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]; // anonymous local
-    let @9: Rc<Array<i32, 2 : usize>>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}]; // anonymous local
-    let @10: Array<i32, 2 : usize>; // anonymous local
+    let array@1: [i32; 2 : usize]; // local
+    let @2: &'0 ([i32]); // anonymous local
+    let @3: &'1 ([i32; 2 : usize]); // anonymous local
+    let @4: &'1 ([i32; 2 : usize]); // anonymous local
+    let @5: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
+    let @6: alloc::boxed::Box<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let @7: [i32; 2 : usize]; // anonymous local
+    let @8: Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
+    let @9: Rc<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let @10: [i32; 2 : usize]; // anonymous local
     let string@11: String; // local
     let @12: &'2 ((dyn Display + '3)); // anonymous local
     let @13: &'4 (String); // anonymous local
@@ -216,23 +216,23 @@ fn foo()
     storage_live(@6)
     storage_live(@7)
     @7 := copy (array@1)
-    @6 := @BoxNew<Array<i32, 2 : usize>>[{built_in impl Sized for Array<i32, 2 : usize>}](move (@7))
-    @5 := unsize_cast<alloc::boxed::Box<Array<i32, 2 : usize>>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}], alloc::boxed::Box<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}], 2 : usize>(move (@6))
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Array<i32, 2 : usize>, Global>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}]] @6
+    @6 := @BoxNew<[i32; 2 : usize]>[{built_in impl Sized for [i32; 2 : usize]}](move (@7))
+    @5 := unsize_cast<alloc::boxed::Box<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2 : usize>(move (@6))
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] @6
     storage_dead(@7)
     storage_dead(@6)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<Slice<i32>, Global>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]] @5
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] @5
     storage_dead(@5)
     storage_live(@8)
     storage_live(@9)
     storage_live(@10)
     @10 := copy (array@1)
-    @9 := alloc::rc::{Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new<Array<i32, 2 : usize>>[{built_in impl Sized for Array<i32, 2 : usize>}](move (@10))
-    @8 := unsize_cast<Rc<Array<i32, 2 : usize>>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}], Rc<Slice<i32>>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]>(move (@9))
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}<Array<i32, 2 : usize>, Global>[{built_in impl MetaSized for Array<i32, 2 : usize>}, {built_in impl Sized for Global}]] @9
+    @9 := alloc::rc::{Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new<[i32; 2 : usize]>[{built_in impl Sized for [i32; 2 : usize]}](move (@10))
+    @8 := unsize_cast<Rc<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]>(move (@9))
+    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] @9
     storage_dead(@10)
     storage_dead(@9)
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}<Slice<i32>, Global>[{built_in impl MetaSized for Slice<i32>}, {built_in impl Sized for Global}]] @8
+    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] @8
     storage_dead(@8)
     storage_live(string@11)
     string@11 := alloc::string::{String}::new()

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -422,9 +422,9 @@ where
     vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
 }
 
-// Full name: core::slice::{Slice<T>}::iter
+// Full name: core::slice::{[T]}::iter
 #[lang_item("slice_iter")]
-pub fn iter<'_0, T>(@1: &'_0 (Slice<T>)) -> Iter<'_0, T>[@TraitClause0]
+pub fn iter<'_0, T>(@1: &'_0 ([T])) -> Iter<'_0, T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 = <opaque>
@@ -443,16 +443,16 @@ const UNIT_METADATA: () = @Fun0()
 fn main()
 {
     let @0: (); // return
-    let slice@1: &'0 (Slice<i32>); // local
-    let @2: &'1 (Array<i32, 1 : usize>); // anonymous local
-    let @3: &'1 (Array<i32, 1 : usize>); // anonymous local
+    let slice@1: &'0 ([i32]); // local
+    let @2: &'1 ([i32; 1 : usize]); // anonymous local
+    let @3: &'1 ([i32; 1 : usize]); // anonymous local
     let @4: Option<&'2 (i32)>[{built_in impl Sized for &'2 (i32)}]; // anonymous local
     let @5: &'5 mut (Iter<'6, i32>[{built_in impl Sized for i32}]); // anonymous local
     let @6: Iter<'6, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let @7: &'0 (Slice<i32>); // anonymous local
-    let @8: &'1 (Array<i32, 1 : usize>); // anonymous local
-    let @9: &'_ (Array<i32, 1 : usize>); // anonymous local
-    let @10: Array<i32, 1 : usize>; // anonymous local
+    let @7: &'0 ([i32]); // anonymous local
+    let @8: &'1 ([i32; 1 : usize]); // anonymous local
+    let @9: &'_ ([i32; 1 : usize]); // anonymous local
+    let @10: [i32; 1 : usize]; // anonymous local
 
     storage_live(@9)
     storage_live(@10)


### PR DESCRIPTION
This was discussed IRL at some point and wanted to get it done :)
Changed representation of arrays and slices to not use `TyKind::Adt`, and instead just be `TyKind::Array(_, _)` and `TyKind::Slice(_, _)`

Right now tests fail because of mismatches trait clauses with arrays/slices, I'm not exactly sure what part of `typecheck_and_unify.rs` handles it, I tried having a look and couldn't see anything suspicious. The errors look like
```
error: Type error after transformations:
       Mismatched trait clause:
       expected: [@TraitClause0]: MetaSized<missing(@TypeBound(1, 0))>
            got: {built_in impl MetaSized for [u32; 2 : usize]}: MetaSized<[u32; 2 : usize]>
       Visitor stack:
         charon_lib::ast::types::TraitRef
         charon_lib::ids::index_map::IndexMap<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::TraitRef>
         charon_lib::ast::types::GenericArgs
         alloc::boxed::Box<charon_lib::ast::types::GenericArgs>
         charon_lib::ast::expressions::FnPtr
         charon_lib::ast::gast::FnOperand
         charon_lib::ast::gast::Call
         charon_lib::ast::llbc_ast::StatementKind
         charon_lib::ast::llbc_ast::Statement
         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
         charon_lib::ast::llbc_ast::Block
         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
         charon_lib::ast::gast::Body
         charon_lib::ast::gast::FunDecl
       Binding stack (depth 1):
         0:
 --> tests/ui/simple/ptr-from-raw-parts.rs:8:27
  |
8 |     let _: *const [u32] = core::ptr::from_raw_parts(&raw const a, 2);
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```