### PR TITLE
Substitute const expressions in OCaml

### DIFF
--- a/charon-ml/src/ExpressionsUtils.ml
+++ b/charon-ml/src/ExpressionsUtils.ml
@@ -1,3 +1,4 @@
+open Types
 open Expressions
 
 let unop_can_fail : unop -> bool = function
@@ -13,3 +14,9 @@ let binop_can_fail : binop -> bool = function
   | Shr OWrap
   | AddChecked | SubChecked | MulChecked | Cmp -> false
   | Div _ | Rem _ | Add _ | Sub _ | Mul _ | Shl _ | Shr _ | Offset -> true
+
+let constant_expr_of_const_generic : const_generic -> constant_expr_kind =
+  function
+  | CgGlobal g -> CGlobal { id = g; generics = TypesUtils.empty_generic_args }
+  | CgVar v -> CVar v
+  | CgValue c -> CLiteral c

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -5,6 +5,7 @@ open Types
 open TypesUtils
 open GAstUtils
 open Expressions
+open ExpressionsUtils
 open LlbcAst
 
 (* TODO: use Core.Fn.compose *)
@@ -197,6 +198,10 @@ let st_substitute_visitor =
     method! visit_RVar (subst : subst) var = subst.r_subst var
     method! visit_TVar (subst : subst) var = subst.ty_subst var
     method! visit_CgVar (subst : subst) var = subst.cg_subst var
+
+    method! visit_CVar (subst : subst) var =
+      constant_expr_of_const_generic @@ subst.cg_subst var
+
     method! visit_Clause (subst : subst) var = subst.tr_subst var
     method! visit_Self (subst : subst) = subst.tr_self
   end


### PR DESCRIPTION
In `Substitute.ml`, we were missing the substitution of `constant_expr_kind`. I added it and a small conversion function from `const_generic` to `constant_expression_kind`, akin to what is done on the Rust side https://github.com/AeneasVerif/charon/blob/e315e4e90fd0bc93a9cb1f7dfd530624ff4180cf/charon/src/ast/expressions_utils.rs#L222-L233