### PR TITLE
Only consider switch exits within the same loop as the switch entry

### DIFF
--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -622,152 +622,152 @@ fn f2<'_0, '_1>(@1: &'_0 [u8], @2: &'_1 mut [i16]) -> usize
         storage_dead(_9)
         match _8 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(bytes_11)
-                bytes_11 = copy (_8 as variant Option::Some).0
-                storage_live(b1_12)
-                storage_live(_13)
-                storage_live(_14)
-                _14 = const 0 : usize
-                storage_live(_49)
-                _49 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
-                storage_live(_50)
-                _50 = @SliceIndexShared<'_, u8>(move _49, copy _14)
-                _13 = copy (*_50)
-                b1_12 = cast<u8, i16>(move _13)
-                storage_dead(_13)
-                storage_dead(_14)
-                storage_live(b2_15)
-                storage_live(_16)
-                storage_live(_17)
-                _17 = const 1 : usize
-                storage_live(_51)
-                _51 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
-                storage_live(_52)
-                _52 = @SliceIndexShared<'_, u8>(move _51, copy _17)
-                _16 = copy (*_52)
-                b2_15 = cast<u8, i16>(move _16)
-                storage_dead(_16)
-                storage_dead(_17)
-                storage_live(b3_18)
-                storage_live(_19)
-                storage_live(_20)
-                _20 = const 2 : usize
-                storage_live(_53)
-                _53 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
-                storage_live(_54)
-                _54 = @SliceIndexShared<'_, u8>(move _53, copy _20)
-                _19 = copy (*_54)
-                b3_18 = cast<u8, i16>(move _19)
-                storage_dead(_19)
-                storage_dead(_20)
-                storage_live(d1_21)
-                storage_live(_22)
-                storage_live(_23)
-                storage_live(_24)
-                _24 = copy b2_15
-                _23 = move _24 & const 15 : i16
-                storage_dead(_24)
-                _22 = move _23 panic.<< const 8 : i32
-                storage_dead(_23)
-                storage_live(_25)
-                _25 = copy b1_12
-                d1_21 = move _22 | move _25
-                storage_dead(_25)
-                storage_dead(_22)
-                storage_live(d2_26)
-                storage_live(_27)
-                storage_live(_28)
-                _28 = copy b3_18
-                _27 = move _28 panic.<< const 4 : i32
-                storage_dead(_28)
-                storage_live(_29)
-                storage_live(_30)
-                _30 = copy b2_15
-                _29 = move _30 panic.>> const 4 : i32
-                storage_dead(_30)
-                d2_26 = move _27 | move _29
-                storage_dead(_29)
-                storage_dead(_27)
-                storage_live(_31)
-                storage_live(_32)
-                _32 = copy d1_21
-                _31 = move _32 < copy FIELD_MODULUS
-                if move _31 {
-                    storage_dead(_32)
-                    storage_live(_33)
-                    storage_live(_34)
-                    _34 = copy sampled_3
-                    _33 = move _34 < const 16 : usize
-                    if move _33 {
-                        storage_dead(_34)
-                        storage_live(_35)
-                        _35 = copy d1_21
-                        storage_live(_36)
-                        _36 = copy sampled_3
-                        storage_live(_45)
-                        _45 = &mut (*result_2) with_metadata(copy result_2.metadata)
-                        storage_live(_46)
-                        _46 = @SliceIndexMut<'_, i16>(move _45, copy _36)
-                        (*_46) = move _35
-                        storage_dead(_35)
-                        storage_dead(_36)
-                        _37 = copy sampled_3 panic.+ const 1 : usize
-                        sampled_3 = move _37
-                    } else {
-                        storage_dead(_34)
-                    }
-                } else {
-                    storage_dead(_32)
-                }
-                storage_dead(_33)
-                storage_dead(_31)
-                storage_live(_38)
-                storage_live(_39)
-                _39 = copy d2_26
-                _38 = move _39 < copy FIELD_MODULUS
-                if move _38 {
-                    storage_dead(_39)
-                    storage_live(_40)
-                    storage_live(_41)
-                    _41 = copy sampled_3
-                    _40 = move _41 < const 16 : usize
-                    if move _40 {
-                        storage_dead(_41)
-                        storage_live(_42)
-                        _42 = copy d2_26
-                        storage_live(_43)
-                        _43 = copy sampled_3
-                        storage_live(_47)
-                        _47 = &mut (*result_2) with_metadata(copy result_2.metadata)
-                        storage_live(_48)
-                        _48 = @SliceIndexMut<'_, i16>(move _47, copy _43)
-                        (*_48) = move _42
-                        storage_dead(_42)
-                        storage_dead(_43)
-                        _44 = copy sampled_3 panic.+ const 1 : usize
-                        sampled_3 = move _44
-                    } else {
-                        storage_dead(_41)
-                    }
-                } else {
-                    storage_dead(_39)
-                }
-                storage_dead(_40)
-                storage_dead(_38)
-                storage_dead(d2_26)
-                storage_dead(d1_21)
-                storage_dead(b3_18)
-                storage_dead(b2_15)
-                storage_dead(b1_12)
-                storage_dead(bytes_11)
-                storage_dead(_10)
-                storage_dead(_8)
-                continue 0
             },
         }
-        break 0
+        storage_live(bytes_11)
+        bytes_11 = copy (_8 as variant Option::Some).0
+        storage_live(b1_12)
+        storage_live(_13)
+        storage_live(_14)
+        _14 = const 0 : usize
+        storage_live(_49)
+        _49 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
+        storage_live(_50)
+        _50 = @SliceIndexShared<'_, u8>(move _49, copy _14)
+        _13 = copy (*_50)
+        b1_12 = cast<u8, i16>(move _13)
+        storage_dead(_13)
+        storage_dead(_14)
+        storage_live(b2_15)
+        storage_live(_16)
+        storage_live(_17)
+        _17 = const 1 : usize
+        storage_live(_51)
+        _51 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
+        storage_live(_52)
+        _52 = @SliceIndexShared<'_, u8>(move _51, copy _17)
+        _16 = copy (*_52)
+        b2_15 = cast<u8, i16>(move _16)
+        storage_dead(_16)
+        storage_dead(_17)
+        storage_live(b3_18)
+        storage_live(_19)
+        storage_live(_20)
+        _20 = const 2 : usize
+        storage_live(_53)
+        _53 = &(*bytes_11) with_metadata(copy bytes_11.metadata)
+        storage_live(_54)
+        _54 = @SliceIndexShared<'_, u8>(move _53, copy _20)
+        _19 = copy (*_54)
+        b3_18 = cast<u8, i16>(move _19)
+        storage_dead(_19)
+        storage_dead(_20)
+        storage_live(d1_21)
+        storage_live(_22)
+        storage_live(_23)
+        storage_live(_24)
+        _24 = copy b2_15
+        _23 = move _24 & const 15 : i16
+        storage_dead(_24)
+        _22 = move _23 panic.<< const 8 : i32
+        storage_dead(_23)
+        storage_live(_25)
+        _25 = copy b1_12
+        d1_21 = move _22 | move _25
+        storage_dead(_25)
+        storage_dead(_22)
+        storage_live(d2_26)
+        storage_live(_27)
+        storage_live(_28)
+        _28 = copy b3_18
+        _27 = move _28 panic.<< const 4 : i32
+        storage_dead(_28)
+        storage_live(_29)
+        storage_live(_30)
+        _30 = copy b2_15
+        _29 = move _30 panic.>> const 4 : i32
+        storage_dead(_30)
+        d2_26 = move _27 | move _29
+        storage_dead(_29)
+        storage_dead(_27)
+        storage_live(_31)
+        storage_live(_32)
+        _32 = copy d1_21
+        _31 = move _32 < copy FIELD_MODULUS
+        if move _31 {
+            storage_dead(_32)
+            storage_live(_33)
+            storage_live(_34)
+            _34 = copy sampled_3
+            _33 = move _34 < const 16 : usize
+            if move _33 {
+                storage_dead(_34)
+                storage_live(_35)
+                _35 = copy d1_21
+                storage_live(_36)
+                _36 = copy sampled_3
+                storage_live(_45)
+                _45 = &mut (*result_2) with_metadata(copy result_2.metadata)
+                storage_live(_46)
+                _46 = @SliceIndexMut<'_, i16>(move _45, copy _36)
+                (*_46) = move _35
+                storage_dead(_35)
+                storage_dead(_36)
+                _37 = copy sampled_3 panic.+ const 1 : usize
+                sampled_3 = move _37
+            } else {
+                storage_dead(_34)
+            }
+        } else {
+            storage_dead(_32)
+        }
+        storage_dead(_33)
+        storage_dead(_31)
+        storage_live(_38)
+        storage_live(_39)
+        _39 = copy d2_26
+        _38 = move _39 < copy FIELD_MODULUS
+        if move _38 {
+            storage_dead(_39)
+            storage_live(_40)
+            storage_live(_41)
+            _41 = copy sampled_3
+            _40 = move _41 < const 16 : usize
+            if move _40 {
+                storage_dead(_41)
+                storage_live(_42)
+                _42 = copy d2_26
+                storage_live(_43)
+                _43 = copy sampled_3
+                storage_live(_47)
+                _47 = &mut (*result_2) with_metadata(copy result_2.metadata)
+                storage_live(_48)
+                _48 = @SliceIndexMut<'_, i16>(move _47, copy _43)
+                (*_48) = move _42
+                storage_dead(_42)
+                storage_dead(_43)
+                _44 = copy sampled_3 panic.+ const 1 : usize
+                sampled_3 = move _44
+            } else {
+                storage_dead(_41)
+            }
+        } else {
+            storage_dead(_39)
+        }
+        storage_dead(_40)
+        storage_dead(_38)
+        storage_dead(d2_26)
+        storage_dead(d1_21)
+        storage_dead(b3_18)
+        storage_dead(b2_15)
+        storage_dead(b1_12)
+        storage_dead(bytes_11)
+        storage_dead(_10)
+        storage_dead(_8)
+        continue 0
     }
     storage_dead(_10)
     storage_dead(_8)

--- a/charon/tests/ui/control-flow/loop-break.out
+++ b/charon/tests/ui/control-flow/loop-break.out
@@ -70,17 +70,18 @@ fn main()
             storage_live(_3)
             _3 = foo()
             if move _3 {
+                break 0
             } else {
                 storage_live(_4)
                 _4 = bar()
                 if move _4 {
+                    break 0
                 } else {
                     storage_dead(_4)
                     storage_dead(_3)
                     continue 0
                 }
             }
-            break 0
         }
         storage_dead(_4)
         storage_dead(_3)

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -958,22 +958,22 @@ pub fn test_loop2(@1: u32) -> u32
             _8 = copy i_2
             _7 = move _8 == const 17 : u32
             if move _7 {
-            } else {
                 storage_dead(_8)
                 storage_dead(_7)
-                storage_live(_9)
-                _9 = copy i_2
-                _10 = copy s_3 panic.+ copy _9
-                s_3 = move _10
-                storage_dead(_9)
-                _11 = copy i_2 panic.+ const 1 : u32
-                i_2 = move _11
-                storage_dead(_4)
-                continue 0
+                break 0
+            } else {
             }
             storage_dead(_8)
             storage_dead(_7)
-            break 0
+            storage_live(_9)
+            _9 = copy i_2
+            _10 = copy s_3 panic.+ copy _9
+            s_3 = move _10
+            storage_dead(_9)
+            _11 = copy i_2 panic.+ const 1 : u32
+            i_2 = move _11
+            storage_dead(_4)
+            continue 0
         } else {
             storage_dead(_6)
             storage_dead(_5)
@@ -1174,10 +1174,6 @@ pub fn test_loop4(@1: u32) -> u32
                     storage_dead(_13)
                     _11 = move _12 == const 17 : u32
                     if move _11 {
-                        storage_dead(_12)
-                        storage_dead(_11)
-                        storage_dead(_8)
-                        continue 0
                     } else {
                         storage_dead(_12)
                         storage_dead(_11)
@@ -1191,6 +1187,10 @@ pub fn test_loop4(@1: u32) -> u32
                         storage_dead(_8)
                         break 1
                     }
+                    storage_dead(_12)
+                    storage_dead(_11)
+                    storage_dead(_8)
+                    continue 0
                 } else {
                     break 0
                 }
@@ -1351,22 +1351,22 @@ pub fn test_loop6(@1: u32) -> u32
             _8 = copy i_2
             _7 = move _8 > const 3 : u32
             if move _7 {
-            } else {
                 storage_dead(_8)
                 storage_dead(_7)
-                storage_live(_9)
-                _9 = copy i_2
-                _10 = copy s_3 panic.+ copy _9
-                s_3 = move _10
-                storage_dead(_9)
-                _11 = copy i_2 panic.+ const 1 : u32
-                i_2 = move _11
-                storage_dead(_4)
-                continue 0
+                break 0
+            } else {
             }
             storage_dead(_8)
             storage_dead(_7)
-            break 0
+            storage_live(_9)
+            _9 = copy i_2
+            _10 = copy s_3 panic.+ copy _9
+            s_3 = move _10
+            storage_dead(_9)
+            _11 = copy i_2 panic.+ const 1 : u32
+            i_2 = move _11
+            storage_dead(_4)
+            continue 0
         } else {
             storage_dead(_6)
             storage_dead(_5)
@@ -1434,6 +1434,9 @@ pub fn test_loop7(@1: u32) -> u32
                 _11 = copy i_2
                 _10 = move _11 > const 3 : u32
                 if move _10 {
+                    storage_dead(_11)
+                    storage_dead(_10)
+                    break 0
                 } else {
                     storage_dead(_11)
                     storage_dead(_10)
@@ -1447,9 +1450,6 @@ pub fn test_loop7(@1: u32) -> u32
                     storage_dead(_7)
                     continue 0
                 }
-                storage_dead(_11)
-                storage_dead(_10)
-                break 0
             } else {
                 storage_dead(_9)
                 storage_dead(_8)
@@ -1634,16 +1634,16 @@ pub fn nested_loops_enum(@1: usize, @2: usize) -> usize
         storage_dead(_8)
         match _7 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                _10 = copy s_3 panic.+ const 1 : usize
-                s_3 = move _10
-                storage_dead(_9)
-                storage_dead(_7)
-                continue 0
             },
         }
-        break 0
+        _10 = copy s_3 panic.+ const 1 : usize
+        s_3 = move _10
+        storage_dead(_9)
+        storage_dead(_7)
+        continue 0
     }
     storage_dead(_9)
     storage_dead(_7)
@@ -1669,49 +1669,49 @@ pub fn nested_loops_enum(@1: usize, @2: usize) -> usize
         storage_dead(_16)
         match _15 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(_18)
-                storage_live(_19)
-                storage_live(_20)
-                _20 = copy step_in_2
-                _19 = Range { start: const 0 : usize, end: move _20 }
-                storage_dead(_20)
-                _18 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _19)
-                storage_dead(_19)
-                storage_live(iter_21)
-                iter_21 = move _18
-                loop {
-                    storage_live(_22)
-                    storage_live(_23)
-                    storage_live(_24)
-                    _24 = &mut iter_21
-                    _23 = &two-phase-mut (*_24)
-                    _22 = {impl Iterator for Range<A>[@TraitClause0]}::next<'_, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _23)
-                    storage_dead(_23)
-                    match _22 {
-                        Option::None => {
-                        },
-                        Option::Some => {
-                            _25 = copy s_3 panic.+ const 1 : usize
-                            s_3 = move _25
-                            storage_dead(_24)
-                            storage_dead(_22)
-                            continue 0
-                        },
-                    }
-                    break 0
-                }
-                storage_dead(_24)
-                storage_dead(_22)
-                storage_dead(iter_21)
-                storage_dead(_18)
-                storage_dead(_17)
-                storage_dead(_15)
-                continue 0
             },
         }
-        break 0
+        storage_live(_18)
+        storage_live(_19)
+        storage_live(_20)
+        _20 = copy step_in_2
+        _19 = Range { start: const 0 : usize, end: move _20 }
+        storage_dead(_20)
+        _18 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _19)
+        storage_dead(_19)
+        storage_live(iter_21)
+        iter_21 = move _18
+        loop {
+            storage_live(_22)
+            storage_live(_23)
+            storage_live(_24)
+            _24 = &mut iter_21
+            _23 = &two-phase-mut (*_24)
+            _22 = {impl Iterator for Range<A>[@TraitClause0]}::next<'_, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _23)
+            storage_dead(_23)
+            match _22 {
+                Option::None => {
+                    break 0
+                },
+                Option::Some => {
+                },
+            }
+            _25 = copy s_3 panic.+ const 1 : usize
+            s_3 = move _25
+            storage_dead(_24)
+            storage_dead(_22)
+            continue 0
+        }
+        storage_dead(_24)
+        storage_dead(_22)
+        storage_dead(iter_21)
+        storage_dead(_18)
+        storage_dead(_17)
+        storage_dead(_15)
+        continue 0
     }
     storage_dead(_17)
     storage_dead(_15)
@@ -1767,6 +1767,7 @@ pub fn loop_inside_if(@1: bool, @2: u32) -> u32
             storage_dead(_10)
             match _9 {
                 Option::None => {
+                    break 0
                 },
                 Option::Some => {
                     storage_live(i_12)
@@ -1782,7 +1783,6 @@ pub fn loop_inside_if(@1: bool, @2: u32) -> u32
                     continue 0
                 },
             }
-            break 0
         }
         storage_dead(_11)
         storage_dead(_9)
@@ -2003,25 +2003,25 @@ pub fn get_elem_mut<'_0>(@1: &'_0 mut List<usize>[{built_in impl Sized for usize
                 _7 = copy x_2
                 _5 = move _6 == move _7
                 if move _5 {
-                } else {
                     storage_dead(_7)
                     storage_dead(_6)
-                    storage_live(_8)
-                    _8 = &mut (*(*tl_4))
-                    ls_1 = move _8
-                    storage_dead(_8)
+                    _0 = &mut (*y_3)
                     storage_dead(_5)
                     storage_dead(tl_4)
                     storage_dead(y_3)
-                    continue 0
+                    return
+                } else {
                 }
                 storage_dead(_7)
                 storage_dead(_6)
-                _0 = &mut (*y_3)
+                storage_live(_8)
+                _8 = &mut (*(*tl_4))
+                ls_1 = move _8
+                storage_dead(_8)
                 storage_dead(_5)
                 storage_dead(tl_4)
                 storage_dead(y_3)
-                return
+                continue 0
             },
             List::Nil => {
                 panic(core::panicking::panic)
@@ -2058,25 +2058,25 @@ where
                 _6 = copy i_2
                 _5 = move _6 == const 0 : u32
                 if move _5 {
-                } else {
                     storage_dead(_6)
-                    storage_live(_7)
-                    _7 = &mut (*(*tl_4))
-                    ls_1 = move _7
-                    storage_dead(_7)
-                    _8 = copy i_2 panic.- const 1 : u32
-                    i_2 = move _8
+                    _0 = &mut (*x_3)
                     storage_dead(_5)
                     storage_dead(tl_4)
                     storage_dead(x_3)
-                    continue 0
+                    return
+                } else {
                 }
                 storage_dead(_6)
-                _0 = &mut (*x_3)
+                storage_live(_7)
+                _7 = &mut (*(*tl_4))
+                ls_1 = move _7
+                storage_dead(_7)
+                _8 = copy i_2 panic.- const 1 : u32
+                i_2 = move _8
                 storage_dead(_5)
                 storage_dead(tl_4)
                 storage_dead(x_3)
-                return
+                continue 0
             },
             _ => {
                 break 0
@@ -2218,13 +2218,13 @@ pub fn interleaved_loops2()
                 storage_live(_3)
                 _3 = const true
                 if move _3 {
+                    break 1
                 } else {
-                    storage_dead(_3)
-                    storage_dead(_2)
-                    x_1 = const 5 : i32
-                    continue 0
                 }
-                break 1
+                storage_dead(_3)
+                storage_dead(_2)
+                x_1 = const 5 : i32
+                continue 0
             }
         }
         x_1 = const 3 : i32

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -355,25 +355,25 @@ where
                 _6 = copy i_2
                 _5 = move _6 == const 0 : u32
                 if move _5 {
-                } else {
                     storage_dead(_6)
+                    _0 = &mut (*x_3)
                     storage_dead(_5)
-                    _7 = copy i_2 panic.- const 1 : u32
-                    i_2 = move _7
-                    storage_live(_8)
-                    _8 = &mut (*(*tl_4))
-                    l_1 = move _8
-                    storage_dead(_8)
                     storage_dead(tl_4)
                     storage_dead(x_3)
-                    continue 0
+                    return
+                } else {
                 }
                 storage_dead(_6)
-                _0 = &mut (*x_3)
                 storage_dead(_5)
+                _7 = copy i_2 panic.- const 1 : u32
+                i_2 = move _7
+                storage_live(_8)
+                _8 = &mut (*(*tl_4))
+                l_1 = move _8
+                storage_dead(_8)
                 storage_dead(tl_4)
                 storage_dead(x_3)
-                return
+                continue 0
             },
             _ => {
                 break 0

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -574,54 +574,54 @@ where
         storage_dead(_6)
         match _5 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(x_8)
-                x_8 = copy (_5 as variant Option::Some).0
-                storage_live(_9)
-                storage_live(_10)
-                storage_live(args_11)
-                storage_live(_12)
-                _12 = &x_8
-                args_11 = (move _12)
-                storage_dead(_12)
-                storage_live(args_13)
-                storage_live(_14)
-                storage_live(_15)
-                _15 = &(*args_11.0)
-                _14 = new_debug<'13, '_, &'2 T>[{built_in impl Sized for &'2 T}, {impl Debug for &'_0 T}<'2, T>[@TraitClause1]](move _15)
-                storage_dead(_15)
-                args_13 = [move _14]
-                storage_dead(_14)
-                storage_live(_16)
-                storage_live(_17)
-                storage_live(_20)
-                _20 = [const 2 : u8, const 45 : u8, const 32 : u8, const 192 : u8, const 1 : u8, const 10 : u8, const 0 : u8]
-                storage_live(_21)
-                _21 = &_20
-                _17 = move _21
-                _16 = &(*_17)
-                storage_live(_18)
-                storage_live(_19)
-                _19 = &args_13
-                _18 = &(*_19)
-                _10 = new<'18, 7 : usize, 1 : usize>(move _16, move _18)
-                storage_dead(_19)
-                storage_dead(_18)
-                storage_dead(_17)
-                storage_dead(_16)
-                _9 = _eprint<'_>(move _10)
-                storage_dead(_10)
-                storage_dead(args_13)
-                storage_dead(args_11)
-                storage_dead(_9)
-                storage_dead(x_8)
-                storage_dead(_7)
-                storage_dead(_5)
-                continue 0
             },
         }
-        break 0
+        storage_live(x_8)
+        x_8 = copy (_5 as variant Option::Some).0
+        storage_live(_9)
+        storage_live(_10)
+        storage_live(args_11)
+        storage_live(_12)
+        _12 = &x_8
+        args_11 = (move _12)
+        storage_dead(_12)
+        storage_live(args_13)
+        storage_live(_14)
+        storage_live(_15)
+        _15 = &(*args_11.0)
+        _14 = new_debug<'13, '_, &'2 T>[{built_in impl Sized for &'2 T}, {impl Debug for &'_0 T}<'2, T>[@TraitClause1]](move _15)
+        storage_dead(_15)
+        args_13 = [move _14]
+        storage_dead(_14)
+        storage_live(_16)
+        storage_live(_17)
+        storage_live(_20)
+        _20 = [const 2 : u8, const 45 : u8, const 32 : u8, const 192 : u8, const 1 : u8, const 10 : u8, const 0 : u8]
+        storage_live(_21)
+        _21 = &_20
+        _17 = move _21
+        _16 = &(*_17)
+        storage_live(_18)
+        storage_live(_19)
+        _19 = &args_13
+        _18 = &(*_19)
+        _10 = new<'18, 7 : usize, 1 : usize>(move _16, move _18)
+        storage_dead(_19)
+        storage_dead(_18)
+        storage_dead(_17)
+        storage_dead(_16)
+        _9 = _eprint<'_>(move _10)
+        storage_dead(_10)
+        storage_dead(args_13)
+        storage_dead(args_11)
+        storage_dead(_9)
+        storage_dead(x_8)
+        storage_dead(_7)
+        storage_dead(_5)
+        continue 0
     }
     _0 = ()
     storage_dead(_7)

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -687,28 +687,28 @@ fn cbd(@1: [u8; 33 : usize])
         storage_dead(_6)
         match _5 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(i_8)
-                i_8 = copy (_5 as variant Option::Some).0
-                storage_live(_9)
-                _9 = copy i_8
-                storage_live(_10)
-                _10 = const 0 : usize
-                storage_live(_11)
-                _11 = &mut prf_input_1
-                storage_live(_12)
-                _12 = @ArrayIndexMut<'_, u8, 33 : usize>(move _11, copy _10)
-                (*_12) = move _9
-                storage_dead(_9)
-                storage_dead(_10)
-                storage_dead(i_8)
-                storage_dead(_7)
-                storage_dead(_5)
-                continue 0
             },
         }
-        break 0
+        storage_live(i_8)
+        i_8 = copy (_5 as variant Option::Some).0
+        storage_live(_9)
+        _9 = copy i_8
+        storage_live(_10)
+        _10 = const 0 : usize
+        storage_live(_11)
+        _11 = &mut prf_input_1
+        storage_live(_12)
+        _12 = @ArrayIndexMut<'_, u8, 33 : usize>(move _11, copy _10)
+        (*_12) = move _9
+        storage_dead(_9)
+        storage_dead(_10)
+        storage_dead(i_8)
+        storage_dead(_7)
+        storage_dead(_5)
+        continue 0
     }
     _0 = ()
     storage_dead(_7)

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -5253,22 +5253,22 @@ fn main()
         storage_dead(_8)
         match _7 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(v_10)
-                v_10 = copy (_7 as variant Option::Some).0
-                storage_live(_11)
-                _11 = copy v_10
-                _12 = copy i_2 panic.+ copy _11
-                i_2 = move _12
-                storage_dead(_11)
-                storage_dead(v_10)
-                storage_dead(_9)
-                storage_dead(_7)
-                continue 0
             },
         }
-        break 0
+        storage_live(v_10)
+        v_10 = copy (_7 as variant Option::Some).0
+        storage_live(_11)
+        _11 = copy v_10
+        _12 = copy i_2 panic.+ copy _11
+        i_2 = move _12
+        storage_dead(_11)
+        storage_dead(v_10)
+        storage_dead(_9)
+        storage_dead(_7)
+        continue 0
     }
     storage_dead(_9)
     storage_dead(_7)
@@ -5299,26 +5299,26 @@ fn main()
         storage_dead(_19)
         match _18 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(v_21)
-                v_21 = copy (_18 as variant Option::Some).0
-                storage_live(_22)
-                storage_live(_23)
-                _23 = &two-phase-mut i_2
-                storage_live(_24)
-                _24 = copy v_21
-                _22 = {impl AddAssign<&'_0 i32> for i32}::add_assign<'23, '_>(move _23, move _24)
-                storage_dead(_24)
-                storage_dead(_23)
-                storage_dead(_22)
-                storage_dead(v_21)
-                storage_dead(_20)
-                storage_dead(_18)
-                continue 0
             },
         }
-        break 0
+        storage_live(v_21)
+        v_21 = copy (_18 as variant Option::Some).0
+        storage_live(_22)
+        storage_live(_23)
+        _23 = &two-phase-mut i_2
+        storage_live(_24)
+        _24 = copy v_21
+        _22 = {impl AddAssign<&'_0 i32> for i32}::add_assign<'23, '_>(move _23, move _24)
+        storage_dead(_24)
+        storage_dead(_23)
+        storage_dead(_22)
+        storage_dead(v_21)
+        storage_dead(_20)
+        storage_dead(_18)
+        continue 0
     }
     storage_dead(_20)
     storage_dead(_18)
@@ -5347,16 +5347,16 @@ fn main()
         storage_dead(_31)
         match _30 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                _33 = copy i_2 panic.+ const 1 : i32
-                i_2 = move _33
-                storage_dead(_32)
-                storage_dead(_30)
-                continue 0
             },
         }
-        break 0
+        _33 = copy i_2 panic.+ const 1 : i32
+        i_2 = move _33
+        storage_dead(_32)
+        storage_dead(_30)
+        continue 0
     }
     storage_dead(_32)
     storage_dead(_30)
@@ -5385,16 +5385,16 @@ fn main()
         storage_dead(_40)
         match _39 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                _42 = copy i_2 panic.+ const 1 : i32
-                i_2 = move _42
-                storage_dead(_41)
-                storage_dead(_39)
-                continue 0
             },
         }
-        break 0
+        _42 = copy i_2 panic.+ const 1 : i32
+        i_2 = move _42
+        storage_dead(_41)
+        storage_dead(_39)
+        continue 0
     }
     storage_dead(_41)
     storage_dead(_39)

--- a/charon/tests/ui/reconstruct_early_return.out
+++ b/charon/tests/ui/reconstruct_early_return.out
@@ -63,9 +63,9 @@ fn f() -> usize
                     storage_dead(i_1)
                     return
                 } else {
-                    storage_dead(_9)
-                    storage_dead(_8)
                 }
+                storage_dead(_9)
+                storage_dead(_8)
             }
             storage_dead(_6)
             _10 = copy i_1 panic.+ const 1 : i32

--- a/charon/tests/ui/simple/range-iter.out
+++ b/charon/tests/ui/simple/range-iter.out
@@ -464,17 +464,17 @@ fn iter(@1: usize)
         storage_dead(_7)
         match _6 {
             Option::None => {
+                break 0
             },
             Option::Some => {
-                storage_live(i_9)
-                i_9 = copy (_6 as variant Option::Some).0
-                storage_dead(i_9)
-                storage_dead(_8)
-                storage_dead(_6)
-                continue 0
             },
         }
-        break 0
+        storage_live(i_9)
+        i_9 = copy (_6 as variant Option::Some).0
+        storage_dead(i_9)
+        storage_dead(_8)
+        storage_dead(_6)
+        continue 0
     }
     _0 = ()
     storage_dead(_8)


### PR DESCRIPTION
If a switch entry is inside a loop, then at least one of its branches must be inside the loop too, and we want to pick one of these as exit block. This makes use of the "within_loop" data I just introduced in https://github.com/AeneasVerif/charon/pull/976.

ci: use https://github.com/AeneasVerif/eurydice/pull/370