### PR TITLE
Fix an issue in the control-flow reconstruction

### DIFF
--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -639,40 +639,15 @@ impl ExitInfo {
             //     if b {
             //         loop {
             //             if b { return true; }  // bb5: dominated by loop header
-            //             break;                  // bb9→bb4: exits the loop
+            //             break;                 // bb9→bb4: exits the loop
             //         }
             //     }
-            //     false                           // bb4: NOT dominated by loop header
+            //     false                          // bb4: NOT dominated by loop header
             // }
             // ```
             //
-            // Without the filter, bb5 (`return true`) ranks higher than bb4 because it is
-            // closer to the loop header. Picking bb5 as the exit incorrectly turns `return
-            // true` into `break`, producing the following wrong reconstruction:
-            // ```
-            // fn f(b: bool) -> bool {
-            //     if b {
-            //         loop {
-            //             if b { break; }   // was `return true` — wrongly turned into break
-            //             // the actual `break` path is lost here
-            //         }
-            //     }
-            //     false
-            // }
-            // ```
-            // The filter discards bb5 (dominated) so that bb4 (not dominated) is correctly
-            // chosen, producing the correct reconstruction:
-            // ```
-            // fn f(b: bool) -> bool {
-            //     if b {
-            //         loop {
-            //             if b { return true; }  // kept as return
-            //             break;                 // correctly reconstructed
-            //         }
-            //     }
-            //     false
-            // }
-            // ```
+            // Without the filter, bb5 (`return true`) ranks higher than bb4 in the exit
+            // candidates because it is closer to the loop header.
             //
             // Note: for simple `while cond { body } after;` loops, ALL exit candidates are
             // dominated by the loop header (every path from the function entry goes through

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -958,6 +958,7 @@ enum ReconstructMode {
 }
 
 struct ReconstructCtx<'a> {
+    ctx: &'a TransformCtx,
     cfg: CfgInfo,
     body: &'a src::ExprBody,
     /// The depth of `loop` contexts we may `break`/`continue` to.
@@ -971,7 +972,7 @@ struct ReconstructCtx<'a> {
 }
 
 impl<'a> ReconstructCtx<'a> {
-    fn build(ctx: &TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
+    fn build(ctx: &'a TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
         // Compute all sorts of graph-related information about the control-flow graph, including
         // reachability, the dominator tree, loop entries, and loop/switch exits.
         let cfg = CfgInfo::build(ctx, &src_body.body)?;
@@ -980,6 +981,7 @@ impl<'a> ReconstructCtx<'a> {
         // conditional branchings.
         let allow_duplication = true;
         Ok(ReconstructCtx {
+            ctx,
             cfg,
             body: src_body,
             break_context_depth: 0,
@@ -1016,16 +1018,18 @@ impl<'a> ReconstructCtx<'a> {
     /// Translate a jump to the given block. The span is used to create the jump statement, if any.
     #[tracing::instrument(skip(self), ret, fields(stack = ?self.special_jump_stack))]
     fn translate_jump(&mut self, span: Span, target_block: src::BlockId) -> tgt::Block {
-        match self
+        // Look up target_block in the special jump stack (from the top).
+        let found = self
             .special_jump_stack
-            .iter_mut()
+            .iter()
             .rev()
             .enumerate()
             .find(|(_, j)| j.target_block == target_block)
-        {
-            Some((i, jump_target)) => {
+            .map(|(i, j)| (i, j.kind));
+        match found {
+            Some((i, target_kind)) => {
                 let mk_block = |kind| tgt::Statement::new(span, kind).into_block();
-                match jump_target.kind {
+                match target_kind {
                     // The top of the stack is where control-flow goes naturally, no need to add a
                     // `break`/`continue`.
                     SpecialJumpKind::LoopContinue(_) | SpecialJumpKind::ForwardBreak(_)
@@ -1039,7 +1043,35 @@ impl<'a> ReconstructCtx<'a> {
                     SpecialJumpKind::ForwardBreak(depth) | SpecialJumpKind::LoopBreak(depth) => {
                         mk_block(tgt::StatementKind::Break(self.break_context_depth - depth))
                     }
-                    SpecialJumpKind::NextBlock => mk_block(tgt::StatementKind::Nop),
+                    SpecialJumpKind::NextBlock => {
+                        // A NextBlock entry means "this block will be translated after the
+                        // current switch." Normally, we should generate a no-op to fall
+                        // through to the code after the switch.
+                        //
+                        // However, if there is a [LoopContinue]/[LoopBreak] between the top of
+                        // the stack and and this [NextBlock] entry, it means we are inside a loop
+                        // nested within a switch. A no-op here would mean "fall through to the
+                        // end of the loop body" (= implicit continue), which is wrong: the original
+                        // code intended to exit the loop and reach the outer continuation block.
+                        // If we fall into this case, it also means that the block we currently
+                        // want to jump to is *not* one of these loop exits, meaning we can't
+                        // insert a break. Because of this, we instead translate the target
+                        // block inline (duplicating it). This is not optimal but at least is
+                        // sound.
+                        //
+                        // Note: there is a complementary fix in `compute_loop_exits` that
+                        // uses the dominator tree to avoid picking the wrong exit in the
+                        // first place. Together, the two fixes provide defense in depth.
+                        let n = self.special_jump_stack.len();
+                        let has_intervening_loop = i > 0
+                            && self.special_jump_stack[(n - i)..n]
+                                .iter()
+                                .any(|j| matches!(j.kind, SpecialJumpKind::LoopContinue(_)));
+                        if has_intervening_loop {
+                            return self.translate_block(target_block);
+                        }
+                        mk_block(tgt::StatementKind::Nop)
+                    }
                 }
             }
             // Translate the block without a jump.

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -958,7 +958,6 @@ enum ReconstructMode {
 }
 
 struct ReconstructCtx<'a> {
-    ctx: &'a TransformCtx,
     cfg: CfgInfo,
     body: &'a src::ExprBody,
     /// The depth of `loop` contexts we may `break`/`continue` to.
@@ -972,7 +971,7 @@ struct ReconstructCtx<'a> {
 }
 
 impl<'a> ReconstructCtx<'a> {
-    fn build(ctx: &'a TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
+    fn build(ctx: &TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
         // Compute all sorts of graph-related information about the control-flow graph, including
         // reachability, the dominator tree, loop entries, and loop/switch exits.
         let cfg = CfgInfo::build(ctx, &src_body.body)?;
@@ -981,7 +980,6 @@ impl<'a> ReconstructCtx<'a> {
         // conditional branchings.
         let allow_duplication = true;
         Ok(ReconstructCtx {
-            ctx,
             cfg,
             body: src_body,
             break_context_depth: 0,
@@ -1018,18 +1016,16 @@ impl<'a> ReconstructCtx<'a> {
     /// Translate a jump to the given block. The span is used to create the jump statement, if any.
     #[tracing::instrument(skip(self), ret, fields(stack = ?self.special_jump_stack))]
     fn translate_jump(&mut self, span: Span, target_block: src::BlockId) -> tgt::Block {
-        // Look up target_block in the special jump stack (from the top).
-        let found = self
+        match self
             .special_jump_stack
-            .iter()
+            .iter_mut()
             .rev()
             .enumerate()
             .find(|(_, j)| j.target_block == target_block)
-            .map(|(i, j)| (i, j.kind));
-        match found {
-            Some((i, target_kind)) => {
+        {
+            Some((i, jump_target)) => {
                 let mk_block = |kind| tgt::Statement::new(span, kind).into_block();
-                match target_kind {
+                match jump_target.kind {
                     // The top of the stack is where control-flow goes naturally, no need to add a
                     // `break`/`continue`.
                     SpecialJumpKind::LoopContinue(_) | SpecialJumpKind::ForwardBreak(_)
@@ -1043,35 +1039,7 @@ impl<'a> ReconstructCtx<'a> {
                     SpecialJumpKind::ForwardBreak(depth) | SpecialJumpKind::LoopBreak(depth) => {
                         mk_block(tgt::StatementKind::Break(self.break_context_depth - depth))
                     }
-                    SpecialJumpKind::NextBlock => {
-                        // A NextBlock entry means "this block will be translated after the
-                        // current switch." Normally, we should generate a no-op to fall
-                        // through to the code after the switch.
-                        //
-                        // However, if there is a [LoopContinue]/[LoopBreak] between the top of
-                        // the stack and and this [NextBlock] entry, it means we are inside a loop
-                        // nested within a switch. A no-op here would mean "fall through to the
-                        // end of the loop body" (= implicit continue), which is wrong: the original
-                        // code intended to exit the loop and reach the outer continuation block.
-                        // If we fall into this case, it also means that the block we currently
-                        // want to jump to is *not* one of these loop exits, meaning we can't
-                        // insert a break. Because of this, we instead translate the target
-                        // block inline (duplicating it). This is not optimal but at least is
-                        // sound.
-                        //
-                        // Note: there is a complementary fix in `compute_loop_exits` that
-                        // uses the dominator tree to avoid picking the wrong exit in the
-                        // first place. Together, the two fixes provide defense in depth.
-                        let n = self.special_jump_stack.len();
-                        let has_intervening_loop = i > 0
-                            && self.special_jump_stack[(n - i)..n]
-                                .iter()
-                                .any(|j| matches!(j.kind, SpecialJumpKind::LoopContinue(_)));
-                        if has_intervening_loop {
-                            return self.translate_block(target_block);
-                        }
-                        mk_block(tgt::StatementKind::Nop)
-                    }
+                    SpecialJumpKind::NextBlock => mk_block(tgt::StatementKind::Nop),
                 }
             }
             // Translate the block without a jump.

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -657,8 +657,16 @@ impl ExitInfo {
             // Note: we ignore blocks that can only reach error nodes  when checking
             // for non-dominated candidates: we do not consider them as real exits.
             //
-            // Remark: rather than filtering, we could modify LoopExitRank to prioritize
-            // non-dominated blocks.
+            // Example:
+            // ```
+            // for i in 0..5 {
+            //     for j in 0..5 { a[i][j] = f(old[i][j]); }
+            // }
+            // ```
+            // The MIR actually contains two matches because of the iterators, and these
+            // two maches share the same `undefined_behavior` fallthrough block. This block
+            // is not dominated by the inner loop header: so `has_non_dominated` would be true,
+            // causing the filter to discard the inner loop's real exit.
 
             // Computing the set of blocks dominated by the loop - we could do this
             // once and for all and save the information in [CfgInfo] but I doubt

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -111,7 +111,6 @@ struct CfgInfo {
     /// The blocks whose terminators are a switch are stored here.
     pub switch_blocks: HashSet<src::BlockId>,
     /// Tree of which nodes dominates which other nodes.
-    #[expect(unused)]
     pub dominator_tree: Dominators<BlockId>,
     /// Computed data about each block.
     pub block_data: IndexVec<BlockId, Box<BlockData>>,
@@ -664,27 +663,20 @@ impl ExitInfo {
             // }
             // ```
             // The MIR actually contains two matches because of the iterators, and these
-            // two maches share the same `undefined_behavior` fallthrough block. This block
-            // is not dominated by the inner loop header: so `has_non_dominated` would be true,
-            // causing the filter to discard the inner loop's real exit.
+            // two matches share the same `undefined_behavior` fallthrough block. This block
+            // is not dominated by the inner loop header, so `has_non_dominated` would be
+            // true, causing the filter to discard the inner loop's real exit.
 
-            // Computing the set of blocks dominated by the loop - we could do this
-            // once and for all and save the information in [CfgInfo] but I doubt
-            // we would save much complexity-wise.
-            let dominated_by_loop = {
-                let mut set = HashSet::new();
-                let mut stack = vec![loop_id];
-                while let Some(bid) = stack.pop() {
-                    set.insert(bid);
-                    stack.extend(&cfg.block_data[bid].immediately_dominates);
-                }
-                set
+            let is_dominated_by_loop = |bid: &BlockId| -> bool {
+                cfg.dominator_tree
+                    .dominators(*bid)
+                    .is_some_and(|mut doms| doms.any(|d| d == loop_id))
             };
             let has_non_dominated = loop_exits
                 .keys()
-                .any(|bid| !dominated_by_loop.contains(bid) && !cfg.block_data[*bid].only_reach_error);
+                .any(|bid| !is_dominated_by_loop(bid) && !cfg.block_data[*bid].only_reach_error);
             if has_non_dominated {
-                loop_exits.retain(|bid, _| !dominated_by_loop.contains(bid));
+                loop_exits.retain(|bid, _| !is_dominated_by_loop(bid));
             }
 
             // We choose the exit with:

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -958,6 +958,7 @@ enum ReconstructMode {
 }
 
 struct ReconstructCtx<'a> {
+    ctx: &'a TransformCtx,
     cfg: CfgInfo,
     body: &'a src::ExprBody,
     /// The depth of `loop` contexts we may `break`/`continue` to.
@@ -971,7 +972,7 @@ struct ReconstructCtx<'a> {
 }
 
 impl<'a> ReconstructCtx<'a> {
-    fn build(ctx: &TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
+    fn build(ctx: &'a TransformCtx, src_body: &'a src::ExprBody) -> Result<Self, Irreducible> {
         // Compute all sorts of graph-related information about the control-flow graph, including
         // reachability, the dominator tree, loop entries, and loop/switch exits.
         let cfg = CfgInfo::build(ctx, &src_body.body)?;
@@ -980,6 +981,7 @@ impl<'a> ReconstructCtx<'a> {
         // conditional branchings.
         let allow_duplication = true;
         Ok(ReconstructCtx {
+            ctx,
             cfg,
             body: src_body,
             break_context_depth: 0,
@@ -1016,13 +1018,8 @@ impl<'a> ReconstructCtx<'a> {
     /// Translate a jump to the given block. The span is used to create the jump statement, if any.
     #[tracing::instrument(skip(self), ret, fields(stack = ?self.special_jump_stack))]
     fn translate_jump(&mut self, span: Span, target_block: src::BlockId) -> tgt::Block {
-        match self
-            .special_jump_stack
-            .iter_mut()
-            .rev()
-            .enumerate()
-            .find(|(_, j)| j.target_block == target_block)
-        {
+        // Look up target_block in the special jump stack (from the top).
+        match self.special_jump_stack.iter().rev().enumerate().find(|(_, j)| j.target_block == target_block) {
             Some((i, jump_target)) => {
                 let mk_block = |kind| tgt::Statement::new(span, kind).into_block();
                 match jump_target.kind {
@@ -1039,7 +1036,33 @@ impl<'a> ReconstructCtx<'a> {
                     SpecialJumpKind::ForwardBreak(depth) | SpecialJumpKind::LoopBreak(depth) => {
                         mk_block(tgt::StatementKind::Break(self.break_context_depth - depth))
                     }
-                    SpecialJumpKind::NextBlock => mk_block(tgt::StatementKind::Nop),
+                    SpecialJumpKind::NextBlock => {
+                        // A [NextBlock] entry means "this block will be translated after the
+                        // current switch." Normally, we should generate a no-op to fall
+                        // through to the code after the switch.
+                        //
+                        // However, if there is a [LoopContinue]/[LoopBreak] between the top of
+                        // the stack and and this [NextBlock] entry, it means we are inside a loop
+                        // nested within a switch. A no-op here would mean "fall through to the
+                        // end of the loop body" (= implicit continue), which is wrong: the original
+                        // code intended to exit the loop and reach the outer continuation block.
+                        // If we fall into this case, it also means that the block we currently
+                        // want to jump to is *not* one of these loop exits, meaning we can't
+                        // insert a break.
+                        let n = self.special_jump_stack.len();
+                        let has_intervening_loop = i > 0
+                            && self.special_jump_stack[(n - i)..n]
+                                .iter()
+                                .any(|j| matches!(j.kind, SpecialJumpKind::LoopContinue(_)));
+                        if has_intervening_loop {
+                            register_error!(
+                                &self.ctx,
+                                span,
+                                "Could not reconstruct the control-flow",
+                                );
+                        }
+                        mk_block(tgt::StatementKind::Nop)
+                    }
                 }
             }
             // Translate the block without a jump.

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -1019,7 +1019,13 @@ impl<'a> ReconstructCtx<'a> {
     #[tracing::instrument(skip(self), ret, fields(stack = ?self.special_jump_stack))]
     fn translate_jump(&mut self, span: Span, target_block: src::BlockId) -> tgt::Block {
         // Look up target_block in the special jump stack (from the top).
-        match self.special_jump_stack.iter().rev().enumerate().find(|(_, j)| j.target_block == target_block) {
+        match self
+            .special_jump_stack
+            .iter()
+            .rev()
+            .enumerate()
+            .find(|(_, j)| j.target_block == target_block)
+        {
             Some((i, jump_target)) => {
                 let mk_block = |kind| tgt::Statement::new(span, kind).into_block();
                 match jump_target.kind {
@@ -1059,7 +1065,7 @@ impl<'a> ReconstructCtx<'a> {
                                 &self.ctx,
                                 span,
                                 "Could not reconstruct the control-flow",
-                                );
+                            );
                         }
                         mk_block(tgt::StatementKind::Nop)
                     }

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -626,8 +626,81 @@ impl ExitInfo {
     fn compute_loop_exits(ctx: &TransformCtx, cfg: &mut CfgInfo) {
         for &loop_id in &cfg.loop_entries {
             // Compute the candidates.
-            let loop_exits: SeqHashMap<BlockId, LoopExitRank> =
+            let mut loop_exits: SeqHashMap<BlockId, LoopExitRank> =
                 Self::compute_loop_exit_ranks(cfg, loop_id);
+
+            // Hard filter: discard exit candidates that are dominated by the loop header when
+            // non-dominated candidates exist.
+            // This is related to: https://github.com/AeneasVerif/charon/issues/1051
+            //
+            // Example (from issue #1051):
+            // ```
+            // fn f(b: bool) -> bool {
+            //     if b {
+            //         loop {
+            //             if b { return true; }  // bb5: dominated by loop header
+            //             break;                  // bb9→bb4: exits the loop
+            //         }
+            //     }
+            //     false                           // bb4: NOT dominated by loop header
+            // }
+            // ```
+            //
+            // Without the filter, bb5 (`return true`) ranks higher than bb4 because it is
+            // closer to the loop header. Picking bb5 as the exit incorrectly turns `return
+            // true` into `break`, producing the following wrong reconstruction:
+            // ```
+            // fn f(b: bool) -> bool {
+            //     if b {
+            //         loop {
+            //             if b { break; }   // was `return true` — wrongly turned into break
+            //             // the actual `break` path is lost here
+            //         }
+            //     }
+            //     false
+            // }
+            // ```
+            // The filter discards bb5 (dominated) so that bb4 (not dominated) is correctly
+            // chosen, producing the correct reconstruction:
+            // ```
+            // fn f(b: bool) -> bool {
+            //     if b {
+            //         loop {
+            //             if b { return true; }  // kept as return
+            //             break;                 // correctly reconstructed
+            //         }
+            //     }
+            //     false
+            // }
+            // ```
+            //
+            // Note: for simple `while cond { body } after;` loops, ALL exit candidates are
+            // dominated by the loop header (every path from the function entry goes through
+            // the loop header). In that case `has_non_dominated` is false and the filter is
+            // a no-op.
+            //
+            // Remark: rather than filtering, we could modify LoopExitRank to prioritize
+            // non-dominated blocks.
+
+            // Computing the set of blocks dominated by the loop - we could do this
+            // once and for all and save the information in [CfgInfo] but I doubt
+            // we would save much complexity-wise.
+            let dominated_by_loop = {
+                let mut set = HashSet::new();
+                let mut stack = vec![loop_id];
+                while let Some(bid) = stack.pop() {
+                    set.insert(bid);
+                    stack.extend(&cfg.block_data[bid].immediately_dominates);
+                }
+                set
+            };
+            let has_non_dominated = loop_exits
+                .keys()
+                .any(|bid| !dominated_by_loop.contains(bid));
+            if has_non_dominated {
+                loop_exits.retain(|bid, _| !dominated_by_loop.contains(bid));
+            }
+
             // We choose the exit with:
             // - the most occurrences
             // - the least total distance (if there are several possibilities)

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -679,6 +679,9 @@ impl ExitInfo {
             // the loop header). In that case `has_non_dominated` is false and the filter is
             // a no-op.
             //
+            // Note: we ignore blocks that can only reach error nodes  when checking
+            // for non-dominated candidates: we do not consider them as real exits.
+            //
             // Remark: rather than filtering, we could modify LoopExitRank to prioritize
             // non-dominated blocks.
 
@@ -696,7 +699,7 @@ impl ExitInfo {
             };
             let has_non_dominated = loop_exits
                 .keys()
-                .any(|bid| !dominated_by_loop.contains(bid));
+                .any(|bid| !dominated_by_loop.contains(bid) && !cfg.block_data[*bid].only_reach_error);
             if has_non_dominated {
                 loop_exits.retain(|bid, _| !dominated_by_loop.contains(bid));
             }

--- a/charon/tests/ui/control-flow/loop-break.out
+++ b/charon/tests/ui/control-flow/loop-break.out
@@ -60,11 +60,15 @@ fn main()
             storage_live(_3)
             _3 = foo()
             if move _3 {
+                storage_dead(_4)
+                storage_dead(_3)
                 break 0
             } else {
                 storage_live(_4)
                 _4 = bar()
                 if move _4 {
+                    storage_dead(_4)
+                    storage_dead(_3)
                     break 0
                 } else {
                     storage_dead(_4)
@@ -73,8 +77,6 @@ fn main()
                 }
             }
         }
-        storage_dead(_4)
-        storage_dead(_3)
     } else {
     }
     storage_dead(_1)

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -793,29 +793,29 @@ pub fn test_loop4(_1: u32) -> u32
                         _18 = copy j_3 panic.+ const 1 : u32
                         j_3 = move _18
                         storage_dead(_8)
-                        break 1
+                        break 0
                     }
                     storage_dead(_12)
                     storage_dead(_11)
                     storage_dead(_8)
                     continue 0
                 } else {
-                    break 0
+                    storage_dead(_10)
+                    storage_dead(_9)
+                    storage_dead(_8)
+                    j_3 = const 0 : u32
+                    storage_live(_19)
+                    _19 = copy i_2
+                    _20 = copy s_4 panic.+ copy _19
+                    s_4 = move _20
+                    storage_dead(_19)
+                    _21 = copy i_2 panic.+ const 1 : u32
+                    i_2 = move _21
+                    storage_dead(_5)
+                    continue 1
                 }
             }
-            storage_dead(_10)
-            storage_dead(_9)
-            storage_dead(_8)
-            j_3 = const 0 : u32
-            storage_live(_19)
-            _19 = copy i_2
-            _20 = copy s_4 panic.+ copy _19
-            s_4 = move _20
-            storage_dead(_19)
-            _21 = copy i_2 panic.+ const 1 : u32
-            i_2 = move _21
-            storage_dead(_5)
-            continue 0
+            break 0
         } else {
             storage_dead(_7)
             storage_dead(_6)
@@ -1044,6 +1044,7 @@ pub fn test_loop7(_1: u32) -> u32
                 if move _10 {
                     storage_dead(_11)
                     storage_dead(_10)
+                    storage_dead(_7)
                     break 0
                 } else {
                     storage_dead(_11)
@@ -1061,10 +1062,10 @@ pub fn test_loop7(_1: u32) -> u32
             } else {
                 storage_dead(_9)
                 storage_dead(_8)
+                storage_dead(_7)
                 break 0
             }
         }
-        storage_dead(_7)
     } else {
         storage_dead(_6)
         storage_dead(_5)
@@ -1375,6 +1376,12 @@ pub fn loop_inside_if(_1: bool, _2: u32) -> u32
             storage_dead(_10)
             match _9 {
                 Option::None => {
+                    storage_dead(_11)
+                    storage_dead(_9)
+                    storage_dead(iter_8)
+                    storage_dead(_5)
+                    _0 = copy s_4
+                    storage_dead(s_4)
                     break 0
                 },
                 Option::Some => {
@@ -1392,12 +1399,6 @@ pub fn loop_inside_if(_1: bool, _2: u32) -> u32
                 },
             }
         }
-        storage_dead(_11)
-        storage_dead(_9)
-        storage_dead(iter_8)
-        storage_dead(_5)
-        _0 = copy s_4
-        storage_dead(s_4)
     } else {
         _0 = const 0 : u32
     }
@@ -1956,6 +1957,65 @@ pub fn trick_exit_computation()
     x_1 = const 12 : i32
     _0 = ()
     storage_dead(x_1)
+    return
+}
+
+// Full name: test_crate::loop_inside_if_return_break
+pub fn loop_inside_if_return_break(_1: u32) -> bool
+{
+    let _0: bool; // return
+    let y_1: u32; // arg #1
+    let _2: bool; // anonymous local
+    let _3: u32; // anonymous local
+    let _4: bool; // anonymous local
+    let _5: u32; // anonymous local
+    let _6: u32; // anonymous local
+    let _7: bool; // anonymous local
+    let _8: u32; // anonymous local
+
+    storage_live(_6)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = copy y_1
+    _2 = move _3 > const 0 : u32
+    if move _2 {
+        storage_dead(_3)
+        loop {
+            storage_live(_4)
+            storage_live(_5)
+            _5 = copy y_1
+            _4 = move _5 == const 0 : u32
+            if move _4 {
+                storage_dead(_5)
+                _0 = const true
+                storage_dead(_4)
+                storage_dead(_2)
+                return
+            } else {
+                storage_dead(_5)
+                storage_dead(_4)
+                _6 = copy y_1 panic.- const 1 : u32
+                y_1 = move _6
+                storage_live(_7)
+                storage_live(_8)
+                _8 = copy y_1
+                _7 = move _8 == const 0 : u32
+                if move _7 {
+                    storage_dead(_8)
+                    storage_dead(_7)
+                    break 0
+                } else {
+                    storage_dead(_8)
+                    storage_dead(_7)
+                    continue 0
+                }
+            }
+        }
+    } else {
+        storage_dead(_3)
+    }
+    storage_dead(_2)
+    _0 = const false
     return
 }
 

--- a/charon/tests/ui/control-flow/loops.rs
+++ b/charon/tests/ui/control-flow/loops.rs
@@ -378,3 +378,20 @@ pub fn trick_exit_computation() {
     }
     x = 12;
 }
+
+// Regression test for https://github.com/AeneasVerif/charon/issues/1051
+// The `return true` inside the loop was incorrectly converted to `break`.
+pub fn loop_inside_if_return_break(mut y: u32) -> bool {
+    if y > 0 {
+        loop {
+            if y == 0 {
+                return true;
+            }
+            y -= 1;
+            if y == 0 {
+                break;
+            }
+        }
+    }
+    false
+}

--- a/charon/tests/ui/control-flow/nested-for-loops-elaborated.out
+++ b/charon/tests/ui/control-flow/nested-for-loops-elaborated.out
@@ -1,0 +1,400 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::clone::Clone
+#[lang_item("clone")]
+pub trait Clone<Self>
+{
+    parent_clause0 : [@TraitClause0]: Sized<Self>
+    fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
+    non-dyn-compatible
+}
+
+#[lang_item("clone_fn")]
+pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
+where
+    [@TraitClause0]: Clone<Self>,
+= <opaque>
+
+// Full name: core::clone::impls::{impl Clone for usize}::clone
+pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
+= <opaque>
+
+// Full name: core::clone::impls::{impl Clone for usize}
+impl Clone for usize {
+    parent_clause0 = {built_in impl Sized for usize}
+    fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: core::cmp::PartialEq
+#[lang_item("eq")]
+pub trait PartialEq<Self, Rhs>
+{
+    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialEq::{vtable}<Rhs>
+}
+
+#[lang_item("cmp_partialeq_eq")]
+pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
+where
+    [@TraitClause0]: PartialEq<Self, Rhs>,
+= <opaque>
+
+// Full name: core::cmp::Ordering
+#[lang_item("Ordering")]
+pub enum Ordering {
+  Less,
+  Equal,
+  Greater,
+}
+
+// Full name: core::option::Option
+#[lang_item("Option")]
+pub enum Option<T>
+where
+    [@TraitClause0]: Sized<T>,
+{
+  None,
+  Some(T),
+}
+
+// Full name: core::cmp::PartialOrd
+#[lang_item("partial_ord")]
+pub trait PartialOrd<Self, Rhs>
+{
+    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialOrd::{vtable}<Rhs>
+}
+
+#[lang_item("cmp_partialord_cmp")]
+pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+where
+    [@TraitClause0]: PartialOrd<Self, Rhs>,
+= <opaque>
+
+// Full name: core::cmp::impls::{impl PartialEq<usize> for usize}::eq
+pub fn {impl PartialEq<usize> for usize}::eq<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
+= <opaque>
+
+// Full name: core::cmp::impls::{impl PartialEq<usize> for usize}
+impl PartialEq<usize> for usize {
+    fn eq<'_0_1, '_1_1> = {impl PartialEq<usize> for usize}::eq<'_0_1, '_1_1>
+    vtable: {impl PartialEq<usize> for usize}::{vtable}
+}
+
+// Full name: core::cmp::impls::{impl PartialOrd<usize> for usize}::partial_cmp
+pub fn {impl PartialOrd<usize> for usize}::partial_cmp<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+= <opaque>
+
+// Full name: core::cmp::impls::{impl PartialOrd<usize> for usize}
+impl PartialOrd<usize> for usize {
+    parent_clause0 = {impl PartialEq<usize> for usize}
+    fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
+    vtable: {impl PartialOrd<usize> for usize}::{vtable}
+}
+
+// Full name: core::iter::range::Step
+#[lang_item("range_step")]
+pub trait Step<Self>
+{
+    parent_clause0 : [@TraitClause0]: Sized<Self>
+    parent_clause1 : [@TraitClause1]: Clone<Self>
+    parent_clause2 : [@TraitClause2]: PartialOrd<Self, Self>
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
+    fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
+    fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
+    non-dyn-compatible
+}
+
+pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+where
+    [@TraitClause0]: Step<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: Step<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: Step<Self>,
+= <opaque>
+
+// Full name: core::iter::range::{impl Step for usize}::backward_checked
+pub fn {impl Step for usize}::backward_checked(_1: usize, _2: usize) -> Option<usize>[{built_in impl Sized for usize}]
+= <opaque>
+
+// Full name: core::iter::range::{impl Step for usize}::forward_checked
+pub fn {impl Step for usize}::forward_checked(_1: usize, _2: usize) -> Option<usize>[{built_in impl Sized for usize}]
+= <opaque>
+
+// Full name: core::iter::range::{impl Step for usize}::steps_between
+pub fn {impl Step for usize}::steps_between<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+= <opaque>
+
+// Full name: core::iter::range::{impl Step for usize}
+impl Step for usize {
+    parent_clause0 = {built_in impl Sized for usize}
+    parent_clause1 = {impl Clone for usize}
+    parent_clause2 = {impl PartialOrd<usize> for usize}
+    fn steps_between<'_0_1, '_1_1> = {impl Step for usize}::steps_between<'_0_1, '_1_1>
+    fn forward_checked = {impl Step for usize}::forward_checked
+    fn backward_checked = {impl Step for usize}::backward_checked
+    non-dyn-compatible
+}
+
+// Full name: core::ops::range::Range
+#[lang_item("Range")]
+pub struct Range<Idx>
+where
+    [@TraitClause0]: Sized<Idx>,
+{
+  start: Idx,
+  end: Idx,
+}
+
+// Full name: core::iter::traits::iterator::Iterator
+#[lang_item("iterator")]
+pub trait Iterator<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    type Item
+    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
+}
+
+// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}::next
+pub fn {impl Iterator for Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[@TraitClause0]) -> Option<A>[@TraitClause0]
+where
+    [@TraitClause0]: Sized<A>,
+    [@TraitClause1]: Step<A>,
+= <opaque>
+
+// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}
+impl<A> Iterator for Range<A>[@TraitClause0]
+where
+    [@TraitClause0]: Sized<A>,
+    [@TraitClause1]: Step<A>,
+{
+    parent_clause0 = {built_in impl MetaSized for Range<A>[@TraitClause0]}
+    parent_clause1 = @TraitClause0
+    type Item = A
+    fn next<'_0_1> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
+    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+}
+
+// Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
+pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
+where
+    [@TraitClause0]: Sized<I>,
+    [@TraitClause1]: Iterator<I>,
+= <opaque>
+
+#[lang_item("next")]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+where
+    [@TraitClause0]: Iterator<Self>,
+= <opaque>
+
+fn UNIT_METADATA()
+{
+    let _0: (); // return
+
+    _0 = ()
+    return
+}
+
+const UNIT_METADATA: () = @Fun0()
+
+// Full name: test_crate::nested_for_complex
+pub fn nested_for_complex<'_0>(_1: &'_0 mut [[u32; 5 : usize]; 5 : usize])
+{
+    let _0: (); // return
+    let a_1: &'1 mut [[u32; 5 : usize]; 5 : usize]; // arg #1
+    let old_2: [[u32; 5 : usize]; 5 : usize]; // local
+    let _3: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _4: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let iter_5: Range<usize>[{built_in impl Sized for usize}]; // local
+    let _6: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _7: &'3 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _8: &'4 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let i_9: usize; // local
+    let _10: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _11: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let iter_12: Range<usize>[{built_in impl Sized for usize}]; // local
+    let _13: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _14: &'5 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _15: &'6 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let j_16: usize; // local
+    let _17: u32; // anonymous local
+    let _18: usize; // anonymous local
+    let _19: usize; // anonymous local
+    let _20: u32; // anonymous local
+    let _21: usize; // anonymous local
+    let _22: usize; // anonymous local
+    let _23: usize; // anonymous local
+    let _24: usize; // anonymous local
+    let _25: usize; // anonymous local
+    let _26: usize; // anonymous local
+    let _27: usize; // anonymous local
+    let _28: &'_ [[u32; 5 : usize]; 5 : usize]; // anonymous local
+    let _29: &'_ [u32; 5 : usize]; // anonymous local
+    let _30: &'_ [u32; 5 : usize]; // anonymous local
+    let _31: &'_ u32; // anonymous local
+    let _32: &'_ [[u32; 5 : usize]; 5 : usize]; // anonymous local
+    let _33: &'_ [u32; 5 : usize]; // anonymous local
+    let _34: &'_ [u32; 5 : usize]; // anonymous local
+    let _35: &'_ u32; // anonymous local
+    let _36: &'_ mut [[u32; 5 : usize]; 5 : usize]; // anonymous local
+    let _37: &'_ mut [u32; 5 : usize]; // anonymous local
+    let _38: &'_ mut [u32; 5 : usize]; // anonymous local
+    let _39: &'_ mut u32; // anonymous local
+
+    storage_live(_25)
+    _0 = ()
+    storage_live(old_2)
+    old_2 = copy (*a_1)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = Range { start: const 0 : usize, end: const 5 : usize }
+    _3 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _4)
+    storage_dead(_4)
+    storage_live(iter_5)
+    iter_5 = move _3
+    loop {
+        storage_live(_6)
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &mut iter_5
+        _7 = &two-phase-mut (*_8)
+        _6 = {impl Iterator for Range<A>[@TraitClause0]}::next<'8, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _7)
+        storage_dead(_7)
+        match _6 {
+            Option::None => {
+                break 0
+            },
+            Option::Some => {
+            },
+        }
+        storage_live(i_9)
+        i_9 = copy (_6 as variant Option::Some).0
+        storage_live(_10)
+        storage_live(_11)
+        _11 = Range { start: const 0 : usize, end: const 5 : usize }
+        _10 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _11)
+        storage_dead(_11)
+        storage_live(iter_12)
+        iter_12 = move _10
+        loop {
+            storage_live(_13)
+            storage_live(_14)
+            storage_live(_15)
+            _15 = &mut iter_12
+            _14 = &two-phase-mut (*_15)
+            _13 = {impl Iterator for Range<A>[@TraitClause0]}::next<'10, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _14)
+            storage_dead(_14)
+            match _13 {
+                Option::None => {
+                    break 0
+                },
+                Option::Some => {
+                },
+            }
+            storage_live(j_16)
+            j_16 = copy (_13 as variant Option::Some).0
+            storage_live(_17)
+            storage_live(_18)
+            _18 = copy i_9
+            storage_live(_19)
+            _19 = copy j_16
+            storage_live(_28)
+            _28 = &old_2
+            storage_live(_29)
+            _29 = @ArrayIndexShared<'_, [u32; 5 : usize], 5 : usize>(move _28, copy _18)
+            storage_live(_30)
+            _30 = &(*_29)
+            storage_live(_31)
+            _31 = @ArrayIndexShared<'_, u32, 5 : usize>(move _30, copy _19)
+            _17 = copy (*_31)
+            storage_live(_20)
+            storage_live(_21)
+            _21 = copy i_9
+            storage_live(_22)
+            storage_live(_23)
+            storage_live(_24)
+            _24 = copy j_16
+            _25 = copy _24 panic.+ const 1 : usize
+            _23 = move _25
+            storage_dead(_24)
+            _22 = move _23 panic.% const 5 : usize
+            storage_dead(_23)
+            storage_live(_32)
+            _32 = &old_2
+            storage_live(_33)
+            _33 = @ArrayIndexShared<'_, [u32; 5 : usize], 5 : usize>(move _32, copy _21)
+            storage_live(_34)
+            _34 = &(*_33)
+            storage_live(_35)
+            _35 = @ArrayIndexShared<'_, u32, 5 : usize>(move _34, copy _22)
+            _20 = copy (*_35)
+            storage_live(_26)
+            _26 = copy i_9
+            storage_live(_27)
+            _27 = copy j_16
+            storage_live(_36)
+            _36 = &mut (*a_1)
+            storage_live(_37)
+            _37 = @ArrayIndexMut<'_, [u32; 5 : usize], 5 : usize>(move _36, copy _26)
+            storage_live(_38)
+            _38 = &mut (*_37)
+            storage_live(_39)
+            _39 = @ArrayIndexMut<'_, u32, 5 : usize>(move _38, copy _27)
+            (*_39) = move _17 ^ move _20
+            storage_dead(_20)
+            storage_dead(_17)
+            storage_dead(_27)
+            storage_dead(_26)
+            storage_dead(_22)
+            storage_dead(_21)
+            storage_dead(_19)
+            storage_dead(_18)
+            storage_dead(j_16)
+            storage_dead(_15)
+            storage_dead(_13)
+            continue 0
+        }
+        storage_dead(_15)
+        storage_dead(_13)
+        storage_dead(iter_12)
+        storage_dead(_10)
+        storage_dead(i_9)
+        storage_dead(_8)
+        storage_dead(_6)
+        continue 0
+    }
+    _0 = ()
+    storage_dead(_8)
+    storage_dead(_6)
+    storage_dead(iter_5)
+    storage_dead(_3)
+    storage_dead(old_2)
+    return
+}
+
+
+

--- a/charon/tests/ui/control-flow/nested-for-loops-elaborated.rs
+++ b/charon/tests/ui/control-flow/nested-for-loops-elaborated.rs
@@ -1,0 +1,18 @@
+//! Regression test: nested for-loops with `--mir elaborated` must produce idiomatic LLBC
+//! (inner loop exits with `break 0`, not `continue 1`).
+//!
+//! With `--mir elaborated`, drop elaboration inserts per-call unwind blocks. This causes
+//! the `undefined_behavior` block (from match fallthrough) to be shared across inner and
+//! outer switches, making it not dominated by the inner loop header. The dominance filter
+//! in `compute_loop_exits` must ignore error-only blocks when deciding whether non-dominated
+//! candidates exist, otherwise it discards the real exit and produces `continue 1`.
+//@ charon-args=--mir elaborated
+
+pub fn nested_for_complex(a: &mut [[u32; 5]; 5]) {
+    let old = *a;
+    for i in 0..5usize {
+        for j in 0..5usize {
+            a[i][j] = old[i][j] ^ old[i][(j + 1) % 5];
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/charon/issues/1051

This PR is AI generated *but*: I carefully reviewed the code and prompted the AI until I was globally happy with it, before doing the last modifications by hand. I reviewed all the code line by line.

This PR does two things:
1. improve the heuristics in `compute_loop_exits` to find better loop exits in the presence of branchings
2. fix `translate_jump` by detecting the case problematic in #issue1051 and failing

About 2.: I tried fixing it by inlining the target of the jump instead of introducing a no-op. I think a solution along those lines would make sense, but just inlining probably doesn't work: for instance, I'm not completely sure what happens in case this inlined code ends with, e.g., a break or a continue. As the initial attempt made sense I committed it to keep track of it, but then reverted it. The version I submit in this PR simply fails in the problematic case.