### PR TITLE
lift-assoc-tys: Fix missing assoc type paths in impls

### DIFF
--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -171,6 +171,33 @@ mod trait_ref_path {
             new_ref
         }
 
+        /// Apply `self` onto a real `TraitRef`, going up through the `tref`'s parent
+        /// clauses. Returns `None` if the crate did not contain all the `TraitDecl`s we need to do
+        /// that.
+        pub fn on_real_tref(
+            &self,
+            krate: &TranslatedCrate,
+            mut tref: TraitRef,
+        ) -> Option<TraitRef> {
+            assert!(self.base.is_self_clause());
+            for &parent_id in &self.parent_path {
+                let pred = tref
+                    .trait_decl_ref
+                    .skip_binder
+                    .clone()
+                    .move_from_under_binder()?;
+                let tdecl = krate.get_item(pred.id)?;
+                let tdecl = tdecl.as_trait_decl()?;
+                let clause = &tdecl.implied_clauses[parent_id];
+                let next_pred = clause.trait_.clone().substitute(&pred.generics);
+                tref = TraitRef::new(
+                    TraitRefKind::ParentClause(Box::new(tref), parent_id),
+                    next_pred,
+                );
+            }
+            Some(tref)
+        }
+
         /// References the same clause one level up.
         pub fn pop_base(&self) -> Self {
             let mut new_ref = self.clone();
@@ -789,6 +816,7 @@ impl<'a> ComputeItemModifications<'a> {
 
     /// Returns the associated types values known for the given impl. If the impl is cyclic, the
     /// set will not be exhaustive.
+    #[tracing::instrument(skip(self))]
     fn compute_assoc_tys_for_impl(&mut self, id: TraitImplId) -> Option<&TypeConstraintSet> {
         if let CycleDetector::Unprocessed = self.impl_assoc_tys[id] {
             if let Some(timpl) = self.ctx.translated.trait_impls.get(id) {
@@ -807,92 +835,33 @@ impl<'a> ComputeItemModifications<'a> {
                 // its implied clauses.
                 for (clause_id, tref) in timpl.implied_trait_refs.iter_indexed() {
                     let clause_path = TraitRefPath::parent_clause(clause_id);
-                    for (path, ty) in self.compute_assoc_tys_for_tref(timpl.item_meta.span, tref) {
-                        let path = path.on_tref(&clause_path);
-                        set.insert_path(&path, ty);
+                    let pred = &tref.trait_decl_ref;
+                    if let Some(pred) = pred.skip_binder.clone().move_from_under_binder()
+                            // This takes a `&mut self`, so we reborrow it shared below.
+                            && let _ = self.compute_trait_modifications(pred.id)
+                            && let Some(trait_mods) = self.trait_modifications[pred.id].as_processed()
+                    {
+                        for path in trait_mods.required_extra_params() {
+                            if let Some(tref) =
+                                path.tref.on_real_tref(&self.ctx.translated, tref.clone())
+                            {
+                                // This will get normalized further by `lookup_type_replacement`.
+                                let ty = TyKind::TraitType(tref, path.type_name).into_ty();
+                                let path = path.on_tref(&clause_path);
+                                set.insert_path(&path, ty);
+                            }
+                        }
                     }
                 }
+                trace!(
+                    "compute_assoc_tys_for_impl({}) = {set:?}",
+                    timpl.def_id.with_ctx(&self.ctx.into_fmt()),
+                );
 
                 self.impl_assoc_tys[id] = CycleDetector::Processed(set);
             }
         }
         self.impl_assoc_tys[id].as_processed()
-    }
-
-    /// Returns the associated types values known for the given trait ref. E.g. for `T:
-    /// FnOnce<..>`, we get `Self::Output = ...`. The returned trait refs should be based on
-    /// `Self`.
-    fn compute_assoc_tys_for_tref(
-        &mut self,
-        span: Span,
-        tref: &TraitRef,
-    ) -> Vec<(AssocTypePath, Ty)> {
-        let mut tys = vec![];
-        match &tref.kind {
-            // TODO: give something here
-            TraitRefKind::Clause(..) | TraitRefKind::ParentClause(..) | TraitRefKind::SelfId => {}
-            TraitRefKind::ItemClause(..) => {}
-            TraitRefKind::TraitImpl(impl_ref) => {
-                if let Some(set_for_clause) = self.compute_assoc_tys_for_impl(impl_ref.id) {
-                    tys.extend(set_for_clause.iter_self_paths_subst(&impl_ref.generics));
-                }
-            }
-            TraitRefKind::BuiltinOrAuto {
-                parent_trait_refs,
-                types,
-                ..
-            } => {
-                for (name, assoc_ty) in types.iter().cloned() {
-                    let path = TraitRefPath::self_ref().with_assoc_type(name);
-                    tys.push((path, assoc_ty.value));
-                }
-                for (parent_clause_id, parent_ref) in parent_trait_refs.iter_indexed() {
-                    let clause_path = TraitRefPath::parent_clause(parent_clause_id);
-                    tys.extend(
-                        self.compute_assoc_tys_for_tref(span, parent_ref)
-                            .into_iter()
-                            .map(|(path, ty)| {
-                                let path = path.on_tref(&clause_path);
-                                (path, ty)
-                            }),
-                    )
-                }
-            }
-            TraitRefKind::Dyn => {
-                let pred = &tref.trait_decl_ref;
-                let self_ty = pred.skip_binder.generics.types[0]
-                    .clone()
-                    .move_from_under_binder()
-                    .unwrap();
-                if !self_ty.is_error() {
-                    let TyKind::DynTrait(dyn_pred) = self_ty.kind() else {
-                        unreachable!(
-                            "`TraitRefKind::Dyn` only makes sense with a `dyn Trait` Self type"
-                        )
-                    };
-                    tys.extend(
-                        self.compute_constraint_set(&dyn_pred.binder.params)
-                            .iter()
-                            // Paths apply to the first clause of the binder, which is the one
-                            // that's being implemented. FIXME: is that true? if not, ask hax to
-                            // resolve the correct clause.
-                            .filter(|(path, _ty)| {
-                                matches!(path.tref.base, BaseClause::Local(id)
-                                    if id == DeBruijnVar::new_at_zero(TraitClauseId::ZERO))
-                            })
-                            .map(|(path, ty)| {
-                                (
-                                    path.pop_base(),
-                                    ty.move_from_under_binder()
-                                        .expect("unepected dyn type constraint"),
-                                )
-                            }),
-                    );
-                }
-            }
-            TraitRefKind::Unknown(_) => {}
-        }
-        tys
     }
 }
 
@@ -932,7 +901,16 @@ impl UpdateItemBody<'_> {
             _ => self.type_replacements.depth(),
         };
         let ty = self.type_replacements[dbid].find(&path)?;
-        Some(ty.clone().move_under_binders(dbid))
+        let mut ty = ty.clone().move_under_binders(dbid);
+        if let TyKind::TraitType(tref, name) = ty.kind() {
+            let path = TraitRefPath::self_ref().with_assoc_type(*name);
+            // Unnormalizable types may very well show up, e.g. when trait loopiness forces us to
+            // create new assoc types.
+            if let Some(new_ty) = self.lookup_path_on_trait_ref(&path, tref) {
+                ty = new_ty;
+            }
+        }
+        Some(ty)
     }
 
     fn lookup_path_on_trait_ref(&self, path: &AssocTypePath, tref: &TraitRef) -> Option<Ty> {

--- a/charon/tests/ui/simple/issue-1036-failed-assoc-ty-lifting.out
+++ b/charon/tests/ui/simple/issue-1036-failed-assoc-ty-lifting.out
@@ -1,9 +1,43 @@
-error: Could not compute the value of Self::Clause1::A (on Self) needed to update item reference test_crate::T2<@TypeBound(0, 0)>.
-       Constraints in scope:
-         - ClauseBound(0, 1)::A = @TypeBound(0, 1)
- --> tests/ui/simple/issue-1036-failed-assoc-ty-lifting.rs:8:1
-  |
-8 | impl<I: T1> T2 for I {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::T1
+trait T1<Self, Self_A>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self_A>
+    vtable: test_crate::T1::{vtable}<Self_A>
+}
+
+// Full name: test_crate::T2
+trait T2<Self, Self_Clause1_A>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: T1<Self, Self_Clause1_A>
+    vtable: test_crate::T2::{vtable}<Self_Clause1_A>
+}
+
+// Full name: test_crate::{impl T2<Clause1_A> for I}
+impl<I, Clause1_A> T2<Clause1_A> for I
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: T1<I, Clause1_A>,
+{
+    parent_clause0 = @TraitClause0::parent_clause0
+    parent_clause1 = @TraitClause1
+    vtable: {impl T2<Clause1_A> for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
+}
+
+
+

--- a/charon/tests/ui/simple/issue-1036-failed-assoc-ty-lifting.rs
+++ b/charon/tests/ui/simple/issue-1036-failed-assoc-ty-lifting.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--remove-associated-types=_
 trait T1 {
     type A;


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/charon/issues/1036.