### PR TITLE
Make predicate numbering more robust

### DIFF
--- a/charon/hax-frontend/src/traits.rs
+++ b/charon/hax-frontend/src/traits.rs
@@ -79,6 +79,7 @@ pub enum ImplExprAtom {
         /// The nth (non-self) predicate found for this item. We use predicates from
         /// `required_predicates` starting from the parentmost item.
         index: usize,
+        id: GenericPredicateId,
         r#trait: Binder<TraitRef>,
         path: Vec<ImplExprPathChunk>,
     },

--- a/charon/hax-frontend/src/traits.rs
+++ b/charon/hax-frontend/src/traits.rs
@@ -3,8 +3,8 @@ use crate::{id_table::hash_consing::HashConsed, prelude::*};
 pub mod resolution;
 mod utils;
 pub use utils::{
-    Predicates, ToPolyTraitRef, erase_and_norm, erase_free_regions, implied_predicates, normalize,
-    predicates_defined_on, required_predicates, self_predicate,
+    ItemPredicate, ItemPredicateId, ItemPredicates, ToPolyTraitRef, erase_and_norm,
+    erase_free_regions, implied_predicates, normalize, required_predicates, self_predicate,
 };
 
 pub use resolution::PredicateSearcher;
@@ -282,13 +282,13 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
 fn solve_item_traits_inner<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     generics: ty::GenericArgsRef<'tcx>,
-    predicates: utils::Predicates<'tcx>,
+    predicates: utils::ItemPredicates<'tcx>,
 ) -> Vec<ImplExpr> {
     let tcx = s.base().tcx;
     let typing_env = s.typing_env();
     predicates
         .iter()
-        .map(|(clause, _span)| *clause)
+        .map(|pred| pred.clause)
         .filter_map(|clause| clause.as_trait_clause())
         .map(|clause| clause.to_poly_trait_ref())
         // Substitute the item generics

--- a/charon/hax-frontend/src/traits.rs
+++ b/charon/hax-frontend/src/traits.rs
@@ -76,9 +76,6 @@ pub enum ImplExprAtom {
     Concrete(ItemRef),
     /// A context-bound clause like `where T: Trait`.
     LocalBound {
-        /// The nth (non-self) predicate found for this item. We use predicates from
-        /// `required_predicates` starting from the parentmost item.
-        index: usize,
         id: GenericPredicateId,
         r#trait: Binder<TraitRef>,
         path: Vec<ImplExprPathChunk>,

--- a/charon/hax-frontend/src/traits/resolution.rs
+++ b/charon/hax-frontend/src/traits/resolution.rs
@@ -117,20 +117,8 @@ pub struct ImplExpr<'tcx> {
     pub r#impl: ImplExprAtom<'tcx>,
 }
 
-/// Items have various predicates in scope. `path_to` uses them as a starting point for trait
-/// resolution. This tracks where each of them comes from.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum BoundPredicateOrigin {
-    /// The `Self: Trait` predicate implicitly present within trait declarations (note: we
-    /// don't add it for trait implementations, should we?).
-    SelfPred,
-    /// A predicate found for this item.
-    Item,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct AnnotatedTraitPred<'tcx> {
-    pub origin: BoundPredicateOrigin,
+pub struct ItemClause<'tcx> {
     pub id: ItemPredicateId,
     pub clause: PolyTraitPredicate<'tcx>,
 }
@@ -201,16 +189,18 @@ fn parents_trait_predicates<'tcx>(
 struct Candidate<'tcx> {
     path: Path<'tcx>,
     pred: PolyTraitPredicate<'tcx>,
-    origin: AnnotatedTraitPred<'tcx>,
+    origin: ItemClause<'tcx>,
 }
 
 impl<'tcx> Candidate<'tcx> {
-    fn into_impl_expr(self, tcx: TyCtxt<'tcx>) -> ImplExprAtom<'tcx> {
+    fn into_impl_expr(self, tcx: TyCtxt<'tcx>, implicit_self_clause: bool) -> ImplExprAtom<'tcx> {
         let path = self.path;
         let r#trait = self.origin.clause.to_poly_trait_ref();
-        match self.origin.origin {
-            BoundPredicateOrigin::SelfPred => ImplExprAtom::SelfImpl { r#trait, path },
-            BoundPredicateOrigin::Item => ImplExprAtom::LocalBound {
+        match self.origin.id {
+            ItemPredicateId::TraitSelf if implicit_self_clause => {
+                ImplExprAtom::SelfImpl { r#trait, path }
+            }
+            _ => ImplExprAtom::LocalBound {
                 predicate: self.origin.clause.upcast(tcx),
                 id: self.origin.id,
                 r#trait,
@@ -229,11 +219,15 @@ pub struct PredicateSearcher<'tcx> {
     candidates: HashMap<PolyTraitPredicate<'tcx>, Candidate<'tcx>>,
     /// Resolution options.
     options: BoundsOptions,
+    /// Whether we're in a trait declaration context where an implicit `Self: Trait` clause is
+    /// accessible.
+    implicit_self_clause: bool,
 }
 
 impl<'tcx> PredicateSearcher<'tcx> {
     /// Initialize the elaborator with the predicates accessible within this item.
     pub fn new_for_owner(tcx: TyCtxt<'tcx>, owner_id: DefId, options: BoundsOptions) -> Self {
+        let initial_self_pred = initial_self_pred(tcx, owner_id);
         let mut out = Self {
             tcx,
             typing_env: TypingEnv {
@@ -242,14 +236,12 @@ impl<'tcx> PredicateSearcher<'tcx> {
             },
             candidates: Default::default(),
             options,
+            implicit_self_clause: initial_self_pred.is_some(),
         };
-        out.insert_predicates(
-            initial_self_pred(tcx, owner_id).map(|clause| AnnotatedTraitPred {
-                origin: BoundPredicateOrigin::SelfPred,
-                id: ItemPredicateId::TraitSelf,
-                clause,
-            }),
-        );
+        out.insert_predicates(initial_self_pred.map(|clause| ItemClause {
+            id: ItemPredicateId::TraitSelf,
+            clause,
+        }));
         out.insert_bound_predicates(local_bound_predicates(tcx, owner_id, options));
         out
     }
@@ -262,13 +254,10 @@ impl<'tcx> PredicateSearcher<'tcx> {
         preds: impl IntoIterator<Item = ItemPredicate<'tcx>>,
     ) {
         self.insert_predicates(preds.into_iter().filter_map(|pred| {
-            pred.clause
-                .as_trait_clause()
-                .map(|clause| AnnotatedTraitPred {
-                    origin: BoundPredicateOrigin::Item,
-                    id: pred.id,
-                    clause,
-                })
+            pred.clause.as_trait_clause().map(|clause| ItemClause {
+                id: pred.id,
+                clause,
+            })
         }));
     }
 
@@ -280,7 +269,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
 
     /// Insert annotated predicates in the search context. Prefer inserting them all at once as
     /// this will give priority to shorter resolution paths.
-    fn insert_predicates(&mut self, preds: impl IntoIterator<Item = AnnotatedTraitPred<'tcx>>) {
+    fn insert_predicates(&mut self, preds: impl IntoIterator<Item = ItemClause<'tcx>>) {
         self.insert_candidates(preds.into_iter().map(|clause| Candidate {
             path: vec![],
             pred: clause.clause,
@@ -452,7 +441,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             },
             Ok(ImplSource::Param(_)) => {
                 match self.resolve_local(erased_tref.upcast(self.tcx), warn)? {
-                    Some(candidate) => candidate.into_impl_expr(tcx),
+                    Some(candidate) => candidate.into_impl_expr(tcx, self.implicit_self_clause),
                     None => {
                         let msg = format!(
                             "Could not find a clause for `{tref:?}` in the item parameters"
@@ -540,7 +529,9 @@ impl<'tcx> PredicateSearcher<'tcx> {
                                 // We've added `Destruct` impls on everything, we should be able to resolve
                                 // it.
                                 match self.resolve_local(erased_tref.upcast(self.tcx), warn)? {
-                                    Some(candidate) => Either::Right(candidate.into_impl_expr(tcx)),
+                                    Some(candidate) => Either::Right(
+                                        candidate.into_impl_expr(tcx, self.implicit_self_clause),
+                                    ),
                                     None => {
                                         let msg = format!(
                                             "Cannot find virtual `Destruct` clause: `{tref:?}`"

--- a/charon/hax-frontend/src/traits/resolution.rs
+++ b/charon/hax-frontend/src/traits/resolution.rs
@@ -2,6 +2,7 @@
 //! This module is independent from the rest of hax, in particular it doesn't use its
 //! state-tracking machinery.
 
+use crate::ItemPredicate;
 use crate::options::BoundsOptions;
 use itertools::{Either, Itertools};
 use std::collections::{HashMap, hash_map::Entry};
@@ -12,6 +13,7 @@ use rustc_middle::traits::CodegenObligationError;
 use rustc_middle::ty::{self, *};
 use rustc_trait_selection::traits::ImplSource;
 
+use super::ItemPredicateId;
 use super::utils::{
     self, ToPolyTraitRef, erase_and_norm, implied_predicates, normalize_bound_val,
     required_predicates, self_predicate,
@@ -50,6 +52,7 @@ pub enum ImplExprAtom<'tcx> {
         /// The nth (non-self) predicate found for this item. We use predicates from
         /// `required_predicates` starting from the parentmost item.
         index: usize,
+        id: ItemPredicateId,
         r#trait: PolyTraitRef<'tcx>,
         path: Path<'tcx>,
     },
@@ -132,6 +135,7 @@ pub enum BoundPredicateOrigin {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct AnnotatedTraitPred<'tcx> {
     pub origin: BoundPredicateOrigin,
+    pub id: ItemPredicateId,
     pub clause: PolyTraitPredicate<'tcx>,
 }
 
@@ -160,22 +164,18 @@ fn local_bound_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: rustc_span::def_id::DefId,
     options: BoundsOptions,
-) -> Vec<PolyTraitPredicate<'tcx>> {
+) -> Vec<ItemPredicate<'tcx>> {
     fn acc_predicates<'tcx>(
         tcx: TyCtxt<'tcx>,
         def_id: rustc_span::def_id::DefId,
         options: BoundsOptions,
-        predicates: &mut Vec<PolyTraitPredicate<'tcx>>,
+        predicates: &mut Vec<ItemPredicate<'tcx>>,
     ) {
         if crate::inherits_parent_clauses(tcx, def_id) {
             let parent = tcx.parent(def_id);
             acc_predicates(tcx, parent, options, predicates);
         }
-        predicates.extend(
-            required_predicates(tcx, def_id, options)
-                .iter()
-                .filter_map(|pred| pred.clause.as_trait_clause()),
-        );
+        predicates.extend(required_predicates(tcx, def_id, options).iter());
     }
 
     let mut predicates = vec![];
@@ -217,6 +217,7 @@ impl<'tcx> Candidate<'tcx> {
             BoundPredicateOrigin::Item(index) => ImplExprAtom::LocalBound {
                 predicate: self.origin.clause.upcast(tcx),
                 index,
+                id: self.origin.id,
                 r#trait,
                 path,
             },
@@ -253,6 +254,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         out.insert_predicates(
             initial_self_pred(tcx, owner_id).map(|clause| AnnotatedTraitPred {
                 origin: BoundPredicateOrigin::SelfPred,
+                id: ItemPredicateId::TraitSelf,
                 clause,
             }),
         );
@@ -265,19 +267,29 @@ impl<'tcx> PredicateSearcher<'tcx> {
     /// insertion order.
     pub fn insert_bound_predicates(
         &mut self,
-        clauses: impl IntoIterator<Item = PolyTraitPredicate<'tcx>>,
+        preds: impl IntoIterator<Item = ItemPredicate<'tcx>>,
     ) {
         let mut count = usize::MAX;
         // Swap to avoid borrow conflicts.
         std::mem::swap(&mut count, &mut self.bound_clause_count);
-        self.insert_predicates(clauses.into_iter().map(|clause| {
-            let i = count;
-            count += 1;
-            AnnotatedTraitPred {
-                origin: BoundPredicateOrigin::Item(i),
-                clause,
-            }
-        }));
+        self.insert_predicates(
+            preds
+                .into_iter()
+                .filter_map(|pred| {
+                    pred.clause
+                        .as_trait_clause()
+                        .map(|clause| (pred.id, clause))
+                })
+                .map(|(id, pred)| {
+                    let i = count;
+                    count += 1;
+                    AnnotatedTraitPred {
+                        origin: BoundPredicateOrigin::Item(i),
+                        id,
+                        clause: pred,
+                    }
+                }),
+        );
         std::mem::swap(&mut count, &mut self.bound_clause_count);
     }
 

--- a/charon/hax-frontend/src/traits/resolution.rs
+++ b/charon/hax-frontend/src/traits/resolution.rs
@@ -174,8 +174,7 @@ fn local_bound_predicates<'tcx>(
         predicates.extend(
             required_predicates(tcx, def_id, options)
                 .iter()
-                .map(|(clause, _span)| *clause)
-                .filter_map(|clause| clause.as_trait_clause()),
+                .filter_map(|pred| pred.clause.as_trait_clause()),
         );
     }
 
@@ -193,10 +192,9 @@ fn parents_trait_predicates<'tcx>(
     let self_trait_ref = pred.to_poly_trait_ref();
     implied_predicates(tcx, pred.def_id(), options)
         .iter()
-        .map(|(clause, _span)| *clause)
         // Substitute with the `self` args so that the clause makes sense in the
         // outside context.
-        .map(|clause| clause.instantiate_supertrait(tcx, self_trait_ref))
+        .map(|pred| pred.clause.instantiate_supertrait(tcx, self_trait_ref))
         .filter_map(|pred| pred.as_trait_clause())
         .collect()
 }
@@ -370,8 +368,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         let item_bounds = implied_predicates(tcx, alias_ty.def_id, self.options);
         let item_bounds = item_bounds
             .iter()
-            .map(|(clause, _span)| *clause)
-            .filter_map(|pred| pred.as_trait_clause())
+            .filter_map(|pred| pred.clause.as_trait_clause())
             // Substitute the item generics
             .map(|pred| EarlyBinder::bind(pred).instantiate(tcx, alias_ty.args))
             .enumerate();
@@ -638,15 +635,14 @@ impl<'tcx> PredicateSearcher<'tcx> {
     pub fn resolve_predicates(
         &mut self,
         generics: GenericArgsRef<'tcx>,
-        predicates: utils::Predicates<'tcx>,
+        predicates: utils::ItemPredicates<'tcx>,
         // Call back into hax-related code to display a nice warning.
         warn: &impl Fn(&str),
     ) -> Result<Vec<ImplExpr<'tcx>>, String> {
         let tcx = self.tcx;
         predicates
             .iter()
-            .map(|(clause, _span)| *clause)
-            .filter_map(|clause| clause.as_trait_clause())
+            .filter_map(|pred| pred.clause.as_trait_clause())
             .map(|trait_pred| trait_pred.map_bound(|p| p.trait_ref))
             // Substitute the item generics
             .map(|trait_ref| EarlyBinder::bind(trait_ref).instantiate(tcx, generics))

--- a/charon/hax-frontend/src/traits/resolution.rs
+++ b/charon/hax-frontend/src/traits/resolution.rs
@@ -49,9 +49,6 @@ pub enum ImplExprAtom<'tcx> {
     /// A context-bound clause like `where T: Trait`.
     LocalBound {
         predicate: Predicate<'tcx>,
-        /// The nth (non-self) predicate found for this item. We use predicates from
-        /// `required_predicates` starting from the parentmost item.
-        index: usize,
         id: ItemPredicateId,
         r#trait: PolyTraitRef<'tcx>,
         path: Path<'tcx>,
@@ -127,9 +124,8 @@ pub enum BoundPredicateOrigin {
     /// The `Self: Trait` predicate implicitly present within trait declarations (note: we
     /// don't add it for trait implementations, should we?).
     SelfPred,
-    /// The nth (non-self) predicate found for this item. We use predicates from
-    /// `required_predicates` starting from the parentmost item.
-    Item(usize),
+    /// A predicate found for this item.
+    Item,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -214,9 +210,8 @@ impl<'tcx> Candidate<'tcx> {
         let r#trait = self.origin.clause.to_poly_trait_ref();
         match self.origin.origin {
             BoundPredicateOrigin::SelfPred => ImplExprAtom::SelfImpl { r#trait, path },
-            BoundPredicateOrigin::Item(index) => ImplExprAtom::LocalBound {
+            BoundPredicateOrigin::Item => ImplExprAtom::LocalBound {
                 predicate: self.origin.clause.upcast(tcx),
-                index,
                 id: self.origin.id,
                 r#trait,
                 path,
@@ -234,8 +229,6 @@ pub struct PredicateSearcher<'tcx> {
     candidates: HashMap<PolyTraitPredicate<'tcx>, Candidate<'tcx>>,
     /// Resolution options.
     options: BoundsOptions,
-    /// Count the number of bound clauses in scope; used to identify clauses uniquely.
-    bound_clause_count: usize,
 }
 
 impl<'tcx> PredicateSearcher<'tcx> {
@@ -249,7 +242,6 @@ impl<'tcx> PredicateSearcher<'tcx> {
             },
             candidates: Default::default(),
             options,
-            bound_clause_count: 0,
         };
         out.insert_predicates(
             initial_self_pred(tcx, owner_id).map(|clause| AnnotatedTraitPred {
@@ -269,28 +261,15 @@ impl<'tcx> PredicateSearcher<'tcx> {
         &mut self,
         preds: impl IntoIterator<Item = ItemPredicate<'tcx>>,
     ) {
-        let mut count = usize::MAX;
-        // Swap to avoid borrow conflicts.
-        std::mem::swap(&mut count, &mut self.bound_clause_count);
-        self.insert_predicates(
-            preds
-                .into_iter()
-                .filter_map(|pred| {
-                    pred.clause
-                        .as_trait_clause()
-                        .map(|clause| (pred.id, clause))
+        self.insert_predicates(preds.into_iter().filter_map(|pred| {
+            pred.clause
+                .as_trait_clause()
+                .map(|clause| AnnotatedTraitPred {
+                    origin: BoundPredicateOrigin::Item,
+                    id: pred.id,
+                    clause,
                 })
-                .map(|(id, pred)| {
-                    let i = count;
-                    count += 1;
-                    AnnotatedTraitPred {
-                        origin: BoundPredicateOrigin::Item(i),
-                        id,
-                        clause: pred,
-                    }
-                }),
-        );
-        std::mem::swap(&mut count, &mut self.bound_clause_count);
+        }));
     }
 
     /// Override the param env; we use this when resolving `dyn` predicates to add more clauses to

--- a/charon/hax-frontend/src/traits/utils.rs
+++ b/charon/hax-frontend/src/traits/utils.rs
@@ -27,35 +27,76 @@
 //! benefit of reducing the size of signatures. Moreover, the rules on which bounds are required vs
 //! implied are subtle. We may change this if this proves to be a problem.
 use crate::options::BoundsOptions;
+use itertools::Itertools;
 use rustc_hir::LangItem;
 use rustc_hir::def::DefKind;
 use rustc_middle::ty::*;
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span};
-use std::borrow::Cow;
 
-pub type Predicates<'tcx> = Cow<'tcx, [(Clause<'tcx>, Span)]>;
+/// Uniquely identifies a predicate.
+#[derive(Debug, Clone, Copy)]
+pub enum ItemPredicateId {
+    /// A predicate that counts as "input" for an item, e.g. `where` clauses on a function or impl.
+    /// Numbered in some arbitrary but consistent order.
+    Required(DefId, u32),
+    /// A predicate that counts as "output" of an item, e.g. supertrait clauses in a trait. Note
+    /// that we count `where` clauses on a trait as implied.
+    /// Numbered in some arbitrary but consistent order.
+    Implied(DefId, u32),
+    /// The special `Self: Trait` clause available within trait `Trait`.
+    TraitSelf,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ItemPredicate<'tcx> {
+    // pub id: ItemPredicateId,
+    pub clause: Clause<'tcx>,
+    pub span: Span,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ItemPredicates<'tcx> {
+    pub predicates: Vec<ItemPredicate<'tcx>>,
+}
+
+impl<'tcx> ItemPredicates<'tcx> {
+    pub fn new(predicates: impl IntoIterator<Item = (Clause<'tcx>, Span)>) -> Self {
+        Self {
+            predicates: predicates
+                .into_iter()
+                .map(|(clause, span)| ItemPredicate { clause, span })
+                .collect(),
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ItemPredicate<'tcx>> {
+        self.predicates.iter().copied()
+    }
+}
 
 /// Returns a list of type predicates for the definition with ID `def_id`, including inferred
 /// lifetime constraints. This is the basic list of predicates we use for essentially all items.
-pub fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId) -> Predicates<'_> {
-    let mut result = Cow::Borrowed(tcx.explicit_predicates_of(def_id).predicates);
-    let inferred_outlives = tcx.inferred_outlives_of(def_id);
-    if !inferred_outlives.is_empty() {
-        result.to_mut().extend(
-            inferred_outlives
+fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId) -> ItemPredicates<'_> {
+    let predicates = tcx
+        .explicit_predicates_of(def_id)
+        .predicates
+        .iter()
+        .copied()
+        .chain(
+            tcx.inferred_outlives_of(def_id)
                 .iter()
-                .map(|(clause, span)| ((*clause).upcast(tcx), *span)),
+                .copied()
+                .map(|(clause, span)| (clause.upcast(tcx), span)),
         );
-    }
-    result
+    ItemPredicates::new(predicates)
 }
 
 /// Add `T: Destruct` bounds for every generic parameter of the given item.
 fn add_destruct_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
-    predicates: &mut Vec<(Clause<'tcx>, Span)>,
+    predicates: &mut ItemPredicates<'tcx>,
 ) {
     let def_kind = tcx.def_kind(def_id);
     if matches!(def_kind, DefKind::Closure) {
@@ -73,8 +114,11 @@ fn add_destruct_bounds<'tcx>(
         .map(|param| tcx.mk_param_from_def(param))
         .map(|ty| Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty])))
         .map(|tref| tref.upcast(tcx))
-        .map(|clause| (clause, DUMMY_SP));
-    predicates.extend(extra_bounds);
+        .map(|clause| ItemPredicate {
+            clause,
+            span: DUMMY_SP,
+        });
+    predicates.predicates.extend(extra_bounds);
 }
 
 /// The predicates that must hold to mention this item. E.g.
@@ -92,7 +136,7 @@ pub fn required_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     options: BoundsOptions,
-) -> Predicates<'tcx> {
+) -> ItemPredicates<'tcx> {
     use DefKind::*;
     let def_kind = tcx.def_kind(def_id);
     let mut predicates = match def_kind {
@@ -120,12 +164,18 @@ pub fn required_predicates<'tcx>(
         && let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
     {
         let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
-        predicates.to_mut().insert(0, (self_clause, DUMMY_SP));
+        predicates.predicates.insert(
+            0,
+            ItemPredicate {
+                clause: self_clause,
+                span: DUMMY_SP,
+            },
+        );
     }
     if options.resolve_destruct && !matches!(def_kind, Trait | TraitAlias) {
         // Add a `T: Destruct` bound for every generic. For traits we consider these predicates
         // implied instead of required.
-        add_destruct_bounds(tcx, def_id, predicates.to_mut());
+        add_destruct_bounds(tcx, def_id, &mut predicates);
     }
     if options.prune_sized {
         prune_sized_predicates(tcx, &mut predicates);
@@ -156,7 +206,7 @@ pub fn implied_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     options: BoundsOptions,
-) -> Predicates<'tcx> {
+) -> ItemPredicates<'tcx> {
     use DefKind::*;
     let parent = tcx.opt_parent(def_id);
     let mut predicates = match tcx.def_kind(def_id) {
@@ -178,25 +228,34 @@ pub fn implied_predicates<'tcx>(
                             | LangItem::Tuple
                     )
                 ) {
-                    add_destruct_bounds(tcx, def_id, predicates.to_mut());
+                    add_destruct_bounds(tcx, def_id, &mut predicates);
                 }
             }
             predicates
         }
         AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
             // `skip_binder` is for the GAT `EarlyBinder`
-            let mut predicates = Cow::Borrowed(tcx.explicit_item_bounds(def_id).skip_binder());
+            let mut predicates = tcx
+                .explicit_item_bounds(def_id)
+                .skip_binder()
+                .iter()
+                .copied()
+                .map(|(clause, span)| ItemPredicate { clause, span })
+                .collect_vec();
             if options.resolve_destruct {
                 // Add a `Drop` bound to the assoc item.
                 let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
                 let ty =
                     Ty::new_projection(tcx, def_id, GenericArgs::identity_for_item(tcx, def_id));
                 let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
-                predicates.to_mut().push((tref.upcast(tcx), DUMMY_SP));
+                predicates.push(ItemPredicate {
+                    clause: tref.upcast(tcx),
+                    span: DUMMY_SP,
+                });
             }
-            predicates
+            ItemPredicates { predicates }
         }
-        _ => Predicates::default(),
+        _ => ItemPredicates::default(),
     };
     if options.prune_sized {
         prune_sized_predicates(tcx, &mut predicates);
@@ -306,19 +365,12 @@ pub fn is_sized_related_trait<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
 
 /// Given a `GenericPredicates`, prune every occurence of a sized-related clause.
 /// Prunes bounds of the shape `T: MetaSized`, `T: Sized` or `T: PointeeSized`.
-fn prune_sized_predicates<'tcx>(tcx: TyCtxt<'tcx>, generic_predicates: &mut Predicates<'tcx>) {
-    let predicates: Vec<(Clause<'tcx>, rustc_span::Span)> = generic_predicates
-        .iter()
-        .filter(|(clause, _)| {
-            clause.as_trait_clause().is_none_or(|trait_predicate| {
-                !is_sized_related_trait(tcx, trait_predicate.skip_binder().def_id())
-            })
+fn prune_sized_predicates<'tcx>(tcx: TyCtxt<'tcx>, generic_predicates: &mut ItemPredicates<'tcx>) {
+    generic_predicates.predicates.retain(|pred| {
+        pred.clause.as_trait_clause().is_none_or(|trait_predicate| {
+            !is_sized_related_trait(tcx, trait_predicate.skip_binder().def_id())
         })
-        .copied()
-        .collect();
-    if predicates.len() != generic_predicates.len() {
-        *generic_predicates.to_mut() = predicates;
-    }
+    });
 }
 
 pub trait ToPolyTraitRef<'tcx> {

--- a/charon/hax-frontend/src/traits/utils.rs
+++ b/charon/hax-frontend/src/traits/utils.rs
@@ -35,7 +35,7 @@ use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span};
 
 /// Uniquely identifies a predicate.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ItemPredicateId {
     /// A predicate that counts as "input" for an item, e.g. `where` clauses on a function or impl.
     /// Numbered in some arbitrary but consistent order.
@@ -44,6 +44,9 @@ pub enum ItemPredicateId {
     /// that we count `where` clauses on a trait as implied.
     /// Numbered in some arbitrary but consistent order.
     Implied(DefId, u32),
+    /// Predicate inside a non-item binder, e.g. within a `dyn Trait`.
+    /// Numbered in some arbitrary but consistent order.
+    Unmapped(u32),
     /// The special `Self: Trait` clause available within trait `Trait`.
     TraitSelf,
 }
@@ -58,6 +61,11 @@ impl ItemPredicateId {
             ItemPredicateId::Implied(def_id, i)
         }
     }
+    fn new_unmapped(next_id: &mut usize) -> Self {
+        let i = *next_id as u32;
+        *next_id += 1;
+        ItemPredicateId::Unmapped(i)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -71,7 +79,7 @@ pub struct ItemPredicate<'tcx> {
 pub struct ItemPredicates<'tcx> {
     required: bool,
     next_id: usize,
-    predicates: Vec<ItemPredicate<'tcx>>,
+    pub predicates: Vec<ItemPredicate<'tcx>>,
 }
 
 impl<'tcx> ItemPredicates<'tcx> {
@@ -91,6 +99,21 @@ impl<'tcx> ItemPredicates<'tcx> {
         Self {
             next_id,
             required,
+            predicates,
+        }
+    }
+    pub fn new_unmapped(span: Span, predicates: impl IntoIterator<Item = Clause<'tcx>>) -> Self {
+        let mut next_id = 0;
+        let predicates = predicates
+            .into_iter()
+            .map(|clause| {
+                let id = ItemPredicateId::new_unmapped(&mut next_id);
+                ItemPredicate { id, clause, span }
+            })
+            .collect_vec();
+        Self {
+            next_id,
+            required: true,
             predicates,
         }
     }

--- a/charon/hax-frontend/src/traits/utils.rs
+++ b/charon/hax-frontend/src/traits/utils.rs
@@ -48,36 +48,79 @@ pub enum ItemPredicateId {
     TraitSelf,
 }
 
+impl ItemPredicateId {
+    fn new(def_id: DefId, required: bool, next_id: &mut usize) -> Self {
+        let i = *next_id as u32;
+        *next_id += 1;
+        if required {
+            ItemPredicateId::Required(def_id, i)
+        } else {
+            ItemPredicateId::Implied(def_id, i)
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ItemPredicate<'tcx> {
-    // pub id: ItemPredicateId,
+    pub id: ItemPredicateId,
     pub clause: Clause<'tcx>,
     pub span: Span,
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct ItemPredicates<'tcx> {
-    pub predicates: Vec<ItemPredicate<'tcx>>,
+    required: bool,
+    next_id: usize,
+    predicates: Vec<ItemPredicate<'tcx>>,
 }
 
 impl<'tcx> ItemPredicates<'tcx> {
-    pub fn new(predicates: impl IntoIterator<Item = (Clause<'tcx>, Span)>) -> Self {
+    pub fn new(
+        def_id: DefId,
+        required: bool,
+        predicates: impl IntoIterator<Item = (Clause<'tcx>, Span)>,
+    ) -> Self {
+        let mut next_id = 0;
+        let predicates = predicates
+            .into_iter()
+            .map(|(clause, span)| {
+                let id = ItemPredicateId::new(def_id, required, &mut next_id);
+                ItemPredicate { id, clause, span }
+            })
+            .collect_vec();
         Self {
-            predicates: predicates
-                .into_iter()
-                .map(|(clause, span)| ItemPredicate { clause, span })
-                .collect(),
+            next_id,
+            required,
+            predicates,
         }
+    }
+
+    pub fn add_synthetic_predicates(
+        &mut self,
+        def_id: DefId,
+        predicates: impl IntoIterator<Item = Clause<'tcx>>,
+    ) {
+        self.predicates.extend(predicates.into_iter().map(|clause| {
+            let id = ItemPredicateId::new(def_id, self.required, &mut self.next_id);
+            ItemPredicate {
+                id,
+                clause,
+                span: DUMMY_SP,
+            }
+        }));
     }
 
     pub fn iter(&self) -> impl Iterator<Item = ItemPredicate<'tcx>> {
         self.predicates.iter().copied()
     }
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ItemPredicate<'tcx>> {
+        self.predicates.iter_mut()
+    }
 }
 
 /// Returns a list of type predicates for the definition with ID `def_id`, including inferred
 /// lifetime constraints. This is the basic list of predicates we use for essentially all items.
-fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId) -> ItemPredicates<'_> {
+fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId, required: bool) -> ItemPredicates<'_> {
     let predicates = tcx
         .explicit_predicates_of(def_id)
         .predicates
@@ -89,7 +132,7 @@ fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId) -> ItemPredicates<'_> {
                 .copied()
                 .map(|(clause, span)| (clause.upcast(tcx), span)),
         );
-    ItemPredicates::new(predicates)
+    ItemPredicates::new(def_id, required, predicates)
 }
 
 /// Add `T: Destruct` bounds for every generic parameter of the given item.
@@ -113,12 +156,8 @@ fn add_destruct_bounds<'tcx>(
         .filter(|param| matches!(param.kind, GenericParamDefKind::Type { .. }))
         .map(|param| tcx.mk_param_from_def(param))
         .map(|ty| Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty])))
-        .map(|tref| tref.upcast(tcx))
-        .map(|clause| ItemPredicate {
-            clause,
-            span: DUMMY_SP,
-        });
-    predicates.predicates.extend(extra_bounds);
+        .map(|tref| tref.upcast(tcx));
+    predicates.add_synthetic_predicates(def_id, extra_bounds);
 }
 
 /// The predicates that must hold to mention this item. E.g.
@@ -152,7 +191,7 @@ pub fn required_predicates<'tcx>(
         | Static { .. }
         | Struct
         | TyAlias
-        | Union => predicates_defined_on(tcx, def_id),
+        | Union => predicates_defined_on(tcx, def_id, true),
         // We consider all predicates on traits to be outputs
         Trait | TraitAlias => Default::default(),
         // `predicates_defined_on` ICEs on other def kinds.
@@ -167,6 +206,7 @@ pub fn required_predicates<'tcx>(
         predicates.predicates.insert(
             0,
             ItemPredicate {
+                id: ItemPredicateId::TraitSelf,
                 clause: self_clause,
                 span: DUMMY_SP,
             },
@@ -212,7 +252,7 @@ pub fn implied_predicates<'tcx>(
     let mut predicates = match tcx.def_kind(def_id) {
         // We consider all predicates on traits to be outputs
         Trait | TraitAlias => {
-            let mut predicates = predicates_defined_on(tcx, def_id);
+            let mut predicates = predicates_defined_on(tcx, def_id, false);
             if options.resolve_destruct {
                 // Add a `T: Drop` bound for every generic, unless the current trait is `Drop` itself, or a
                 // built-in marker trait that we know doesn't need the bound.
@@ -235,25 +275,23 @@ pub fn implied_predicates<'tcx>(
         }
         AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
             // `skip_binder` is for the GAT `EarlyBinder`
-            let mut predicates = tcx
-                .explicit_item_bounds(def_id)
-                .skip_binder()
-                .iter()
-                .copied()
-                .map(|(clause, span)| ItemPredicate { clause, span })
-                .collect_vec();
+            let mut predicates = ItemPredicates::new(
+                def_id,
+                false,
+                tcx.explicit_item_bounds(def_id)
+                    .skip_binder()
+                    .iter()
+                    .copied(),
+            );
             if options.resolve_destruct {
                 // Add a `Drop` bound to the assoc item.
                 let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
                 let ty =
                     Ty::new_projection(tcx, def_id, GenericArgs::identity_for_item(tcx, def_id));
                 let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
-                predicates.push(ItemPredicate {
-                    clause: tref.upcast(tcx),
-                    span: DUMMY_SP,
-                });
+                predicates.add_synthetic_predicates(def_id, [tref.upcast(tcx)]);
             }
-            ItemPredicates { predicates }
+            predicates
         }
         _ => ItemPredicates::default(),
     };

--- a/charon/hax-frontend/src/types/new/full_def.rs
+++ b/charon/hax-frontend/src/types/new/full_def.rs
@@ -1329,22 +1329,18 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     args: Option<ty::GenericArgsRef<'tcx>>,
 ) -> GenericPredicates {
-    use std::borrow::Cow;
     let tcx = s.base().tcx;
     let def_id = s.owner_id();
     let typing_env = s.typing_env();
     let mut implied_predicates = implied_predicates(tcx, def_id, s.base().options.bounds_options);
     if args.is_some() {
-        implied_predicates = Cow::Owned(
-            implied_predicates
-                .iter()
-                .copied()
-                .map(|(clause, span)| {
-                    let clause = substitute(tcx, typing_env, args, clause);
-                    (clause, span)
-                })
-                .collect(),
-        );
+        implied_predicates.predicates = implied_predicates
+            .iter()
+            .map(|ItemPredicate { clause, span }| {
+                let clause = substitute(tcx, typing_env, args, clause);
+                ItemPredicate { clause, span }
+            })
+            .collect();
     }
     implied_predicates.sinto(s)
 }

--- a/charon/hax-frontend/src/types/new/full_def.rs
+++ b/charon/hax-frontend/src/types/new/full_def.rs
@@ -1334,13 +1334,9 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     let typing_env = s.typing_env();
     let mut implied_predicates = implied_predicates(tcx, def_id, s.base().options.bounds_options);
     if args.is_some() {
-        implied_predicates.predicates = implied_predicates
-            .iter()
-            .map(|ItemPredicate { clause, span }| {
-                let clause = substitute(tcx, typing_env, args, clause);
-                ItemPredicate { clause, span }
-            })
-            .collect();
+        for pred in implied_predicates.iter_mut() {
+            pred.clause = substitute(tcx, typing_env, args, pred.clause);
+        }
     }
     implied_predicates.sinto(s)
 }

--- a/charon/hax-frontend/src/types/ty.rs
+++ b/charon/hax-frontend/src/types/ty.rs
@@ -861,13 +861,12 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
 ) -> DynBinder<R> {
     fn searcher_for_traits<'tcx, S: UnderOwnerState<'tcx>>(
         s: &S,
-        clauses: &Vec<ty::Clause<'tcx>>,
+        preds: &ItemPredicates<'tcx>,
     ) -> PredicateSearcher<'tcx> {
         let tcx = s.base().tcx;
         // Populate a predicate searcher that knows about the `dyn` clauses.
         let mut predicate_searcher = s.with_predicate_searcher(|ps| ps.clone());
-        predicate_searcher
-            .insert_bound_predicates(clauses.iter().filter_map(|clause| clause.as_trait_clause()));
+        predicate_searcher.insert_bound_predicates(preds.iter());
         predicate_searcher.set_param_env(
             rustc_trait_selection::traits::normalize_param_env_or_error(
                 tcx,
@@ -876,7 +875,7 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
                         s.param_env()
                             .caller_bounds()
                             .iter()
-                            .chain(clauses.iter().copied()),
+                            .chain(preds.iter().map(|pred| pred.clause)),
                     ),
                 ),
                 rustc_trait_selection::traits::ObligationCause::dummy(),
@@ -901,23 +900,21 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
     let new_ty = new_param_ty.to_ty(tcx);
 
     // Set the new type as the `Self` parameter of our predicates.
-    let clauses: Vec<ty::Clause<'_>> = epreds
-        .iter()
-        .map(|epred| epred.with_self_ty(tcx, new_ty))
-        .collect();
+    let predicates = epreds.iter().map(|epred| epred.with_self_ty(tcx, new_ty));
+    let predicates: ItemPredicates<'_> = ItemPredicates::new_unmapped(span, predicates);
 
     // Populate a predicate searcher that knows about the `dyn` clauses.
-    let mut predicate_searcher = searcher_for_traits(s, &clauses);
+    let mut predicate_searcher = searcher_for_traits(s, &predicates);
     let val = f(&mut predicate_searcher, new_ty);
 
     // Using the predicate searcher, translate the predicates. Only the projection predicates need
     // to be handled specially.
-    let predicates = clauses
-        .into_iter()
-        .map(|clause| {
-            let clause = match clause.as_projection_clause() {
+    let predicates = predicates
+        .iter()
+        .map(|pred| {
+            match pred.clause.as_projection_clause() {
                 // Translate normally
-                None => clause.sinto(s),
+                None => pred.sinto(s),
                 // Translate by hand using our predicate searcher. This does the same as
                 // `clause.sinto(s)` except that it uses our predicate searcher to resolve the
                 // projection `ImplExpr`.
@@ -946,10 +943,14 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
                         value: ClauseKind::Projection(proj),
                         bound_vars,
                     };
-                    Clause { kind }
+                    let clause = Clause { kind };
+                    GenericPredicate {
+                        id: pred.id.sinto(s),
+                        clause,
+                        span,
+                    }
                 }
-            };
-            (clause, span.clone())
+            }
         })
         .collect();
 
@@ -1339,26 +1340,40 @@ impl<T> Binder<T> {
     }
 }
 
-/// Reflects [`ty::GenericPredicates`]
+/// Uniquely identifies a predicate.
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: ty::GenericPredicates<'tcx>, state: S as s)]
-#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
-pub struct GenericPredicates {
-    #[value(self.predicates.iter().map(|x| x.sinto(s)).collect())]
-    pub predicates: Vec<(Clause, Span)>,
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicateId, state: S as s)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum GenericPredicateId {
+    /// A predicate that counts as "input" for an item, e.g. `where` clauses on a function or impl.
+    /// Numbered in some arbitrary but consistent order.
+    Required(DefId, u32),
+    /// A predicate that counts as "output" of an item, e.g. supertrait clauses in a trait. Note
+    /// that we count `where` clauses on a trait as implied.
+    /// Numbered in some arbitrary but consistent order.
+    Implied(DefId, u32),
+    /// Predicate inside a non-item binder, e.g. within a `dyn Trait`.
+    /// Numbered in some arbitrary but consistent order.
+    Unmapped(u32),
+    /// The special `Self: Trait` clause available within trait `Trait`.
+    TraitSelf,
 }
 
-impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GenericPredicates>
-    for crate::traits::ItemPredicates<'tcx>
-{
-    fn sinto(&self, s: &S) -> GenericPredicates {
-        GenericPredicates {
-            predicates: self
-                .iter()
-                .map(|pred| (pred.clause.sinto(s), pred.span.sinto(s)))
-                .collect(),
-        }
-    }
+#[derive(AdtInto)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicate<'tcx>, state: S as s)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct GenericPredicate {
+    pub id: GenericPredicateId,
+    pub clause: Clause,
+    pub span: Span,
+}
+
+/// Reflects [`ty::GenericPredicates`]
+#[derive(AdtInto)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicates<'tcx>, state: S as s)]
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct GenericPredicates {
+    pub predicates: Vec<GenericPredicate>,
 }
 
 impl<'tcx, S: UnderOwnerState<'tcx>, T1, T2> SInto<S, Binder<T2>> for ty::Binder<'tcx, T1>

--- a/charon/hax-frontend/src/types/ty.rs
+++ b/charon/hax-frontend/src/types/ty.rs
@@ -1349,11 +1349,14 @@ pub struct GenericPredicates {
 }
 
 impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GenericPredicates>
-    for crate::traits::Predicates<'tcx>
+    for crate::traits::ItemPredicates<'tcx>
 {
     fn sinto(&self, s: &S) -> GenericPredicates {
         GenericPredicates {
-            predicates: self.as_ref().sinto(s),
+            predicates: self
+                .iter()
+                .map(|pred| (pred.clause.sinto(s), pred.span.sinto(s)))
+                .collect(),
         }
     }
 }

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -42,8 +42,10 @@ pub(crate) struct BindingLevel {
     pub closure_call_method_region: Option<RegionId>,
     /// The map from rust type variable indices to translated type variable indices.
     pub type_vars_map: HashMap<u32, TypeVarId>,
-    /// The map from rust const generic variables to translate const generic variable indices.
+    /// The map from rust const generic variables to translated const generic variable indices.
     pub const_generic_vars_map: HashMap<u32, ConstGenericVarId>,
+    /// The map from trait predicates to translated trait clause indices.
+    pub trait_preds: HashMap<hax::GenericPredicateId, TraitClauseId>,
     /// The types of the captured variables, when we're translating a closure item. This is
     /// translated early because this translation requires adding new lifetime generics to the
     /// current binder.
@@ -295,34 +297,12 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     pub(crate) fn lookup_clause_var(
         &mut self,
         span: Span,
-        mut id: usize,
+        id: &hax::GenericPredicateId,
     ) -> Result<ClauseDbVar, Error> {
-        // The clause indices returned by hax count clauses in order, starting from the parentmost.
-        // While adding clauses to a binding level we already need to translate types and clauses,
-        // so the innermost item binder may not have all the clauses yet. Hence for that binder we
-        // ignore the clause count.
-        let innermost_item_binder_id = self
-            .binding_levels
-            .iter_enumerated()
-            .find(|(_, bl)| bl.is_item_binder)
-            .unwrap()
-            .0;
-        // Iterate over the binders, starting from the outermost.
-        for (dbid, bl) in self.binding_levels.iter_enumerated().rev() {
-            let num_clauses_bound_at_this_level = bl.params.trait_clauses.elem_count();
-            if id < num_clauses_bound_at_this_level || dbid == innermost_item_binder_id {
-                let id = TraitClauseId::from_usize(id);
-                return Ok(DeBruijnVar::bound(dbid, id));
-            } else {
-                id -= num_clauses_bound_at_this_level
-            }
-        }
-        // Actually unreachable
-        raise_error!(
-            self,
+        self.lookup_param(
             span,
-            "Unexpected error: could not find clause variable {}",
-            id
+            |bl| bl.trait_preds.get(id).copied(),
+            || format!("the trait clause variable {id:?}"),
         )
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -25,10 +25,6 @@ use charon_lib::ids::IndexVec;
 pub(crate) struct BindingLevel {
     /// The parameters and predicates bound at this level.
     pub params: GenericParams,
-    /// Whether this binder corresponds to an item (method, type) or not (`for<..>` predicate, `fn`
-    /// pointer, etc). This indicates whether it corresponds to a rustc `ParamEnv` and therefore
-    /// whether we should resolve rustc variables there.
-    pub is_item_binder: bool,
     /// Rust makes the distinction between early and late-bound region parameters. We do not make
     /// this distinction, and merge early and late bound regions. For details, see:
     /// <https://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/>
@@ -68,9 +64,8 @@ fn translate_region_name(s: hax::Symbol) -> Option<String> {
 }
 
 impl BindingLevel {
-    pub(crate) fn new(is_item_binder: bool) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            is_item_binder,
             ..Default::default()
         }
     }
@@ -436,7 +431,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         kind: &TransItemSourceKind,
     ) -> Result<(), Error> {
         assert!(self.binding_levels.len() == 0);
-        self.binding_levels.push(BindingLevel::new(true));
+        self.binding_levels.push(BindingLevel::new());
         self.push_generics_for_def(span, def)?;
         self.push_late_bound_generics_for_def(span, def)?;
 
@@ -475,17 +470,12 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     }
 
     /// Push a new binding level, run the provided function inside it, then return the bound value.
-    pub(crate) fn inside_binder<F, U>(
-        &mut self,
-        kind: BinderKind,
-        is_item_binder: bool,
-        f: F,
-    ) -> Result<Binder<U>, Error>
+    pub(crate) fn inside_binder<F, U>(&mut self, kind: BinderKind, f: F) -> Result<Binder<U>, Error>
     where
         F: FnOnce(&mut Self) -> Result<U, Error>,
     {
         assert!(!self.binding_levels.is_empty());
-        self.binding_levels.push(BindingLevel::new(is_item_binder));
+        self.binding_levels.push(BindingLevel::new());
 
         // Call the continuation. Important: do not short-circuit on error here.
         let res = f(self);
@@ -515,7 +505,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     {
         let inner_hax_state = self.t_ctx.hax_state.clone().with_hax_owner(&def.def_id());
         let outer_hax_state = mem::replace(&mut self.hax_state, inner_hax_state);
-        let ret = self.inside_binder(kind, true, |this| {
+        let ret = self.inside_binder(kind, |this| {
             this.push_generics_for_def_without_parents(span, def)?;
             this.push_late_bound_generics_for_def(span, def)?;
             this.innermost_binder().params.check_consistency();
@@ -537,7 +527,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     where
         F: FnOnce(&mut Self, &T) -> Result<U, Error>,
     {
-        let binder = self.inside_binder(BinderKind::Other, false, |this| {
+        let binder = self.inside_binder(BinderKind::Other, |this| {
             this.innermost_binder_mut()
                 .push_params_from_binder(binder.rebind(()))?;
             f(this, binder.hax_skip_binder_ref())

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -672,13 +672,14 @@ impl ItemTransCtx<'_, '_> {
             raise_error!(self, span, "Unexpected definition: {def:?}");
         };
 
-        // Register implied predicates.
-        let mut preds =
-            self.translate_predicates(implied_predicates, PredicateOrigin::WhereClauseOnTrait)?;
-        let implied_clauses = mem::take(&mut preds.trait_clauses);
-        // Consider the other predicates as required since the distinction doesn't matter for
-        // non-trait-clauses.
-        self.innermost_generics_mut().take_predicates_from(preds);
+        // Register implied predicates. We gather the clauses and consider the other predicates as
+        // required since the distinction doesn't matter for non-trait-clauses.
+        let mut implied_clauses = Default::default();
+        self.translate_predicates(
+            implied_predicates,
+            PredicateOrigin::WhereClauseOnTrait,
+            Some(&mut implied_clauses),
+        )?;
 
         let vtable = self.translate_vtable_struct_ref_no_enqueue(span, def.this())?;
 
@@ -884,14 +885,12 @@ impl ItemTransCtx<'_, '_> {
                     let assoc_ty =
                         self.translate_binder_for_def(item_span, binder_kind, &item_def, |ctx| {
                             // Also add the implied predicates.
-                            let mut preds = ctx.translate_predicates(
+                            let mut implied_clauses = Default::default();
+                            ctx.translate_predicates(
                                 &implied_predicates,
                                 PredicateOrigin::TraitItem(item_name.clone()),
+                                Some(&mut implied_clauses),
                             )?;
-                            let implied_clauses = mem::take(&mut preds.trait_clauses);
-                            // Consider the other predicates as required since the distinction doesn't
-                            // matter for non-trait-clauses.
-                            ctx.innermost_generics_mut().take_predicates_from(preds);
 
                             let default = default
                                 .as_ref()

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -475,9 +475,8 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
                             implied_predicates, ..
                         } = item_def.kind()
                         {
-                            let predicates = &implied_predicates.predicates;
-                            if let Some((c, _)) = predicates.first() {
-                                if let hax::ClauseKind::Trait(p) = &c.kind.value {
+                            if let Some(pred) = implied_predicates.predicates.first() {
+                                if let hax::ClauseKind::Trait(p) = &pred.clause.kind.value {
                                     assoc_types = Some(p.trait_ref.generic_args.clone());
                                     break;
                                 }

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -455,7 +455,7 @@ impl<'tcx, 'ctx> TranslateCtx<'tcx> {
             let trans_id = self.register_no_enqueue(&None, src).unwrap();
             let span = self.def_span(&item_ref.def_id);
             let mut bt_ctx = ItemTransCtx::new(src.clone(), trans_id, self);
-            bt_ctx.binding_levels.push(BindingLevel::new(true));
+            bt_ctx.binding_levels.push(BindingLevel::new());
 
             let trait_def = bt_ctx.t_ctx.hax_def_for_item(&src.item)?;
             let mut assoc_types = None;

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -55,6 +55,29 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         preds: &hax::GenericPredicates,
         origin: PredicateOrigin,
     ) -> Result<(), Error> {
+        // Register the mapping from trait preds to their id early on, as these can be mentioned
+        // while translating any other predicate including themselves. Each trait pred gives rise
+        // to exactly one trait clause inserted into `trait_clauses`, which we use to compute
+        // clause ids. This is error-prone but I don't know a better way.
+        let next_clause_id = self.innermost_generics_mut().trait_clauses.next_id();
+        for (i, pred) in preds
+            .predicates
+            .iter()
+            .filter(|pred| {
+                matches!(
+                    pred.clause.kind.hax_skip_binder_ref(),
+                    hax::ClauseKind::Trait(_)
+                )
+            })
+            .enumerate()
+        {
+            let prev = self
+                .innermost_binder_mut()
+                .trait_preds
+                .insert(pred.id.clone(), next_clause_id + i);
+            assert_eq!(prev, None);
+        }
+
         let preds = self.translate_predicates(preds, origin)?;
         self.innermost_generics_mut().take_predicates_from(preds);
         Ok(())
@@ -70,18 +93,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         origin: PredicateOrigin,
     ) -> Result<GenericParams, Error> {
         let mut out = GenericParams::empty();
-        // Translate the trait predicates first, because associated type constraints may refer to
-        // them. E.g. in `fn foo<I: Iterator<Item=usize>>()`, the `I: Iterator` clause must be
-        // translated before the `<I as Iterator>::Item = usize` predicate.
         for pred in &preds.predicates {
-            if matches!(pred.clause.kind.value, hax::ClauseKind::Trait(_)) {
-                self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
-            }
-        }
-        for pred in &preds.predicates {
-            if !matches!(pred.clause.kind.value, hax::ClauseKind::Trait(_)) {
-                self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
-            }
+            self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
         }
         Ok(out)
     }
@@ -263,15 +276,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     "impl source (self or clause): param:\n- trait_ref: {:?}\n- path: {:?}",
                     trait_ref, path,
                 );
-                // If we are refering to a trait clause, we need to find the relevant one.
+                // If we are referring to a trait clause, we need to find the relevant one.
                 let mut tref_kind = match &impl_source.r#impl {
                     ImplExprAtom::SelfImpl { .. } => TraitRefKind::SelfId,
-                    ImplExprAtom::LocalBound { index, .. } => {
-                        match self.lookup_clause_var(span, *index) {
-                            Ok(var) => TraitRefKind::Clause(var),
-                            Err(err) => TraitRefKind::Unknown(err.msg),
-                        }
-                    }
+                    ImplExprAtom::LocalBound { id, .. } => match self.lookup_clause_var(span, id) {
+                        Ok(var) => TraitRefKind::Clause(var),
+                        Err(err) => TraitRefKind::Unknown(err.msg),
+                    },
                     _ => unreachable!(),
                 };
 

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -55,29 +55,6 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         preds: &hax::GenericPredicates,
         origin: PredicateOrigin,
     ) -> Result<(), Error> {
-        // Register the mapping from trait preds to their id early on, as these can be mentioned
-        // while translating any other predicate including themselves. Each trait pred gives rise
-        // to exactly one trait clause inserted into `trait_clauses`, which we use to compute
-        // clause ids. This is error-prone but I don't know a better way.
-        let next_clause_id = self.innermost_generics_mut().trait_clauses.next_id();
-        for (i, pred) in preds
-            .predicates
-            .iter()
-            .filter(|pred| {
-                matches!(
-                    pred.clause.kind.hax_skip_binder_ref(),
-                    hax::ClauseKind::Trait(_)
-                )
-            })
-            .enumerate()
-        {
-            let prev = self
-                .innermost_binder_mut()
-                .trait_preds
-                .insert(pred.id.clone(), next_clause_id + i);
-            assert_eq!(prev, None);
-        }
-
         self.translate_predicates(preds, origin, None)?;
         Ok(())
     }
@@ -91,13 +68,31 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         // Either put clauses there or in the innermost binder.
         mut trait_clauses: Option<&mut IndexMap<TraitClauseId, TraitParam>>,
     ) -> Result<(), Error> {
+        if trait_clauses.is_none() {
+            // Register the mapping from trait preds to their id early on, as these can be mentioned
+            // while translating any other predicate including themselves. Each trait pred gives rise
+            // to exactly one trait clause inserted into `trait_clauses`, which we use to compute
+            // clause ids.
+            let next_clause_id = self.innermost_generics_mut().trait_clauses.next_id();
+            for (i, pred) in preds
+                .predicates
+                .iter()
+                .filter(|pred| {
+                    matches!(
+                        pred.clause.kind.hax_skip_binder_ref(),
+                        hax::ClauseKind::Trait(_)
+                    )
+                })
+                .enumerate()
+            {
+                self.innermost_binder_mut()
+                    .trait_preds
+                    .insert(pred.id.clone(), next_clause_id + i);
+            }
+        }
+
         for pred in &preds.predicates {
-            self.translate_predicate(
-                &pred.clause,
-                &pred.span,
-                origin.clone(),
-                trait_clauses.as_deref_mut(),
-            )?;
+            self.translate_predicate(pred, origin.clone(), trait_clauses.as_deref_mut())?;
         }
         Ok(())
     }
@@ -142,28 +137,39 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
 
     pub(crate) fn translate_predicate(
         &mut self,
-        clause: &hax::Clause,
-        hspan: &hax::Span,
+        pred: &hax::GenericPredicate,
         origin: PredicateOrigin,
         // Either put clauses there or in the innermost binder.
-        trait_clauses: Option<&mut IndexMap<TraitClauseId, TraitParam>>,
+        mut trait_clauses: Option<&mut IndexMap<TraitClauseId, TraitParam>>,
     ) -> Result<(), Error> {
         use hax::ClauseKind;
+        let clause = &pred.clause;
         trace!("{:?}", clause);
-        let span = self.translate_span(hspan);
+        let span = self.translate_span(&pred.span);
         match clause.kind.hax_skip_binder_ref() {
             ClauseKind::Trait(trait_pred) => {
-                let pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {
+                let trait_pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {
                     ctx.translate_trait_predicate(span, trait_pred)
                 })?;
-                trait_clauses
+                let clause_id = trait_clauses
+                    .as_deref_mut()
                     .unwrap_or(&mut self.innermost_generics_mut().trait_clauses)
                     .push_with(|clause_id| TraitParam {
                         clause_id,
                         origin,
                         span: Some(span),
-                        trait_: pred,
+                        trait_: trait_pred,
                     });
+
+                if trait_clauses.is_none() {
+                    // Sanity check.
+                    let expected_clause_id = self
+                        .innermost_binder_mut()
+                        .trait_preds
+                        .get(&pred.id)
+                        .unwrap();
+                    debug_assert_eq!(clause_id, *expected_clause_id);
+                }
             }
             ClauseKind::RegionOutlives(p) => {
                 let pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -78,25 +78,28 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             assert_eq!(prev, None);
         }
 
-        let preds = self.translate_predicates(preds, origin)?;
-        self.innermost_generics_mut().take_predicates_from(preds);
+        self.translate_predicates(preds, origin, None)?;
         Ok(())
     }
 
-    /// Translates the given predicates. Returns a `GenericParams` that only contains predicates.
-    ///
-    /// This function should be called **after** we translated the generics (type parameters,
-    /// regions...).
+    /// Translates the given predicates. This function should be called **after** we translated the
+    /// generics (type parameters, regions...).
     pub(crate) fn translate_predicates(
         &mut self,
         preds: &hax::GenericPredicates,
         origin: PredicateOrigin,
-    ) -> Result<GenericParams, Error> {
-        let mut out = GenericParams::empty();
+        // Either put clauses there or in the innermost binder.
+        mut trait_clauses: Option<&mut IndexMap<TraitClauseId, TraitParam>>,
+    ) -> Result<(), Error> {
         for pred in &preds.predicates {
-            self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
+            self.translate_predicate(
+                &pred.clause,
+                &pred.span,
+                origin.clone(),
+                trait_clauses.as_deref_mut(),
+            )?;
         }
-        Ok(out)
+        Ok(())
     }
 
     pub(crate) fn translate_poly_trait_ref(
@@ -142,7 +145,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         clause: &hax::Clause,
         hspan: &hax::Span,
         origin: PredicateOrigin,
-        into: &mut GenericParams,
+        // Either put clauses there or in the innermost binder.
+        trait_clauses: Option<&mut IndexMap<TraitClauseId, TraitParam>>,
     ) -> Result<(), Error> {
         use hax::ClauseKind;
         trace!("{:?}", clause);
@@ -152,12 +156,14 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 let pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {
                     ctx.translate_trait_predicate(span, trait_pred)
                 })?;
-                into.trait_clauses.push_with(|clause_id| TraitParam {
-                    clause_id,
-                    origin,
-                    span: Some(span),
-                    trait_: pred,
-                });
+                trait_clauses
+                    .unwrap_or(&mut self.innermost_generics_mut().trait_clauses)
+                    .push_with(|clause_id| TraitParam {
+                        clause_id,
+                        origin,
+                        span: Some(span),
+                        trait_: pred,
+                    });
             }
             ClauseKind::RegionOutlives(p) => {
                 let pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {
@@ -165,7 +171,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     let r1 = ctx.translate_region(span, &p.rhs)?;
                     Ok(OutlivesPred(r0, r1))
                 })?;
-                into.regions_outlive.push(pred);
+                self.innermost_generics_mut().regions_outlive.push(pred);
             }
             ClauseKind::TypeOutlives(p) => {
                 let pred = self.translate_region_binder(span, &clause.kind, |ctx, _| {
@@ -173,7 +179,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     let r = ctx.translate_region(span, &p.rhs)?;
                     Ok(OutlivesPred(ty, r))
                 })?;
-                into.types_outlive.push(pred);
+                self.innermost_generics_mut().types_outlive.push(pred);
             }
             ClauseKind::Projection(p) => {
                 // This is used to express constraints over associated types.
@@ -192,7 +198,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                         ty,
                     })
                 })?;
-                into.trait_type_constraints.push(pred);
+                self.innermost_generics_mut()
+                    .trait_type_constraints
+                    .push(pred);
             }
             ClauseKind::ConstArgHasType(..) => {
                 // These are used for trait resolution to get access to the type of const generics.

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -73,14 +73,14 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         // Translate the trait predicates first, because associated type constraints may refer to
         // them. E.g. in `fn foo<I: Iterator<Item=usize>>()`, the `I: Iterator` clause must be
         // translated before the `<I as Iterator>::Item = usize` predicate.
-        for (clause, span) in &preds.predicates {
-            if matches!(clause.kind.value, hax::ClauseKind::Trait(_)) {
-                self.translate_predicate(clause, span, origin.clone(), &mut out)?;
+        for pred in &preds.predicates {
+            if matches!(pred.clause.kind.value, hax::ClauseKind::Trait(_)) {
+                self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
             }
         }
-        for (clause, span) in &preds.predicates {
-            if !matches!(clause.kind.value, hax::ClauseKind::Trait(_)) {
-                self.translate_predicate(clause, span, origin.clone(), &mut out)?;
+        for pred in &preds.predicates {
+            if !matches!(pred.clause.kind.value, hax::ClauseKind::Trait(_)) {
+                self.translate_predicate(&pred.clause, &pred.span, origin.clone(), &mut out)?;
             }
         }
         Ok(out)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -88,8 +88,9 @@ impl ItemTransCtx<'_, '_> {
         preds: &hax::GenericPredicates,
     ) -> Result<(), Error> {
         // Only the first clause is allowed to have methods.
-        for (clause, _) in preds.predicates.iter().skip(1) {
-            if let hax::ClauseKind::Trait(trait_predicate) = clause.kind.hax_skip_binder_ref() {
+        for pred in preds.predicates.iter().skip(1) {
+            if let hax::ClauseKind::Trait(trait_predicate) = pred.clause.kind.hax_skip_binder_ref()
+            {
                 let trait_def_id = &trait_predicate.trait_ref.def_id;
                 let trait_def = self.poly_hax_def(trait_def_id)?;
                 let has_methods = match trait_def.kind() {
@@ -321,8 +322,9 @@ impl ItemTransCtx<'_, '_> {
         }
 
         // Supertrait fields.
-        for (i, (clause, _span)) in implied_predicates.predicates.iter().enumerate() {
+        for (i, pred) in implied_predicates.predicates.iter().enumerate() {
             // If a clause looks like `Self: OtherTrait<...>`, we consider it a supertrait.
+            let clause = &pred.clause;
             if let hax::ClauseKind::Trait(pred) = clause.kind.hax_skip_binder_ref()
                 && self.pred_is_for_self(&pred.trait_ref)
             {
@@ -1436,9 +1438,8 @@ impl ItemTransCtx<'_, '_> {
                     implied_predicates, ..}
                     = item_def.kind() {
                     trace!("MONO: show:\n {:?}", item_def.kind());
-                    let predicates = &implied_predicates.predicates;
-                    if let Some((c, _)) = predicates.first() {
-                        if let hax::ClauseKind::Trait(p) = &c.kind.value {
+                    if let Some(pred) = implied_predicates.predicates.first() {
+                        if let hax::ClauseKind::Trait(p) = &pred.clause.kind.value {
                             assoc_types = Some(p.trait_ref.generic_args.clone());
                         }
                     }

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -124,7 +124,7 @@ impl ItemTransCtx<'_, '_> {
         self.check_at_most_one_pred_has_methods(span, &binder.predicates)?;
 
         // Add a binder that contains the existentially quantified type.
-        self.binding_levels.push(BindingLevel::new(true));
+        self.binding_levels.push(BindingLevel::new());
 
         // Add the existentially quantified type.
         let ty_id = self
@@ -399,7 +399,7 @@ impl ItemTransCtx<'_, '_> {
                     } else {
                         // The method is defined in a context that has an extra `Self: Trait` clause, so
                         // we translate it bound first.
-                        let bound_sig = self.inside_binder(BinderKind::Other, true, |ctx| {
+                        let bound_sig = self.inside_binder(BinderKind::Other, |ctx| {
                             ctx.innermost_binder_mut()
                                 .trait_preds
                                 .insert(hax::GenericPredicateId::TraitSelf, TraitClauseId::ZERO);

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -131,9 +131,10 @@ impl ItemTransCtx<'_, '_> {
             .innermost_binder_mut()
             .push_type_var(binder.existential_ty.index, binder.existential_ty.name);
         let ty = TyKind::TypeVar(DeBruijnVar::new_at_zero(ty_id)).into_ty();
-        let val = f(self, ty, &binder.val)?;
 
         self.register_predicates(&binder.predicates, PredicateOrigin::Dyn)?;
+
+        let val = f(self, ty, &binder.val)?;
 
         // As illustrated inside translate_trait_decl, associated items take an extra explicit `Self: Trait` clause in Hax.
         // Therefore, in mono mode, projection predicates in dyn binders may refer to clause vars with an
@@ -363,6 +364,7 @@ impl ItemTransCtx<'_, '_> {
     fn gen_vtable_struct_fields(
         &mut self,
         span: Span,
+        self_trait_ref: &TraitRef,
         vtable_data: &VTableData,
     ) -> Result<IndexVec<FieldId, Field>, Error> {
         let mut fields = IndexVec::new();
@@ -395,9 +397,20 @@ impl ItemTransCtx<'_, '_> {
                         let erased_ptr_ty = Ty::new(TyKind::RawPtr(Ty::mk_unit(), RefKind::Shared));
                         (field_name, erased_ptr_ty)
                     } else {
-                        // It's ok to translate the method signature in the context of the trait because
-                        // `vtable_sig: Some(_)` ensures the method has no generics of its own.
-                        let sig = self.translate_poly_fun_sig(span, &sig)?;
+                        // The method is defined in a context that has an extra `Self: Trait` clause, so
+                        // we translate it bound first.
+                        let bound_sig = self.inside_binder(BinderKind::Other, true, |ctx| {
+                            ctx.innermost_binder_mut()
+                                .trait_preds
+                                .insert(hax::GenericPredicateId::TraitSelf, TraitClauseId::ZERO);
+                            ctx.translate_poly_fun_sig(span, &sig)
+                        })?;
+                        let sig = bound_sig.apply(&{
+                            let mut generics = GenericArgs::empty();
+                            // Provide the `Self` clause.
+                            generics.trait_refs.push(self_trait_ref.clone());
+                            generics
+                        });
                         let ty = TyKind::FnPtr(sig).into_ty();
                         (field_name, ty)
                     }
@@ -539,11 +552,13 @@ impl ItemTransCtx<'_, '_> {
         }
 
         let (hax::FullDefKind::Trait {
+            self_predicate,
             dyn_self,
             implied_predicates,
             ..
         }
         | hax::FullDefKind::TraitAlias {
+            self_predicate,
             dyn_self,
             implied_predicates,
             ..
@@ -554,6 +569,11 @@ impl ItemTransCtx<'_, '_> {
         let Some(dyn_self) = dyn_self else {
             panic!("Trying to generate a vtable for a non-dyn-compatible trait")
         };
+
+        let self_trait_ref = TraitRef::new(
+            TraitRefKind::SelfId,
+            RegionBinder::empty(self.translate_trait_predicate(span, self_predicate)?),
+        );
 
         let mut field_map = IndexVec::new();
         let mut supertrait_map: IndexMap<TraitClauseId, _> =
@@ -566,7 +586,7 @@ impl ItemTransCtx<'_, '_> {
             // First construct fields that use the real method signatures (which may use the `Self`
             // type). We fixup the types and generics below.
             let vtable_data = self.prepare_vtable_fields(trait_def, implied_predicates)?;
-            let fields = self.gen_vtable_struct_fields(span, &vtable_data)?;
+            let fields = self.gen_vtable_struct_fields(span, &self_trait_ref, &vtable_data)?;
 
             let kind = TypeDeclKind::Struct(fields);
             let layout = self.generate_naive_layout(span, &kind)?;

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -254,7 +254,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 })?;
 
                 if let hax::ClauseKind::Trait(trait_predicate) = dyn_binder.predicates.predicates[0]
-                    .0
+                    .clause
                     .kind
                     .hax_skip_binder_ref()
                 {
@@ -422,7 +422,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 hax::TyKind::Dynamic(dyn_binder, _) => {
                     let vtable = self.translate_region_binder(
                         span,
-                        &dyn_binder.predicates.predicates[0].0.kind,
+                        &dyn_binder.predicates.predicates[0].clause.kind,
                         |ctx, kind: &hax::ClauseKind| {
                             let hax::ClauseKind::Trait(trait_predicate) = kind else {
                                 unreachable!()

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1688:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1708:13:
 Could not determine method index for drop in vtable
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `core::fmt::Display`.
@@ -11,7 +11,7 @@ note: the error occurred when translating `core::fmt::Display::{vtable_drop_pres
 12 |     let _ = dyn_to_string(&str);
    |                           ----
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1566:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1586:13:
 Could not determine method index for method_fmt in vtable
 error: Thread panicked when extracting item `core::fmt::Display`.
  --> /rustc/library/core/src/fmt/mod.rs:1186:1

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1687:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1688:13:
 Could not determine method index for drop in vtable
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `core::fmt::Display`.
@@ -11,7 +11,7 @@ note: the error occurred when translating `core::fmt::Display::{vtable_drop_pres
 12 |     let _ = dyn_to_string(&str);
    |                           ----
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1565:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1566:13:
 Could not determine method index for method_fmt in vtable
 error: Thread panicked when extracting item `core::fmt::Display`.
  --> /rustc/library/core/src/fmt/mod.rs:1186:1

--- a/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
@@ -87,18 +87,18 @@ where
 }
 
 // Full name: test_crate::{impl Broken for T}::broken::{vtable_method}
-fn {vtable_method}<'_0, T>(_1: &'_0 (dyn Broken))
+fn {vtable_method}<'_0, T>(_1: &'_0 (dyn Broken<Assoc = ()>))
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Foo<()>,
 {
     let _0: (); // return
-    let _1: &'_0 (dyn Broken + '0); // arg #1
+    let _1: &'_0 (dyn Broken<Assoc = ()> + '0); // arg #1
     let _2: &'_0 T; // anonymous local
 
     _0 = ()
     storage_live(_2)
-    _2 = concretize<&'_0 (dyn Broken + '1), &'_0 T>(move _1)
+    _2 = concretize<&'_0 (dyn Broken<Assoc = ()> + '1), &'_0 T>(move _1)
     _0 = {impl Broken for T}::broken<'_0, T>[@TraitClause0, @TraitClause1](move _2)
     return
 }


### PR DESCRIPTION
This resolves a long-standing wart where we had to be very careful to keep the order of trait clauses identical between hax and charon. Now trait clauses get a global identifier which avoids tricky manual computation of indices.