### PR TITLE
Improve error when trying to lift an associated type in a type alias

### DIFF
--- a/charon/hax-frontend/src/state.rs
+++ b/charon/hax-frontend/src/state.rs
@@ -121,8 +121,6 @@ mod types {
         pub opt_def_id: Option<rustc_hir::def_id::DefId>,
         pub cache: Rc<RefCell<GlobalCache<'tcx>>>,
         pub tcx: ty::TyCtxt<'tcx>,
-        /// Silence the warnings in case of trait resolution failure.
-        pub silence_resolution_errors: bool,
     }
 
     impl<'tcx> Base<'tcx> {
@@ -135,7 +133,6 @@ mod types {
                 // `opt_def_id` is used in `utils` for error reporting
                 opt_def_id: None,
                 local_ctx: Rc::new(RefCell::new(LocalContextS::new())),
-                silence_resolution_errors: false,
             }
         }
     }

--- a/charon/hax-frontend/src/traits.rs
+++ b/charon/hax-frontend/src/traits.rs
@@ -197,11 +197,7 @@ pub fn solve_trait<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
 ) -> ImplExpr {
-    let warn = |msg: &str| {
-        if !s.base().silence_resolution_errors {
-            crate::warning!(s, "{}", msg)
-        }
-    };
+    let warn = |_msg: &str| {};
     if let Some(impl_expr) = s.with_cache(|cache| cache.impl_exprs.get(&trait_ref).cloned()) {
         return impl_expr;
     }

--- a/charon/hax-frontend/src/types/new/full_def.rs
+++ b/charon/hax-frontend/src/types/new/full_def.rs
@@ -662,19 +662,10 @@ where
                 ),
             }
         }
-        RDefKind::TyAlias { .. } => {
-            let s = &s.with_base(Base {
-                // Rust doesn't enforce bounds on generic parameters in type aliases. Thus, when
-                // translating type aliases, we need to disable trait resolution errors. For more
-                // details, please see https://github.com/hacspec/hax/issues/707.
-                silence_resolution_errors: true,
-                ..s.base()
-            });
-            FullDefKind::TyAlias {
-                param_env: get_param_env(s, args),
-                ty: type_of_self().sinto(s),
-            }
-        }
+        RDefKind::TyAlias { .. } => FullDefKind::TyAlias {
+            param_env: get_param_env(s, args),
+            ty: type_of_self().sinto(s),
+        },
         RDefKind::ForeignTy => FullDefKind::ForeignTy,
         RDefKind::AssocTy { .. } => FullDefKind::AssocTy {
             param_env: get_param_env(s, args),

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -696,7 +696,7 @@ pub fn translate<'tcx, 'ctx>(
     let mut error_ctx = ErrorCtx::new(!cli_options.abort_on_error, cli_options.error_on_warnings);
     let translate_options = TranslateOptions::new(&mut error_ctx, cli_options);
 
-    let mut hax_state = hax::state::State::new(
+    let hax_state = hax::state::State::new(
         tcx,
         hax::options::Options {
             item_ref_use_concrete_impl: true,
@@ -707,9 +707,6 @@ pub fn translate<'tcx, 'ctx>(
             },
         },
     );
-    // This suppresses warnings when trait resolution fails. We don't need them since we emit our
-    // own.
-    hax_state.base.silence_resolution_errors = true;
 
     let crate_def_id: hax::DefId = rustc_span::def_id::CRATE_DEF_ID
         .to_def_id()

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -870,6 +870,8 @@ struct UpdateItemBody<'a> {
     /// remporarily remove them for in-place modification.
     ctx: &'a TransformCtx,
     span: Span,
+    // Whether the current item is a type alias, which affects error messages.
+    is_type_alias: bool,
     item_modifications: &'a HashMap<GenericsSource, ItemModifications>,
     // It's a reversed stack, for when we go under binders.
     type_replacements: BindingStack<TypeConstraintSet>,
@@ -996,22 +998,32 @@ impl UpdateItemBody<'_> {
             let ty = if let Some(ty) = self.lookup_path_on_trait_ref(&path, &base_tref) {
                 ty.clone()
             } else {
-                let fmt_ctx = &self.ctx.into_fmt();
-                let item_name = target.item_name(&self.ctx.translated, fmt_ctx);
-                let base_tref = base_tref.with_ctx(fmt_ctx);
-                let args = args.with_ctx(fmt_ctx);
-                register_error!(
-                    self.ctx,
-                    self.span,
-                    "Could not compute the value of {path} (on {base_tref}) needed to update \
-                    item reference {item_name}{args}.\
-                    \nConstraints in scope:\n{}",
-                    self.type_replacements
-                        .iter()
-                        .flat_map(|x| x.iter())
-                        .map(|(path, ty)| format!("  - {path} = {}", ty.with_ctx(fmt_ctx)))
-                        .join("\n"),
-                );
+                if self.is_type_alias {
+                    register_error!(
+                        self.ctx,
+                        self.span,
+                        "Could not compute the value of {path}: type aliases are allowed to \
+                        make use of unproved trait facts. To fix this, add the necessary \
+                        trait bound to the type alias, ignoring the `type_alias_bounds` warning."
+                    );
+                } else {
+                    let fmt_ctx = &self.ctx.into_fmt();
+                    let item_name = target.item_name(&self.ctx.translated, fmt_ctx);
+                    let base_tref = base_tref.with_ctx(fmt_ctx);
+                    let args = args.with_ctx(fmt_ctx);
+                    register_error!(
+                        self.ctx,
+                        self.span,
+                        "Could not compute the value of {path} (on {base_tref}) needed to update \
+                        item reference {item_name}{args}.\
+                        \nConstraints in scope:\n{}",
+                        self.type_replacements
+                            .iter()
+                            .flat_map(|x| x.iter())
+                            .map(|(path, ty)| format!("  - {path} = {}", ty.with_ctx(fmt_ctx)))
+                            .join("\n"),
+                    );
+                }
                 TyKind::Error(format!("Can't compute {path}")).into_ty()
             };
             args.types.push(ty);
@@ -1353,9 +1365,11 @@ impl TransformPass for Transform {
 
             // Update the rest of the items: all the `GenericArgs` and the non-top-level binders
             // (trait methods and inherent impls in `Name`s).
+            let is_type_alias = matches!(&item, ItemRefMut::Type(tdecl) if matches!(tdecl.kind, TypeDeclKind::Alias(..)));
             let _ = item.drive_mut(&mut UpdateItemBody {
                 ctx,
                 span,
+                is_type_alias,
                 item_modifications: &item_modifications,
                 type_replacements: BindingStack::new(type_replacements),
             });

--- a/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
+++ b/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
@@ -1,0 +1,9 @@
+error: Could not compute the value of Self::Assoc (on UNKNOWN(Could not find a clause for `Binder { value: <B as HasAssoc>, bound_vars: [] }` in the current context: `Unimplemented`)) needed to update item reference test_crate::HasAssoc<@TypeBound(1, 0)>.
+       Constraints in scope:
+       
+ --> tests/ui/associated_types/lift-assoc-ty-in-alias.rs:7:1
+  |
+7 | pub type Alias<B> = <B as HasAssoc>::Assoc;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
+++ b/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
@@ -1,6 +1,4 @@
-error: Could not compute the value of Self::Assoc (on UNKNOWN(Could not find a clause for `Binder { value: <B as HasAssoc>, bound_vars: [] }` in the current context: `Unimplemented`)) needed to update item reference test_crate::HasAssoc<@TypeBound(1, 0)>.
-       Constraints in scope:
-       
+error: Could not compute the value of Self::Assoc: type aliases are allowed to make use of unproved trait facts. To fix this, add the necessary trait bound to the type alias, ignoring the `type_alias_bounds` warning.
  --> tests/ui/associated_types/lift-assoc-ty-in-alias.rs:7:1
   |
 7 | pub type Alias<B> = <B as HasAssoc>::Assoc;

--- a/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.rs
+++ b/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.rs
@@ -1,0 +1,7 @@
+//@ known-failure
+//@ charon-args=--lift-associated-types=*
+pub trait HasAssoc {
+    type Assoc;
+}
+
+pub type Alias<B> = <B as HasAssoc>::Assoc;


### PR DESCRIPTION
Found here https://github.com/AeneasVerif/charon/issues/967. I won't try to actually fix that error as that would require synthesizing trait bounds out of thin air. I have good hopes that rustc will move to making type aliases sane eventually.