### PR TITLE
Add timestamps to release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
+      - name: Generate Tag
+        id: tag
+        run: |
+          set -eo pipefail
+
+          # Generates a sortable timestamp: YYYY.MM.DD.HHMMSS
+          # We append the SHA for uniqueness.
+          TAG_NAME="build-$(date +'%Y.%m.%d.%H%M%S')-${{ github.sha }}"
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: build-${{ github.sha }}
+          tag_name: ${{ steps.tag.outputs.tag_name }}
           prerelease: true
           make_latest: false
           generate_release_notes: true
@@ -93,5 +105,5 @@ jobs:
       - name: Upload Artifact
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: build-${{ github.sha }}
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
           files: ${{ matrix.artifact_name }}.tar.gz


### PR DESCRIPTION
The timestamp ensures that, on the GitHub Releases page, releases are sorted in descending order of recency.