### PR TITLE
Fix incorrect substitutions in clause typecheck

### DIFF
--- a/charon/tests/ui/simple/min.out
+++ b/charon/tests/ui/simple/min.out
@@ -1,0 +1,50 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = drop_in_place<Self>
+    vtable: core::marker::Destruct::{vtable}
+}
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::cmp::impls::{impl Ord for u64}::min
+#[lang_item("cmp_ord_min")]
+pub fn {impl Ord for u64}::min(@1: u64, @2: u64) -> u64
+where
+    [@TraitClause0]: Sized<u64>,
+    [@TraitClause1]: Destruct<u64>,
+= <opaque>
+
+// Full name: core::marker::Destruct::drop_in_place
+unsafe fn drop_in_place<Self>(@1: *mut Self)
+= <opaque>
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let _1: u64; // anonymous local
+
+    _0 = ()
+    storage_live(_1)
+    _1 = {impl Ord for u64}::min[{built_in impl Sized for u64}, {built_in impl Destruct for u64}](const 1 : u64, const 2 : u64)
+    storage_dead(_1)
+    _0 = ()
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/min.rs
+++ b/charon/tests/ui/simple/min.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = 1u64.min(2u64);
+}


### PR DESCRIPTION
That was the cause of many spurious "mismatched clause" warnings.