### PR TITLE
Add `Extern` and `Intrinsic` body types

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.180"
+let supported_charon_version = "0.1.181"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -27,6 +27,18 @@ type trait_impl_group = TraitImplId.id g_declaration_group [@@deriving show]
 type mixed_declaration_group = item_id g_declaration_group [@@deriving show]
 
 (* Hand-written because the rust equivalent isn't generic *)
+type 'body body =
+  | Body of 'body gexpr_body
+  | TraitMethodWithoutDefault
+  | Extern of string
+  | Intrinsic of { name : string; arg_names : string list }
+  | TargetDispatch of (string * fun_decl_ref) list
+  | Opaque
+  | Missing
+  | Error of error
+[@@deriving show]
+
+(* Hand-written because the rust equivalent isn't generic *)
 type 'body gfun_decl = {
   def_id : FunDeclId.id;
   item_meta : item_meta;
@@ -34,7 +46,7 @@ type 'body gfun_decl = {
   signature : fun_sig;
   src : item_source;
   is_global_initializer : GlobalDeclId.id option;
-  body : 'body gexpr_body option;
+  body : 'body body;
 }
 [@@deriving show]
 

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -20,8 +20,7 @@ let option_list_of_json of_json = list_of_json (option_of_json of_json)
 
 (* This is written by hand because the corresponding rust type is not type-generic. *)
 let rec gfun_decl_of_json
-    (body_of_json :
-      of_json_ctx -> json -> ('body gexpr_body option, string) result)
+    (body_of_json : of_json_ctx -> json -> ('body body, string) result)
     (ctx : of_json_ctx) (js : json) : ('body gfun_decl, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -84,8 +83,7 @@ and id_to_file_of_json (ctx : of_json_ctx) (js : json) :
    type-generic. Note: because of hash-cons deduplication, we must make sure to
    deserialize in the exact same order as the rust side. *)
 and gtranslated_crate_of_json
-    (body_of_json :
-      of_json_ctx -> json -> ('body gexpr_body option, string) result)
+    (body_of_json : of_json_ctx -> json -> ('body body, string) result)
     (js : json) : ('body gcrate, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
@@ -172,8 +170,7 @@ and gtranslated_crate_of_json
     | _ -> Error "")
 
 and gcrate_of_json
-    (body_of_json :
-      of_json_ctx -> json -> ('body gexpr_body option, string) result)
+    (body_of_json : of_json_ctx -> json -> ('body body, string) result)
     (js : json) : ('body gcrate, string) result =
   match js with
   | `Assoc [ ("charon_version", charon_version); ("translated", translated) ]

--- a/charon-ml/src/LlbcAst.ml
+++ b/charon-ml/src/LlbcAst.ml
@@ -6,7 +6,7 @@ include GAst
 include Generated_LlbcAst
 
 type expr_body = block gexpr_body [@@deriving show]
-type fun_body = expr_body [@@deriving show]
+type fun_body = block body [@@deriving show]
 type fun_decl = block gfun_decl [@@deriving show]
 
 (** LLBC crate *)

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -15,8 +15,8 @@ let fun_decl_list_from_crate (crate : crate) : fun_decl list =
     returns None *)
 let get_fun_args (fun_decl : fun_decl) : local list option =
   match fun_decl.body with
-  | Some body -> Some (GAstUtils.locals_get_input_vars body.locals)
-  | None -> None
+  | Body body -> Some (GAstUtils.locals_get_input_vars body.locals)
+  | _ -> None
 
 (** Check if a {!type:Charon.LlbcAst.statement} contains loops *)
 let block_has_loops (blk : block) : bool =
@@ -34,8 +34,8 @@ let block_has_loops (blk : block) : bool =
 (** Check if a {!type:Charon.LlbcAst.fun_decl} contains loops *)
 let fun_decl_has_loops (fd : fun_decl) : bool =
   match fd.body with
-  | Some body -> block_has_loops body.body
-  | None -> false
+  | Body body -> block_has_loops body.body
+  | _ -> false
 
 let crate_get_item_meta (m : crate) (id : item_id) : Types.item_meta option =
   match id with
@@ -91,7 +91,27 @@ class ['self] map_crate =
       let is_global_initializer =
         self#visit_option self#visit_global_decl_id env is_global_initializer
       in
-      let body = self#visit_option self#visit_expr_body env body in
+      let body =
+        match body with
+        | Body b -> Body (self#visit_expr_body env b)
+        | TraitMethodWithoutDefault -> TraitMethodWithoutDefault
+        | Extern sym -> Extern (self#visit_string env sym)
+        | Intrinsic { name; arg_names } ->
+            Intrinsic
+              {
+                name = self#visit_string env name;
+                arg_names = List.map (self#visit_string env) arg_names;
+              }
+        | TargetDispatch targets ->
+            TargetDispatch
+              (self#visit_list
+                 (fun env (tgt, fref) ->
+                   (self#visit_string env tgt, self#visit_fun_decl_ref env fref))
+                 env targets)
+        | Opaque -> Opaque
+        | Missing -> Missing
+        | Error err -> Error (self#visit_error env err)
+      in
       {
         def_id;
         item_meta;
@@ -218,7 +238,22 @@ class ['self] iter_crate =
       self#visit_fun_sig env signature;
       self#visit_item_source env src;
       self#visit_option self#visit_global_decl_id env is_global_initializer;
-      self#visit_option self#visit_expr_body env body
+      match body with
+      | Body b -> self#visit_expr_body env b
+      | TraitMethodWithoutDefault -> ()
+      | Extern sym -> self#visit_string env sym
+      | Intrinsic { name; arg_names } ->
+          self#visit_string env name;
+          List.iter (self#visit_string env) arg_names
+      | TargetDispatch targets ->
+          self#visit_list
+            (fun env (tgt, fref) ->
+              self#visit_string env tgt;
+              self#visit_fun_decl_ref env fref)
+            env targets
+      | Opaque -> ()
+      | Missing -> ()
+      | Error err -> self#visit_error env err
 
     method visit_declaration_group env (g : declaration_group) : unit =
       match g with

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -22,7 +22,9 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Extern", sym) ] ->
         let* sym = string_of_json ctx sym in
         Ok (Extern sym)
-    | `Assoc [ ("Intrinsic", name) ] ->
+    | `Assoc
+        [ ("Intrinsic", `Assoc [ ("name", name); ("arg_names", arg_names) ]) ]
+      ->
         let* name = string_of_json ctx name in
         let* arg_names = list_of_json string_of_json ctx arg_names in
         Ok (Intrinsic { name; arg_names })

--- a/charon-ml/src/LlbcOfJson.ml
+++ b/charon-ml/src/LlbcOfJson.ml
@@ -9,13 +9,36 @@ include GAstOfJson
 include Generated_LlbcOfJson
 
 let expr_body_of_json (ctx : of_json_ctx) (js : json) :
-    (expr_body option, string) result =
+    (fun_body, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Structured", body) ] ->
         let* body = gexpr_body_of_json block_of_json ctx body in
-        Ok (Some body)
-    | _ -> Ok None)
+        Ok (Body body)
+    | `Assoc [ ("Unstructured", _) ] ->
+        (* Some .llbc bodies are emitted in ULLBC mode (e.g. UNIT_METADATA). *)
+        Ok Opaque
+    | `String "TraitMethodWithoutDefault" -> Ok TraitMethodWithoutDefault
+    | `Assoc [ ("Extern", sym) ] ->
+        let* sym = string_of_json ctx sym in
+        Ok (Extern sym)
+    | `Assoc [ ("Intrinsic", name) ] ->
+        let* name = string_of_json ctx name in
+        let* arg_names = list_of_json string_of_json ctx arg_names in
+        Ok (Intrinsic { name; arg_names })
+    | `Assoc [ ("TargetDispatch", targets) ] ->
+        let* targets =
+          list_of_json
+            (key_value_pair_of_json string_of_json fun_decl_ref_of_json)
+            ctx targets
+        in
+        Ok (TargetDispatch targets)
+    | `String "Opaque" -> Ok Opaque
+    | `String "Missing" -> Ok Missing
+    | `Assoc [ ("Error", e) ] ->
+        let* e = error_of_json ctx e in
+        Ok (GAst.Error e)
+    | _ -> Error "")
 
 let crate_of_json (js : json) : (crate, string) result =
   gcrate_of_json expr_body_of_json js

--- a/charon-ml/src/OfJsonBasic.ml
+++ b/charon-ml/src/OfJsonBasic.ml
@@ -13,29 +13,30 @@ let combine_error_msgs (js : json) (msg : string) (res : ('a, string) result) :
     ('a, string) result =
   match res with
   | Ok x -> Ok x
-  | Error e -> Error ("[" ^ msg ^ "]" ^ " failed on: " ^ show js ^ "\n\n" ^ e)
+  | Error e ->
+      Error ("[" ^ msg ^ "]" ^ " failed on: " ^ to_string js ^ "\n\n" ^ e)
 
 let bool_of_json (ctx : 'ctx) (js : json) : (bool, string) result =
   match js with
   | `Bool b -> Ok b
-  | _ -> Error ("bool_of_json: not a bool: " ^ show js)
+  | _ -> Error ("bool_of_json: not a bool: " ^ to_string js)
 
 let int_of_json (ctx : 'ctx) (js : json) : (int, string) result =
   match js with
   | `Int i -> Ok i
-  | _ -> Error ("int_of_json: not an int: " ^ show js)
+  | _ -> Error ("int_of_json: not an int: " ^ to_string js)
 
 let char_of_json (ctx : 'ctx) (js : json) : (Uchar.t, string) result =
   match js with
   | `String c ->
       if String.length c > 4 then
-        Error ("char_of_json: stricly more than four bytes in: " ^ show js)
+        Error ("char_of_json: stricly more than four bytes in: " ^ to_string js)
       else
         let uchar = String.get_utf_8_uchar c 0 in
         if Uchar.utf_decode_is_valid uchar then
           Ok (Uchar.utf_decode_uchar uchar)
-        else Error ("char_of_json: invalid UTF-8 character: " ^ show js)
-  | _ -> Error ("char_of_json: not a char: " ^ show js)
+        else Error ("char_of_json: invalid UTF-8 character: " ^ to_string js)
+  | _ -> Error ("char_of_json: not a char: " ^ to_string js)
 
 let rec of_json_list (a_of_json : 'ctx -> json -> ('a, string) result)
     (ctx : 'ctx) (jsl : json list) : ('a list, string) result =
@@ -54,7 +55,7 @@ let pair_of_json (a_of_json : 'ctx -> json -> ('a, string) result)
       let* a = a_of_json ctx a in
       let* b = b_of_json ctx b in
       Ok (a, b)
-  | _ -> Error ("pair_of_json failed on: " ^ show js)
+  | _ -> Error ("pair_of_json failed on: " ^ to_string js)
 
 let triple_of_json (a_of_json : 'ctx -> json -> ('a, string) result)
     (b_of_json : 'ctx -> json -> ('b, string) result)
@@ -66,19 +67,19 @@ let triple_of_json (a_of_json : 'ctx -> json -> ('a, string) result)
       let* b = b_of_json ctx b in
       let* c = c_of_json ctx c in
       Ok (a, b, c)
-  | _ -> Error ("triple_of_json failed on: " ^ show js)
+  | _ -> Error ("triple_of_json failed on: " ^ to_string js)
 
 let list_of_json (a_of_json : 'ctx -> json -> ('a, string) result) (ctx : 'ctx)
     (js : json) : ('a list, string) result =
   combine_error_msgs js "list_of_json"
     (match js with
     | `List jsl -> of_json_list a_of_json ctx jsl
-    | _ -> Error ("not a list: " ^ show js))
+    | _ -> Error ("not a list: " ^ to_string js))
 
 let string_of_json (ctx : 'ctx) (js : json) : (string, string) result =
   match js with
   | `String str -> Ok str
-  | _ -> Error ("string_of_json: not a string: " ^ show js)
+  | _ -> Error ("string_of_json: not a string: " ^ to_string js)
 
 let option_of_json (a_of_json : 'ctx -> json -> ('a, string) result)
     (ctx : 'ctx) (js : json) : ('a option, string) result =
@@ -105,4 +106,4 @@ let key_value_pair_of_json (a_of_json : 'ctx -> json -> ('a, string) result)
       let* a = a_of_json ctx a in
       let* b = b_of_json ctx b in
       Ok (a, b)
-  | _ -> Error ("key_value_pair_of_json failed on: " ^ show js)
+  | _ -> Error ("key_value_pair_of_json failed on: " ^ to_string js)

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -125,9 +125,9 @@ let gfun_decl_to_string (env : 'a fmt_env) (indent : string)
       fun_sig_with_name_to_string env indent indent_incr
         (Some ("extern:" ^ sym))
         (Some name) None sg
-  | Intrinsic sym ->
+  | Intrinsic { name; _ } ->
       fun_sig_with_name_to_string env indent indent_incr
-        (Some ("intrinsic:" ^ sym))
+        (Some ("intrinsic:" ^ name))
         (Some name) None sg
   | TargetDispatch targets ->
       let targets =

--- a/charon-ml/src/PrintGAst.ml
+++ b/charon-ml/src/PrintGAst.ml
@@ -112,10 +112,38 @@ let gfun_decl_to_string (env : 'a fmt_env) (indent : string)
    * (we have access to a body) *)
   let sg = bound_fun_sig_of_decl def in
   match def.body with
-  | None ->
+  | Opaque ->
       fun_sig_with_name_to_string env indent indent_incr (Some "opaque")
         (Some name) None sg
-  | Some body ->
+  | Missing ->
+      fun_sig_with_name_to_string env indent indent_incr (Some "missing")
+        (Some name) None sg
+  | TraitMethodWithoutDefault ->
+      fun_sig_with_name_to_string env indent indent_incr
+        (Some "method_without_default_body") (Some name) None sg
+  | Extern sym ->
+      fun_sig_with_name_to_string env indent indent_incr
+        (Some ("extern:" ^ sym))
+        (Some name) None sg
+  | Intrinsic sym ->
+      fun_sig_with_name_to_string env indent indent_incr
+        (Some ("intrinsic:" ^ sym))
+        (Some name) None sg
+  | TargetDispatch targets ->
+      let targets =
+        targets
+        |> List.map (fun (tgt, fref) ->
+               tgt ^ " => " ^ fun_decl_ref_to_string env fref)
+        |> String.concat ","
+      in
+      fun_sig_with_name_to_string env indent indent_incr
+        (Some ("target_dispatch(" ^ targets ^ ")"))
+        (Some name) None sg
+  | Error err ->
+      fun_sig_with_name_to_string env indent indent_incr
+        (Some ("error(\"" ^ err.msg ^ "\")"))
+        (Some name) None sg
+  | Body body ->
       (* Locally update the environment *)
       let locals = List.map (fun v -> (v.index, v.name)) body.locals.locals in
       let env = { env with locals } in

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -430,13 +430,23 @@ let block_substitute (subst : subst) (blk : block) : block =
     the body. *)
 let fun_body_substitute_in_body (subst : subst) (body : fun_body) :
     local list * block =
-  let locals =
-    List.map
-      (fun (v : local) -> { v with local_ty = ty_substitute subst v.local_ty })
-      body.locals.locals
-  in
-  let body = block_substitute subst body.body in
-  (locals, body)
+  match body with
+  | Body body ->
+      let locals =
+        List.map
+          (fun (v : local) ->
+            { v with local_ty = ty_substitute subst v.local_ty })
+          body.locals.locals
+      in
+      let body = block_substitute subst body.body in
+      (locals, body)
+  | TraitMethodWithoutDefault
+  | Extern _
+  | Intrinsic _
+  | TargetDispatch _
+  | Opaque
+  | Missing
+  | Error _ -> raise (Failure "Can't substitute a non-structured function body")
 
 let trait_type_constraint_substitute (subst : subst)
     (ttc : trait_type_constraint) : trait_type_constraint =

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -428,25 +428,15 @@ let block_substitute (subst : subst) (blk : block) : block =
 
 (** Apply a type substitution to a function body. Return the local variables and
     the body. *)
-let fun_body_substitute_in_body (subst : subst) (body : fun_body) :
-    local list * block =
-  match body with
-  | Body body ->
-      let locals =
-        List.map
-          (fun (v : local) ->
-            { v with local_ty = ty_substitute subst v.local_ty })
-          body.locals.locals
-      in
-      let body = block_substitute subst body.body in
-      (locals, body)
-  | TraitMethodWithoutDefault
-  | Extern _
-  | Intrinsic _
-  | TargetDispatch _
-  | Opaque
-  | Missing
-  | Error _ -> raise (Failure "Can't substitute a non-structured function body")
+let expr_body_substitute (subst : subst) (body : expr_body) : local list * block
+    =
+  let locals =
+    List.map
+      (fun (v : local) -> { v with local_ty = ty_substitute subst v.local_ty })
+      body.locals.locals
+  in
+  let body = block_substitute subst body.body in
+  (locals, body)
 
 let trait_type_constraint_substitute (subst : subst)
     (ttc : trait_type_constraint) : trait_type_constraint =

--- a/charon-ml/src/UllbcAst.ml
+++ b/charon-ml/src/UllbcAst.ml
@@ -7,7 +7,7 @@ include GAst
 include Generated_UllbcAst
 
 type expr_body = blocks gexpr_body [@@deriving show]
-type fun_body = expr_body [@@deriving show]
+type fun_body = blocks body [@@deriving show]
 type fun_decl = blocks gfun_decl [@@deriving show]
 
 (** ULLBC crate *)

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -10,13 +10,33 @@ include GAstOfJson
 include Generated_UllbcOfJson
 
 let expr_body_of_json (ctx : of_json_ctx) (js : json) :
-    (expr_body option, string) result =
+    (fun_body, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Unstructured", body) ] ->
         let* body = gexpr_body_of_json (list_of_json block_of_json) ctx body in
-        Ok (Some body)
-    | _ -> Ok None)
+        Ok (Body body)
+    | `String "TraitMethodWithoutDefault" -> Ok TraitMethodWithoutDefault
+    | `Assoc [ ("Extern", sym) ] ->
+        let* sym = string_of_json ctx sym in
+        Ok (Extern sym)
+    | `Assoc [ ("Intrinsic", name) ] ->
+        let* name = string_of_json ctx name in
+        let* arg_names = list_of_json string_of_json ctx arg_names in
+        Ok (Intrinsic { name; arg_names })
+    | `Assoc [ ("TargetDispatch", targets) ] ->
+        let* targets =
+          list_of_json
+            (key_value_pair_of_json string_of_json fun_decl_ref_of_json)
+            ctx targets
+        in
+        Ok (TargetDispatch targets)
+    | `String "Opaque" -> Ok Opaque
+    | `String "Missing" -> Ok Missing
+    | `Assoc [ ("Error", e) ] ->
+        let* e = error_of_json ctx e in
+        Ok (GAst.Error e)
+    | _ -> Error "")
 
 let crate_of_json (js : json) : (crate, string) result =
   gcrate_of_json expr_body_of_json js

--- a/charon-ml/src/UllbcOfJson.ml
+++ b/charon-ml/src/UllbcOfJson.ml
@@ -20,7 +20,9 @@ let expr_body_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Extern", sym) ] ->
         let* sym = string_of_json ctx sym in
         Ok (Extern sym)
-    | `Assoc [ ("Intrinsic", name) ] ->
+    | `Assoc
+        [ ("Intrinsic", `Assoc [ ("name", name); ("arg_names", arg_names) ]) ]
+      ->
         let* name = string_of_json ctx name in
         let* arg_names = list_of_json string_of_json ctx arg_names in
         Ok (Intrinsic { name; arg_names })

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -155,7 +155,12 @@ module PatternTest = struct
           and list_block_calls (blk : block) : call list =
             List.concat_map list_stmt_calls blk.statements
           in
-          let calls = list_block_calls (Option.get decl.body).body in
+          let body =
+            match decl.body with
+            | Body body -> body
+            | _ -> failwith "Expected a function body with contents"
+          in
+          let calls = list_block_calls body.body in
           let fn_ptrs =
             List.map
               (fun call ->

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.180"
+version = "0.1.181"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.180"
+version = "0.1.181"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -100,10 +100,17 @@ pub enum Body {
     /// The body of the function item we add for each trait method declaration, if the trait
     /// doesn't provide a default for that method.
     TraitMethodWithoutDefault,
-    /// Function declared in an `extern { ... }` block. The string is the foreign symbol name.
+    /// Function declared in an `extern { ... }` block.
     Extern(#[drive(skip)] String),
     /// Rust intrinsic function.
-    Intrinsic(#[drive(skip)] String),
+    Intrinsic {
+        /// The intrinsic name.
+        #[drive(skip)]
+        name: String,
+        /// The argument names, None if not available.
+        #[drive(skip)]
+        arg_names: Vec<Option<String>>,
+    },
     /// A body that the user chose not to translate, based on opacity settings like
     /// `--include`/`--opaque`.
     Opaque,

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -100,6 +100,10 @@ pub enum Body {
     /// The body of the function item we add for each trait method declaration, if the trait
     /// doesn't provide a default for that method.
     TraitMethodWithoutDefault,
+    /// Function declared in an `extern { ... }` block. The string is the foreign symbol name.
+    Extern(#[drive(skip)] String),
+    /// Rust intrinsic function.
+    Intrinsic(#[drive(skip)] String),
     /// A body that the user chose not to translate, based on opacity settings like
     /// `--include`/`--opaque`.
     Opaque,
@@ -218,9 +222,7 @@ pub struct FunDecl {
     /// Whether this function is in fact the body of a constant/static that we turned into an
     /// initializer function.
     pub is_global_initializer: Option<GlobalDeclId>,
-    /// The function body, unless the function is opaque.
-    /// Opaque functions are: external functions, or local functions tagged
-    /// as opaque.
+    /// The function body.
     pub body: Body,
 }
 

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -100,7 +100,7 @@ pub enum Body {
     /// The body of the function item we add for each trait method declaration, if the trait
     /// doesn't provide a default for that method.
     TraitMethodWithoutDefault,
-    /// Function declared in an `extern { ... }` block.
+    /// Function declared in an `extern { ... }` block. The string is the foreign symbol name.
     Extern(#[drive(skip)] String),
     /// Rust intrinsic function.
     Intrinsic {

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -16,7 +16,7 @@ impl Body {
             Body::Unstructured(..) | Body::Structured(..) => true,
             Body::TraitMethodWithoutDefault
             | Body::Extern(..)
-            | Body::Intrinsic(..)
+            | Body::Intrinsic { .. }
             | Body::Opaque
             | Body::Missing
             | Body::Error(..)

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -15,6 +15,8 @@ impl Body {
         match self {
             Body::Unstructured(..) | Body::Structured(..) => true,
             Body::TraitMethodWithoutDefault
+            | Body::Extern(..)
+            | Body::Intrinsic(..)
             | Body::Opaque
             | Body::Missing
             | Body::Error(..)

--- a/charon/src/bin/charon-driver/translate/translate_functions.rs
+++ b/charon/src/bin/charon-driver/translate/translate_functions.rs
@@ -69,4 +69,25 @@ impl ItemTransCtx<'_, '_> {
         };
         Ok(fun_id)
     }
+
+    /// Translate the names of the arguments of this definition, if they are available,
+    /// otherwise naming arguments `arg0`, `arg1`, etc.
+    /// Note that the names of the arguments are not always available, even when
+    /// we can retrieve the MIR body, in which case we also fall back to `argN`.
+    pub fn translate_argument_names(
+        &mut self,
+        span: Span,
+        def: &hax::FullDef,
+        n_args: usize,
+    ) -> Vec<Option<String>> {
+        let Ok(Some(body)) = self.get_mir(def.this(), span) else {
+            return vec![None; n_args];
+        };
+        body.local_decls
+            .iter_enumerated()
+            .skip(1)
+            .take(body.arg_count)
+            .map(|(index, _)| hax::name_of_local(index, &body.var_debug_info))
+            .collect()
+    }
 }

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -604,9 +604,10 @@ impl ItemTransCtx<'_, '_> {
             .then(|| self.register_item(span, def.this(), TransItemSourceKind::Global));
 
         let body = if let Some(name) = intrinsic_name {
-            Body::Intrinsic(name)
-        } else if let Some(symbol_name) = self.t_ctx.extern_item_symbol_name(def) {
-            Body::Extern(symbol_name)
+            let arg_names = self.translate_argument_names(span, def, signature.inputs.len());
+            Body::Intrinsic { name, arg_names }
+        } else if let Some(name) = self.t_ctx.extern_item_symbol_name(def) {
+            Body::Extern(name)
         } else if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
         } else if is_trait_method_decl_without_default {

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -588,6 +588,12 @@ impl ItemTransCtx<'_, '_> {
             _ => false,
         };
 
+        let intrinsic_name = def
+            .def_id()
+            .as_rust_def_id()
+            .and_then(|id| self.tcx.intrinsic(id))
+            .map(|i| i.name.to_ident_string());
+
         let is_global_initializer = matches!(
             def.kind(),
             hax::FullDefKind::Const { .. }
@@ -597,7 +603,11 @@ impl ItemTransCtx<'_, '_> {
         let is_global_initializer = is_global_initializer
             .then(|| self.register_item(span, def.this(), TransItemSourceKind::Global));
 
-        let body = if item_meta.opacity.with_private_contents().is_opaque() {
+        let body = if let Some(name) = intrinsic_name {
+            Body::Intrinsic(name)
+        } else if let Some(symbol_name) = self.t_ctx.extern_item_symbol_name(def) {
+            Body::Extern(symbol_name)
+        } else if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
         } else if is_trait_method_decl_without_default {
             Body::TraitMethodWithoutDefault

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -738,6 +738,20 @@ impl<'tcx> TranslateCtx<'tcx> {
             .is_some_and(|parent| matches!(parent.kind, hax::DefKind::ForeignMod))
     }
 
+    /// If this is an item declared in an `extern { .. }` block, return its symbol name.
+    pub(crate) fn extern_item_symbol_name(&mut self, def: &hax::FullDef) -> Option<String> {
+        if !self.is_extern_item(def) {
+            return None;
+        }
+        let path_item = def.def_id().path_item(&self.hax_state);
+        match path_item.data {
+            hax::DefPathItem::ValueNs(name) | hax::DefPathItem::TypeNs(name) => {
+                Some(name.to_string())
+            }
+            _ => None,
+        }
+    }
+
     /// Compute the meta information for a Rust item.
     pub(crate) fn translate_item_meta(
         &mut self,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -575,12 +575,32 @@ impl<C: AstFormatter> FmtWithCtx<C> for FunDecl {
         write!(f, "{params}")?;
 
         // Arguments
+        let n_args = self.signature.inputs.len();
+        let args_of_locals = |l: &Locals| {
+            l.locals
+                .iter()
+                .skip(1)
+                .take(n_args)
+                .map(|l| format!("{l}"))
+                .collect::<Vec<String>>()
+        };
+
+        let arg_names = match &self.body {
+            Body::Unstructured(body) => args_of_locals(&body.locals),
+            Body::Structured(body) => args_of_locals(&body.locals),
+            Body::Error(..)
+            | Body::Extern(..)
+            | Body::Intrinsic(..)
+            | Body::Missing
+            | Body::Opaque
+            | Body::TraitMethodWithoutDefault
+            | Body::TargetDispatch(..) => (0..n_args)
+                .map(|i| format!("{}", LocalId::new(i + 1).with_ctx(ctx)))
+                .collect(),
+        };
         let mut args: Vec<String> = Vec::new();
-        for (i, ty) in self.signature.inputs.iter().enumerate() {
-            // The input variables start at index 1
-            // TODO: use the locals to get the variable names
-            let id = LocalId::new(i + 1);
-            args.push(format!("{}: {}", id.with_ctx(ctx), ty.with_ctx(ctx)));
+        for (ty, name) in self.signature.inputs.iter().zip(arg_names.into_iter()) {
+            args.push(format!("{}: {}", name, ty.with_ctx(ctx)));
         }
         let args = args.join(", ");
         write!(f, "({args})")?;

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -251,6 +251,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for gast::Body {
                 write!(f, "{{\n{body}{tab}}}")
             }
             Body::TraitMethodWithoutDefault => write!(f, "= <method_without_default_body>"),
+            Body::Extern(name) => write!(f, "= <extern:{name}>"),
+            Body::Intrinsic(name) => write!(f, "= <intrinsic:{name}>"),
             Body::Opaque => write!(f, "= <opaque>"),
             Body::Missing => write!(f, "= <missing>"),
             Body::Error(error) => write!(f, "= error(\"{}\")", error.msg),

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -252,7 +252,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for gast::Body {
             }
             Body::TraitMethodWithoutDefault => write!(f, "= <method_without_default_body>"),
             Body::Extern(name) => write!(f, "= <extern:{name}>"),
-            Body::Intrinsic(name) => write!(f, "= <intrinsic:{name}>"),
+            Body::Intrinsic { name, .. } => write!(f, "= <intrinsic:{name}>"),
             Body::Opaque => write!(f, "= <opaque>"),
             Body::Missing => write!(f, "= <missing>"),
             Body::Error(error) => write!(f, "= error(\"{}\")", error.msg),
@@ -588,9 +588,19 @@ impl<C: AstFormatter> FmtWithCtx<C> for FunDecl {
         let arg_names = match &self.body {
             Body::Unstructured(body) => args_of_locals(&body.locals),
             Body::Structured(body) => args_of_locals(&body.locals),
+            Body::Intrinsic { arg_names, .. } => arg_names
+                .iter()
+                .enumerate()
+                .map(|(i, name)| {
+                    let id = LocalId::new(i + 1);
+                    match name {
+                        Some(name) => format!("{name}_{id}"),
+                        None => format!("_{id}"),
+                    }
+                })
+                .collect(),
             Body::Error(..)
             | Body::Extern(..)
-            | Body::Intrinsic(..)
             | Body::Missing
             | Body::Opaque
             | Body::TraitMethodWithoutDefault

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -84,7 +84,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 struct closure {}
 
 // Full name: test_cargo_dependencies::main::silly_incr::{impl FnOnce<(u32,)> for closure}::call_once
-fn {impl FnOnce<(u32,)> for closure}::call_once(_1: closure, _2: (u32,)) -> u32
+fn {impl FnOnce<(u32,)> for closure}::call_once(_1: closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: closure; // arg #1
@@ -117,7 +117,7 @@ impl FnOnce<(u32,)> for closure {
 }
 
 // Full name: test_cargo_dependencies::main::silly_incr
-fn silly_incr<'_0>(_1: &'_0 mut u32)
+fn silly_incr<'_0>(x_1: &'_0 mut u32)
 {
     let _0: (); // return
     let x_1: &'1 mut u32; // arg #1

--- a/charon/tests/cargo/multi-targets.out
+++ b/charon/tests/cargo/multi-targets.out
@@ -1,4 +1,4 @@
-pub fn multi_targets::no_os::riscv64gc-unknown-none-elf(_1: u64, _2: u64) -> u64
+pub fn multi_targets::no_os::riscv64gc-unknown-none-elf(left_1: u64, right_2: u64) -> u64
 {
     let _0: u64; // return
     let left_1: u64; // arg #1
@@ -20,7 +20,7 @@ pub fn multi_targets::no_os::riscv64gc-unknown-none-elf(_1: u64, _2: u64) -> u64
     return
 }
 
-pub fn multi_targets::on_unix::i686-unknown-linux-gnu(_1: u64, _2: u64) -> u64
+pub fn multi_targets::on_unix::i686-unknown-linux-gnu(left_1: u64, right_2: u64) -> u64
 {
     let _0: u64; // return
     let left_1: u64; // arg #1
@@ -42,7 +42,7 @@ pub fn multi_targets::on_unix::i686-unknown-linux-gnu(_1: u64, _2: u64) -> u64
     return
 }
 
-pub fn multi_targets::on_unix::x86_64-apple-darwin(_1: u64, _2: u64) -> u64
+pub fn multi_targets::on_unix::x86_64-apple-darwin(left_1: u64, right_2: u64) -> u64
 {
     let _0: u64; // return
     let left_1: u64; // arg #1

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -23,7 +23,7 @@ where
 }
 
 // Full name: core::option::{Option<T>[@TraitClause0]}::is_some
-pub fn is_some<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/advanced-const-generics.out
+++ b/charon/tests/ui/advanced-const-generics.out
@@ -107,7 +107,7 @@ enum Foo {
 }
 
 // Full name: test_crate::{impl Eq for Foo}::assert_receiver_is_total_eq
-pub fn {impl Eq for Foo}::assert_receiver_is_total_eq<'_0>(_1: &'_0 Foo)
+pub fn {impl Eq for Foo}::assert_receiver_is_total_eq<'_0>(self_1: &'_0 Foo)
 {
     let _0: (); // return
     let self_1: &'1 Foo; // arg #1
@@ -118,7 +118,7 @@ pub fn {impl Eq for Foo}::assert_receiver_is_total_eq<'_0>(_1: &'_0 Foo)
 }
 
 // Full name: test_crate::{impl PartialEq<Foo> for Foo}::eq
-pub fn {impl PartialEq<Foo> for Foo}::eq<'_0, '_1>(_1: &'_0 Foo, _2: &'_1 Foo) -> bool
+pub fn {impl PartialEq<Foo> for Foo}::eq<'_0, '_1>(self_1: &'_0 Foo, other_2: &'_1 Foo) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 Foo; // arg #1
@@ -180,7 +180,7 @@ impl ConstParamTy_ for Foo {
 }
 
 // Full name: test_crate::{impl Debug for Foo}::fmt
-pub fn {impl Debug for Foo}::fmt<'_0, '_1, '_2>(_1: &'_0 Foo, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
+pub fn {impl Debug for Foo}::fmt<'_0, '_1, '_2>(self_1: &'_0 Foo, f_2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 {
     let _0: Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]; // return
     let self_1: &'1 Foo; // arg #1

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -332,7 +332,7 @@ pub enum AB {
 }
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(_1: &'_0 mut u32)
+pub fn incr<'_0>(x_1: &'_0 mut u32)
 {
     let _0: (); // return
     let x_1: &'1 mut u32; // arg #1
@@ -347,7 +347,7 @@ pub fn incr<'_0>(_1: &'_0 mut u32)
 }
 
 // Full name: test_crate::array_to_shared_slice_
-pub fn array_to_shared_slice_<'_0, T>(_1: &'_0 [T; 32 : usize]) -> &'_0 [T]
+pub fn array_to_shared_slice_<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> &'_0 [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -363,7 +363,7 @@ where
 }
 
 // Full name: test_crate::array_to_mut_slice_
-pub fn array_to_mut_slice_<'_0, T>(_1: &'_0 mut [T; 32 : usize]) -> &'_0 mut [T]
+pub fn array_to_mut_slice_<'_0, T>(s_1: &'_0 mut [T; 32 : usize]) -> &'_0 mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -383,7 +383,7 @@ where
 }
 
 // Full name: test_crate::array_len
-pub fn array_len<T>(_1: [T; 32 : usize]) -> usize
+pub fn array_len<T>(s_1: [T; 32 : usize]) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -404,7 +404,7 @@ where
 }
 
 // Full name: test_crate::shared_array_len
-pub fn shared_array_len<'_0, T>(_1: &'_0 [T; 32 : usize]) -> usize
+pub fn shared_array_len<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -424,7 +424,7 @@ where
 }
 
 // Full name: test_crate::shared_slice_len
-pub fn shared_slice_len<'_0, T>(_1: &'_0 [T]) -> usize
+pub fn shared_slice_len<'_0, T>(s_1: &'_0 [T]) -> usize
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -440,7 +440,7 @@ where
 }
 
 // Full name: test_crate::index_array_shared
-pub fn index_array_shared<'_0, T>(_1: &'_0 [T; 32 : usize], _2: usize) -> &'_0 T
+pub fn index_array_shared<'_0, T>(s_1: &'_0 [T; 32 : usize], i_2: usize) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -467,7 +467,7 @@ where
 }
 
 // Full name: test_crate::index_array_u32
-pub fn index_array_u32(_1: [u32; 32 : usize], _2: usize) -> u32
+pub fn index_array_u32(s_1: [u32; 32 : usize], i_2: usize) -> u32
 {
     let _0: u32; // return
     let s_1: [u32; 32 : usize]; // arg #1
@@ -488,7 +488,7 @@ pub fn index_array_u32(_1: [u32; 32 : usize], _2: usize) -> u32
 }
 
 // Full name: test_crate::index_array_copy
-pub fn index_array_copy<'_0>(_1: &'_0 [u32; 32 : usize]) -> u32
+pub fn index_array_copy<'_0>(x_1: &'_0 [u32; 32 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 [u32; 32 : usize]; // arg #1
@@ -508,7 +508,7 @@ pub fn index_array_copy<'_0>(_1: &'_0 [u32; 32 : usize]) -> u32
 }
 
 // Full name: test_crate::index_mut_array
-pub fn index_mut_array<'_0, T>(_1: &'_0 mut [T; 32 : usize], _2: usize) -> &'_0 mut T
+pub fn index_mut_array<'_0, T>(s_1: &'_0 mut [T; 32 : usize], i_2: usize) -> &'_0 mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -539,7 +539,7 @@ where
 }
 
 // Full name: test_crate::index_slice
-pub fn index_slice<'_0, T>(_1: &'_0 [T], _2: usize) -> &'_0 T
+pub fn index_slice<'_0, T>(s_1: &'_0 [T], i_2: usize) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -566,7 +566,7 @@ where
 }
 
 // Full name: test_crate::index_mut_slice
-pub fn index_mut_slice<'_0, T>(_1: &'_0 mut [T], _2: usize) -> &'_0 mut T
+pub fn index_mut_slice<'_0, T>(s_1: &'_0 mut [T], i_2: usize) -> &'_0 mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -597,7 +597,7 @@ where
 }
 
 // Full name: test_crate::slice_subslice_shared_
-pub fn slice_subslice_shared_<'_0>(_1: &'_0 [u32], _2: usize, _3: usize) -> &'_0 [u32]
+pub fn slice_subslice_shared_<'_0>(x_1: &'_0 [u32], y_2: usize, z_3: usize) -> &'_0 [u32]
 {
     let _0: &'1 [u32]; // return
     let x_1: &'2 [u32]; // arg #1
@@ -633,7 +633,7 @@ pub fn slice_subslice_shared_<'_0>(_1: &'_0 [u32], _2: usize, _3: usize) -> &'_0
 }
 
 // Full name: test_crate::slice_subslice_mut_
-pub fn slice_subslice_mut_<'_0>(_1: &'_0 mut [u32], _2: usize, _3: usize) -> &'_0 mut [u32]
+pub fn slice_subslice_mut_<'_0>(x_1: &'_0 mut [u32], y_2: usize, z_3: usize) -> &'_0 mut [u32]
 {
     let _0: &'1 mut [u32]; // return
     let x_1: &'2 mut [u32]; // arg #1
@@ -673,7 +673,7 @@ pub fn slice_subslice_mut_<'_0>(_1: &'_0 mut [u32], _2: usize, _3: usize) -> &'_
 }
 
 // Full name: test_crate::array_to_slice_shared_
-pub fn array_to_slice_shared_<'_0>(_1: &'_0 [u32; 32 : usize]) -> &'_0 [u32]
+pub fn array_to_slice_shared_<'_0>(x_1: &'_0 [u32; 32 : usize]) -> &'_0 [u32]
 {
     let _0: &'1 [u32]; // return
     let x_1: &'3 [u32; 32 : usize]; // arg #1
@@ -687,7 +687,7 @@ pub fn array_to_slice_shared_<'_0>(_1: &'_0 [u32; 32 : usize]) -> &'_0 [u32]
 }
 
 // Full name: test_crate::array_to_slice_mut_
-pub fn array_to_slice_mut_<'_0>(_1: &'_0 mut [u32; 32 : usize]) -> &'_0 mut [u32]
+pub fn array_to_slice_mut_<'_0>(x_1: &'_0 mut [u32; 32 : usize]) -> &'_0 mut [u32]
 {
     let _0: &'1 mut [u32]; // return
     let x_1: &'3 mut [u32; 32 : usize]; // arg #1
@@ -705,7 +705,7 @@ pub fn array_to_slice_mut_<'_0>(_1: &'_0 mut [u32; 32 : usize]) -> &'_0 mut [u32
 }
 
 // Full name: test_crate::array_subslice_shared_
-pub fn array_subslice_shared_<'_0>(_1: &'_0 [u32; 32 : usize], _2: usize, _3: usize) -> &'_0 [u32]
+pub fn array_subslice_shared_<'_0>(x_1: &'_0 [u32; 32 : usize], y_2: usize, z_3: usize) -> &'_0 [u32]
 {
     let _0: &'1 [u32]; // return
     let x_1: &'3 [u32; 32 : usize]; // arg #1
@@ -741,7 +741,7 @@ pub fn array_subslice_shared_<'_0>(_1: &'_0 [u32; 32 : usize], _2: usize, _3: us
 }
 
 // Full name: test_crate::array_subslice_mut_
-pub fn array_subslice_mut_<'_0>(_1: &'_0 mut [u32; 32 : usize], _2: usize, _3: usize) -> &'_0 mut [u32]
+pub fn array_subslice_mut_<'_0>(x_1: &'_0 mut [u32; 32 : usize], y_2: usize, z_3: usize) -> &'_0 mut [u32]
 {
     let _0: &'1 mut [u32]; // return
     let x_1: &'3 mut [u32; 32 : usize]; // arg #1
@@ -781,7 +781,7 @@ pub fn array_subslice_mut_<'_0>(_1: &'_0 mut [u32; 32 : usize], _2: usize, _3: u
 }
 
 // Full name: test_crate::index_slice_0
-pub fn index_slice_0<'_0, T>(_1: &'_0 [T]) -> &'_0 T
+pub fn index_slice_0<'_0, T>(s_1: &'_0 [T]) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -807,7 +807,7 @@ where
 }
 
 // Full name: test_crate::index_array_0
-pub fn index_array_0<'_0, T>(_1: &'_0 [T; 32 : usize]) -> &'_0 T
+pub fn index_array_0<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -833,7 +833,7 @@ where
 }
 
 // Full name: test_crate::index_index_array
-pub fn index_index_array(_1: [[u32; 32 : usize]; 32 : usize], _2: usize, _3: usize) -> u32
+pub fn index_index_array(s_1: [[u32; 32 : usize]; 32 : usize], i_2: usize, j_3: usize) -> u32
 {
     let _0: u32; // return
     let s_1: [[u32; 32 : usize]; 32 : usize]; // arg #1
@@ -865,7 +865,7 @@ pub fn index_index_array(_1: [[u32; 32 : usize]; 32 : usize], _2: usize, _3: usi
 }
 
 // Full name: test_crate::update_update_array
-pub fn update_update_array(_1: [[u32; 32 : usize]; 32 : usize], _2: usize, _3: usize)
+pub fn update_update_array(s_1: [[u32; 32 : usize]; 32 : usize], i_2: usize, j_3: usize)
 {
     let _0: (); // return
     let s_1: [[u32; 32 : usize]; 32 : usize]; // arg #1
@@ -899,7 +899,7 @@ pub fn update_update_array(_1: [[u32; 32 : usize]; 32 : usize], _2: usize, _3: u
 }
 
 // Full name: test_crate::incr_array_self
-pub fn incr_array_self<'_0>(_1: &'_0 mut [u32; 2 : usize])
+pub fn incr_array_self<'_0>(s_1: &'_0 mut [u32; 2 : usize])
 {
     let _0: (); // return
     let s_1: &'1 mut [u32; 2 : usize]; // arg #1
@@ -930,7 +930,7 @@ pub fn incr_array_self<'_0>(_1: &'_0 mut [u32; 2 : usize])
 }
 
 // Full name: test_crate::incr_slice_self
-pub fn incr_slice_self<'_0>(_1: &'_0 mut [u32])
+pub fn incr_slice_self<'_0>(s_1: &'_0 mut [u32])
 {
     let _0: (); // return
     let s_1: &'1 mut [u32]; // arg #1
@@ -961,7 +961,7 @@ pub fn incr_slice_self<'_0>(_1: &'_0 mut [u32])
 }
 
 // Full name: test_crate::array_local_deep_copy
-pub fn array_local_deep_copy<'_0>(_1: &'_0 [u32; 32 : usize])
+pub fn array_local_deep_copy<'_0>(x_1: &'_0 [u32; 32 : usize])
 {
     let _0: (); // return
     let x_1: &'1 [u32; 32 : usize]; // arg #1
@@ -1139,7 +1139,7 @@ pub fn take_all()
 }
 
 // Full name: test_crate::index_array
-pub fn index_array(_1: [u32; 2 : usize]) -> u32
+pub fn index_array(x_1: [u32; 2 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: [u32; 2 : usize]; // arg #1
@@ -1159,7 +1159,7 @@ pub fn index_array(_1: [u32; 2 : usize]) -> u32
 }
 
 // Full name: test_crate::index_array_borrow
-pub fn index_array_borrow<'_0>(_1: &'_0 [u32; 2 : usize]) -> u32
+pub fn index_array_borrow<'_0>(x_1: &'_0 [u32; 2 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 [u32; 2 : usize]; // arg #1
@@ -1179,7 +1179,7 @@ pub fn index_array_borrow<'_0>(_1: &'_0 [u32; 2 : usize]) -> u32
 }
 
 // Full name: test_crate::index_slice_u32_0
-pub fn index_slice_u32_0<'_0>(_1: &'_0 [u32]) -> u32
+pub fn index_slice_u32_0<'_0>(x_1: &'_0 [u32]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 [u32]; // arg #1
@@ -1199,7 +1199,7 @@ pub fn index_slice_u32_0<'_0>(_1: &'_0 [u32]) -> u32
 }
 
 // Full name: test_crate::index_mut_slice_u32_0
-pub fn index_mut_slice_u32_0<'_0>(_1: &'_0 mut [u32]) -> u32
+pub fn index_mut_slice_u32_0<'_0>(x_1: &'_0 mut [u32]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 mut [u32]; // arg #1
@@ -1331,7 +1331,7 @@ pub fn index_all() -> u32
 }
 
 // Full name: test_crate::update_array
-pub fn update_array(_1: [u32; 2 : usize])
+pub fn update_array(x_1: [u32; 2 : usize])
 {
     let _0: (); // return
     let x_1: [u32; 2 : usize]; // arg #1
@@ -1353,7 +1353,7 @@ pub fn update_array(_1: [u32; 2 : usize])
 }
 
 // Full name: test_crate::update_array_mut_borrow
-pub fn update_array_mut_borrow<'_0>(_1: &'_0 mut [u32; 2 : usize])
+pub fn update_array_mut_borrow<'_0>(x_1: &'_0 mut [u32; 2 : usize])
 {
     let _0: (); // return
     let x_1: &'1 mut [u32; 2 : usize]; // arg #1
@@ -1375,7 +1375,7 @@ pub fn update_array_mut_borrow<'_0>(_1: &'_0 mut [u32; 2 : usize])
 }
 
 // Full name: test_crate::update_mut_slice
-pub fn update_mut_slice<'_0>(_1: &'_0 mut [u32])
+pub fn update_mut_slice<'_0>(x_1: &'_0 mut [u32])
 {
     let _0: (); // return
     let x_1: &'1 mut [u32]; // arg #1
@@ -1494,7 +1494,7 @@ pub fn range_all()
 }
 
 // Full name: test_crate::deref_array_borrow
-pub fn deref_array_borrow<'_0>(_1: &'_0 [u32; 2 : usize]) -> u32
+pub fn deref_array_borrow<'_0>(x_1: &'_0 [u32; 2 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 [u32; 2 : usize]; // arg #1
@@ -1518,7 +1518,7 @@ pub fn deref_array_borrow<'_0>(_1: &'_0 [u32; 2 : usize]) -> u32
 }
 
 // Full name: test_crate::deref_array_mut_borrow
-pub fn deref_array_mut_borrow<'_0>(_1: &'_0 mut [u32; 2 : usize]) -> u32
+pub fn deref_array_mut_borrow<'_0>(x_1: &'_0 mut [u32; 2 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 mut [u32; 2 : usize]; // arg #1
@@ -1587,7 +1587,7 @@ pub fn non_copyable_array()
 }
 
 // Full name: test_crate::sum
-pub fn sum<'_0>(_1: &'_0 [u32]) -> u32
+pub fn sum<'_0>(s_1: &'_0 [u32]) -> u32
 {
     let _0: u32; // return
     let s_1: &'1 [u32]; // arg #1
@@ -1653,7 +1653,7 @@ pub fn sum<'_0>(_1: &'_0 [u32]) -> u32
 }
 
 // Full name: test_crate::sum2
-pub fn sum2<'_0, '_1>(_1: &'_0 [u32], _2: &'_1 [u32]) -> u32
+pub fn sum2<'_0, '_1>(s_1: &'_0 [u32], s2_2: &'_1 [u32]) -> u32
 {
     let _0: u32; // return
     let s_1: &'1 [u32]; // arg #1
@@ -1840,7 +1840,7 @@ pub fn f2(_1: u32)
 }
 
 // Full name: test_crate::f4
-pub fn f4<'_0>(_1: &'_0 [u32; 32 : usize], _2: usize, _3: usize) -> &'_0 [u32]
+pub fn f4<'_0>(x_1: &'_0 [u32; 32 : usize], y_2: usize, z_3: usize) -> &'_0 [u32]
 {
     let _0: &'1 [u32]; // return
     let x_1: &'3 [u32; 32 : usize]; // arg #1
@@ -1951,7 +1951,7 @@ pub fn SZ() -> usize
 pub const SZ: usize = SZ()
 
 // Full name: test_crate::f5
-pub fn f5<'_0>(_1: &'_0 [u32; 32 : usize]) -> u32
+pub fn f5<'_0>(x_1: &'_0 [u32; 32 : usize]) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 [u32; 32 : usize]; // arg #1
@@ -2029,7 +2029,7 @@ pub fn ite()
 }
 
 // Full name: test_crate::zero_slice
-pub fn zero_slice<'_0>(_1: &'_0 mut [u8])
+pub fn zero_slice<'_0>(a_1: &'_0 mut [u8])
 {
     let _0: (); // return
     let a_1: &'1 mut [u8]; // arg #1
@@ -2089,7 +2089,7 @@ pub fn zero_slice<'_0>(_1: &'_0 mut [u8])
 }
 
 // Full name: test_crate::iter_mut_slice
-pub fn iter_mut_slice<'_0>(_1: &'_0 mut [u8])
+pub fn iter_mut_slice<'_0>(a_1: &'_0 mut [u8])
 {
     let _0: (); // return
     let a_1: &'1 mut [u8]; // arg #1
@@ -2138,7 +2138,7 @@ pub fn iter_mut_slice<'_0>(_1: &'_0 mut [u8])
 }
 
 // Full name: test_crate::sum_mut_slice
-pub fn sum_mut_slice<'_0>(_1: &'_0 mut [u32]) -> u32
+pub fn sum_mut_slice<'_0>(a_1: &'_0 mut [u32]) -> u32
 {
     let _0: u32; // return
     let a_1: &'1 mut [u32]; // arg #1
@@ -2204,7 +2204,7 @@ pub fn sum_mut_slice<'_0>(_1: &'_0 mut [u32]) -> u32
 }
 
 // Full name: test_crate::slice_pattern_1
-fn slice_pattern_1(_1: [(); 1 : usize])
+fn slice_pattern_1(x_1: [(); 1 : usize])
 {
     let _0: (); // return
     let x_1: [(); 1 : usize]; // arg #1
@@ -2225,7 +2225,7 @@ fn slice_pattern_1(_1: [(); 1 : usize])
 }
 
 // Full name: test_crate::slice_pattern_2
-fn slice_pattern_2<'_0, T>(_1: [&'_0 mut T; 3 : usize])
+fn slice_pattern_2<'_0, T>(x_1: [&'_0 mut T; 3 : usize])
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -2268,7 +2268,7 @@ where
 }
 
 // Full name: test_crate::slice_pattern_3
-fn slice_pattern_3<'_0>(_1: &'_0 [(); 1 : usize])
+fn slice_pattern_3<'_0>(x_1: &'_0 [(); 1 : usize])
 {
     let _0: (); // return
     let x_1: &'1 [(); 1 : usize]; // arg #1
@@ -2289,7 +2289,7 @@ fn slice_pattern_3<'_0>(_1: &'_0 [(); 1 : usize])
 }
 
 // Full name: test_crate::slice_pattern_4
-fn slice_pattern_4<'_0>(_1: &'_0 [()])
+fn slice_pattern_4<'_0>(x_1: &'_0 [()])
 {
     let _0: (); // return
     let x_1: &'1 [()]; // arg #1

--- a/charon/tests/ui/arrays_const_generics.out
+++ b/charon/tests/ui/arrays_const_generics.out
@@ -13,7 +13,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::index_array_generic
-pub fn index_array_generic<const N : usize>(_1: [u32; N], _2: usize) -> u32
+pub fn index_array_generic<const N : usize>(s_1: [u32; N], i_2: usize) -> u32
 {
     let _0: u32; // return
     let s_1: [u32; N]; // arg #1
@@ -34,7 +34,7 @@ pub fn index_array_generic<const N : usize>(_1: [u32; N], _2: usize) -> u32
 }
 
 // Full name: test_crate::index_array_generic_call
-pub fn index_array_generic_call<const N : usize>(_1: [u32; N], _2: usize) -> u32
+pub fn index_array_generic_call<const N : usize>(s_1: [u32; N], i_2: usize) -> u32
 {
     let _0: u32; // return
     let s_1: [u32; N]; // arg #1

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
@@ -33,7 +33,7 @@ trait Trait<Self, Self_Assoc>
 }
 
 // Full name: test_crate::takes_trait
-fn takes_trait<I, Clause1_Assoc>(_1: I)
+fn takes_trait<I, Clause1_Assoc>(it_1: I)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: Trait<I, Clause1_Assoc>,
@@ -57,7 +57,7 @@ trait IntoIterator<Self, Self_IntoIter>
 }
 
 // Full name: test_crate::collect
-fn collect<I, Clause1_IntoIter>(_1: Clause1_IntoIter)
+fn collect<I, Clause1_IntoIter>(it_1: Clause1_IntoIter)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: IntoIterator<I, Clause1_IntoIter>,

--- a/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
@@ -50,7 +50,7 @@ where
 }
 
 // Full name: test_crate::assert_is_iterator
-fn assert_is_iterator<I>(_1: I)
+fn assert_is_iterator<I>(it_1: I)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: IsIterator<I>,
@@ -75,7 +75,7 @@ pub trait IntoIterator<Self, Self_Item, Self_IntoIter>
 }
 
 // Full name: test_crate::check
-fn check<I, Clause1_Item, Clause1_IntoIter>(_1: Clause1_IntoIter)
+fn check<I, Clause1_Item, Clause1_IntoIter>(it_1: Clause1_IntoIter)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: IntoIterator<I, Clause1_Item, Clause1_IntoIter>,

--- a/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
@@ -101,7 +101,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<F> for F}::call
-pub fn {impl Trait<F> for F}::call<'_0, F>(_1: &'_0 F)
+pub fn {impl Trait<F> for F}::call<'_0, F>(self_1: &'_0 F)
 where
     [@TraitClause0]: Fn<F, (), ()>,
     [@TraitClause1]: Sized<F>,

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -172,7 +172,7 @@ where
     [@TraitClause0]: test_crate::Foo<'a, Self, Clause0_Item>,
 = <method_without_default_body>
 
-fn test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Clause1_Item>(_1: Clause0_Item) -> Clause0_Item
+fn test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Clause1_Item>(x_1: Clause0_Item) -> Clause0_Item
 where
     [@TraitClause0]: test_crate::Foo<'a, Self, Clause0_Item>,
     [@TraitClause1]: test_crate::Foo<'a, Clause0_Item, Clause1_Item>,
@@ -185,7 +185,7 @@ where
 }
 
 // Full name: test_crate::{impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_required
-fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_required<'a, T>(_1: Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'a T>[{built_in impl Sized for &'_ T}]
+fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_required<'a, T>(x_1: Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'a T>[{built_in impl Sized for &'_ T}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -197,7 +197,7 @@ where
 }
 
 // Full name: test_crate::{impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_provided
-fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_provided<'a, T, Clause1_Item>(_1: Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'a T>[{built_in impl Sized for &'_ T}]
+fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}]> for &'a T}::use_item_provided<'a, T, Clause1_Item>(x_1: Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'a T>[{built_in impl Sized for &'_ T}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'_ T}], Clause1_Item>,
@@ -224,7 +224,7 @@ where
 }
 
 // Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required
-fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required<'a, T>(_1: T) -> T
+fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required<'a, T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -238,7 +238,7 @@ where
 }
 
 // Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided
-fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided<'a, T, Clause2_Item>(_1: T) -> T
+fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided<'a, T, Clause2_Item>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -269,7 +269,7 @@ where
 }
 
 // Full name: test_crate::external_use_item
-fn external_use_item<'a, T, Clause1_Item, Clause2_Item>(_1: Clause1_Item) -> Clause1_Item
+fn external_use_item<'a, T, Clause1_Item, Clause2_Item>(x_1: Clause1_Item) -> Clause1_Item
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: test_crate::Foo<'a, T, Clause1_Item>,
@@ -313,7 +313,7 @@ fn call_fn()
 }
 
 // Full name: test_crate::type_equality
-fn type_equality<'a, I, J, Clause2_Item>(_1: Clause2_Item) -> Clause2_Item
+fn type_equality<'a, I, J, Clause2_Item>(x_1: Clause2_Item) -> Clause2_Item
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: Sized<J>,

--- a/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -135,7 +135,7 @@ where
 }
 
 // Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call<'_0, F, Clause1_Repr>(_1: &'_0 closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], _2: ((),))
+fn {impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call<'_0, F, Clause1_Repr>(_1: &'_0 closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], tupled_args_2: ((),))
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: PrimeField<F, Clause1_Repr>,
@@ -153,7 +153,7 @@ where
 }
 
 // Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, Clause1_Repr>(_1: &'_0 mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], _2: ((),))
+fn {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, Clause1_Repr>(state_1: &'_0 mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], args_2: ((),))
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: PrimeField<F, Clause1_Repr>,

--- a/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
@@ -93,7 +93,7 @@ where
 }
 
 // Full name: test_crate::callee
-fn callee<T, Clause1_Item>(_1: Clause1_Item) -> Clause1_Item
+fn callee<T, Clause1_Item>(t_1: Clause1_Item) -> Clause1_Item
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Iterator<T, Clause1_Item>,
@@ -107,7 +107,7 @@ where
 }
 
 // Full name: test_crate::caller
-fn caller<T, Clause1_Item, Clause2_Item, Clause2_IntoIter>(_1: Clause1_Item) -> Clause2_Item
+fn caller<T, Clause1_Item, Clause2_Item, Clause2_IntoIter>(t_1: Clause1_Item) -> Clause2_Item
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Iterator<T, Clause1_Item>,
@@ -157,7 +157,7 @@ trait B<Self, Self_Clause1_Assoc>
 }
 
 // Full name: test_crate::a
-fn a<T, Clause1_Clause1_Assoc>(_1: T) -> Clause1_Clause1_Assoc
+fn a<T, Clause1_Clause1_Assoc>(x_1: T) -> Clause1_Clause1_Assoc
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: A<T, Clause1_Clause1_Assoc>,
@@ -175,7 +175,7 @@ where
 }
 
 // Full name: test_crate::b
-fn b<T, Clause1_Clause1_Assoc>(_1: T) -> Clause1_Clause1_Assoc
+fn b<T, Clause1_Clause1_Assoc>(x_1: T) -> Clause1_Clause1_Assoc
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: B<T, Clause1_Clause1_Assoc>,
@@ -193,7 +193,7 @@ where
 }
 
 // Full name: test_crate::x
-fn x<T, Clause1_Clause1_Assoc, Clause2_Clause1_Assoc>(_1: T) -> (Clause1_Clause1_Assoc, Clause1_Clause1_Assoc)
+fn x<T, Clause1_Clause1_Assoc, Clause2_Clause1_Assoc>(x_1: T) -> (Clause1_Clause1_Assoc, Clause1_Clause1_Assoc)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: A<T, Clause1_Clause1_Assoc>,

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -67,7 +67,7 @@ impl StructuralPartialEq for Enum {
 }
 
 // Full name: test_crate::{impl PartialEq<Enum> for Enum}::eq
-pub fn {impl PartialEq<Enum> for Enum}::eq<'_0, '_1>(_1: &'_0 Enum, _2: &'_1 Enum) -> bool
+pub fn {impl PartialEq<Enum> for Enum}::eq<'_0, '_1>(self_1: &'_0 Enum, other_2: &'_1 Enum) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 Enum; // arg #1

--- a/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
+++ b/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
@@ -49,7 +49,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl FromIterator<()> for ()}::from_iter
-pub fn {impl FromIterator<()> for ()}::from_iter<I>(_1: I)
+pub fn {impl FromIterator<()> for ()}::from_iter<I>(iter_1: I)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: IntoIterator<I, ()>,

--- a/charon/tests/ui/associated_types/supertrait-item-bound-has-assoc-ty.out
+++ b/charon/tests/ui/associated_types/supertrait-item-bound-has-assoc-ty.out
@@ -59,7 +59,7 @@ impl ParentTrait<u32, u32> for u32 {
 }
 
 // Full name: test_crate::{impl ChildTrait<u32, u32> for u32}::convert
-pub fn {impl ChildTrait<u32, u32> for u32}::convert(_1: u32) -> u32
+pub fn {impl ChildTrait<u32, u32> for u32}::convert(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1

--- a/charon/tests/ui/bitwise.out
+++ b/charon/tests/ui/bitwise.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::shift_u32
-pub fn shift_u32(_1: u32) -> u32
+pub fn shift_u32(a_1: u32) -> u32
 {
     let _0: u32; // return
     let a_1: u32; // arg #1
@@ -32,7 +32,7 @@ pub fn shift_u32(_1: u32) -> u32
 }
 
 // Full name: test_crate::shift_i32
-pub fn shift_i32(_1: i32) -> i32
+pub fn shift_i32(a_1: i32) -> i32
 {
     let _0: i32; // return
     let a_1: i32; // arg #1
@@ -63,7 +63,7 @@ pub fn shift_i32(_1: i32) -> i32
 }
 
 // Full name: test_crate::xor_u32
-pub fn xor_u32(_1: u32, _2: u32) -> u32
+pub fn xor_u32(a_1: u32, b_2: u32) -> u32
 {
     let _0: u32; // return
     let a_1: u32; // arg #1
@@ -82,7 +82,7 @@ pub fn xor_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::or_u32
-pub fn or_u32(_1: u32, _2: u32) -> u32
+pub fn or_u32(a_1: u32, b_2: u32) -> u32
 {
     let _0: u32; // return
     let a_1: u32; // arg #1
@@ -101,7 +101,7 @@ pub fn or_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::and_u32
-pub fn and_u32(_1: u32, _2: u32) -> u32
+pub fn and_u32(a_1: u32, b_2: u32) -> u32
 {
     let _0: u32; // return
     let a_1: u32; // arg #1

--- a/charon/tests/ui/closure-as-fn.out
+++ b/charon/tests/ui/closure-as-fn.out
@@ -99,7 +99,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 struct closure {}
 
 // Full name: test_crate::main::{impl Fn<()> for closure}::call
-fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, _2: ())
+fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: &'1 closure; // arg #1
@@ -115,7 +115,7 @@ fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, _2: ())
 }
 
 // Full name: test_crate::main::{impl FnMut<()> for closure}::call_mut
-fn {impl FnMut<()> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: ())
+fn {impl FnMut<()> for closure}::call_mut<'_0>(state_1: &'_0 mut closure, args_2: ())
 {
     let _0: (); // return
     let state_1: &'_0 mut closure; // arg #1

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -178,7 +178,7 @@ impl<A> Destruct for (A,) {
 }
 
 // Full name: test_crate::incr_u32
-pub fn incr_u32(_1: u32) -> u32
+pub fn incr_u32(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -195,7 +195,7 @@ pub fn incr_u32(_1: u32) -> u32
 }
 
 // Full name: test_crate::map_option
-pub fn map_option<T, F>(_1: Option<T>[@TraitClause0], _2: F) -> Option<T>[@TraitClause0]
+pub fn map_option<T, F>(x_1: Option<T>[@TraitClause0], f_2: F) -> Option<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -242,7 +242,7 @@ where
 }
 
 // Full name: test_crate::map_option_pointer_ref
-pub fn map_option_pointer_ref<'a, T, F>(_1: &'a Option<T>[@TraitClause0], _2: fn<'_0_1>(&'_0_1 T) -> T) -> Option<T>[@TraitClause0]
+pub fn map_option_pointer_ref<'a, T, F>(x_1: &'a Option<T>[@TraitClause0], f_2: fn<'_0_1>(&'_0_1 T) -> T) -> Option<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -281,7 +281,7 @@ where
 }
 
 // Full name: test_crate::test_map_option1
-pub fn test_map_option1(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option1(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -297,7 +297,7 @@ pub fn test_map_option1(_1: Option<u32>[{built_in impl Sized for u32}]) -> Optio
 struct test_crate::test_closure_u32::closure {}
 
 // Full name: test_crate::test_closure_u32::{impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call
-fn {impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call<'_0>(_1: &'_0 test_crate::test_closure_u32::closure, _2: (u32,)) -> u32
+fn {impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call<'_0>(_1: &'_0 test_crate::test_closure_u32::closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_closure_u32::closure; // arg #1
@@ -311,7 +311,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call<'_0>(_
 }
 
 // Full name: test_crate::test_closure_u32::{impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}::call_mut
-fn {impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_closure_u32::closure, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}::call_mut<'_0>(state_1: &'_0 mut test_crate::test_closure_u32::closure, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut test_crate::test_closure_u32::closure; // arg #1
@@ -349,7 +349,7 @@ fn {impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure}::call_on
     return
 }
 
-fn test_crate::test_closure_u32::closure::as_fn(_1: u32) -> u32
+fn test_crate::test_closure_u32::closure::as_fn(arg1_1: u32) -> u32
 {
     let _0: u32; // return
     let arg1_1: u32; // arg #1
@@ -365,7 +365,7 @@ fn test_crate::test_closure_u32::closure::as_fn(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_closure_u32
-pub fn test_closure_u32(_1: u32) -> u32
+pub fn test_closure_u32(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -423,7 +423,7 @@ impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure {
 struct test_crate::test_closure_u32s::closure {}
 
 // Full name: test_crate::test_closure_u32s::{impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call
-fn {impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call<'_0>(_1: &'_0 test_crate::test_closure_u32s::closure, _2: (u32, u32)) -> u32
+fn {impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call<'_0>(_1: &'_0 test_crate::test_closure_u32s::closure, tupled_args_2: (u32, u32)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_closure_u32s::closure; // arg #1
@@ -451,7 +451,7 @@ fn {impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call<'
 }
 
 // Full name: test_crate::test_closure_u32s::{impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call_mut
-fn {impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_closure_u32s::closure, _2: (u32, u32)) -> u32
+fn {impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call_mut<'_0>(state_1: &'_0 mut test_crate::test_closure_u32s::closure, args_2: (u32, u32)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut test_crate::test_closure_u32s::closure; // arg #1
@@ -489,7 +489,7 @@ fn {impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::ca
     return
 }
 
-fn test_crate::test_closure_u32s::closure::as_fn(_1: u32, _2: u32) -> u32
+fn test_crate::test_closure_u32s::closure::as_fn(arg1_1: u32, arg2_2: u32) -> u32
 {
     let _0: u32; // return
     let arg1_1: u32; // arg #1
@@ -506,7 +506,7 @@ fn test_crate::test_closure_u32s::closure::as_fn(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::test_closure_u32s
-pub fn test_closure_u32s(_1: u32) -> u32
+pub fn test_closure_u32s(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -568,7 +568,7 @@ impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure {
 struct test_crate::test_closure_ref_u32::closure {}
 
 // Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call
-fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call<'_0, '_1>(_1: &'_1 test_crate::test_closure_ref_u32::closure, _2: (&'_0 u32,)) -> &'_0 u32
+fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call<'_0, '_1>(_1: &'_1 test_crate::test_closure_ref_u32::closure, tupled_args_2: (&'_0 u32,)) -> &'_0 u32
 {
     let _0: &'0 u32; // return
     let _1: &'2 test_crate::test_closure_ref_u32::closure; // arg #1
@@ -582,7 +582,7 @@ fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}:
 }
 
 // Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call_mut
-fn {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::test_closure_ref_u32::closure, _2: (&'_0 u32,)) -> &'_0 u32
+fn {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call_mut<'_0, '_1>(state_1: &'_1 mut test_crate::test_closure_ref_u32::closure, args_2: (&'_0 u32,)) -> &'_0 u32
 {
     let _0: &'_0 u32; // return
     let state_1: &'_1 mut test_crate::test_closure_ref_u32::closure; // arg #1
@@ -620,7 +620,7 @@ fn {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closu
     return
 }
 
-fn test_crate::test_closure_ref_u32::closure::as_fn<'_0>(_1: &'_0 u32) -> &'_0 u32
+fn test_crate::test_closure_ref_u32::closure::as_fn<'_0>(arg1_1: &'_0 u32) -> &'_0 u32
 {
     let _0: &'_0 u32; // return
     let arg1_1: &'_0 u32; // arg #1
@@ -636,7 +636,7 @@ fn test_crate::test_closure_ref_u32::closure::as_fn<'_0>(_1: &'_0 u32) -> &'_0 u
 }
 
 // Full name: test_crate::test_closure_ref_u32
-pub fn test_closure_ref_u32<'a>(_1: &'a u32) -> &'a u32
+pub fn test_closure_ref_u32<'a>(x_1: &'a u32) -> &'a u32
 {
     let _0: &'1 u32; // return
     let x_1: &'2 u32; // arg #1
@@ -701,7 +701,7 @@ where
 {}
 
 // Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::closure<T>[@TraitClause0], _2: (&'_0 T,)) -> &'_0 T
+fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::closure<T>[@TraitClause0], tupled_args_2: (&'_0 T,)) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -717,7 +717,7 @@ where
 }
 
 // Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut<'_0, '_1, T>(_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0], _2: (&'_0 T,)) -> &'_0 T
+fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0], args_2: (&'_0 T,)) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -764,7 +764,7 @@ where
     return
 }
 
-fn test_crate::test_closure_ref_param::closure::as_fn<'_0, T>(_1: &'_0 T) -> &'_0 T
+fn test_crate::test_closure_ref_param::closure::as_fn<'_0, T>(arg1_1: &'_0 T) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -782,7 +782,7 @@ where
 }
 
 // Full name: test_crate::test_closure_ref_param
-pub fn test_closure_ref_param<'_0, T>(_1: &'_0 T) -> &'_0 T
+pub fn test_closure_ref_param<'_0, T>(x_1: &'_0 T) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -866,7 +866,7 @@ where
 {}
 
 // Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], _2: (&'_1 T,)) -> &'_1 T
+fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_1 T,)) -> &'_1 T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Trait<'a, T>,
@@ -883,7 +883,7 @@ where
 }
 
 // Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, T>(_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], _2: (&'_1 T,)) -> &'_1 T
+fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, T>(state_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], args_2: (&'_1 T,)) -> &'_1 T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Trait<'a, T>,
@@ -934,7 +934,7 @@ where
     return
 }
 
-fn test_crate::test_closure_ref_early_bound::closure::as_fn<'a, '_1, T>(_1: &'_1 T) -> &'_1 T
+fn test_crate::test_closure_ref_early_bound::closure::as_fn<'a, '_1, T>(arg1_1: &'_1 T) -> &'_1 T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Trait<'a, T>,
@@ -953,7 +953,7 @@ where
 }
 
 // Full name: test_crate::test_closure_ref_early_bound
-pub fn test_closure_ref_early_bound<'a, T>(_1: &'a T) -> &'a T
+pub fn test_closure_ref_early_bound<'a, T>(x_1: &'a T) -> &'a T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Trait<'a, T>,
@@ -1030,7 +1030,7 @@ where
 struct test_crate::test_map_option2::closure {}
 
 // Full name: test_crate::test_map_option2::{impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call
-fn {impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call<'_0>(_1: &'_0 test_crate::test_map_option2::closure, _2: (u32,)) -> u32
+fn {impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call<'_0>(_1: &'_0 test_crate::test_map_option2::closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_map_option2::closure; // arg #1
@@ -1051,7 +1051,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call<'_0>(_
 }
 
 // Full name: test_crate::test_map_option2::{impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}::call_mut
-fn {impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_map_option2::closure, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}::call_mut<'_0>(state_1: &'_0 mut test_crate::test_map_option2::closure, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut test_crate::test_map_option2::closure; // arg #1
@@ -1089,7 +1089,7 @@ fn {impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure}::call_on
     return
 }
 
-fn test_crate::test_map_option2::closure::as_fn(_1: u32) -> u32
+fn test_crate::test_map_option2::closure::as_fn(arg1_1: u32) -> u32
 {
     let _0: u32; // return
     let arg1_1: u32; // arg #1
@@ -1105,7 +1105,7 @@ fn test_crate::test_map_option2::closure::as_fn(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_map_option2
-pub fn test_map_option2(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option2(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -1161,7 +1161,7 @@ impl Fn<(u32,), u32> for test_crate::test_map_option2::closure {
 }
 
 // Full name: test_crate::id
-pub fn id<T>(_1: T) -> T
+pub fn id<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1174,7 +1174,7 @@ where
 }
 
 // Full name: test_crate::test_map_option_id1
-pub fn test_map_option_id1(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option_id1(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -1188,7 +1188,7 @@ pub fn test_map_option_id1(_1: Option<u32>[{built_in impl Sized for u32}]) -> Op
 }
 
 // Full name: test_crate::test_map_option_id2
-pub fn test_map_option_id2(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option_id2(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -1210,7 +1210,7 @@ pub fn test_map_option_id2(_1: Option<u32>[{built_in impl Sized for u32}]) -> Op
 }
 
 // Full name: test_crate::id_clone
-pub fn id_clone<T>(_1: T) -> T
+pub fn id_clone<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -1228,7 +1228,7 @@ where
 }
 
 // Full name: test_crate::test_id_clone
-pub fn test_id_clone(_1: u32) -> u32
+pub fn test_id_clone(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -1250,7 +1250,7 @@ pub fn test_id_clone(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_id_clone_param
-pub fn test_id_clone_param<T>(_1: T) -> T
+pub fn test_id_clone_param<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -1276,7 +1276,7 @@ where
 }
 
 // Full name: test_crate::test_map_option_id_clone
-pub fn test_map_option_id_clone(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option_id_clone(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -1292,7 +1292,7 @@ pub fn test_map_option_id_clone(_1: Option<u32>[{built_in impl Sized for u32}]) 
 struct test_crate::test_map_option3::closure {}
 
 // Full name: test_crate::test_map_option3::{impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call
-fn {impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call<'_0>(_1: &'_0 test_crate::test_map_option3::closure, _2: (u32,)) -> u32
+fn {impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call<'_0>(_1: &'_0 test_crate::test_map_option3::closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_map_option3::closure; // arg #1
@@ -1313,7 +1313,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call<'_0>(_
 }
 
 // Full name: test_crate::test_map_option3::{impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}::call_mut
-fn {impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_map_option3::closure, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}::call_mut<'_0>(state_1: &'_0 mut test_crate::test_map_option3::closure, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut test_crate::test_map_option3::closure; // arg #1
@@ -1382,7 +1382,7 @@ impl Fn<(u32,), u32> for test_crate::test_map_option3::closure {
 }
 
 // Full name: test_crate::test_map_option3
-pub fn test_map_option3(_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
+pub fn test_map_option3(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Option<u32>[{built_in impl Sized for u32}]
 {
     let _0: Option<u32>[{built_in impl Sized for u32}]; // return
     let x_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1
@@ -1402,7 +1402,7 @@ pub fn test_map_option3(_1: Option<u32>[{built_in impl Sized for u32}]) -> Optio
 struct test_crate::test_regions::closure {}
 
 // Full name: test_crate::test_regions::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call
-fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::closure, _2: (&'_0 &'_1 u32,)) -> u32
+fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::closure, tupled_args_2: (&'_0 &'_1 u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions::closure; // arg #1
@@ -1416,7 +1416,7 @@ fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'_
 }
 
 // Full name: test_crate::test_regions
-pub fn test_regions<'a>(_1: &'a u32) -> u32
+pub fn test_regions<'a>(x_1: &'a u32) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 u32; // arg #1
@@ -1446,7 +1446,7 @@ pub fn test_regions<'a>(_1: &'a u32) -> u32
 }
 
 // Full name: test_crate::test_regions::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call_mut
-fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_regions::closure, _2: (&'_0 &'_1 u32,)) -> u32
+fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call_mut<'_0, '_1, '_2>(state_1: &'_2 mut test_crate::test_regions::closure, args_2: (&'_0 &'_1 u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_2 mut test_crate::test_regions::closure; // arg #1
@@ -1517,7 +1517,7 @@ impl<'_0, '_1> Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure {
 struct test_crate::test_regions_casted::closure {}
 
 // Full name: test_crate::test_regions_casted::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call
-fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::closure, _2: (&'_0 &'_1 u32,)) -> u32
+fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::closure, tupled_args_2: (&'_0 &'_1 u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions_casted::closure; // arg #1
@@ -1531,7 +1531,7 @@ fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::
 }
 
 // Full name: test_crate::test_regions_casted::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call_mut
-fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_regions_casted::closure, _2: (&'_0 &'_1 u32,)) -> u32
+fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call_mut<'_0, '_1, '_2>(state_1: &'_2 mut test_crate::test_regions_casted::closure, args_2: (&'_0 &'_1 u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_2 mut test_crate::test_regions_casted::closure; // arg #1
@@ -1569,7 +1569,7 @@ fn {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closur
     return
 }
 
-fn test_crate::test_regions_casted::closure::as_fn<'_0, '_1>(_1: &'_0 &'_1 u32) -> u32
+fn test_crate::test_regions_casted::closure::as_fn<'_0, '_1>(arg1_1: &'_0 &'_1 u32) -> u32
 {
     let _0: u32; // return
     let arg1_1: &'_0 &'_1 u32; // arg #1
@@ -1585,7 +1585,7 @@ fn test_crate::test_regions_casted::closure::as_fn<'_0, '_1>(_1: &'_0 &'_1 u32) 
 }
 
 // Full name: test_crate::test_regions_casted
-pub fn test_regions_casted<'a>(_1: &'a u32) -> u32
+pub fn test_regions_casted<'a>(x_1: &'a u32) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 u32; // arg #1
@@ -1650,7 +1650,7 @@ struct test_crate::test_closure_capture::closure<'_0, '_1> {
 }
 
 // Full name: test_crate::test_closure_capture::{impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call
-fn {impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_closure_capture::closure<'_0, '_1>, _2: (u32,)) -> u32
+fn {impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_closure_capture::closure<'_0, '_1>, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_closure_capture::closure<'_0, '_1>; // arg #1
@@ -1686,7 +1686,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>
 }
 
 // Full name: test_crate::test_closure_capture
-pub fn test_closure_capture(_1: u32, _2: u32) -> u32
+pub fn test_closure_capture(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -1721,7 +1721,7 @@ pub fn test_closure_capture(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::test_closure_capture::{impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call_mut
-fn {impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_closure_capture::closure<'_0, '_1>, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(state_1: &'_2 mut test_crate::test_closure_capture::closure<'_0, '_1>, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_2 mut test_crate::test_closure_capture::closure<'_0, '_1>; // arg #1
@@ -1796,7 +1796,7 @@ where
 {}
 
 // Full name: test_crate::test_closure_clone::{impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], _2: (T,)) -> T
+fn {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: (T,)) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -1818,7 +1818,7 @@ where
 }
 
 // Full name: test_crate::test_closure_clone
-pub fn test_closure_clone<T>(_1: T) -> T
+pub fn test_closure_clone<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -1853,7 +1853,7 @@ where
 }
 
 // Full name: test_crate::test_closure_clone::{impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(_1: &'_0 mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], _2: (T,)) -> T
+fn {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], args_2: (T,)) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -1959,7 +1959,7 @@ impl Destruct for test_crate::test_array_map::closure {
 }
 
 // Full name: test_crate::test_array_map::{impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}::call_mut
-fn {impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_array_map::closure, _2: (i32,)) -> i32
+fn {impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::test_array_map::closure, tupled_args_2: (i32,)) -> i32
 {
     let _0: i32; // return
     let _1: &'1 mut test_crate::test_array_map::closure; // arg #1
@@ -2008,7 +2008,7 @@ impl FnMut<(i32,), i32> for test_crate::test_array_map::closure {
 }
 
 // Full name: test_crate::test_array_map
-pub fn test_array_map(_1: [i32; 256 : usize]) -> [i32; 256 : usize]
+pub fn test_array_map(x_1: [i32; 256 : usize]) -> [i32; 256 : usize]
 {
     let _0: [i32; 256 : usize]; // return
     let x_1: [i32; 256 : usize]; // arg #1
@@ -2030,7 +2030,7 @@ struct test_crate::test_fnmut_with_ref::closure<'_0> {
 }
 
 // Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut
-fn {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_fnmut_with_ref::closure<'_0>, _2: (&'_1 usize,))
+fn {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_fnmut_with_ref::closure<'_0>, tupled_args_2: (&'_1 usize,))
 {
     let _0: (); // return
     let _1: &'1 mut test_crate::test_fnmut_with_ref::closure<'_0>; // arg #1

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -128,7 +128,7 @@ where
 }
 
 // Full name: test_crate::test::{impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T, const K : usize>(_1: &'_0 mut closure<T, K>[@TraitClause0, @TraitClause1], _2: (usize,)) -> T
+fn {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T, const K : usize>(_1: &'_0 mut closure<T, K>[@TraitClause0, @TraitClause1], tupled_args_2: (usize,)) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Ops<T, K>,

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -95,7 +95,7 @@ fn function_call(_1: u32)
 }
 
 // Full name: test_crate::sum
-pub fn sum<'_0>(_1: &'_0 [u32]) -> u32
+pub fn sum<'_0>(s_1: &'_0 [u32]) -> u32
 {
     let _0: u32; // return
     let s_1: &'1 [u32]; // arg #1
@@ -502,7 +502,7 @@ pub fn thing()
 }
 
 // Full name: test_crate::fake_read
-pub fn fake_read(_1: u32)
+pub fn fake_read(x_1: u32)
 {
     let _0: (); // return
     let x_1: u32; // arg #1

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -72,7 +72,7 @@ pub fn X2() -> u32
 pub const X2: u32 = X2()
 
 // Full name: test_crate::incr
-pub fn incr(_1: u32) -> u32
+pub fn incr(n_1: u32) -> u32
 {
     let _0: u32; // return
     let n_1: u32; // arg #1
@@ -101,7 +101,7 @@ pub fn X3() -> u32
 pub const X3: u32 = X3()
 
 // Full name: test_crate::mk_pair0
-pub fn mk_pair0(_1: u32, _2: u32) -> (u32, u32)
+pub fn mk_pair0(x_1: u32, y_2: u32) -> (u32, u32)
 {
     let _0: (u32, u32); // return
     let x_1: u32; // arg #1
@@ -130,7 +130,7 @@ where
 }
 
 // Full name: test_crate::mk_pair1
-pub fn mk_pair1(_1: u32, _2: u32) -> Pair<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]
+pub fn mk_pair1(x_1: u32, y_2: u32) -> Pair<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]
 {
     let _0: Pair<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]; // return
     let x_1: u32; // arg #1
@@ -205,7 +205,7 @@ where
 }
 
 // Full name: test_crate::{Wrap<T>[@TraitClause0]}::new
-pub fn new<T>(_1: T) -> Wrap<T>[@TraitClause0]
+pub fn new<T>(value_1: T) -> Wrap<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -279,7 +279,7 @@ pub fn get_z1() -> i32
 }
 
 // Full name: test_crate::add
-pub fn add(_1: i32, _2: i32) -> i32
+pub fn add(a_1: i32, b_2: i32) -> i32
 {
     let _0: i32; // return
     let a_1: i32; // arg #1

--- a/charon/tests/ui/control-flow/duplicated-statement.out
+++ b/charon/tests/ui/control-flow/duplicated-statement.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::rej_sample
-fn rej_sample<'_0>(_1: &'_0 [u8]) -> usize
+fn rej_sample<'_0>(a_1: &'_0 [u8]) -> usize
 {
     let _0: usize; // return
     let a_1: &'1 [u8]; // arg #1

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -90,7 +90,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::f1
-fn f1<'_0>(_1: &'_0 [u8]) -> usize
+fn f1<'_0>(a_1: &'_0 [u8]) -> usize
 {
     let _0: usize; // return
     let a_1: &'1 [u8]; // arg #1
@@ -170,7 +170,7 @@ fn FIELD_MODULUS() -> i16
 const FIELD_MODULUS: i16 = FIELD_MODULUS()
 
 // Full name: test_crate::f2
-fn f2<'_0, '_1>(_1: &'_0 [u8], _2: &'_1 mut [i16]) -> usize
+fn f2<'_0, '_1>(a_1: &'_0 [u8], result_2: &'_1 mut [i16]) -> usize
 {
     let _0: usize; // return
     let a_1: &'1 [u8]; // arg #1

--- a/charon/tests/ui/control-flow/issue-507-cfg.out
+++ b/charon/tests/ui/control-flow/issue-507-cfg.out
@@ -42,7 +42,7 @@ fn f0()
 }
 
 // Full name: test_crate::f1
-fn f1<'_0>(_1: &'_0 [u8; 1 : usize])
+fn f1<'_0>(serialized_1: &'_0 [u8; 1 : usize])
 {
     let _0: (); // return
     let serialized_1: &'1 [u8; 1 : usize]; // arg #1

--- a/charon/tests/ui/control-flow/issue-899-forward-jump-incorrectly-reconstructed.out
+++ b/charon/tests/ui/control-flow/issue-899-forward-jump-incorrectly-reconstructed.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::condition
-fn condition(_1: u32) -> bool
+fn condition(_x_1: u32) -> bool
 {
     let _0: bool; // return
     let _x_1: u32; // arg #1

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -476,7 +476,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::test_loop1
-pub fn test_loop1(_1: u32) -> u32
+pub fn test_loop1(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -532,7 +532,7 @@ pub fn test_loop1(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop2
-pub fn test_loop2(_1: u32) -> u32
+pub fn test_loop2(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -598,7 +598,7 @@ pub fn test_loop2(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop3
-pub fn test_loop3(_1: u32) -> u32
+pub fn test_loop3(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -716,7 +716,7 @@ pub fn test_loop3(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop4
-pub fn test_loop4(_1: u32) -> u32
+pub fn test_loop4(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -833,7 +833,7 @@ pub fn test_loop4(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop5
-pub fn test_loop5(_1: u32) -> u32
+pub fn test_loop5(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -923,7 +923,7 @@ pub fn test_loop5(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop6
-pub fn test_loop6(_1: u32) -> u32
+pub fn test_loop6(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -994,7 +994,7 @@ pub fn test_loop6(_1: u32) -> u32
 }
 
 // Full name: test_crate::test_loop7
-pub fn test_loop7(_1: u32) -> u32
+pub fn test_loop7(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -1194,7 +1194,7 @@ pub fn test_loops()
 }
 
 // Full name: test_crate::nested_loops_enum
-pub fn nested_loops_enum(_1: usize, _2: usize) -> usize
+pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
 {
     let _0: usize; // return
     let step_out_1: usize; // arg #1
@@ -1333,7 +1333,7 @@ pub fn nested_loops_enum(_1: usize, _2: usize) -> usize
 }
 
 // Full name: test_crate::loop_inside_if
-pub fn loop_inside_if(_1: bool, _2: u32) -> u32
+pub fn loop_inside_if(b_1: bool, n_2: u32) -> u32
 {
     let _0: u32; // return
     let b_1: bool; // arg #1
@@ -1407,7 +1407,7 @@ pub fn loop_inside_if(_1: bool, _2: u32) -> u32
     return
 }
 
-pub fn test_crate::sum(_1: u32) -> u32
+pub fn test_crate::sum(max_1: u32) -> u32
 {
     let _0: u32; // return
     let max_1: u32; // arg #1
@@ -1463,7 +1463,7 @@ pub fn test_crate::sum(_1: u32) -> u32
 }
 
 // Full name: test_crate::sum_array
-pub fn sum_array<const N : usize>(_1: [u32; N]) -> u32
+pub fn sum_array<const N : usize>(a_1: [u32; N]) -> u32
 {
     let _0: u32; // return
     let a_1: [u32; N]; // arg #1
@@ -1520,7 +1520,7 @@ pub fn sum_array<const N : usize>(_1: [u32; N]) -> u32
 }
 
 // Full name: test_crate::clear
-pub fn clear<'_0>(_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
+pub fn clear<'_0>(v_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
     let v_1: &'1 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]; // arg #1
@@ -1587,7 +1587,7 @@ where
 }
 
 // Full name: test_crate::get_elem_mut
-pub fn get_elem_mut<'_0>(_1: &'_0 mut List<usize>[{built_in impl Sized for usize}], _2: usize) -> &'_0 mut usize
+pub fn get_elem_mut<'_0>(ls_1: &'_0 mut List<usize>[{built_in impl Sized for usize}], x_2: usize) -> &'_0 mut usize
 {
     let _0: &'1 mut usize; // return
     let ls_1: &'3 mut List<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1641,7 +1641,7 @@ pub fn get_elem_mut<'_0>(_1: &'_0 mut List<usize>[{built_in impl Sized for usize
 }
 
 // Full name: test_crate::list_nth_mut_loop_with_id
-pub fn list_nth_mut_loop_with_id<'_0, T>(_1: &'_0 mut List<T>[@TraitClause0], _2: u32) -> &'_0 mut T
+pub fn list_nth_mut_loop_with_id<'_0, T>(ls_1: &'_0 mut List<T>[@TraitClause0], i_2: u32) -> &'_0 mut T
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/control-flow/simple-fallthrough.out
+++ b/charon/tests/ui/control-flow/simple-fallthrough.out
@@ -65,7 +65,7 @@ fn do_something_at_the_end()
 }
 
 // Full name: test_crate::foo
-fn foo(_1: Option<u32>[{built_in impl Sized for u32}])
+fn foo(opt_1: Option<u32>[{built_in impl Sized for u32}])
 {
     let _0: (); // return
     let opt_1: Option<u32>[{built_in impl Sized for u32}]; // arg #1

--- a/charon/tests/ui/control-flow/ullbc-control-flow.out
+++ b/charon/tests/ui/control-flow/ullbc-control-flow.out
@@ -281,7 +281,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::nested_loops_enum
-pub fn nested_loops_enum(_1: usize, _2: usize) -> usize
+pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
 {
     let _0: usize; // return
     let step_out_1: usize; // arg #1

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -153,7 +153,7 @@ pub trait Copy<Self>
 }
 
 // Full name: core::intrinsics::ctpop
-pub fn ctpop<T>(_1: T) -> u32
+pub fn ctpop<T>(x_1: T) -> u32
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -157,12 +157,7 @@ pub fn ctpop<T>(_1: T) -> u32
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
-{
-    let _0: u32; // return
-    let x_1: T; // arg #1
-
-    undefined_behavior
-}
+= <intrinsic:ctpop>
 
 // Full name: core::panicking::panic_nounwind_fmt::compiletime
 fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
@@ -178,20 +173,12 @@ fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
 pub fn size_of<T>() -> usize
 where
     [@TraitClause0]: Sized<T>,
-{
-    let _0: usize; // return
-
-    undefined_behavior
-}
+= <intrinsic:size_of>
 
 pub fn core::intrinsics::align_of<T>() -> usize
 where
     [@TraitClause0]: Sized<T>,
-{
-    let _0: usize; // return
-
-    undefined_behavior
-}
+= <intrinsic:align_of>
 
 // Full name: core::marker::{impl Copy for usize}
 impl Copy for usize {

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -44,7 +44,7 @@ where
     [@TraitClause0]: Clone<Self>,
 = <method_without_default_body>
 
-pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 Self)
+pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
     [@TraitClause0]: Clone<Self>,
     [@TraitClause1]: Destruct<Self>,
@@ -64,7 +64,7 @@ where
 }
 
 // Full name: core::clone::impls::{impl Clone for usize}::clone
-pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
+pub fn {impl Clone for usize}::clone<'_0>(self_1: &'_0 usize) -> usize
 {
     let _0: usize; // return
     let self_1: &'1 usize; // arg #1
@@ -74,7 +74,7 @@ pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 }
 
 // Full name: core::clone::impls::{impl Clone for usize}::clone_from
-pub fn {impl Clone for usize}::clone_from<'_0, '_1>(_1: &'_0 mut usize, _2: &'_1 usize)
+pub fn {impl Clone for usize}::clone_from<'_0, '_1>(self_1: &'_0 mut usize, source_2: &'_1 usize)
 where
     [@TraitClause0]: Destruct<usize>,
 {
@@ -160,7 +160,7 @@ where
 = <intrinsic:ctpop>
 
 // Full name: core::panicking::panic_nounwind_fmt::compiletime
-fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+fn compiletime<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -192,7 +192,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <missing>
 
 // Full name: core::panicking::panic_nounwind_fmt
-pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+pub fn panic_nounwind_fmt<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -212,7 +212,7 @@ pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
     _0 = compiletime<'6>(move _3.0, move _3.1)
 }
 
-fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(_1: usize)
+fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(align_1: usize)
 {
     let _0: (); // return
     let align_1: usize; // arg #1
@@ -357,7 +357,7 @@ where
 }
 
 // Full name: core::ptr::alignment::{Alignment}::new
-pub fn new(_1: usize) -> Option<Alignment>[{built_in impl Sized for Alignment}]
+pub fn new(align_1: usize) -> Option<Alignment>[{built_in impl Sized for Alignment}]
 {
     let _0: Option<Alignment>[{built_in impl Sized for Alignment}]; // return
     let align_1: usize; // arg #1
@@ -405,7 +405,7 @@ fn unwrap_failed() -> !
 
 // Full name: core::option::{Option<T>[@TraitClause0]}::unwrap
 #[lang_item("option_unwrap")]
-pub fn unwrap<T>(_1: Option<T>[@TraitClause0]) -> T
+pub fn unwrap<T>(self_1: Option<T>[@TraitClause0]) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -644,7 +644,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(_1: *const (), _2: *mut ()
 
 // Full name: core::ptr::copy_nonoverlapping
 #[lang_item("ptr_copy_nonoverlapping")]
-pub unsafe fn copy_nonoverlapping<T>(_1: *const T, _2: *mut T, _3: usize)
+pub unsafe fn copy_nonoverlapping<T>(src_1: *const T, dst_2: *mut T, count_3: usize)
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -688,7 +688,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::write
-fn write<'_0, '_1, T>(_1: &'_0 mut T, _2: &'_1 T)
+fn write<'_0, '_1, T>(x_1: &'_0 mut T, y_2: &'_1 T)
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -29,7 +29,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::choose
-pub fn choose<'a, T>(_1: bool, _2: &'a mut T, _3: &'a mut T) -> &'a mut T
+pub fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -63,7 +63,7 @@ where
 }
 
 // Full name: test_crate::mul2_add1
-pub fn mul2_add1(_1: u32) -> u32
+pub fn mul2_add1(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -91,7 +91,7 @@ pub fn mul2_add1(_1: u32) -> u32
 }
 
 // Full name: test_crate::use_mul2_add1
-pub fn use_mul2_add1(_1: u32, _2: u32) -> u32
+pub fn use_mul2_add1(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -116,7 +116,7 @@ pub fn use_mul2_add1(_1: u32, _2: u32) -> u32
     return
 }
 
-pub fn test_crate::incr<'a>(_1: &'a mut u32)
+pub fn test_crate::incr<'a>(x_1: &'a mut u32)
 {
     let _0: (); // return
     let x_1: &'1 mut u32; // arg #1
@@ -190,7 +190,7 @@ where
 }
 
 // Full name: test_crate::list_nth
-pub fn list_nth<'a, T>(_1: &'a CList<T>[@TraitClause0], _2: u32) -> &'a T
+pub fn list_nth<'a, T>(l_1: &'a CList<T>[@TraitClause0], i_2: u32) -> &'a T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -250,7 +250,7 @@ where
 }
 
 // Full name: test_crate::list_nth_mut
-pub fn list_nth_mut<'a, T>(_1: &'a mut CList<T>[@TraitClause0], _2: u32) -> &'a mut T
+pub fn list_nth_mut<'a, T>(l_1: &'a mut CList<T>[@TraitClause0], i_2: u32) -> &'a mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -330,7 +330,7 @@ where
 }
 
 // Full name: test_crate::list_nth_mut1
-pub fn list_nth_mut1<'a, T>(_1: &'a mut CList<T>[@TraitClause0], _2: u32) -> &'a mut T
+pub fn list_nth_mut1<'a, T>(l_1: &'a mut CList<T>[@TraitClause0], i_2: u32) -> &'a mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -386,7 +386,7 @@ where
 }
 
 // Full name: test_crate::i32_id
-pub fn i32_id(_1: i32) -> i32
+pub fn i32_id(i_1: i32) -> i32
 {
     let _0: i32; // return
     let i_1: i32; // arg #1
@@ -427,7 +427,7 @@ pub fn i32_id(_1: i32) -> i32
 }
 
 // Full name: test_crate::list_tail
-pub fn list_tail<'a, T>(_1: &'a mut CList<T>[@TraitClause0]) -> &'a mut CList<T>[@TraitClause0]
+pub fn list_tail<'a, T>(l_1: &'a mut CList<T>[@TraitClause0]) -> &'a mut CList<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -479,7 +479,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Counter for usize}::incr
-pub fn {impl Counter for usize}::incr<'_0>(_1: &'_0 mut usize) -> usize
+pub fn {impl Counter for usize}::incr<'_0>(self_1: &'_0 mut usize) -> usize
 {
     let _0: usize; // return
     let self_1: &'1 mut usize; // arg #1
@@ -504,7 +504,7 @@ impl Counter for usize {
 }
 
 // Full name: test_crate::use_counter
-pub fn use_counter<'a, T>(_1: &'a mut T) -> usize
+pub fn use_counter<'a, T>(cnt_1: &'a mut T) -> usize
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Counter<T>,

--- a/charon/tests/ui/desugar_drops_to_calls.out
+++ b/charon/tests/ui/desugar_drops_to_calls.out
@@ -183,7 +183,7 @@ struct Point {
 }
 
 // Full name: test_crate::{impl Drop for Point}::drop
-pub fn {impl Drop for Point}::drop<'_0>(_1: &'_0 mut Point)
+pub fn {impl Drop for Point}::drop<'_0>(self_1: &'_0 mut Point)
 {
     let _0: (); // return
     let self_1: &'1 mut Point; // arg #1

--- a/charon/tests/ui/diverging.out
+++ b/charon/tests/ui/diverging.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::my_panic
-fn my_panic(_1: u32) -> !
+fn my_panic(_x_1: u32) -> !
 {
     let _0: !; // return
     let _x_1: u32; // arg #1

--- a/charon/tests/ui/drop_after_overflow.out
+++ b/charon/tests/ui/drop_after_overflow.out
@@ -59,7 +59,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 struct Foo {}
 
 // Full name: test_crate::{impl Drop for Foo}::drop
-pub fn {impl Drop for Foo}::drop<'_0>(_1: &'_0 mut Foo)
+pub fn {impl Drop for Foo}::drop<'_0>(self_1: &'_0 mut Foo)
 {
     let _0: (); // return
     let self_1: &'1 mut Foo; // arg #1

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -158,7 +158,7 @@ where
 = <opaque>
 
 // Full name: test_crate::destruct
-fn destruct<'_0>(_1: &'_0 (dyn Display + '_0)) -> String
+fn destruct<'_0>(x_1: &'_0 (dyn Display + '_0)) -> String
 {
     let _0: String; // return
     let x_1: &'3 (dyn Display + '4); // arg #1

--- a/charon/tests/ui/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.out
@@ -155,7 +155,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Super<i32> for i32}::super_method
-fn {impl Super<i32> for i32}::super_method<'_0>(_1: &'_0 i32, _2: i32) -> i32
+fn {impl Super<i32> for i32}::super_method<'_0>(self_1: &'_0 i32, arg_2: i32) -> i32
 {
     let _0: i32; // return
     let self_1: &'1 i32; // arg #1
@@ -188,7 +188,7 @@ fn {impl Super<i32> for i32}::super_method::{vtable_method}<'_0>(_1: &'_0 (dyn S
 }
 
 // Full name: test_crate::{impl Super<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Super<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn Super<i32>))
+unsafe fn {impl Super<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Super<i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Super<i32> + '0); // arg #1
@@ -227,7 +227,7 @@ impl Super<i32> for i32 {
 }
 
 // Full name: test_crate::{impl Internal for i32}::internal_method
-fn {impl Internal for i32}::internal_method<'_0>(_1: &'_0 i32) -> i32
+fn {impl Internal for i32}::internal_method<'_0>(self_1: &'_0 i32) -> i32
 {
     let _0: i32; // return
     let self_1: &'1 i32; // arg #1
@@ -257,7 +257,7 @@ fn {impl Internal for i32}::internal_method::{vtable_method}<'_0>(_1: &'_0 (dyn 
 }
 
 // Full name: test_crate::{impl Internal for i32}::{vtable_drop_shim}
-unsafe fn {impl Internal for i32}::{vtable_drop_shim}(_1: *mut (dyn Internal<Internal = i32>))
+unsafe fn {impl Internal for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Internal<Internal = i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Internal<Internal = i32> + '0); // arg #1
@@ -297,7 +297,7 @@ impl Internal for i32 {
 }
 
 // Full name: test_crate::{impl Left for i32}::left_method
-fn {impl Left for i32}::left_method<'_0>(_1: &'_0 i32) -> i32
+fn {impl Left for i32}::left_method<'_0>(self_1: &'_0 i32) -> i32
 {
     let _0: i32; // return
     let self_1: &'1 i32; // arg #1
@@ -327,7 +327,7 @@ fn {impl Left for i32}::left_method::{vtable_method}<'_0>(_1: &'_0 (dyn Left<par
 }
 
 // Full name: test_crate::{impl Left for i32}::{vtable_drop_shim}
-unsafe fn {impl Left for i32}::{vtable_drop_shim}(_1: *mut (dyn Left<parent_clause1::Internal = i32, Left = i32>))
+unsafe fn {impl Left for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Left<parent_clause1::Internal = i32, Left = i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Left<parent_clause1::Internal = i32, Left = i32> + '0); // arg #1
@@ -371,7 +371,7 @@ impl Left for i32 {
 }
 
 // Full name: test_crate::{impl Right<i32> for i32}::right_method
-fn {impl Right<i32> for i32}::right_method<'_0>(_1: &'_0 i32) -> i32
+fn {impl Right<i32> for i32}::right_method<'_0>(self_1: &'_0 i32) -> i32
 {
     let _0: i32; // return
     let self_1: &'1 i32; // arg #1
@@ -431,7 +431,7 @@ fn {impl Right<i32> for i32}::right_method::{vtable_method}<'_0>(_1: &'_0 (dyn R
 }
 
 // Full name: test_crate::{impl Right<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Right<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32>))
+unsafe fn {impl Right<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32> + '0); // arg #1
@@ -480,7 +480,7 @@ impl Right<i32> for i32 {
 }
 
 // Full name: test_crate::{impl Join<i32> for i32}::join_method
-fn {impl Join<i32> for i32}::join_method<'_0>(_1: &'_0 i32) -> (i32, i32)
+fn {impl Join<i32> for i32}::join_method<'_0>(self_1: &'_0 i32) -> (i32, i32)
 {
     let _0: (i32, i32); // return
     let self_1: &'1 i32; // arg #1
@@ -519,7 +519,7 @@ fn {impl Join<i32> for i32}::join_method::{vtable_method}<'_0>(_1: &'_0 (dyn Joi
 }
 
 // Full name: test_crate::{impl Join<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Join<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause2::Right = i32, parent_clause1::Left = i32>))
+unsafe fn {impl Join<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause2::Right = i32, parent_clause1::Left = i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause2::Right = i32, parent_clause1::Left = i32> + '0); // arg #1

--- a/charon/tests/ui/explicit-drop-bounds.out
+++ b/charon/tests/ui/explicit-drop-bounds.out
@@ -51,7 +51,7 @@ trait Trait<Self, T>
     non-dyn-compatible
 }
 
-fn test_crate::Trait::foo<Self, T, U>(_1: U)
+fn test_crate::Trait::foo<Self, T, U>(x_1: U)
 where
     [@TraitClause0]: Trait<Self, T>,
     [@TraitClause1]: Sized<U>,
@@ -67,7 +67,7 @@ where
 }
 
 // Full name: test_crate::{impl Trait<u32> for ()}::foo
-fn {impl Trait<u32> for ()}::foo<U>(_1: U)
+fn {impl Trait<u32> for ()}::foo<U>(x_1: U)
 where
     [@TraitClause0]: Sized<U>,
     [@TraitClause1]: Destruct<U>,
@@ -95,7 +95,7 @@ impl Trait<u32> for () {
 }
 
 // Full name: test_crate::use_trait
-fn use_trait<T, X>(_1: T, _2: X)
+fn use_trait<T, X>(_x_1: T, _y_2: X)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<X>,

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -241,7 +241,7 @@ fn UNIT_METADATA()
 // Full name: UNIT_METADATA
 const UNIT_METADATA: () = UNIT_METADATA()
 
-pub fn test_crate::swap<'a, T>(_1: &'a mut T, _2: &'a mut T)
+pub fn test_crate::swap<'a, T>(x_1: &'a mut T, y_2: &'a mut T)
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -263,7 +263,7 @@ where
 }
 
 // Full name: test_crate::test_new_non_zero_u32
-pub fn test_new_non_zero_u32(_1: u32) -> NonZero<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}]
+pub fn test_new_non_zero_u32(x_1: u32) -> NonZero<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}]
 {
     let _0: NonZero<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}]; // return
     let x_1: u32; // arg #1
@@ -304,7 +304,7 @@ pub fn test_vec_push()
 }
 
 // Full name: test_crate::use_get
-pub fn use_get<'_0>(_1: &'_0 Cell<u32>[{built_in impl MetaSized for u32}]) -> u32
+pub fn use_get<'_0>(rc_1: &'_0 Cell<u32>[{built_in impl MetaSized for u32}]) -> u32
 {
     let _0: u32; // return
     let rc_1: &'1 Cell<u32>[{built_in impl MetaSized for u32}]; // arg #1
@@ -318,7 +318,7 @@ pub fn use_get<'_0>(_1: &'_0 Cell<u32>[{built_in impl MetaSized for u32}]) -> u3
 }
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(_1: &'_0 mut Cell<u32>[{built_in impl MetaSized for u32}])
+pub fn incr<'_0>(rc_1: &'_0 mut Cell<u32>[{built_in impl MetaSized for u32}])
 {
     let _0: (); // return
     let rc_1: &'1 mut Cell<u32>[{built_in impl MetaSized for u32}]; // arg #1

--- a/charon/tests/ui/filtering/inner-items.out
+++ b/charon/tests/ui/filtering/inner-items.out
@@ -41,7 +41,7 @@ impl Trait for () {
 struct Bar {}
 
 // Full name: test_crate::{Bar}::bar
-fn bar<'_0>(_1: &'_0 Bar)
+fn bar<'_0>(self_1: &'_0 Bar)
 {
     let _0: (); // return
     let self_1: &'1 Bar; // arg #1

--- a/charon/tests/ui/filtering/opacity.out
+++ b/charon/tests/ui/filtering/opacity.out
@@ -29,7 +29,7 @@ where
 = <opaque>
 
 // Full name: core::convert::{impl Into<U> for T}::into
-pub fn {impl Into<U> for T}::into<T, U>(_1: T) -> U
+pub fn {impl Into<U> for T}::into<T, U>(self_1: T) -> U
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<U>,
@@ -43,7 +43,7 @@ where
 }
 
 // Full name: core::convert::num::{impl From<u32> for u64}::from
-pub fn {impl From<u32> for u64}::from(_1: u32) -> u64
+pub fn {impl From<u32> for u64}::from(small_1: u32) -> u64
 {
     let _0: u64; // return
     let small_1: u32; // arg #1
@@ -71,7 +71,7 @@ where
 }
 
 // Full name: core::option::{Option<T>[@TraitClause0]}::is_some
-pub fn is_some<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/filtering/opacity.out
+++ b/charon/tests/ui/filtering/opacity.out
@@ -162,7 +162,7 @@ struct Struct {}
 
 // Full name: test_crate::extern_fn
 unsafe fn extern_fn(_1: i32)
-= <opaque>
+= <extern:extern_fn>
 
 
 

--- a/charon/tests/ui/filtering/opaque_attribute.out
+++ b/charon/tests/ui/filtering/opaque_attribute.out
@@ -48,7 +48,7 @@ where
 = <opaque>
 
 // Full name: test_crate::{impl BoolTrait for bool}::get_bool
-pub fn {impl BoolTrait for bool}::get_bool<'_0>(_1: &'_0 bool) -> bool
+pub fn {impl BoolTrait for bool}::get_bool<'_0>(self_1: &'_0 bool) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 bool; // arg #1
@@ -65,7 +65,7 @@ impl BoolTrait for bool {
 }
 
 // Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::get_bool
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: BoolTrait<T>,

--- a/charon/tests/ui/float.out
+++ b/charon/tests/ui/float.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::test_float
-fn test_float(_1: f64) -> f64
+fn test_float(x_1: f64) -> f64
 {
     let _0: f64; // return
     let x_1: f64; // arg #1
@@ -11,7 +11,7 @@ fn test_float(_1: f64) -> f64
 }
 
 // Full name: test_crate::sum_float
-fn sum_float(_1: f64, _2: f64) -> f64
+fn sum_float(x_1: f64, y_2: f64) -> f64
 {
     let _0: f64; // return
     let x_1: f64; // arg #1

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -130,7 +130,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::debug_slice
-fn debug_slice<'_0, T>(_1: &'_0 [T])
+fn debug_slice<'_0, T>(slice_1: &'_0 [T])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Debug<T>,

--- a/charon/tests/ui/hide-marker-traits.out
+++ b/charon/tests/ui/hide-marker-traits.out
@@ -20,7 +20,7 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<T>(_1: T)
+fn foo<T>(_x_1: T)
 {
     let _0: (); // return
     let _x_1: T; // arg #1

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -116,7 +116,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Foo for ()}::get_ty
-pub fn {impl Foo for ()}::get_ty<'_0>(_1: &'_0 ()) -> &'_0 u32
+pub fn {impl Foo for ()}::get_ty<'_0>(self_1: &'_0 ()) -> &'_0 u32
 {
     let _0: &'1 u32; // return
     let self_1: &'3 (); // arg #1
@@ -292,7 +292,7 @@ where
 }
 
 // Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once
-fn {impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once<'_0, U>(_1: closure<U>[@TraitClause0], _2: (&'_0 U,)) -> WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
+fn {impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once<'_0, U>(_1: closure<U>[@TraitClause0], tupled_args_2: (&'_0 U,)) -> WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
 where
     [@TraitClause0]: Sized<U>,
 {

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -31,7 +31,7 @@ pub trait Destruct<Self>
 }
 
 // Full name: core::bool::{bool}::then_some
-pub fn then_some<T>(_1: bool, _2: T) -> Option<T>[@TraitClause0]
+pub fn then_some<T>(self_1: bool, t_2: T) -> Option<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
@@ -72,7 +72,7 @@ where
 
 // Full name: core::cmp::PartialEq::ne
 #[lang_item("cmp_partialeq_ne")]
-pub fn ne<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
+pub fn ne<'_0, '_1, Self, Rhs>(self_1: &'_0 Self, other_2: &'_1 Rhs) -> bool
 where
     [@TraitClause0]: PartialEq<Self, Rhs>,
 {
@@ -89,7 +89,7 @@ where
 }
 
 // Full name: core::convert::num::{impl From<i32> for i64}::from
-pub fn {impl From<i32> for i64}::from(_1: i32) -> i64
+pub fn {impl From<i32> for i64}::from(small_1: i32) -> i64
 {
     let _0: i64; // return
     let small_1: i32; // arg #1
@@ -267,7 +267,7 @@ fn use_inlines() -> u32
 }
 
 // Full name: test_crate::bool_to_opt
-fn bool_to_opt(_1: bool) -> Option<()>[{built_in impl Sized for ()}]
+fn bool_to_opt(b_1: bool) -> Option<()>[{built_in impl Sized for ()}]
 {
     let _0: Option<()>[{built_in impl Sized for ()}]; // return
     let b_1: bool; // arg #1
@@ -285,7 +285,7 @@ fn bool_to_opt(_1: bool) -> Option<()>[{built_in impl Sized for ()}]
 }
 
 // Full name: test_crate::convert
-fn convert(_1: i32) -> i64
+fn convert(x_1: i32) -> i64
 {
     let _0: i64; // return
     let x_1: i32; // arg #1
@@ -299,7 +299,7 @@ fn convert(_1: i32) -> i64
 }
 
 // Full name: test_crate::vec
-fn vec(_1: Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
+fn vec(_x_1: Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
     let _x_1: Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]; // arg #1
@@ -320,7 +320,7 @@ fn max() -> usize
 }
 
 // Full name: test_crate::partial_eq
-fn partial_eq<T>(_1: T)
+fn partial_eq<T>(_x_1: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: PartialEq<T, T>,

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -49,7 +49,7 @@ pub trait Copy<Self>
 struct Foo {}
 
 // Full name: test_crate::{impl Clone for Foo}::clone
-pub fn {impl Clone for Foo}::clone<'_0>(_1: &'_0 Foo) -> Foo
+pub fn {impl Clone for Foo}::clone<'_0>(self_1: &'_0 Foo) -> Foo
 {
     let _0: Foo; // return
     let self_1: &'1 Foo; // arg #1
@@ -80,7 +80,7 @@ impl Copy for Foo {
 }
 
 // Full name: test_crate::copy_foo
-fn copy_foo(_1: Foo)
+fn copy_foo(x_1: Foo)
 {
     let _0: (); // return
     let x_1: Foo; // arg #1
@@ -99,7 +99,7 @@ fn copy_foo(_1: Foo)
 }
 
 // Full name: test_crate::copy_generic
-fn copy_generic<T>(_1: T)
+fn copy_generic<T>(x_1: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -131,7 +131,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::copy_assoc_ty
-fn copy_assoc_ty<T>(_1: @TraitClause1::Ty)
+fn copy_assoc_ty<T>(x_1: @TraitClause1::Ty)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Trait<T>,

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -61,7 +61,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::discriminant_value
-fn discriminant_value<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> isize
+fn discriminant_value<'_0, T>(opt_1: &'_0 Option<T>[@TraitClause0]) -> isize
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -77,7 +77,7 @@ where
 }
 
 // Full name: test_crate::is_some
-fn is_some<T>(_1: Option<T>[@TraitClause0]) -> bool
+fn is_some<T>(opt_1: Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -102,7 +102,7 @@ where
 }
 
 // Full name: test_crate::my_is_some
-fn my_is_some<T>(_1: Option<T>[@TraitClause0]) -> isize
+fn my_is_some<T>(opt_1: Option<T>[@TraitClause0]) -> isize
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/issue-166-self-constructors.out
+++ b/charon/tests/ui/issue-166-self-constructors.out
@@ -21,7 +21,7 @@ struct Bar<'a> {
 }
 
 // Full name: test_crate::{Bar<'a>}::new
-fn new<'a>(_1: &'a i32) -> Bar<'a>
+fn new<'a>(r_1: &'a i32) -> Bar<'a>
 {
     let _0: Bar<'1>; // return
     let r_1: &'3 i32; // arg #1

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -212,7 +212,7 @@ fn slice_pat3()
 }
 
 // Full name: test_crate::slice_pat4
-fn slice_pat4<'_0>(_1: &'_0 [u32])
+fn slice_pat4<'_0>(x_1: &'_0 [u32])
 {
     let _0: (); // return
     let x_1: &'1 [u32]; // arg #1
@@ -255,7 +255,7 @@ struct Unsized {
 }
 
 // Full name: test_crate::slice_pat5
-fn slice_pat5<'_0>(_1: &'_0 Unsized)
+fn slice_pat5<'_0>(x_1: &'_0 Unsized)
 {
     let _0: (); // return
     let x_1: &'1 Unsized; // arg #1

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -82,7 +82,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 struct Rng {}
 
 // Full name: test_crate::{Rng}::next_u64
-fn next_u64<'_0>(_1: &'_0 mut Rng)
+fn next_u64<'_0>(self_1: &'_0 mut Rng)
 {
     let _0: (); // return
     let self_1: &'1 mut Rng; // arg #1
@@ -98,7 +98,7 @@ struct closure<'_0> {
 }
 
 // Full name: test_crate::new
-fn new<'_0>(_1: &'_0 mut Rng)
+fn new<'_0>(rng_1: &'_0 mut Rng)
 {
     let _0: (); // return
     let rng_1: &'1 mut Rng; // arg #1
@@ -117,7 +117,7 @@ fn new<'_0>(_1: &'_0 mut Rng)
 }
 
 // Full name: test_crate::new::{impl FnMut<()> for closure<'_0>}::call_mut
-fn {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, _2: ())
+fn {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: &'1 mut closure<'_0>; // arg #1

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -106,7 +106,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 struct closure<'a> {}
 
 // Full name: test_crate::sparse_transitions::{impl FnMut<()> for closure<'a>}::call_mut
-fn {impl FnMut<()> for closure<'a>}::call_mut<'a, '_1>(_1: &'_1 mut closure<'a>, _2: ()) -> Option<u8>[{built_in impl Sized for u8}]
+fn {impl FnMut<()> for closure<'a>}::call_mut<'a, '_1>(_1: &'_1 mut closure<'a>, tupled_args_2: ()) -> Option<u8>[{built_in impl Sized for u8}]
 {
     let _0: Option<u8>[{built_in impl Sized for u8}]; // return
     let _1: &'1 mut closure<'a>; // arg #1

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -150,7 +150,7 @@ where
 = <opaque>
 
 // Full name: test_crate::trait_error
-pub fn trait_error<'_0>(_1: &'_0 [u8])
+pub fn trait_error<'_0>(s_1: &'_0 [u8])
 {
     let _0: (); // return
     let s_1: &'1 [u8]; // arg #1

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -150,7 +150,7 @@ where
 = <opaque>
 
 // Full name: test_crate::trait_error
-fn trait_error<'_0>(_1: &'_0 [u8])
+fn trait_error<'_0>(s_1: &'_0 [u8])
 {
     let _0: (); // return
     let s_1: &'1 [u8]; // arg #1

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -320,7 +320,7 @@ impl Destruct for closure {
 }
 
 // Full name: test_crate::map::{impl FnMut<(i32,)> for closure}::call_mut
-fn {impl FnMut<(i32,)> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: (i32,)) -> i32
+fn {impl FnMut<(i32,)> for closure}::call_mut<'_0>(_1: &'_0 mut closure, tupled_args_2: (i32,)) -> i32
 {
     let _0: i32; // return
     let _1: &'1 mut closure; // arg #1
@@ -369,7 +369,7 @@ impl FnMut<(i32,)> for closure {
     non-dyn-compatible
 }
 
-pub fn test_crate::map(_1: [i32; 256 : usize]) -> [i32; 256 : usize]
+pub fn test_crate::map(x_1: [i32; 256 : usize]) -> [i32; 256 : usize]
 {
     let _0: [i32; 256 : usize]; // return
     let x_1: [i32; 256 : usize]; // arg #1
@@ -396,7 +396,7 @@ pub fn array<const LEN : usize>() -> [u8; LEN]
 }
 
 // Full name: test_crate::cbd
-fn cbd(_1: [u8; 33 : usize])
+fn cbd(prf_input_1: [u8; 33 : usize])
 {
     let _0: (); // return
     let prf_input_1: [u8; 33 : usize]; // arg #1
@@ -462,7 +462,7 @@ fn cbd(_1: [u8; 33 : usize])
 }
 
 // Full name: test_crate::select
-fn select<'_0, '_1>(_1: &'_0 [u8], _2: &'_1 [u8])
+fn select<'_0, '_1>(lhs_1: &'_0 [u8], rhs_2: &'_1 [u8])
 {
     let _0: (); // return
     let lhs_1: &'1 [u8]; // arg #1

--- a/charon/tests/ui/issue-70-override-provided-method.2.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2.out
@@ -31,7 +31,7 @@ where
     [@TraitClause0]: Trait<Self>,
 = <method_without_default_body>
 
-fn test_crate::Trait::provided1<'_0, Self>(_1: &'_0 Self)
+fn test_crate::Trait::provided1<'_0, Self>(self_1: &'_0 Self)
 where
     [@TraitClause0]: Trait<Self>,
 {
@@ -59,7 +59,7 @@ where
     return
 }
 
-fn test_crate::Trait::provided2<'_0, Self>(_1: &'_0 Self)
+fn test_crate::Trait::provided2<'_0, Self>(self_1: &'_0 Self)
 where
     [@TraitClause0]: Trait<Self>,
 {
@@ -91,7 +91,7 @@ where
 struct Foo {}
 
 // Full name: test_crate::{impl Trait for Foo}::provided1
-fn {impl Trait for Foo}::provided1<'_0>(_1: &'_0 Foo)
+fn {impl Trait for Foo}::provided1<'_0>(self_1: &'_0 Foo)
 {
     let _0: (); // return
     let self_1: &'1 Foo; // arg #1
@@ -118,7 +118,7 @@ fn {impl Trait for Foo}::provided1<'_0>(_1: &'_0 Foo)
 }
 
 // Full name: test_crate::{impl Trait for Foo}::provided2
-fn {impl Trait for Foo}::provided2<'_0>(_1: &'_0 Foo)
+fn {impl Trait for Foo}::provided2<'_0>(self_1: &'_0 Foo)
 {
     let _0: (); // return
     let self_1: &'1 Foo; // arg #1
@@ -145,7 +145,7 @@ fn {impl Trait for Foo}::provided2<'_0>(_1: &'_0 Foo)
 }
 
 // Full name: test_crate::{impl Trait for Foo}::required
-fn {impl Trait for Foo}::required<'_0>(_1: &'_0 Foo)
+fn {impl Trait for Foo}::required<'_0>(self_1: &'_0 Foo)
 {
     let _0: (); // return
     let self_1: &'1 Foo; // arg #1
@@ -176,7 +176,7 @@ impl Trait for Foo {
 struct Bar {}
 
 // Full name: test_crate::{impl Trait for Bar}::provided2
-fn {impl Trait for Bar}::provided2<'_0>(_1: &'_0 Bar)
+fn {impl Trait for Bar}::provided2<'_0>(self_1: &'_0 Bar)
 {
     let _0: (); // return
     let self_1: &'1 Bar; // arg #1
@@ -203,7 +203,7 @@ fn {impl Trait for Bar}::provided2<'_0>(_1: &'_0 Bar)
 }
 
 // Full name: test_crate::{impl Trait for Bar}::required
-fn {impl Trait for Bar}::required<'_0>(_1: &'_0 Bar)
+fn {impl Trait for Bar}::required<'_0>(self_1: &'_0 Bar)
 {
     let _0: (); // return
     let self_1: &'1 Bar; // arg #1
@@ -222,7 +222,7 @@ fn {impl Trait for Bar}::required<'_0>(_1: &'_0 Bar)
 }
 
 // Full name: test_crate::{impl Trait for Bar}::provided1
-fn {impl Trait for Bar}::provided1<'_0>(_1: &'_0 Bar)
+fn {impl Trait for Bar}::provided1<'_0>(self_1: &'_0 Bar)
 {
     let _0: (); // return
     let self_1: &'1 Bar; // arg #1

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -121,7 +121,7 @@ where
     [@TraitClause0]: GenericTrait<Self, T>,
 = <method_without_default_body>
 
-fn test_crate::GenericTrait::provided<Self, T, U>(_1: T, _2: U)
+fn test_crate::GenericTrait::provided<Self, T, U>(x_1: T, y_2: U)
 where
     [@TraitClause0]: GenericTrait<Self, T>,
     [@TraitClause1]: Sized<U>,
@@ -178,7 +178,7 @@ where
 }
 
 // Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided<T, U>(_1: Option<T>[@TraitClause0], _2: U)
+fn {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided<T, U>(x_1: Option<T>[@TraitClause0], y_2: U)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -249,7 +249,7 @@ where
 }
 
 // Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided<T, U>(_1: Option<T>[@TraitClause0], _2: U)
+fn {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided<T, U>(x_1: Option<T>[@TraitClause0], y_2: U)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -152,7 +152,7 @@ impl StructuralPartialEq for Foo {
 }
 
 // Full name: test_crate::{impl PartialEq<Foo> for Foo}::eq
-pub fn {impl PartialEq<Foo> for Foo}::eq<'_0, '_1>(_1: &'_0 Foo, _2: &'_1 Foo) -> bool
+pub fn {impl PartialEq<Foo> for Foo}::eq<'_0, '_1>(self_1: &'_0 Foo, other_2: &'_1 Foo) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 Foo; // arg #1
@@ -177,7 +177,7 @@ impl PartialEq<Foo> for Foo {
 }
 
 // Full name: test_crate::{impl PartialOrd<Foo> for Foo}::partial_cmp
-pub fn {impl PartialOrd<Foo> for Foo}::partial_cmp<'_0, '_1>(_1: &'_0 Foo, _2: &'_1 Foo) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+pub fn {impl PartialOrd<Foo> for Foo}::partial_cmp<'_0, '_1>(self_1: &'_0 Foo, other_2: &'_1 Foo) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 {
     let _0: Option<Ordering>[{built_in impl Sized for Ordering}]; // return
     let self_1: &'1 Foo; // arg #1

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -56,7 +56,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Hash for u32}::hash
-pub fn {impl Hash for u32}::hash<'_0, '_1, H>(_1: &'_0 u32, _2: &'_1 mut H)
+pub fn {impl Hash for u32}::hash<'_0, '_1, H>(self_1: &'_0 u32, _state_2: &'_1 mut H)
 where
     [@TraitClause0]: Sized<H>,
     [@TraitClause1]: Hasher<H>,

--- a/charon/tests/ui/issue-73-extern.out
+++ b/charon/tests/ui/issue-73-extern.out
@@ -15,7 +15,7 @@ static CONST: u8 = CONST()
 opaque type Type
 
 // Full name: test_crate::use_type
-fn use_type<'_0>(_1: &'_0 Type)
+fn use_type<'_0>(_x_1: &'_0 Type)
 {
     let _0: (); // return
     let _x_1: &'1 Type; // arg #1

--- a/charon/tests/ui/issue-73-extern.out
+++ b/charon/tests/ui/issue-73-extern.out
@@ -2,11 +2,11 @@
 
 // Full name: test_crate::foo
 unsafe fn foo(_1: i32)
-= <opaque>
+= <extern:foo>
 
 // Full name: test_crate::CONST
 fn CONST() -> u8
-= <opaque>
+= <extern:CONST>
 
 // Full name: test_crate::CONST
 static CONST: u8 = CONST()

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -52,7 +52,7 @@ enum Foo {
 }
 
 // Full name: test_crate::{impl Clone for Foo}::clone
-pub fn {impl Clone for Foo}::clone<'_0>(_1: &'_0 Foo) -> Foo
+pub fn {impl Clone for Foo}::clone<'_0>(self_1: &'_0 Foo) -> Foo
 {
     let _0: Foo; // return
     let self_1: &'1 Foo; // arg #1

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -102,7 +102,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::T6::f
-pub fn f<Self, T>(_1: u64)
+pub fn f<Self, T>(x_1: u64)
 where
     [@TraitClause0]: T6<Self, T>,
 {

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -40,7 +40,7 @@ where
 }
 
 // Full name: test_crate::{AVLTree<T>[@TraitClause0]}::insert
-pub fn insert<'_0, T>(_1: &'_0 mut AVLTree<T>[@TraitClause0])
+pub fn insert<'_0, T>(self_1: &'_0 mut AVLTree<T>[@TraitClause0])
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Ord<T>,
@@ -59,7 +59,7 @@ impl Ord for u32 {
 }
 
 // Full name: test_crate::test
-pub fn test(_1: AVLTree<u32>[{built_in impl Sized for u32}])
+pub fn test(tree_1: AVLTree<u32>[{built_in impl Sized for u32}])
 {
     let _0: (); // return
     let tree_1: AVLTree<u32>[{built_in impl Sized for u32}]; // arg #1

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -32,7 +32,7 @@ pub enum E1 {
 }
 
 // Full name: test_crate::test1
-pub fn test1(_1: E1) -> bool
+pub fn test1(x_1: E1) -> bool
 {
     let _0: bool; // return
     let x_1: E1; // arg #1
@@ -50,7 +50,7 @@ pub fn test1(_1: E1) -> bool
 }
 
 // Full name: test_crate::id
-pub fn id<T>(_1: T) -> T
+pub fn id<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -70,7 +70,7 @@ pub enum E2 {
 }
 
 // Full name: test_crate::test2
-pub fn test2(_1: E2) -> u32
+pub fn test2(x_1: E2) -> u32
 {
     let _0: u32; // return
     let x_1: E2; // arg #1
@@ -96,7 +96,7 @@ pub fn test2(_1: E2) -> u32
 }
 
 // Full name: test_crate::test3
-pub fn test3(_1: E2) -> u32
+pub fn test3(x_1: E2) -> u32
 {
     let _0: u32; // return
     let x_1: E2; // arg #1

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -83,7 +83,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for ()}::method2
-fn {impl Trait for ()}::method2<T>(_1: (), _2: T)
+fn {impl Trait for ()}::method2<T>(self_1: (), _other_2: T)
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -98,7 +98,7 @@ where
 }
 
 // Full name: test_crate::{impl Trait for ()}::method1
-fn {impl Trait for ()}::method1(_1: (), _2: &'static u32) -> bool
+fn {impl Trait for ()}::method1(self_1: (), _other_2: &'static u32) -> bool
 {
     let _0: bool; // return
     let self_1: (); // arg #1
@@ -131,7 +131,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl MyCompare<&'a ()> for &'a ()}::compare
-fn {impl MyCompare<&'a ()> for &'a ()}::compare<'a>(_1: &'a (), _2: &'a ()) -> bool
+fn {impl MyCompare<&'a ()> for &'a ()}::compare<'a>(self_1: &'a (), _other_2: &'a ()) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 (); // arg #1
@@ -236,7 +236,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Foo for ()}::foo
-fn {impl Foo for ()}::foo<'a, 'b>(_1: &'b (), _2: &'a ()) -> &'b ()
+fn {impl Foo for ()}::foo<'a, 'b>(x_1: &'b (), y_2: &'a ()) -> &'b ()
 {
     let _0: &'1 (); // return
     let x_1: &'2 (); // arg #1
@@ -254,7 +254,7 @@ impl Foo for () {
 }
 
 // Full name: test_crate::call_foo
-fn call_foo<'e>(_1: &'e ()) -> &'e ()
+fn call_foo<'e>(x_1: &'e ()) -> &'e ()
 {
     let _0: &'1 (); // return
     let x_1: &'2 (); // arg #1

--- a/charon/tests/ui/ml-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-mono-name-matcher-tests.out
@@ -124,7 +124,7 @@ fn test_crate::funs_with_disambiguator::f() -> u32
 }
 
 // Full name: test_crate::funs_with_disambiguator
-fn funs_with_disambiguator(_1: bool) -> u32
+fn funs_with_disambiguator(b_1: bool) -> u32
 {
     let _0: u32; // return
     let b_1: bool; // arg #1
@@ -151,7 +151,7 @@ struct MonoContainer::<&'_ Str> {
   item: &'_ Str,
 }
 
-fn test_crate::{MonoContainer::<i32>}::create::<i32>(_1: i32) -> MonoContainer::<i32>
+fn test_crate::{MonoContainer::<i32>}::create::<i32>(item_1: i32) -> MonoContainer::<i32>
 {
     let _0: MonoContainer::<i32>; // return
     let item_1: i32; // arg #1
@@ -164,7 +164,7 @@ fn test_crate::{MonoContainer::<i32>}::create::<i32>(_1: i32) -> MonoContainer::
     return
 }
 
-fn test_crate::{MonoContainer::<&'_ Str>}::create::<&'_ Str>(_1: &'_ Str) -> MonoContainer::<&'_ Str>
+fn test_crate::{MonoContainer::<&'_ Str>}::create::<&'_ Str>(item_1: &'_ Str) -> MonoContainer::<&'_ Str>
 {
     let _0: MonoContainer::<&'_ Str>; // return
     let item_1: &'0 Str; // arg #1

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -345,7 +345,7 @@ fn test_crate::funs_with_disambiguator::f() -> u32
 }
 
 // Full name: test_crate::funs_with_disambiguator
-fn funs_with_disambiguator(_1: bool) -> u32
+fn funs_with_disambiguator(b_1: bool) -> u32
 {
     let _0: u32; // return
     let b_1: bool; // arg #1
@@ -371,7 +371,7 @@ where
 }
 
 // Full name: test_crate::{MonoContainer<T>[@TraitClause0]}::create
-fn create<T>(_1: T) -> MonoContainer<T>[@TraitClause0]
+fn create<T>(item_1: T) -> MonoContainer<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -421,7 +421,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get
-fn {impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get<'a, T>(_1: &'a MonoContainer<T>[@TraitClause0]) -> &'a T
+fn {impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get<'a, T>(self_1: &'a MonoContainer<T>[@TraitClause0]) -> &'a T
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/monomorphization/bound_lifetime.out
+++ b/charon/tests/ui/monomorphization/bound_lifetime.out
@@ -20,7 +20,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::foo
-fn foo<'_0>(_1: &'_0 u32) -> Option::<&'_ u32>
+fn foo<'_0>(x_1: &'_0 u32) -> Option::<&'_ u32>
 {
     let _0: Option::<&'_ u32>; // return
     let x_1: &'1 u32; // arg #1

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -121,7 +121,7 @@ impl<'_0, '_1> Fn<(u8, u8)> for closure<'_0, '_1> {
 }
 
 // Full name: test_crate::apply_to::<closure<'_, '_>>
-fn apply_to::<closure<'_, '_>><'_0>(_1: &'_0 closure<'_, '_>) -> u8
+fn apply_to::<closure<'_, '_>><'_0>(f_1: &'_0 closure<'_, '_>) -> u8
 {
     let _0: u8; // return
     let f_1: &'3 closure<'4, '5>; // arg #1
@@ -139,7 +139,7 @@ fn apply_to::<closure<'_, '_>><'_0>(_1: &'_0 closure<'_, '_>) -> u8
 }
 
 // Full name: test_crate::apply_to_mut::<closure<'_, '_>>
-fn apply_to_mut::<closure<'_, '_>><'_0>(_1: &'_0 mut closure<'_, '_>) -> u8
+fn apply_to_mut::<closure<'_, '_>><'_0>(f_1: &'_0 mut closure<'_, '_>) -> u8
 {
     let _0: u8; // return
     let f_1: &'3 mut closure<'4, '5>; // arg #1
@@ -161,7 +161,7 @@ impl<'_0, '_1> Destruct for closure<'_0, '_1> {    non-dyn-compatible
 }
 
 // Full name: test_crate::apply_to_once::<closure<'_, '_>>
-fn apply_to_once::<closure<'_, '_>>(_1: closure<'_, '_>) -> u8
+fn apply_to_once::<closure<'_, '_>>(f_1: closure<'_, '_>) -> u8
 {
     let _0: u8; // return
     let f_1: closure<'0, '1>; // arg #1

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -75,7 +75,7 @@ impl FnOnce<(u8,)> for closure {
 }
 
 // Full name: test_crate::apply_to_zero_once::<closure>
-fn apply_to_zero_once::<closure>(_1: closure) -> u8
+fn apply_to_zero_once::<closure>(f_1: closure) -> u8
 {
     let _0: u8; // return
     let f_1: closure; // arg #1

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -134,7 +134,7 @@ impl<'_0> Fn<(u8,)> for test_crate::main::closure<'_0> {
 }
 
 // Full name: test_crate::apply_to_zero::<test_crate::main::closure<'_>>
-fn apply_to_zero::<test_crate::main::closure<'_>>(_1: test_crate::main::closure<'_>) -> u8
+fn apply_to_zero::<test_crate::main::closure<'_>>(f_1: test_crate::main::closure<'_>) -> u8
 {
     let _0: u8; // return
     let f_1: test_crate::main::closure<'0>; // arg #1
@@ -174,7 +174,7 @@ impl<'_0> FnMut<(u8,)> for test_crate::main::closure#1<'_0> {
 }
 
 // Full name: test_crate::apply_to_zero_mut::<test_crate::main::closure#1<'_>>
-fn apply_to_zero_mut::<test_crate::main::closure#1<'_>>(_1: test_crate::main::closure#1<'_>) -> u8
+fn apply_to_zero_mut::<test_crate::main::closure#1<'_>>(f_1: test_crate::main::closure#1<'_>) -> u8
 {
     let _0: u8; // return
     let f_1: test_crate::main::closure#1<'0>; // arg #1
@@ -205,7 +205,7 @@ impl FnOnce<(u8,)> for test_crate::main::closure#2 {
 }
 
 // Full name: test_crate::apply_to_zero_once::<test_crate::main::closure#2>
-fn apply_to_zero_once::<test_crate::main::closure#2>(_1: test_crate::main::closure#2) -> u8
+fn apply_to_zero_once::<test_crate::main::closure#2>(f_1: test_crate::main::closure#2) -> u8
 {
     let _0: u8; // return
     let f_1: test_crate::main::closure#2; // arg #1

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -61,7 +61,7 @@ pub trait Fn<Self, Args>
 }
 
 // Full name: test_crate::foo::<u32>
-fn foo::<u32><'a>(_1: &'a u32)
+fn foo::<u32><'a>(x_1: &'a u32)
 {
     let _0: (); // return
     let x_1: &'1 u32; // arg #1
@@ -88,7 +88,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::foo::<u8>
-fn foo::<u8><'a>(_1: &'a u8)
+fn foo::<u8><'a>(x_1: &'a u8)
 {
     let _0: (); // return
     let x_1: &'1 u8; // arg #1
@@ -99,7 +99,7 @@ fn foo::<u8><'a>(_1: &'a u8)
 }
 
 // Full name: test_crate::foo::<char>
-fn foo::<char><'a>(_1: &'a char)
+fn foo::<char><'a>(x_1: &'a char)
 {
     let _0: (); // return
     let x_1: &'1 char; // arg #1
@@ -110,7 +110,7 @@ fn foo::<char><'a>(_1: &'a char)
 }
 
 // Full name: test_crate::takes_closure::<for<'a> foo::<u32><'a>>
-fn takes_closure::<for<'a> foo::<u32><'a>>(_1: for<'a> foo::<u32><'a>)
+fn takes_closure::<for<'a> foo::<u32><'a>>(c_1: for<'a> foo::<u32><'a>)
 {
     let _0: (); // return
     let c_1: for<'a> foo::<u32><'a>; // arg #1

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -121,7 +121,7 @@ fn call_once::<()>(_1: closure::<()>, _2: ((),))
 }
 
 // Full name: test_crate::foo::{const}::closure::as_fn::<()>
-fn as_fn::<()>(_1: ())
+fn as_fn::<()>(arg1_1: ())
 {
     let _0: (); // return
     let arg1_1: (); // arg #1
@@ -138,7 +138,7 @@ fn as_fn::<()>(_1: ())
 }
 
 // Full name: test_crate::foo::<()>
-fn foo::<()>(_1: ())
+fn foo::<()>(x_1: ())
 {
     let _0: (); // return
     let x_1: (); // arg #1

--- a/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
+++ b/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
@@ -34,7 +34,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool>
-unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {vtable_drop_preshim}::<bool>(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1
@@ -51,7 +51,7 @@ unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool>
-fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<Item = bool>))
+fn {vtable_method_preshim}::<bool><'_0>(dyn_self_1: &'_0 (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<Item = bool> + '0); // arg #1
@@ -68,7 +68,7 @@ fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<Item = bool>))
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<u32>
-unsafe fn {vtable_drop_preshim}::<u32>(_1: *mut (dyn Trait<Item = u32>))
+unsafe fn {vtable_drop_preshim}::<u32>(dyn_self_1: *mut (dyn Trait<Item = u32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = u32> + '0); // arg #1
@@ -85,7 +85,7 @@ unsafe fn {vtable_drop_preshim}::<u32>(_1: *mut (dyn Trait<Item = u32>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<u32>
-fn {vtable_method_preshim}::<u32><'_0>(_1: &'_0 (dyn Trait<Item = u32>))
+fn {vtable_method_preshim}::<u32><'_0>(dyn_self_1: &'_0 (dyn Trait<Item = u32>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<Item = u32> + '0); // arg #1
@@ -108,7 +108,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<Item = u32>))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for i32}::comsume
-fn {impl Trait for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -133,7 +133,7 @@ fn {impl Trait for i32}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait<Item 
 }
 
 // Full name: test_crate::{impl Trait for i32}::{vtable_drop_shim}
-unsafe fn {impl Trait for i32}::{vtable_drop_shim}(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {impl Trait for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1
@@ -182,7 +182,7 @@ impl Trait for i32 {
 }
 
 // Full name: test_crate::{impl Trait for usize}::comsume
-fn {impl Trait for usize}::comsume<'_0>(_1: &'_0 usize)
+fn {impl Trait for usize}::comsume<'_0>(self_1: &'_0 usize)
 {
     let _0: (); // return
     let self_1: &'1 usize; // arg #1
@@ -207,7 +207,7 @@ fn {impl Trait for usize}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait<Ite
 }
 
 // Full name: test_crate::{impl Trait for usize}::{vtable_drop_shim}
-unsafe fn {impl Trait for usize}::{vtable_drop_shim}(_1: *mut (dyn Trait<Item = u32>))
+unsafe fn {impl Trait for usize}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<Item = u32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = u32> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
@@ -34,7 +34,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool>
-unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {vtable_drop_preshim}::<bool>(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1
@@ -51,7 +51,7 @@ unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool>
-fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<Item = bool>))
+fn {vtable_method_preshim}::<bool><'_0>(dyn_self_1: &'_0 (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<Item = bool> + '0); // arg #1
@@ -71,7 +71,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<Item = bool>))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for i32}::comsume
-fn {impl Trait for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -96,7 +96,7 @@ fn {impl Trait for i32}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait<Item 
 }
 
 // Full name: test_crate::{impl Trait for i32}::{vtable_drop_shim}
-unsafe fn {impl Trait for i32}::{vtable_drop_shim}(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {impl Trait for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1
@@ -145,7 +145,7 @@ impl Trait for i32 {
 }
 
 // Full name: test_crate::{impl Trait for usize}::comsume
-fn {impl Trait for usize}::comsume<'_0>(_1: &'_0 usize)
+fn {impl Trait for usize}::comsume<'_0>(self_1: &'_0 usize)
 {
     let _0: (); // return
     let self_1: &'1 usize; // arg #1
@@ -170,7 +170,7 @@ fn {impl Trait for usize}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait<Ite
 }
 
 // Full name: test_crate::{impl Trait for usize}::{vtable_drop_shim}
-unsafe fn {impl Trait for usize}::{vtable_drop_shim}(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {impl Trait for usize}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
@@ -34,7 +34,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool>
-unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {vtable_drop_preshim}::<bool>(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1
@@ -51,7 +51,7 @@ unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<Item = bool>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool>
-fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<Item = bool>))
+fn {vtable_method_preshim}::<bool><'_0>(dyn_self_1: &'_0 (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<Item = bool> + '0); // arg #1
@@ -71,7 +71,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<Item = bool>))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for i32}::comsume
-fn {impl Trait for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -96,7 +96,7 @@ fn {vtable_method}<'_0>(_1: &'_0 (dyn Trait<Item = bool>))
 }
 
 // Full name: test_crate::{impl Trait for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn Trait<Item = bool>))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<Item = bool> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-generics-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-2.out
@@ -43,7 +43,7 @@ trait Trait<Self, T>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool>
-unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<bool>))
+unsafe fn {vtable_drop_preshim}::<bool>(dyn_self_1: *mut (dyn Trait<bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool> + '0); // arg #1
@@ -60,7 +60,7 @@ unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<bool>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool>
-fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<bool>)) -> bool
+fn {vtable_method_preshim}::<bool><'_0>(dyn_self_1: &'_0 (dyn Trait<bool>)) -> bool
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<bool> + '0); // arg #1
@@ -76,7 +76,7 @@ fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<bool>)) -> bool
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<usize>
-unsafe fn {vtable_drop_preshim}::<usize>(_1: *mut (dyn Trait<usize>))
+unsafe fn {vtable_drop_preshim}::<usize>(dyn_self_1: *mut (dyn Trait<usize>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize> + '0); // arg #1
@@ -93,7 +93,7 @@ unsafe fn {vtable_drop_preshim}::<usize>(_1: *mut (dyn Trait<usize>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<usize>
-fn {vtable_method_preshim}::<usize><'_0>(_1: &'_0 (dyn Trait<usize>)) -> usize
+fn {vtable_method_preshim}::<usize><'_0>(dyn_self_1: &'_0 (dyn Trait<usize>)) -> usize
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<usize> + '0); // arg #1
@@ -115,7 +115,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<usize>)) -> usize
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<bool> for i32}::comsume
-fn {impl Trait<bool> for i32}::comsume<'_0>(_1: &'_0 i32) -> bool
+fn {impl Trait<bool> for i32}::comsume<'_0>(self_1: &'_0 i32) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 i32; // arg #1
@@ -138,7 +138,7 @@ fn {impl Trait<bool> for i32}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait
 }
 
 // Full name: test_crate::{impl Trait<bool> for i32}::{vtable_drop_shim}
-unsafe fn {impl Trait<bool> for i32}::{vtable_drop_shim}(_1: *mut (dyn Trait<bool>))
+unsafe fn {impl Trait<bool> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool> + '0); // arg #1
@@ -188,7 +188,7 @@ impl Trait<bool> for i32 {
 }
 
 // Full name: test_crate::{impl Trait<usize> for u32}::comsume
-fn {impl Trait<usize> for u32}::comsume<'_0>(_1: &'_0 u32) -> usize
+fn {impl Trait<usize> for u32}::comsume<'_0>(self_1: &'_0 u32) -> usize
 {
     let _0: usize; // return
     let self_1: &'1 u32; // arg #1
@@ -211,7 +211,7 @@ fn {impl Trait<usize> for u32}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trai
 }
 
 // Full name: test_crate::{impl Trait<usize> for u32}::{vtable_drop_shim}
-unsafe fn {impl Trait<usize> for u32}::{vtable_drop_shim}(_1: *mut (dyn Trait<usize>))
+unsafe fn {impl Trait<usize> for u32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<usize>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
@@ -43,7 +43,7 @@ trait Trait<Self, T>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<usize, bool>
-unsafe fn {vtable_drop_preshim}::<usize, bool>(_1: *mut (dyn Trait<usize, Item = bool>))
+unsafe fn {vtable_drop_preshim}::<usize, bool>(dyn_self_1: *mut (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize, Item = bool> + '0); // arg #1
@@ -60,7 +60,7 @@ unsafe fn {vtable_drop_preshim}::<usize, bool>(_1: *mut (dyn Trait<usize, Item =
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<usize, bool>
-fn {vtable_method_preshim}::<usize, bool><'_0>(_1: &'_0 (dyn Trait<usize, Item = bool>))
+fn {vtable_method_preshim}::<usize, bool><'_0>(dyn_self_1: &'_0 (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<usize, Item = bool> + '0); // arg #1
@@ -77,7 +77,7 @@ fn {vtable_method_preshim}::<usize, bool><'_0>(_1: &'_0 (dyn Trait<usize, Item =
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool, usize>
-unsafe fn {vtable_drop_preshim}::<bool, usize>(_1: *mut (dyn Trait<bool, Item = usize>))
+unsafe fn {vtable_drop_preshim}::<bool, usize>(dyn_self_1: *mut (dyn Trait<bool, Item = usize>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool, Item = usize> + '0); // arg #1
@@ -94,7 +94,7 @@ unsafe fn {vtable_drop_preshim}::<bool, usize>(_1: *mut (dyn Trait<bool, Item = 
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool, usize>
-fn {vtable_method_preshim}::<bool, usize><'_0>(_1: &'_0 (dyn Trait<bool, Item = usize>))
+fn {vtable_method_preshim}::<bool, usize><'_0>(dyn_self_1: &'_0 (dyn Trait<bool, Item = usize>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<bool, Item = usize> + '0); // arg #1
@@ -117,7 +117,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<bool, Item = usize>))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<usize> for i32}::comsume
-fn {impl Trait<usize> for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait<usize> for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -142,7 +142,7 @@ fn {impl Trait<usize> for i32}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trai
 }
 
 // Full name: test_crate::{impl Trait<usize> for i32}::{vtable_drop_shim}
-unsafe fn {impl Trait<usize> for i32}::{vtable_drop_shim}(_1: *mut (dyn Trait<usize, Item = bool>))
+unsafe fn {impl Trait<usize> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize, Item = bool> + '0); // arg #1
@@ -192,7 +192,7 @@ impl Trait<usize> for i32 {
 }
 
 // Full name: test_crate::{impl Trait<bool> for bool}::comsume
-fn {impl Trait<bool> for bool}::comsume<'_0>(_1: &'_0 bool)
+fn {impl Trait<bool> for bool}::comsume<'_0>(self_1: &'_0 bool)
 {
     let _0: (); // return
     let self_1: &'1 bool; // arg #1
@@ -217,7 +217,7 @@ fn {impl Trait<bool> for bool}::comsume::{vtable_method}<'_0>(_1: &'_0 (dyn Trai
 }
 
 // Full name: test_crate::{impl Trait<bool> for bool}::{vtable_drop_shim}
-unsafe fn {impl Trait<bool> for bool}::{vtable_drop_shim}(_1: *mut (dyn Trait<bool, Item = usize>))
+unsafe fn {impl Trait<bool> for bool}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<bool, Item = usize>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool, Item = usize> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
@@ -43,7 +43,7 @@ trait Trait<Self, T>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<usize, bool>
-unsafe fn {vtable_drop_preshim}::<usize, bool>(_1: *mut (dyn Trait<usize, Item = bool>))
+unsafe fn {vtable_drop_preshim}::<usize, bool>(dyn_self_1: *mut (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize, Item = bool> + '0); // arg #1
@@ -60,7 +60,7 @@ unsafe fn {vtable_drop_preshim}::<usize, bool>(_1: *mut (dyn Trait<usize, Item =
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<usize, bool>
-fn {vtable_method_preshim}::<usize, bool><'_0>(_1: &'_0 (dyn Trait<usize, Item = bool>))
+fn {vtable_method_preshim}::<usize, bool><'_0>(dyn_self_1: &'_0 (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<usize, Item = bool> + '0); // arg #1
@@ -80,7 +80,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<usize, Item = bool>))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<usize> for i32}::comsume
-fn {impl Trait<usize> for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait<usize> for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -105,7 +105,7 @@ fn {vtable_method}<'_0>(_1: &'_0 (dyn Trait<usize, Item = bool>))
 }
 
 // Full name: test_crate::{impl Trait<usize> for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn Trait<usize, Item = bool>))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<usize, Item = bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<usize, Item = bool> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-generics.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics.out
@@ -43,7 +43,7 @@ trait Trait<Self, T>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}::<bool>
-unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<bool>))
+unsafe fn {vtable_drop_preshim}::<bool>(dyn_self_1: *mut (dyn Trait<bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool> + '0); // arg #1
@@ -60,7 +60,7 @@ unsafe fn {vtable_drop_preshim}::<bool>(_1: *mut (dyn Trait<bool>))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}::<bool>
-fn {vtable_method_preshim}::<bool><'_0>(_1: &'_0 (dyn Trait<bool>)) -> bool
+fn {vtable_method_preshim}::<bool><'_0>(dyn_self_1: &'_0 (dyn Trait<bool>)) -> bool
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait<bool> + '0); // arg #1
@@ -79,7 +79,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait<bool>)) -> bool
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<bool> for i32}::comsume
-fn {impl Trait<bool> for i32}::comsume<'_0>(_1: &'_0 i32) -> bool
+fn {impl Trait<bool> for i32}::comsume<'_0>(self_1: &'_0 i32) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 i32; // arg #1
@@ -102,7 +102,7 @@ fn {vtable_method}<'_0>(_1: &'_0 (dyn Trait<bool>)) -> bool
 }
 
 // Full name: test_crate::{impl Trait<bool> for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn Trait<bool>))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn Trait<bool>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait<bool> + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple-trait-two-methods.out
+++ b/charon/tests/ui/monomorphization/simple-trait-two-methods.out
@@ -35,7 +35,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}
-unsafe fn {vtable_drop_preshim}(_1: *mut (dyn Trait))
+unsafe fn {vtable_drop_preshim}(dyn_self_1: *mut (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait + '0); // arg #1
@@ -51,7 +51,7 @@ unsafe fn {vtable_drop_preshim}(_1: *mut (dyn Trait))
     return
 }
 
-fn test_crate::Trait::consume::{vtable_method_preshim}<'_0>(_1: &'_0 (dyn Trait))
+fn test_crate::Trait::consume::{vtable_method_preshim}<'_0>(dyn_self_1: &'_0 (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait + '0); // arg #1
@@ -67,7 +67,7 @@ fn test_crate::Trait::consume::{vtable_method_preshim}<'_0>(_1: &'_0 (dyn Trait)
     return
 }
 
-fn test_crate::Trait::another::{vtable_method_preshim}<'_0>(_1: &'_0 (dyn Trait))
+fn test_crate::Trait::another::{vtable_method_preshim}<'_0>(dyn_self_1: &'_0 (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait + '0); // arg #1
@@ -87,7 +87,7 @@ fn test_crate::Trait::consume<'_0>(_1: &'_0 (dyn Trait))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for i32}::another
-fn another<'_0>(_1: &'_0 i32)
+fn another<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -112,7 +112,7 @@ fn {impl Trait for i32}::another::{vtable_method}<'_0>(_1: &'_0 (dyn Trait))
 }
 
 // Full name: test_crate::{impl Trait for i32}::consume
-fn {impl Trait for i32}::consume<'_0>(_1: &'_0 i32)
+fn {impl Trait for i32}::consume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -137,7 +137,7 @@ fn {impl Trait for i32}::consume::{vtable_method}<'_0>(_1: &'_0 (dyn Trait))
 }
 
 // Full name: test_crate::{impl Trait for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn Trait))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait + '0); // arg #1

--- a/charon/tests/ui/monomorphization/simple_trait.out
+++ b/charon/tests/ui/monomorphization/simple_trait.out
@@ -34,7 +34,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::Trait::{vtable_drop_preshim}
-unsafe fn {vtable_drop_preshim}(_1: *mut (dyn Trait))
+unsafe fn {vtable_drop_preshim}(dyn_self_1: *mut (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait + '0); // arg #1
@@ -51,7 +51,7 @@ unsafe fn {vtable_drop_preshim}(_1: *mut (dyn Trait))
 }
 
 // Full name: test_crate::Trait::comsume::{vtable_method_preshim}
-fn {vtable_method_preshim}<'_0>(_1: &'_0 (dyn Trait))
+fn {vtable_method_preshim}<'_0>(dyn_self_1: &'_0 (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: &'_0 (dyn Trait + '0); // arg #1
@@ -71,7 +71,7 @@ fn test_crate::Trait::comsume<'_0>(_1: &'_0 (dyn Trait))
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for i32}::comsume
-fn {impl Trait for i32}::comsume<'_0>(_1: &'_0 i32)
+fn {impl Trait for i32}::comsume<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -96,7 +96,7 @@ fn {vtable_method}<'_0>(_1: &'_0 (dyn Trait))
 }
 
 // Full name: test_crate::{impl Trait for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn Trait))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn Trait))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Trait + '0); // arg #1

--- a/charon/tests/ui/monomorphization/trait_impls.out
+++ b/charon/tests/ui/monomorphization/trait_impls.out
@@ -13,7 +13,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::{impl Trait for bool}::method
-pub fn method<'_0>(_1: &'_0 bool)
+pub fn method<'_0>(self_1: &'_0 bool)
 {
     let _0: (); // return
     let self_1: &'1 bool; // arg #1
@@ -24,7 +24,7 @@ pub fn method<'_0>(_1: &'_0 bool)
 }
 
 // Full name: test_crate::do_test::<bool>
-fn do_test::<bool>(_1: bool)
+fn do_test::<bool>(x_1: bool)
 {
     let _0: (); // return
     let x_1: bool; // arg #1

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -19,7 +19,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::do_test::<bool>
-fn do_test::<bool>(_1: bool, _2: bool)
+fn do_test::<bool>(init_1: bool, expected_2: bool)
 {
     let _0: (); // return
     let init_1: bool; // arg #1

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -37,7 +37,7 @@ trait MyIterator<Self>
 struct A {}
 
 // Full name: test_crate::MyIterator::method
-fn method<'_0>(_1: &'_0 A)
+fn method<'_0>(self_1: &'_0 A)
 {
     let _0: (); // return
     let self_1: &'1 A; // arg #1
@@ -51,7 +51,7 @@ fn method<'_0>(_1: &'_0 A)
 struct B {}
 
 // Full name: test_crate::MyIterator::method
-fn method<'_0>(_1: &'_0 B)
+fn method<'_0>(self_1: &'_0 B)
 {
     let _0: (); // return
     let self_1: &'1 B; // arg #1

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -104,7 +104,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::identity
-fn identity<T>(_1: T) -> T
+fn identity<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -116,7 +116,7 @@ where
     return
 }
 
-fn test_crate::identity::<&_ mut _><'_0, T0>(_1: &'_0 mut T0) -> &'_0 mut T0
+fn test_crate::identity::<&_ mut _><'_0, T0>(x_1: &'_0 mut T0) -> &'_0 mut T0
 where
     [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
 {
@@ -128,7 +128,7 @@ where
     return
 }
 
-fn test_crate::identity::<Option<&_ mut _>><'_0, T0>(_1: Option<&'_0 mut T0>) -> Option<&'_0 mut T0>
+fn test_crate::identity::<Option<&_ mut _>><'_0, T0>(x_1: Option<&'_0 mut T0>) -> Option<&'_0 mut T0>
 where
     [@TraitClause0]: core::marker::Sized::<Option<&_ mut _>><'_0, T0>,
 {
@@ -140,7 +140,7 @@ where
     return
 }
 
-fn test_crate::identity::<Option<Option<&_ mut _>>><'_0, T0>(_1: Option<Option<&'_0 mut T0>>) -> Option<Option<&'_0 mut T0>>
+fn test_crate::identity::<Option<Option<&_ mut _>>><'_0, T0>(x_1: Option<Option<&'_0 mut T0>>) -> Option<Option<&'_0 mut T0>>
 where
     [@TraitClause0]: core::marker::Sized::<Option<Option<&_ mut _>>><'_0, T0>,
 {
@@ -153,7 +153,7 @@ where
 }
 
 // Full name: test_crate::use_id_mut
-fn use_id_mut<X, A>(_1: A)
+fn use_id_mut<X, A>(x_1: A)
 where
     [@TraitClause0]: Sized<X>,
     [@TraitClause1]: Sized<A>,

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -328,7 +328,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::option_mut
-fn option_mut<X, A>(_1: A)
+fn option_mut<X, A>(x_1: A)
 where
     [@TraitClause0]: Sized<X>,
     [@TraitClause1]: Sized<A>,
@@ -391,7 +391,7 @@ where
 }
 
 // Full name: test_crate::identity
-fn identity<T>(_1: T) -> T
+fn identity<T>(x_1: T) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -403,7 +403,7 @@ where
     return
 }
 
-fn test_crate::identity::<&_ mut _><'_0, T0>(_1: &'_0 mut T0) -> &'_0 mut T0
+fn test_crate::identity::<&_ mut _><'_0, T0>(x_1: &'_0 mut T0) -> &'_0 mut T0
 where
     [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
 {
@@ -415,7 +415,7 @@ where
     return
 }
 
-fn test_crate::identity::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>(_1: core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]) -> core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]
+fn test_crate::identity::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>(x_1: core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]) -> core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
     [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
@@ -428,7 +428,7 @@ where
     return
 }
 
-fn test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause1, @TraitClause2]><'_0, T0>(_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]) -> core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]
+fn test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause1, @TraitClause2]><'_0, T0>(x_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]) -> core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]
 where
     [@TraitClause0]: core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2],
     [@TraitClause1]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause2],
@@ -442,7 +442,7 @@ where
     return
 }
 
-fn test_crate::identity::<IterMut<_, _>[@TraitClause1]><'_0, T0>(_1: IterMut<'_0, T0>[@TraitClause1]) -> IterMut<'_0, T0>[@TraitClause1]
+fn test_crate::identity::<IterMut<_, _>[@TraitClause1]><'_0, T0>(x_1: IterMut<'_0, T0>[@TraitClause1]) -> IterMut<'_0, T0>[@TraitClause1]
 where
     [@TraitClause0]: core::marker::Sized::<IterMut<_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
     [@TraitClause1]: Sized<T0>,
@@ -458,7 +458,7 @@ where
 }
 
 // Full name: test_crate::mutable_identity
-fn mutable_identity<'_0, T>(_1: &'_0 mut T) -> &'_0 mut T
+fn mutable_identity<'_0, T>(x_1: &'_0 mut T) -> &'_0 mut T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -482,7 +482,7 @@ where
 }
 
 // Full name: test_crate::use_id_mut
-fn use_id_mut<X, A>(_1: A)
+fn use_id_mut<X, A>(x_1: A)
 where
     [@TraitClause0]: Sized<X>,
     [@TraitClause1]: Sized<A>,
@@ -809,7 +809,7 @@ fn use_const_generic<'_0, '_1>(_1: test_crate::ArrayWrapper::<&_ mut _, 1 : usiz
 }
 
 // Full name: test_crate::use_opaque_iter
-fn use_opaque_iter<'a, 'b, T>(_1: IterMut<'a, bool>[{built_in impl Sized for bool}])
+fn use_opaque_iter<'a, 'b, T>(x_1: IterMut<'a, bool>[{built_in impl Sized for bool}])
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target-from-symcrypt.out
@@ -307,7 +307,7 @@ where
 
 pub struct test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {}
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin(_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin(a_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, b_2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
 {
     let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
     let a_1: core::core_arch::x86::__m128i::x86_64-apple-darwin; // arg #1
@@ -325,7 +325,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate:
     return
 }
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0>(dst_1: &'_0 mut [u16; 8 : usize], val_2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
 {
     let _0: (); // return
     let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -356,7 +356,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate:
     return
 }
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0>(src_1: &'_0 [u16; 8 : usize]) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
 {
     let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
     let src_1: &'1 [u16; 8 : usize]; // arg #1
@@ -395,7 +395,7 @@ impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXm
 
 pub struct test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {}
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin(_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin(a_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, b_2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
 {
     let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
     let a_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // arg #1
@@ -413,7 +413,7 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate
     return
 }
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0>(dst_1: &'_0 mut [u16; 8 : usize], val_2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
 {
     let _0: (); // return
     let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -440,7 +440,7 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate
     return
 }
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0>(src_1: &'_0 [u16; 8 : usize]) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
 {
     let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
     let src_1: &'1 [u16; 8 : usize]; // arg #1
@@ -473,7 +473,7 @@ impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsN
     non-dyn-compatible
 }
 
-fn test_crate::ntt_layer_generic<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+fn test_crate::ntt_layer_generic<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -567,7 +567,7 @@ fn test_crate::ntt_layer_generic<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'
     return
 }
 
-fn test_crate::ntt_layer_vec128<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+fn test_crate::ntt_layer_vec128<'_0, '_1, T>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 where
     [@TraitClause0]: core::marker::Sized<T>,
     [@TraitClause1]: test_crate::NttIntrinsicsInterface<T>,
@@ -641,7 +641,7 @@ fn test_crate::SYMCRYPT_CPU_FEATURE_NEON() -> u32
 
 const test_crate::SYMCRYPT_CPU_FEATURE_NEON: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON()
 
-fn test_crate::cpu_features_present(_1: u32) -> bool
+fn test_crate::cpu_features_present(_mask_1: u32) -> bool
 {
     let _0: bool; // return
     let _mask_1: u32; // arg #1
@@ -650,7 +650,7 @@ fn test_crate::cpu_features_present(_1: u32) -> bool
     return
 }
 
-fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -693,7 +693,7 @@ fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mu
     return
 }
 
-fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -147,7 +147,7 @@ where
 }
 
 // Full name: test_crate::use_tuple_struct
-pub fn use_tuple_struct<'_0>(_1: &'_0 mut Tuple<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}])
+pub fn use_tuple_struct<'_0>(x_1: &'_0 mut Tuple<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}])
 {
     let _0: (); // return
     let x_1: &'1 mut Tuple<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]; // arg #1
@@ -159,7 +159,7 @@ pub fn use_tuple_struct<'_0>(_1: &'_0 mut Tuple<u32, u32>[{built_in impl Sized f
 }
 
 // Full name: test_crate::create_tuple_struct
-pub fn create_tuple_struct(_1: u32, _2: u64) -> Tuple<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]
+pub fn create_tuple_struct(x_1: u32, y_2: u64) -> Tuple<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]
 {
     let _0: Tuple<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]; // return
     let x_1: u32; // arg #1
@@ -178,7 +178,7 @@ pub fn create_tuple_struct(_1: u32, _2: u64) -> Tuple<u32, u64>[{built_in impl S
 }
 
 // Full name: test_crate::create_pair
-pub fn create_pair(_1: u32, _2: u64) -> Pair<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]
+pub fn create_pair(x_1: u32, y_2: u64) -> Pair<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]
 {
     let _0: Pair<u32, u64>[{built_in impl Sized for u32}, {built_in impl Sized for u64}]; // return
     let x_1: u32; // arg #1
@@ -220,7 +220,7 @@ where
 }
 
 // Full name: test_crate::use_id_type
-pub fn use_id_type<T>(_1: IdType<T>[@TraitClause0]) -> T
+pub fn use_id_type<T>(x_1: IdType<T>[@TraitClause0]) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -233,7 +233,7 @@ where
 }
 
 // Full name: test_crate::create_id_type
-pub fn create_id_type<T>(_1: T) -> IdType<T>[@TraitClause0]
+pub fn create_id_type<T>(x_1: T) -> IdType<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -251,7 +251,7 @@ where
 }
 
 // Full name: test_crate::cast_u32_to_i32
-pub fn cast_u32_to_i32(_1: u32) -> i32
+pub fn cast_u32_to_i32(x_1: u32) -> i32
 {
     let _0: i32; // return
     let x_1: u32; // arg #1
@@ -265,7 +265,7 @@ pub fn cast_u32_to_i32(_1: u32) -> i32
 }
 
 // Full name: test_crate::cast_bool_to_i32
-pub fn cast_bool_to_i32(_1: bool) -> i32
+pub fn cast_bool_to_i32(x_1: bool) -> i32
 {
     let _0: i32; // return
     let x_1: bool; // arg #1
@@ -279,7 +279,7 @@ pub fn cast_bool_to_i32(_1: bool) -> i32
 }
 
 // Full name: test_crate::cast_bool_to_bool
-pub fn cast_bool_to_bool(_1: bool) -> bool
+pub fn cast_bool_to_bool(x_1: bool) -> bool
 {
     let _0: bool; // return
     let x_1: bool; // arg #1
@@ -354,7 +354,7 @@ pub fn test2()
 }
 
 // Full name: test_crate::get_max
-pub fn get_max(_1: u32, _2: u32) -> u32
+pub fn get_max(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -452,7 +452,7 @@ pub fn test_box1()
 }
 
 // Full name: test_crate::copy_int
-pub fn copy_int(_1: i32) -> i32
+pub fn copy_int(x_1: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -462,7 +462,7 @@ pub fn copy_int(_1: i32) -> i32
 }
 
 // Full name: test_crate::test_unreachable
-pub fn test_unreachable(_1: bool)
+pub fn test_unreachable(b_1: bool)
 {
     let _0: (); // return
     let b_1: bool; // arg #1
@@ -478,7 +478,7 @@ pub fn test_unreachable(_1: bool)
 }
 
 // Full name: test_crate::is_cons
-pub fn is_cons<'_0, T>(_1: &'_0 List<T>[@TraitClause0]) -> bool
+pub fn is_cons<'_0, T>(l_1: &'_0 List<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -498,7 +498,7 @@ where
 }
 
 // Full name: test_crate::split_list
-pub fn split_list<T>(_1: List<T>[@TraitClause0]) -> (T, List<T>[@TraitClause0])
+pub fn split_list<T>(l_1: List<T>[@TraitClause0]) -> (T, List<T>[@TraitClause0])
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -565,7 +565,7 @@ where
 }
 
 // Full name: test_crate::even
-pub fn even(_1: u32) -> bool
+pub fn even(x_1: u32) -> bool
 {
     let _0: bool; // return
     let x_1: u32; // arg #1
@@ -599,7 +599,7 @@ pub fn even(_1: u32) -> bool
 }
 
 // Full name: test_crate::odd
-pub fn odd(_1: u32) -> bool
+pub fn odd(x_1: u32) -> bool
 {
     let _0: bool; // return
     let x_1: u32; // arg #1
@@ -735,7 +735,7 @@ pub fn new_pair1() -> StructWithPair<u32, u32>[{built_in impl Sized for u32}, {b
 }
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(_1: &'_0 mut u32)
+pub fn incr<'_0>(x_1: &'_0 mut u32)
 {
     let _0: (); // return
     let x_1: &'1 mut u32; // arg #1
@@ -750,7 +750,7 @@ pub fn incr<'_0>(_1: &'_0 mut u32)
 }
 
 // Full name: test_crate::read_then_incr
-pub fn read_then_incr<'_0>(_1: &'_0 mut u32) -> u32
+pub fn read_then_incr<'_0>(x_1: &'_0 mut u32) -> u32
 {
     let _0: u32; // return
     let x_1: &'1 mut u32; // arg #1

--- a/charon/tests/ui/params.out
+++ b/charon/tests/ui/params.out
@@ -17,7 +17,7 @@ pub trait Sized<Self>
 pub struct Global {}
 
 // Full name: test_crate::test_static
-fn test_static(_1: &'static u32) -> &'static u32
+fn test_static(x_1: &'static u32) -> &'static u32
 {
     let _0: &'1 u32; // return
     let x_1: &'2 u32; // arg #1

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -264,7 +264,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::get_or_insert
-pub fn get_or_insert<'_0>(_1: &'_0 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]) -> &'_0 u32
+pub fn get_or_insert<'_0>(map_1: &'_0 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]) -> &'_0 u32
 {
     let _0: &'1 u32; // return
     let map_1: &'3 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // arg #1

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -118,7 +118,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::wrap
-fn wrap<'a>(_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
+fn wrap<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {
     let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
     let x_1: &'9 u32; // arg #1
@@ -132,7 +132,7 @@ fn wrap<'a>(_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 }
 
 // Full name: test_crate::wrap2
-fn wrap2<'a>(_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'_ u32}]
+fn wrap2<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'_ u32}]
 where
     [@TraitClause0]: Clone<&'a ()>,
 {

--- a/charon/tests/ui/projection-index-from-end.out
+++ b/charon/tests/ui/projection-index-from-end.out
@@ -13,7 +13,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::slice_pattern_end
-fn slice_pattern_end<'_0>(_1: &'_0 [()])
+fn slice_pattern_end<'_0>(x_1: &'_0 [()])
 {
     let _0: (); // return
     let x_1: &'1 [()]; // arg #1

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -144,7 +144,7 @@ pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
 pub opaque type NonNull<T>
 
 // Full name: core::ptr::const_ptr::{*const T}::offset::precondition_check
-fn precondition_check(_1: *const (), _2: isize, _3: usize)
+fn precondition_check(this_1: *const (), count_2: isize, size_3: usize)
 {
     let _0: (); // return
     let this_1: *const (); // arg #1
@@ -272,7 +272,7 @@ fn precondition_check(_1: *const (), _2: isize, _3: usize)
 }
 
 // Full name: core::ptr::const_ptr::{*const T}::offset
-pub unsafe fn offset<T>(_1: *const T, _2: isize) -> *const T
+pub unsafe fn offset<T>(self_1: *const T, count_2: isize) -> *const T
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -14,7 +14,7 @@ pub opaque type Argument<'a>
 
 // Full name: core::intrinsics::cold_path
 pub fn cold_path()
-= <opaque>
+= <intrinsic:cold_path>
 
 // Full name: core::marker::MetaSized
 #[lang_item("meta_sized")]

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -157,7 +157,7 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<F>(_1: F)
+fn foo<F>(_f_1: F)
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: for<'a> FnMut<F, (&'a (),)>,

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -242,12 +242,7 @@ pub fn ctpop<T>(_1: T) -> u32
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
-{
-    let _0: u32; // return
-    let x_1: T; // arg #1
-
-    undefined_behavior
-}
+= <intrinsic:ctpop>
 
 fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(_1: usize)
 {
@@ -818,11 +813,7 @@ where
 pub fn core::intrinsics::align_of<T>() -> usize
 where
     [@TraitClause0]: Sized<T>,
-{
-    let _0: usize; // return
-
-    undefined_behavior
-}
+= <intrinsic:align_of>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -847,11 +838,7 @@ where
 pub fn size_of<T>() -> usize
 where
     [@TraitClause0]: Sized<T>,
-{
-    let _0: usize; // return
-
-    undefined_behavior
-}
+= <intrinsic:size_of>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
@@ -941,15 +928,7 @@ where
 pub unsafe fn write_bytes<T>(_1: *mut T, _2: u8, _3: usize)
 where
     [@TraitClause0]: Sized<T>,
-{
-    let _0: (); // return
-    let dst_1: *mut T; // arg #1
-    let val_2: u8; // arg #2
-    let count_3: usize; // arg #3
-
-    _0 = ()
-    undefined_behavior
-}
+= <intrinsic:write_bytes>
 
 // Full name: core::convert::Infallible
 pub enum Infallible {
@@ -1106,12 +1085,7 @@ pub fn panic_nounwind(_1: &'static Str) -> !
 
 // Full name: core::intrinsics::cold_path
 pub fn cold_path()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
+= <intrinsic:cold_path>
 
 // Full name: core::ub_checks::maybe_is_nonoverlapping::runtime
 fn runtime(_1: *const (), _2: *const (), _3: usize, _4: usize) -> bool
@@ -1788,23 +1762,23 @@ fn core::hint::assert_unchecked::precondition_check(_1: bool)
 
 // Full name: alloc::alloc::__rust_alloc
 unsafe fn __rust_alloc(_1: usize, _2: usize) -> *mut u8
-= <opaque>
+= <extern:__rust_alloc>
 
 // Full name: alloc::alloc::__rust_dealloc
 unsafe fn __rust_dealloc(_1: *mut u8, _2: usize, _3: usize)
-= <opaque>
+= <extern:__rust_dealloc>
 
 // Full name: alloc::alloc::__rust_realloc
 unsafe fn __rust_realloc(_1: *mut u8, _2: usize, _3: usize, _4: usize) -> *mut u8
-= <opaque>
+= <extern:__rust_realloc>
 
 // Full name: alloc::alloc::__rust_alloc_zeroed
 unsafe fn __rust_alloc_zeroed(_1: usize, _2: usize) -> *mut u8
-= <opaque>
+= <extern:__rust_alloc_zeroed>
 
 // Full name: alloc::alloc::__rust_no_alloc_shim_is_unstable_v2
 unsafe fn __rust_no_alloc_shim_is_unstable_v2()
-= <opaque>
+= <extern:__rust_no_alloc_shim_is_unstable_v2>
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -238,7 +238,7 @@ impl Copy for usize {
 }
 
 // Full name: core::intrinsics::ctpop
-pub fn ctpop<T>(_1: T) -> u32
+pub fn ctpop<T>(x_1: T) -> u32
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -925,7 +925,7 @@ where
 }
 
 // Full name: core::intrinsics::write_bytes
-pub unsafe fn write_bytes<T>(_1: *mut T, _2: u8, _3: usize)
+pub unsafe fn write_bytes<T>(dst_1: *mut T, val_2: u8, count_3: usize)
 where
     [@TraitClause0]: Sized<T>,
 = <intrinsic:write_bytes>

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -136,7 +136,7 @@ pub struct Arguments<'a> {
 }
 
 // Full name: core::panicking::panic_nounwind_fmt::compiletime
-fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+fn compiletime<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -146,7 +146,7 @@ fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
 }
 
 // Full name: core::panicking::panic_nounwind_fmt
-pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+pub fn panic_nounwind_fmt<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -194,7 +194,7 @@ pub trait Copy<Self>
 }
 
 // Full name: core::clone::impls::{impl Clone for usize}::clone
-pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
+pub fn {impl Clone for usize}::clone<'_0>(self_1: &'_0 usize) -> usize
 {
     let _0: usize; // return
     let self_1: &'1 usize; // arg #1
@@ -204,7 +204,7 @@ pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 }
 
 // Full name: core::clone::impls::{impl Clone for usize}::clone_from
-pub fn {impl Clone for usize}::clone_from<'_0, '_1>(_1: &'_0 mut usize, _2: &'_1 usize)
+pub fn {impl Clone for usize}::clone_from<'_0, '_1>(self_1: &'_0 mut usize, source_2: &'_1 usize)
 where
     [@TraitClause0]: Destruct<usize>,
 {
@@ -244,7 +244,7 @@ where
     [@TraitClause1]: Copy<T>,
 = <intrinsic:ctpop>
 
-fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(_1: usize)
+fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(align_1: usize)
 {
     let _0: (); // return
     let align_1: usize; // arg #1
@@ -305,7 +305,7 @@ fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(_1: usiz
     return
 }
 
-fn core::alloc::layout::{Layout}::from_size_align_unchecked::precondition_check(_1: usize, _2: usize)
+fn core::alloc::layout::{Layout}::from_size_align_unchecked::precondition_check(size_1: usize, align_2: usize)
 {
     let _0: (); // return
     let size_1: usize; // arg #1
@@ -395,7 +395,7 @@ fn core::alloc::layout::{Layout}::from_size_align_unchecked::precondition_check(
 }
 
 // Full name: core::alloc::layout::{Layout}::from_size_align_unchecked
-pub unsafe fn from_size_align_unchecked(_1: usize, _2: usize) -> Layout
+pub unsafe fn from_size_align_unchecked(size_1: usize, align_2: usize) -> Layout
 {
     let _0: Layout; // return
     let size_1: usize; // arg #1
@@ -441,7 +441,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::ptr::const_ptr::{*const T}::is_aligned_to
-pub fn is_aligned_to<T>(_1: *const T, _2: usize) -> bool
+pub fn is_aligned_to<T>(self_1: *const T, align_2: usize) -> bool
 {
     let _0: bool; // return
     let self_1: *const T; // arg #1
@@ -518,7 +518,7 @@ pub fn is_aligned_to<T>(_1: *const T, _2: usize) -> bool
     return
 }
 
-fn core::ptr::write_bytes::precondition_check(_1: *const (), _2: usize, _3: bool)
+fn core::ptr::write_bytes::precondition_check(addr_1: *const (), align_2: usize, zero_size_3: bool)
 {
     let _0: (); // return
     let addr_1: *const (); // arg #1
@@ -620,7 +620,7 @@ where
   Some(T),
 }
 
-pub fn core::ptr::alignment::{Alignment}::new(_1: usize) -> Option<Alignment>[{built_in impl Sized for Alignment}]
+pub fn core::ptr::alignment::{Alignment}::new(align_1: usize) -> Option<Alignment>[{built_in impl Sized for Alignment}]
 {
     let _0: Option<Alignment>[{built_in impl Sized for Alignment}]; // return
     let align_1: usize; // arg #1
@@ -668,7 +668,7 @@ fn unwrap_failed() -> !
 
 // Full name: core::option::{Option<T>[@TraitClause0]}::unwrap
 #[lang_item("option_unwrap")]
-pub fn unwrap<T>(_1: Option<T>[@TraitClause0]) -> T
+pub fn unwrap<T>(self_1: Option<T>[@TraitClause0]) -> T
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -934,7 +934,7 @@ where
 pub enum Infallible {
 }
 
-pub fn core::alloc::Allocator::allocate_zeroed<'_0, Self>(_1: &'_0 Self, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub fn core::alloc::Allocator::allocate_zeroed<'_0, Self>(self_1: &'_0 Self, layout_2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
@@ -1023,7 +1023,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::fmt::{Arguments<'a>}::from_str
-pub fn from_str<'a>(_1: &'static Str) -> Arguments<'a>
+pub fn from_str<'a>(s_1: &'static Str) -> Arguments<'a>
 {
     let _0: Arguments<'1>; // return
     let s_1: &'3 Str; // arg #1
@@ -1066,7 +1066,7 @@ pub fn from_str<'a>(_1: &'static Str) -> Arguments<'a>
 
 // Full name: core::panicking::panic_nounwind
 #[lang_item("panic_nounwind")]
-pub fn panic_nounwind(_1: &'static Str) -> !
+pub fn panic_nounwind(expr_1: &'static Str) -> !
 {
     let _0: !; // return
     let expr_1: &'1 Str; // arg #1
@@ -1088,7 +1088,7 @@ pub fn cold_path()
 = <intrinsic:cold_path>
 
 // Full name: core::ub_checks::maybe_is_nonoverlapping::runtime
-fn runtime(_1: *const (), _2: *const (), _3: usize, _4: usize) -> bool
+fn runtime(src_1: *const (), dst_2: *const (), size_3: usize, count_4: usize) -> bool
 {
     let _0: bool; // return
     let src_1: *const (); // arg #1
@@ -1160,7 +1160,7 @@ fn runtime(_1: *const (), _2: *const (), _3: usize, _4: usize) -> bool
     _7 = panic_nounwind(const "is_nonoverlapping: `size_of::<T>() * count` overflows a usize")
 }
 
-fn core::ptr::copy_nonoverlapping::precondition_check(_1: *const (), _2: *mut (), _3: usize, _4: usize, _5: usize)
+fn core::ptr::copy_nonoverlapping::precondition_check(src_1: *const (), dst_2: *mut (), size_3: usize, align_4: usize, count_5: usize)
 {
     let _0: (); // return
     let src_1: *const (); // arg #1
@@ -1354,7 +1354,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(_1: *const (), _2: *mut ()
     _13 = panic_nounwind_fmt<'15>(move _14, const false)
 }
 
-pub unsafe fn core::alloc::Allocator::grow<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::grow<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
@@ -1436,7 +1436,7 @@ where
     return
 }
 
-pub unsafe fn core::alloc::Allocator::grow_zeroed<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::grow_zeroed<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
@@ -1518,7 +1518,7 @@ where
     return
 }
 
-pub unsafe fn core::alloc::Allocator::shrink<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn core::alloc::Allocator::shrink<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
     [@TraitClause0]: Allocator<Self>,
 {
@@ -1600,7 +1600,7 @@ where
     return
 }
 
-pub fn core::alloc::Allocator::by_ref<'_0, Self>(_1: &'_0 Self) -> &'_0 Self
+pub fn core::alloc::Allocator::by_ref<'_0, Self>(self_1: &'_0 Self) -> &'_0 Self
 where
     [@TraitClause0]: Allocator<Self>,
     [@TraitClause1]: Sized<Self>,
@@ -1618,7 +1618,7 @@ where
     [@TraitClause0]: Clone<Self>,
 = <method_without_default_body>
 
-pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 Self)
+pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
     [@TraitClause0]: Clone<Self>,
     [@TraitClause1]: Destruct<Self>,
@@ -1646,7 +1646,7 @@ pub struct Unique<T> {
   _marker: PhantomData<T>,
 }
 
-fn core::ptr::non_null::{NonNull<T>}::new_unchecked::precondition_check(_1: *mut ())
+fn core::ptr::non_null::{NonNull<T>}::new_unchecked::precondition_check(ptr_1: *mut ())
 {
     let _0: (); // return
     let ptr_1: *mut (); // arg #1
@@ -1707,7 +1707,7 @@ fn core::ptr::non_null::{NonNull<T>}::new_unchecked::precondition_check(_1: *mut
     _3 = panic_nounwind_fmt<'15>(move _4, const false)
 }
 
-fn core::hint::assert_unchecked::precondition_check(_1: bool)
+fn core::hint::assert_unchecked::precondition_check(cond_1: bool)
 {
     let _0: (); // return
     let cond_1: bool; // arg #1
@@ -1785,7 +1785,7 @@ unsafe fn __rust_no_alloc_shim_is_unstable_v2()
 pub struct Global {}
 
 // Full name: alloc::alloc::{Global}::alloc_impl_runtime
-fn alloc_impl_runtime(_1: Layout, _2: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+fn alloc_impl_runtime(layout_1: Layout, zeroed_2: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let layout_1: Layout; // arg #1
@@ -1985,7 +1985,7 @@ fn alloc_impl_runtime(_1: Layout, _2: bool) -> Result<NonNull<[u8]>, AllocError>
 }
 
 // Full name: alloc::alloc::{Global}::grow_impl_runtime
-fn grow_impl_runtime<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layout, _5: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+fn grow_impl_runtime<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout, zeroed_5: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2266,7 +2266,7 @@ fn grow_impl_runtime<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layo
 }
 
 // Full name: alloc::alloc::{Global}::shrink_impl_runtime
-fn shrink_impl_runtime<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layout, _5: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+fn shrink_impl_runtime<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout, _zeroed_5: bool) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2591,7 +2591,7 @@ fn shrink_impl_runtime<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: La
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::shrink
-pub unsafe fn {impl Allocator for Global}::shrink<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::shrink<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2604,7 +2604,7 @@ pub unsafe fn {impl Allocator for Global}::shrink<'_0>(_1: &'_0 Global, _2: NonN
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::grow_zeroed
-pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2617,7 +2617,7 @@ pub unsafe fn {impl Allocator for Global}::grow_zeroed<'_0>(_1: &'_0 Global, _2:
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::grow
-pub unsafe fn {impl Allocator for Global}::grow<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout, _4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub unsafe fn {impl Allocator for Global}::grow<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2630,7 +2630,7 @@ pub unsafe fn {impl Allocator for Global}::grow<'_0>(_1: &'_0 Global, _2: NonNul
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::deallocate
-pub unsafe fn {impl Allocator for Global}::deallocate<'_0>(_1: &'_0 Global, _2: NonNull<u8>, _3: Layout)
+pub unsafe fn {impl Allocator for Global}::deallocate<'_0>(self_1: &'_0 Global, ptr_2: NonNull<u8>, layout_3: Layout)
 {
     let _0: (); // return
     let self_1: &'1 Global; // arg #1
@@ -2665,7 +2665,7 @@ pub unsafe fn {impl Allocator for Global}::deallocate<'_0>(_1: &'_0 Global, _2: 
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::allocate_zeroed
-pub fn {impl Allocator for Global}::allocate_zeroed<'_0>(_1: &'_0 Global, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub fn {impl Allocator for Global}::allocate_zeroed<'_0>(self_1: &'_0 Global, layout_2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2676,7 +2676,7 @@ pub fn {impl Allocator for Global}::allocate_zeroed<'_0>(_1: &'_0 Global, _2: La
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::allocate
-pub fn {impl Allocator for Global}::allocate<'_0>(_1: &'_0 Global, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
+pub fn {impl Allocator for Global}::allocate<'_0>(self_1: &'_0 Global, layout_2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Global; // arg #1
@@ -2687,7 +2687,7 @@ pub fn {impl Allocator for Global}::allocate<'_0>(_1: &'_0 Global, _2: Layout) -
 }
 
 // Full name: alloc::alloc::{impl Allocator for Global}::by_ref
-pub fn {impl Allocator for Global}::by_ref<'_0>(_1: &'_0 Global) -> &'_0 Global
+pub fn {impl Allocator for Global}::by_ref<'_0>(self_1: &'_0 Global) -> &'_0 Global
 where
     [@TraitClause0]: Sized<Global>,
 {
@@ -2724,7 +2724,7 @@ fn ct_error(_1: Layout) -> !
 }
 
 // Full name: alloc::alloc::handle_alloc_error
-pub fn handle_alloc_error(_1: Layout) -> !
+pub fn handle_alloc_error(layout_1: Layout) -> !
 {
     let _0: !; // return
     let layout_1: Layout; // arg #1
@@ -2741,7 +2741,7 @@ pub fn handle_alloc_error(_1: Layout) -> !
 
 // Full name: alloc::alloc::exchange_malloc
 #[lang_item("exchange_malloc")]
-unsafe fn exchange_malloc(_1: usize, _2: usize) -> *mut u8
+unsafe fn exchange_malloc(size_1: usize, align_2: usize) -> *mut u8
 {
     let _0: *mut u8; // return
     let size_1: usize; // arg #1
@@ -2819,7 +2819,7 @@ where
 }
 
 #[lang_item("box_new")]
-pub fn alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<T>(_1: T) -> Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+pub fn alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<T>(x_1: T) -> Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -2850,7 +2850,7 @@ where
 }
 
 // Full name: alloc::boxed::{Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::from_raw
-pub unsafe fn from_raw<T>(_1: *mut T) -> Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+pub unsafe fn from_raw<T>(raw_1: *mut T) -> Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
     [@TraitClause0]: MetaSized<T>,
 {
@@ -2893,7 +2893,7 @@ where
 }
 
 // Full name: alloc::boxed::{Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::into_raw
-pub fn into_raw<T>(_1: Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]) -> *mut T
+pub fn into_raw<T>(b_1: Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]) -> *mut T
 where
     [@TraitClause0]: MetaSized<T>,
 {
@@ -2911,7 +2911,7 @@ where
 }
 
 // Full name: alloc::boxed::{Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::leak
-pub fn leak<'a, T, A>(_1: Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]) -> &'a mut T
+pub fn leak<'a, T, A>(b_1: Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]) -> &'a mut T
 where
     [@TraitClause0]: MetaSized<T>,
     [@TraitClause1]: Sized<A>,

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -41,7 +41,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl MyTryFrom<&'_0 bool> for bool}::from
-pub fn {impl MyTryFrom<&'_0 bool> for bool}::from<'_0>(_1: &'_0 bool) -> Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
+pub fn {impl MyTryFrom<&'_0 bool> for bool}::from<'_0>(v_1: &'_0 bool) -> Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 {
     let _0: Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]; // return
     let v_1: &'1 bool; // arg #1

--- a/charon/tests/ui/regressions/invalid-reconstruct-assert.out
+++ b/charon/tests/ui/regressions/invalid-reconstruct-assert.out
@@ -118,7 +118,7 @@ fn {impl SliceIndex<[T]> for usize}::get_unchecked::precondition_check(_1: usize
 = <opaque>
 
 // Full name: core::slice::{[T]}::binary_search_by
-pub fn binary_search_by<'a, T, F>(_1: &'a [T], _2: F) -> Result<usize, usize>[{built_in impl Sized for usize}, {built_in impl Sized for usize}]
+pub fn binary_search_by<'a, T, F>(self_1: &'a [T], f_2: F) -> Result<usize, usize>[{built_in impl Sized for usize}, {built_in impl Sized for usize}]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<F>,
@@ -430,7 +430,7 @@ where
 struct closure {}
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for closure}::call_mut
-fn {impl FnMut<(&'_ u32,)> for closure}::call_mut<'_0, '_1>(_1: &'_1 mut closure, _2: (&'_0 u32,)) -> Ordering
+fn {impl FnMut<(&'_ u32,)> for closure}::call_mut<'_0, '_1>(_1: &'_1 mut closure, tupled_args_2: (&'_0 u32,)) -> Ordering
 {
     let _0: Ordering; // return
     let _1: &'1 mut closure; // arg #1

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -111,7 +111,7 @@ where
 struct test_crate::main::closure#1 {}
 
 // Full name: test_crate::main::{impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call
-fn {impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call<'_0, '_1>(_1: &'_1 test_crate::main::closure#1, _2: (&'_0 u16,))
+fn {impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call<'_0, '_1>(_1: &'_1 test_crate::main::closure#1, tupled_args_2: (&'_0 u16,))
 {
     let _0: (); // return
     let _1: &'1 test_crate::main::closure#1; // arg #1
@@ -126,7 +126,7 @@ fn {impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call<'_0, '_1>(_1: &'_
 }
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}::call_mut
-fn {impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::main::closure#1, _2: (&'_0 u16,))
+fn {impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}::call_mut<'_0, '_1>(state_1: &'_1 mut test_crate::main::closure#1, args_2: (&'_0 u16,))
 {
     let _0: (); // return
     let state_1: &'_1 mut test_crate::main::closure#1; // arg #1
@@ -167,7 +167,7 @@ fn {impl FnOnce<(&'_ u16,)> for test_crate::main::closure#1}::call_once<'_0>(_1:
 }
 
 // Full name: test_crate::main::closure#1::as_fn
-fn as_fn<'_0>(_1: &'_0 u16)
+fn as_fn<'_0>(arg1_1: &'_0 u16)
 {
     let _0: (); // return
     let arg1_1: &'_0 u16; // arg #1
@@ -212,7 +212,7 @@ fn main()
 }
 
 // Full name: test_crate::main::{impl Fn<(&'_ u8,)> for test_crate::main::closure}::call
-fn {impl Fn<(&'_ u8,)> for test_crate::main::closure}::call<'_0, '_1>(_1: &'_1 test_crate::main::closure, _2: (&'_0 u8,))
+fn {impl Fn<(&'_ u8,)> for test_crate::main::closure}::call<'_0, '_1>(_1: &'_1 test_crate::main::closure, tupled_args_2: (&'_0 u8,))
 {
     let _0: (); // return
     let _1: &'1 test_crate::main::closure; // arg #1
@@ -227,7 +227,7 @@ fn {impl Fn<(&'_ u8,)> for test_crate::main::closure}::call<'_0, '_1>(_1: &'_1 t
 }
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u8,)> for test_crate::main::closure}::call_mut
-fn {impl FnMut<(&'_ u8,)> for test_crate::main::closure}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::main::closure, _2: (&'_0 u8,))
+fn {impl FnMut<(&'_ u8,)> for test_crate::main::closure}::call_mut<'_0, '_1>(state_1: &'_1 mut test_crate::main::closure, args_2: (&'_0 u8,))
 {
     let _0: (); // return
     let state_1: &'_1 mut test_crate::main::closure; // arg #1

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -195,7 +195,7 @@ pub struct iovec {
 pub opaque type std::sys::io::io_slice::iovec::IoSlice<'a>
 
 // Full name: std::io::{std::io::IoSlice<'a>}::advance_slices
-pub fn advance_slices<'a, '_1, '_2>(_1: &'_1 mut &'_2 mut [std::io::IoSlice<'a>], _2: usize)
+pub fn advance_slices<'a, '_1, '_2>(bufs_1: &'_1 mut &'_2 mut [std::io::IoSlice<'a>], n_2: usize)
 {
     let _0: (); // return
     let bufs_1: &'7 mut &'8 mut [std::io::IoSlice<'9>]; // arg #1
@@ -544,7 +544,7 @@ pub fn advance_slices<'a, '_1, '_2>(_1: &'_1 mut &'_2 mut [std::io::IoSlice<'a>]
 }
 
 // Full name: test_crate::foo
-pub fn foo<'_0, '_1, '_2>(_1: &'_0 mut &'_1 mut [std::io::IoSlice<'_2>])
+pub fn foo<'_0, '_1, '_2>(bufs_1: &'_0 mut &'_1 mut [std::io::IoSlice<'_2>])
 {
     let _0: (); // return
     let bufs_1: &'7 mut &'8 mut [std::io::IoSlice<'9>]; // arg #1

--- a/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
+++ b/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
@@ -83,7 +83,7 @@ impl Destruct for MyStruct {
 }
 
 // Full name: test_crate::{impl MyTrait for MyStruct}::foo
-pub fn {impl MyTrait for MyStruct}::foo<'_0>(_1: &'_0 MyStruct)
+pub fn {impl MyTrait for MyStruct}::foo<'_0>(self_1: &'_0 MyStruct)
 {
     let _0: (); // return
     let self_1: &'1 MyStruct; // arg #1
@@ -108,7 +108,7 @@ fn {vtable_method}<'_0>(_1: &'_0 (dyn MyTrait))
 }
 
 // Full name: test_crate::{impl MyTrait for MyStruct}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}(_1: *mut (dyn MyTrait))
+unsafe fn {vtable_drop_shim}(dyn_self_1: *mut (dyn MyTrait))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn MyTrait + '0); // arg #1

--- a/charon/tests/ui/remove-dynamic-checks.out
+++ b/charon/tests/ui/remove-dynamic-checks.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::neg_test
-pub fn neg_test(_1: i32) -> i32
+pub fn neg_test(x_1: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -15,7 +15,7 @@ pub fn neg_test(_1: i32) -> i32
 }
 
 // Full name: test_crate::add_u32
-pub fn add_u32(_1: u32, _2: u32) -> u32
+pub fn add_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -37,7 +37,7 @@ pub fn add_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(_1: &'_0 mut u32)
+pub fn incr<'_0>(x_1: &'_0 mut u32)
 {
     let _0: (); // return
     let x_1: &'1 mut u32; // arg #1
@@ -52,7 +52,7 @@ pub fn incr<'_0>(_1: &'_0 mut u32)
 }
 
 // Full name: test_crate::subs_u32
-pub fn subs_u32(_1: u32, _2: u32) -> u32
+pub fn subs_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -74,7 +74,7 @@ pub fn subs_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::div_u32
-pub fn div_u32(_1: u32, _2: u32) -> u32
+pub fn div_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -93,7 +93,7 @@ pub fn div_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::div_u32_const
-pub fn div_u32_const(_1: u32) -> u32
+pub fn div_u32_const(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -107,7 +107,7 @@ pub fn div_u32_const(_1: u32) -> u32
 }
 
 // Full name: test_crate::rem_u32
-pub fn rem_u32(_1: u32, _2: u32) -> u32
+pub fn rem_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -126,7 +126,7 @@ pub fn rem_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::mul_u32
-pub fn mul_u32(_1: u32, _2: u32) -> u32
+pub fn mul_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -148,7 +148,7 @@ pub fn mul_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::add_i32
-pub fn add_i32(_1: i32, _2: i32) -> i32
+pub fn add_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -170,7 +170,7 @@ pub fn add_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::subs_i32
-pub fn subs_i32(_1: i32, _2: i32) -> i32
+pub fn subs_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -192,7 +192,7 @@ pub fn subs_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::div_i32
-pub fn div_i32(_1: i32, _2: i32) -> i32
+pub fn div_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -211,7 +211,7 @@ pub fn div_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::div_i32_const
-pub fn div_i32_const(_1: i32) -> i32
+pub fn div_i32_const(x_1: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -225,7 +225,7 @@ pub fn div_i32_const(_1: i32) -> i32
 }
 
 // Full name: test_crate::rem_i32
-pub fn rem_i32(_1: i32, _2: i32) -> i32
+pub fn rem_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -244,7 +244,7 @@ pub fn rem_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::mul_i32
-pub fn mul_i32(_1: i32, _2: i32) -> i32
+pub fn mul_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -266,7 +266,7 @@ pub fn mul_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::mix_arith_u32
-pub fn mix_arith_u32(_1: u32, _2: u32, _3: u32) -> u32
+pub fn mix_arith_u32(x_1: u32, y_2: u32, z_3: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -368,7 +368,7 @@ pub fn mix_arith_u32(_1: u32, _2: u32, _3: u32) -> u32
 }
 
 // Full name: test_crate::mix_arith_i32
-pub fn mix_arith_i32(_1: i32, _2: i32, _3: i32) -> i32
+pub fn mix_arith_i32(x_1: i32, y_2: i32, z_3: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -470,7 +470,7 @@ pub fn mix_arith_i32(_1: i32, _2: i32, _3: i32) -> i32
 }
 
 // Full name: test_crate::shl_u32
-fn shl_u32(_1: u32, _2: u32) -> u32
+fn shl_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -489,7 +489,7 @@ fn shl_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::shr_u32
-fn shr_u32(_1: u32, _2: u32) -> u32
+fn shr_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -508,7 +508,7 @@ fn shr_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::shr_add_u32
-fn shr_add_u32(_1: u32, _2: u32) -> u32
+fn shr_add_u32(x_1: u32, y_2: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -534,7 +534,7 @@ fn shr_add_u32(_1: u32, _2: u32) -> u32
 }
 
 // Full name: test_crate::shl_i32
-fn shl_i32(_1: i32, _2: i32) -> i32
+fn shl_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -553,7 +553,7 @@ fn shl_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::shr_i32
-fn shr_i32(_1: i32, _2: i32) -> i32
+fn shr_i32(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -572,7 +572,7 @@ fn shr_i32(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::shr_i32_manual_cast
-fn shr_i32_manual_cast(_1: i32, _2: i32) -> i32
+fn shr_i32_manual_cast(x_1: i32, y_2: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1
@@ -595,7 +595,7 @@ fn shr_i32_manual_cast(_1: i32, _2: i32) -> i32
 }
 
 // Full name: test_crate::index_slice_ignore_value
-fn index_slice_ignore_value<'_0>(_1: &'_0 [u32])
+fn index_slice_ignore_value<'_0>(x_1: &'_0 [u32])
 {
     let _0: (); // return
     let x_1: &'1 [u32]; // arg #1
@@ -816,7 +816,7 @@ fn div_signed_with_constant() -> i32
 }
 
 // Full name: test_crate::div_unsigned_to_slice
-fn div_unsigned_to_slice<'_0>(_1: &'_0 mut [u32], _2: u32)
+fn div_unsigned_to_slice<'_0>(result_1: &'_0 mut [u32], x_2: u32)
 {
     let _0: (); // return
     let result_1: &'1 mut [u32]; // arg #1
@@ -843,7 +843,7 @@ fn div_unsigned_to_slice<'_0>(_1: &'_0 mut [u32], _2: u32)
 }
 
 // Full name: test_crate::div_signed_to_slice
-fn div_signed_to_slice<'_0>(_1: &'_0 mut [i32], _2: i32)
+fn div_signed_to_slice<'_0>(result_1: &'_0 mut [i32], x_2: i32)
 {
     let _0: (); // return
     let result_1: &'1 mut [i32]; // arg #1
@@ -870,7 +870,7 @@ fn div_signed_to_slice<'_0>(_1: &'_0 mut [i32], _2: i32)
 }
 
 // Full name: test_crate::add_to_slice
-fn add_to_slice<'_0>(_1: &'_0 mut [u32], _2: u32)
+fn add_to_slice<'_0>(result_1: &'_0 mut [u32], x_2: u32)
 {
     let _0: (); // return
     let result_1: &'1 mut [u32]; // arg #1
@@ -900,7 +900,7 @@ fn add_to_slice<'_0>(_1: &'_0 mut [u32], _2: u32)
 }
 
 // Full name: test_crate::add_to_slice2
-fn add_to_slice2<'_0>(_1: &'_0 mut [u8], _2: usize, _3: u8)
+fn add_to_slice2<'_0>(result_1: &'_0 mut [u8], i_2: usize, x_3: u8)
 {
     let _0: (); // return
     let result_1: &'1 mut [u8]; // arg #1

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -38,7 +38,7 @@ where
     [@TraitClause0]: BoolTrait<Self>,
 = <method_without_default_body>
 
-pub fn test_crate::BoolTrait::ret_true<'_0, Self>(_1: &'_0 Self) -> bool
+pub fn test_crate::BoolTrait::ret_true<'_0, Self>(self_1: &'_0 Self) -> bool
 where
     [@TraitClause0]: BoolTrait<Self>,
 {
@@ -50,7 +50,7 @@ where
 }
 
 // Full name: test_crate::{impl BoolTrait for bool}::get_bool
-pub fn {impl BoolTrait for bool}::get_bool<'_0>(_1: &'_0 bool) -> bool
+pub fn {impl BoolTrait for bool}::get_bool<'_0>(self_1: &'_0 bool) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 bool; // arg #1
@@ -60,7 +60,7 @@ pub fn {impl BoolTrait for bool}::get_bool<'_0>(_1: &'_0 bool) -> bool
 }
 
 // Full name: test_crate::{impl BoolTrait for bool}::ret_true
-pub fn {impl BoolTrait for bool}::ret_true<'_0>(_1: &'_0 bool) -> bool
+pub fn {impl BoolTrait for bool}::ret_true<'_0>(self_1: &'_0 bool) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 bool; // arg #1
@@ -78,7 +78,7 @@ impl BoolTrait for bool {
 }
 
 // Full name: test_crate::test_bool_trait
-pub fn test_bool_trait<T>(_1: bool) -> bool
+pub fn test_bool_trait<T>(x_1: bool) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -90,7 +90,7 @@ pub fn {impl Display for u32}::fmt<'_0, '_1, '_2>(_1: &'_0 u32, _2: &'_1 mut For
 = <missing>
 
 // Full name: core::fmt::num::{impl Debug for u32}::fmt
-pub fn {impl Debug for u32}::fmt<'_0, '_1, '_2>(_1: &'_0 u32, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
+pub fn {impl Debug for u32}::fmt<'_0, '_1, '_2>(self_1: &'_0 u32, f_2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 {
     let _0: Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]; // return
     let self_1: &'1 u32; // arg #1
@@ -156,7 +156,7 @@ const UNIT_METADATA: () = UNIT_METADATA()
 fn unwrap_failed<'_0, '_1>(_1: &'_0 Str, _2: &'_1 (dyn Debug + '_1)) -> !
 = <missing>
 
-pub fn core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<T, E>(_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
+pub fn core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<T, E>(self_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<E>,
@@ -187,7 +187,7 @@ where
     return
 }
 
-fn test_crate::unwrap(_1: Result<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]) -> u32
+fn test_crate::unwrap(res_1: Result<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]) -> u32
 {
     let _0: u32; // return
     let res_1: Result<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}]; // arg #1

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -156,7 +156,7 @@ where
 }
 
 // Full name: test_crate::{Generic<T>[@TraitClause0]}::new
-fn new<T>(_1: T) -> Generic<T>[@TraitClause0]
+fn new<T>(value_1: T) -> Generic<T>[@TraitClause0]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -174,7 +174,7 @@ where
 }
 
 // Full name: test_crate::{Generic<T>[@TraitClause0]}::get
-fn get<'_0, T>(_1: &'_0 Generic<T>[@TraitClause0]) -> &'_0 T
+fn get<'_0, T>(self_1: &'_0 Generic<T>[@TraitClause0]) -> &'_0 T
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -300,7 +300,7 @@ fn ptr_casts()
 struct closure {}
 
 // Full name: test_crate::fn_casts::{impl Fn<(u8,)> for closure}::call
-fn {impl Fn<(u8,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u8,))
+fn {impl Fn<(u8,)> for closure}::call<'_0>(_1: &'_0 closure, tupled_args_2: (u8,))
 {
     let _0: (); // return
     let _1: &'1 closure; // arg #1
@@ -315,7 +315,7 @@ fn {impl Fn<(u8,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u8,))
 }
 
 // Full name: test_crate::fn_casts::{impl FnMut<(u8,)> for closure}::call_mut
-fn {impl FnMut<(u8,)> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: (u8,))
+fn {impl FnMut<(u8,)> for closure}::call_mut<'_0>(state_1: &'_0 mut closure, args_2: (u8,))
 {
     let _0: (); // return
     let state_1: &'_0 mut closure; // arg #1
@@ -356,7 +356,7 @@ fn {impl FnOnce<(u8,)> for closure}::call_once(_1: closure, _2: (u8,))
 }
 
 // Full name: test_crate::fn_casts::closure::as_fn
-fn as_fn(_1: u8)
+fn as_fn(arg1_1: u8)
 {
     let _0: (); // return
     let arg1_1: u8; // arg #1
@@ -497,7 +497,7 @@ fn STEAL() -> [(); 1 : usize]
 static STEAL: [(); 1 : usize] = STEAL()
 
 // Full name: test_crate::transmute
-fn transmute(_1: [u32; 2 : usize]) -> u64
+fn transmute(x_1: [u32; 2 : usize]) -> u64
 {
     let _0: u64; // return
     let x_1: [u32; 2 : usize]; // arg #1

--- a/charon/tests/ui/send_bound.out
+++ b/charon/tests/ui/send_bound.out
@@ -29,7 +29,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
 // Full name: test_crate::foo
-fn foo<M>(_1: M)
+fn foo<M>(_msg_1: M)
 where
     [@TraitClause0]: Sized<M>,
     [@TraitClause1]: Send<M>,

--- a/charon/tests/ui/simple/additions.out
+++ b/charon/tests/ui/simple/additions.out
@@ -101,7 +101,7 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
-pub fn core::intrinsics::saturating_add<T>(_1: T, _2: T) -> T
+pub fn core::intrinsics::saturating_add<T>(a_1: T, b_2: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,

--- a/charon/tests/ui/simple/additions.out
+++ b/charon/tests/ui/simple/additions.out
@@ -36,7 +36,7 @@ where
     [@TraitClause0]: Clone<Self>,
 = <method_without_default_body>
 
-pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 Self)
+pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
     [@TraitClause0]: Clone<Self>,
     [@TraitClause1]: Destruct<Self>,
@@ -56,7 +56,7 @@ where
 }
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
-pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
+pub fn {impl Clone for u8}::clone<'_0>(self_1: &'_0 u8) -> u8
 {
     let _0: u8; // return
     let self_1: &'1 u8; // arg #1
@@ -66,7 +66,7 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 }
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone_from
-pub fn {impl Clone for u8}::clone_from<'_0, '_1>(_1: &'_0 mut u8, _2: &'_1 u8)
+pub fn {impl Clone for u8}::clone_from<'_0, '_1>(self_1: &'_0 mut u8, source_2: &'_1 u8)
 where
     [@TraitClause0]: Destruct<u8>,
 {
@@ -118,7 +118,7 @@ impl Copy for u8 {
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <missing>
 
-pub fn core::num::{u8}::saturating_add(_1: u8, _2: u8) -> u8
+pub fn core::num::{u8}::saturating_add(self_1: u8, rhs_2: u8) -> u8
 {
     let _0: u8; // return
     let self_1: u8; // arg #1
@@ -129,7 +129,7 @@ pub fn core::num::{u8}::saturating_add(_1: u8, _2: u8) -> u8
 }
 
 // Full name: core::num::{u8}::wrapping_add
-pub fn wrapping_add(_1: u8, _2: u8) -> u8
+pub fn wrapping_add(self_1: u8, rhs_2: u8) -> u8
 {
     let _0: u8; // return
     let self_1: u8; // arg #1
@@ -140,7 +140,7 @@ pub fn wrapping_add(_1: u8, _2: u8) -> u8
 }
 
 // Full name: core::num::{u8}::overflowing_add
-pub fn overflowing_add(_1: u8, _2: u8) -> (u8, bool)
+pub fn overflowing_add(self_1: u8, rhs_2: u8) -> (u8, bool)
 {
     let _0: (u8, bool); // return
     let self_1: u8; // arg #1

--- a/charon/tests/ui/simple/additions.out
+++ b/charon/tests/ui/simple/additions.out
@@ -105,13 +105,7 @@ pub fn core::intrinsics::saturating_add<T>(_1: T, _2: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
-{
-    let _0: T; // return
-    let a_1: T; // arg #1
-    let b_2: T; // arg #2
-
-    undefined_behavior
-}
+= <intrinsic:saturating_add>
 
 // Full name: core::marker::{impl Copy for u8}
 impl Copy for u8 {

--- a/charon/tests/ui/simple/array_index.out
+++ b/charon/tests/ui/simple/array_index.out
@@ -13,7 +13,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::first
-pub fn first(_1: [u32; 0 : usize]) -> u32
+pub fn first(s_1: [u32; 0 : usize]) -> u32
 {
     let _0: u32; // return
     let s_1: [u32; 0 : usize]; // arg #1

--- a/charon/tests/ui/simple/box-into-inner.out
+++ b/charon/tests/ui/simple/box-into-inner.out
@@ -179,7 +179,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::into_inner
-fn into_inner(_1: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
+fn into_inner(b_1: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
     let b_1: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1

--- a/charon/tests/ui/simple/call-foreign-defaulted-method.out
+++ b/charon/tests/ui/simple/call-foreign-defaulted-method.out
@@ -17,7 +17,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::foo::{impl Trait for ()}::defaulted
-pub fn {impl Trait for ()}::defaulted<'_0>(_1: &'_0 ())
+pub fn {impl Trait for ()}::defaulted<'_0>(self_1: &'_0 ())
 {
     let _0: (); // return
     let self_1: &'1 (); // arg #1
@@ -62,7 +62,7 @@ pub trait Trait<Self>
     vtable: test_crate::foo::Trait::{vtable}
 }
 
-pub fn test_crate::foo::Trait::defaulted<'_0, Self>(_1: &'_0 Self)
+pub fn test_crate::foo::Trait::defaulted<'_0, Self>(self_1: &'_0 Self)
 where
     [@TraitClause0]: Trait<Self>,
 {

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -62,7 +62,7 @@ where
 }
 
 // Full name: test_crate::{HashMap<S>[@TraitClause0]}::get
-pub fn get<S, Q, Clause2_Type>(_1: HashMap<S>[@TraitClause0], _2: Q)
+pub fn get<S, Q, Clause2_Type>(_x_1: HashMap<S>[@TraitClause0], _k_2: Q)
 where
     [@TraitClause0]: Sized<S>,
     [@TraitClause1]: Sized<Q>,
@@ -80,7 +80,7 @@ where
 }
 
 // Full name: test_crate::top_level_get
-pub fn top_level_get<S, Q, Clause2_Type>(_1: HashMap<S>[@TraitClause0], _2: Q)
+pub fn top_level_get<S, Q, Clause2_Type>(_x_1: HashMap<S>[@TraitClause0], _k_2: Q)
 where
     [@TraitClause0]: Sized<S>,
     [@TraitClause1]: Sized<Q>,
@@ -98,7 +98,7 @@ where
 }
 
 // Full name: test_crate::test1
-pub fn test1(_1: HashMap<()>[{built_in impl Sized for ()}])
+pub fn test1(map_1: HashMap<()>[{built_in impl Sized for ()}])
 {
     let _0: (); // return
     let map_1: HashMap<()>[{built_in impl Sized for ()}]; // arg #1
@@ -121,7 +121,7 @@ pub fn test1(_1: HashMap<()>[{built_in impl Sized for ()}])
 }
 
 // Full name: test_crate::test2
-pub fn test2(_1: HashMap<()>[{built_in impl Sized for ()}])
+pub fn test2(map_1: HashMap<()>[{built_in impl Sized for ()}])
 {
     let _0: (); // return
     let map_1: HashMap<()>[{built_in impl Sized for ()}]; // arg #1

--- a/charon/tests/ui/simple/call-method-via-supertrait-bound.out
+++ b/charon/tests/ui/simple/call-method-via-supertrait-bound.out
@@ -65,7 +65,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl HasMethod for T}::method
-fn {impl HasMethod for T}::method<'_0, T>(_1: &'_0 T)
+fn {impl HasMethod for T}::method<'_0, T>(self_1: &'_0 T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: OtherTrait<T>,
@@ -90,7 +90,7 @@ where
 }
 
 // Full name: test_crate::call_method
-fn call_method<T>(_1: T)
+fn call_method<T>(x_1: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ImpliesOtherTrait<T>,

--- a/charon/tests/ui/simple/catch-unwind.out
+++ b/charon/tests/ui/simple/catch-unwind.out
@@ -126,7 +126,7 @@ where
 struct closure {}
 
 // Full name: test_crate::main::{impl FnOnce<()> for closure}::call_once
-fn {impl FnOnce<()> for closure}::call_once(_1: closure, _2: ())
+fn {impl FnOnce<()> for closure}::call_once(_1: closure, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: closure; // arg #1

--- a/charon/tests/ui/simple/closure-capture-ref-by-move.out
+++ b/charon/tests/ui/simple/closure-capture-ref-by-move.out
@@ -84,7 +84,7 @@ struct closure<'_0> {
 }
 
 // Full name: test_crate::foo::{impl FnMut<()> for closure<'_0>}::call_mut
-fn {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, _2: ())
+fn {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: &'1 mut closure<'_0>; // arg #1

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -96,7 +96,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::apply_to
-fn apply_to<'_0, T0>(_1: &'_0 T0) -> u8
+fn apply_to<'_0, T0>(f_1: &'_0 T0) -> u8
 where
     [@TraitClause0]: Sized<T0>,
     [@TraitClause1]: Fn<T0, (u8, u8)>,
@@ -118,7 +118,7 @@ where
 }
 
 // Full name: test_crate::apply_to_mut
-fn apply_to_mut<'_0, T0>(_1: &'_0 mut T0) -> u8
+fn apply_to_mut<'_0, T0>(f_1: &'_0 mut T0) -> u8
 where
     [@TraitClause0]: Sized<T0>,
     [@TraitClause1]: FnMut<T0, (u8, u8)>,
@@ -140,7 +140,7 @@ where
 }
 
 // Full name: test_crate::apply_to_once
-fn apply_to_once<T0>(_1: T0) -> u8
+fn apply_to_once<T0>(f_1: T0) -> u8
 where
     [@TraitClause0]: Sized<T0>,
     [@TraitClause1]: FnOnce<T0, (u8, u8)>,
@@ -169,7 +169,7 @@ struct closure<'_0, '_1> {
 }
 
 // Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}::call
-fn {impl Fn<(u8, u8)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, _2: (u8, u8)) -> u8
+fn {impl Fn<(u8, u8)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, tupled_args_2: (u8, u8)) -> u8
 {
     let _0: u8; // return
     let _1: &'1 closure<'_0, '_1>; // arg #1
@@ -219,7 +219,7 @@ fn {impl Fn<(u8, u8)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closu
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut
-fn {impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0, '_1>, _2: (u8, u8)) -> u8
+fn {impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(state_1: &'_2 mut closure<'_0, '_1>, args_2: (u8, u8)) -> u8
 {
     let _0: u8; // return
     let state_1: &'_2 mut closure<'_0, '_1>; // arg #1

--- a/charon/tests/ui/simple/closure-fnmut.out
+++ b/charon/tests/ui/simple/closure-fnmut.out
@@ -79,7 +79,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::apply_to_zero_mut
-fn apply_to_zero_mut<T0>(_1: T0) -> u8
+fn apply_to_zero_mut<T0>(f_1: T0) -> u8
 where
     [@TraitClause0]: Sized<T0>,
     [@TraitClause1]: FnMut<T0, (u8,)>,
@@ -107,7 +107,7 @@ struct closure<'_0> {
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8,)> for closure<'_0>}::call_mut
-fn {impl FnMut<(u8,)> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, _2: (u8,)) -> u8
+fn {impl FnMut<(u8,)> for closure<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut closure<'_0>, tupled_args_2: (u8,)) -> u8
 {
     let _0: u8; // return
     let _1: &'1 mut closure<'_0>; // arg #1

--- a/charon/tests/ui/simple/closure-fnonce.out
+++ b/charon/tests/ui/simple/closure-fnonce.out
@@ -70,7 +70,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::apply_to_zero_once
-fn apply_to_zero_once<T0>(_1: T0) -> u8
+fn apply_to_zero_once<T0>(f_1: T0) -> u8
 where
     [@TraitClause0]: Sized<T0>,
     [@TraitClause1]: FnOnce<T0, (u8,)>,
@@ -120,7 +120,7 @@ struct closure {
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}::call_once
-fn {impl FnOnce<(u8,)> for closure}::call_once(_1: closure, _2: (u8,)) -> u8
+fn {impl FnOnce<(u8,)> for closure}::call_once(_1: closure, tupled_args_2: (u8,)) -> u8
 {
     let _0: u8; // return
     let _1: closure; // arg #1

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -128,7 +128,7 @@ where
 }
 
 // Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call<'_0, F, T>(_1: &'_0 closure<F, T>[@TraitClause0, @TraitClause1], _2: ((),))
+fn {impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call<'_0, F, T>(_1: &'_0 closure<F, T>[@TraitClause0, @TraitClause1], tupled_args_2: ((),))
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: Sized<T>,
@@ -146,7 +146,7 @@ where
 }
 
 // Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, T>(_1: &'_0 mut closure<F, T>[@TraitClause0, @TraitClause1], _2: ((),))
+fn {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, T>(state_1: &'_0 mut closure<F, T>[@TraitClause0, @TraitClause1], args_2: ((),))
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: Sized<T>,

--- a/charon/tests/ui/simple/closure-inside-inline-const.out
+++ b/charon/tests/ui/simple/closure-inside-inline-const.out
@@ -127,7 +127,7 @@ where
 }
 
 // Full name: test_crate::foo::{const}::{impl Fn<()> for closure<T>[@TraitClause0]}::call
-fn {impl Fn<()> for closure<T>[@TraitClause0]}::call<'_0, T>(_1: &'_0 closure<T>[@TraitClause0], _2: ()) -> i32
+fn {impl Fn<()> for closure<T>[@TraitClause0]}::call<'_0, T>(_1: &'_0 closure<T>[@TraitClause0], tupled_args_2: ()) -> i32
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -140,7 +140,7 @@ where
 }
 
 // Full name: test_crate::foo::{const}::{impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut
-fn {impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut<'_0, T>(_1: &'_0 mut closure<T>[@TraitClause0], _2: ()) -> i32
+fn {impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut<'_0, T>(state_1: &'_0 mut closure<T>[@TraitClause0], args_2: ()) -> i32
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -132,7 +132,7 @@ where
 {}
 
 // Full name: test_crate::Thing::foo::{impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call
-fn {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'_0, Self>(_1: &'_0 closure<Self>[@TraitClause0], _2: (@TraitClause0::Item,))
+fn {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'_0, Self>(_1: &'_0 closure<Self>[@TraitClause0], tupled_args_2: (@TraitClause0::Item,))
 where
     [@TraitClause0]: Thing<Self>,
 {
@@ -150,7 +150,7 @@ where
 }
 
 // Full name: test_crate::Thing::foo
-fn foo<Self>(_1: @TraitClause0::Item)
+fn foo<Self>(i_1: @TraitClause0::Item)
 where
     [@TraitClause0]: Thing<Self>,
 {
@@ -186,7 +186,7 @@ where
 }
 
 // Full name: test_crate::Thing::foo::{impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut
-fn {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut<'_0, Self>(_1: &'_0 mut closure<Self>[@TraitClause0], _2: (@TraitClause0::Item,))
+fn {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut<'_0, Self>(state_1: &'_0 mut closure<Self>[@TraitClause0], args_2: (@TraitClause0::Item,))
 where
     [@TraitClause0]: Thing<Self>,
 {

--- a/charon/tests/ui/simple/closure-with-drops.out
+++ b/charon/tests/ui/simple/closure-with-drops.out
@@ -147,7 +147,7 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<T>(_1: T)
+fn foo<T>(x_1: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
@@ -166,7 +166,7 @@ where
 }
 
 // Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], _2: ())
+fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ())
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Destruct<T>,
@@ -219,7 +219,7 @@ fn bar()
 }
 
 // Full name: test_crate::bar::{impl Fn<()> for test_crate::bar::closure}::call
-fn {impl Fn<()> for test_crate::bar::closure}::call<'_0>(_1: &'_0 test_crate::bar::closure, _2: ())
+fn {impl Fn<()> for test_crate::bar::closure}::call<'_0>(_1: &'_0 test_crate::bar::closure, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: &'1 test_crate::bar::closure; // arg #1
@@ -231,7 +231,7 @@ fn {impl Fn<()> for test_crate::bar::closure}::call<'_0>(_1: &'_0 test_crate::ba
 }
 
 // Full name: test_crate::bar::{impl FnMut<()> for test_crate::bar::closure}::call_mut
-fn {impl FnMut<()> for test_crate::bar::closure}::call_mut<'_0>(_1: &'_0 mut test_crate::bar::closure, _2: ())
+fn {impl FnMut<()> for test_crate::bar::closure}::call_mut<'_0>(state_1: &'_0 mut test_crate::bar::closure, args_2: ())
 {
     let _0: (); // return
     let state_1: &'_0 mut test_crate::bar::closure; // arg #1

--- a/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
+++ b/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
@@ -101,7 +101,7 @@ struct closure<'_0, '_1> {
 }
 
 // Full name: test_crate::call_fn::{impl Fn<(usize,)> for closure<'_0, '_1>}::call
-fn {impl Fn<(usize,)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, _2: (usize,)) -> u8
+fn {impl Fn<(usize,)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, tupled_args_2: (usize,)) -> u8
 {
     let _0: u8; // return
     let _1: &'1 closure<'_0, '_1>; // arg #1
@@ -129,7 +129,7 @@ fn {impl Fn<(usize,)> for closure<'_0, '_1>}::call<'_0, '_1, '_2>(_1: &'_2 closu
 }
 
 // Full name: test_crate::call_fn
-fn call_fn<'_0>(_1: &'_0 [u8], _2: usize) -> u8
+fn call_fn<'_0>(a_1: &'_0 [u8], i_2: usize) -> u8
 {
     let _0: u8; // return
     let a_1: &'1 [u8]; // arg #1
@@ -160,7 +160,7 @@ fn call_fn<'_0>(_1: &'_0 [u8], _2: usize) -> u8
 }
 
 // Full name: test_crate::call_fn::{impl FnMut<(usize,)> for closure<'_0, '_1>}::call_mut
-fn {impl FnMut<(usize,)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0, '_1>, _2: (usize,)) -> u8
+fn {impl FnMut<(usize,)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_2>(state_1: &'_2 mut closure<'_0, '_1>, args_2: (usize,)) -> u8
 {
     let _0: u8; // return
     let state_1: &'_2 mut closure<'_0, '_1>; // arg #1

--- a/charon/tests/ui/simple/defaulted-rpitit.3.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.3.out
@@ -66,7 +66,7 @@ pub trait MyTrait<Self, T>
     non-dyn-compatible
 }
 
-pub fn test_crate::MyTrait::rows<'_0, Self, T>(_1: &'_0 Self) -> Empty<T>[@TraitClause0::parent_clause1]
+pub fn test_crate::MyTrait::rows<'_0, Self, T>(self_1: &'_0 Self) -> Empty<T>[@TraitClause0::parent_clause1]
 where
     [@TraitClause0]: MyTrait<Self, T>,
 {
@@ -78,7 +78,7 @@ where
 }
 
 // Full name: test_crate::{impl MyTrait<T> for ()}::rows
-pub fn {impl MyTrait<T> for ()}::rows<'_0, T>(_1: &'_0 ()) -> Empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]
+pub fn {impl MyTrait<T> for ()}::rows<'_0, T>(self_1: &'_0 ()) -> Empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
@@ -75,7 +75,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Broken for T}::broken
-pub fn {impl Broken for T}::broken<'_0, T>(_1: &'_0 T)
+pub fn {impl Broken for T}::broken<'_0, T>(self_1: &'_0 T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Foo<()>,
@@ -106,7 +106,7 @@ where
 }
 
 // Full name: test_crate::{impl Broken for T}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}<T>(_1: *mut (dyn Broken<Assoc = ()>))
+unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Broken<Assoc = ()>))
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/simple/dyn-cast-to-supertrait.out
@@ -119,7 +119,7 @@ impl Destruct for HouseCat {
 }
 
 // Full name: test_crate::{impl Feline for HouseCat}::hunt
-fn {impl Feline for HouseCat}::hunt<'_0>(_1: &'_0 HouseCat)
+fn {impl Feline for HouseCat}::hunt<'_0>(self_1: &'_0 HouseCat)
 {
     let _0: (); // return
     let self_1: &'1 HouseCat; // arg #1
@@ -144,7 +144,7 @@ fn {impl Feline for HouseCat}::hunt::{vtable_method}<'_0>(_1: &'_0 (dyn Feline))
 }
 
 // Full name: test_crate::{impl Feline for HouseCat}::{vtable_drop_shim}
-unsafe fn {impl Feline for HouseCat}::{vtable_drop_shim}(_1: *mut (dyn Feline))
+unsafe fn {impl Feline for HouseCat}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Feline))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Feline + '0); // arg #1
@@ -183,7 +183,7 @@ impl Feline for HouseCat {
 }
 
 // Full name: test_crate::{impl Pettable for HouseCat}::pet
-fn {impl Pettable for HouseCat}::pet<'_0>(_1: &'_0 HouseCat)
+fn {impl Pettable for HouseCat}::pet<'_0>(self_1: &'_0 HouseCat)
 {
     let _0: (); // return
     let self_1: &'1 HouseCat; // arg #1
@@ -208,7 +208,7 @@ fn {impl Pettable for HouseCat}::pet::{vtable_method}<'_0>(_1: &'_0 (dyn Pettabl
 }
 
 // Full name: test_crate::{impl Pettable for HouseCat}::{vtable_drop_shim}
-unsafe fn {impl Pettable for HouseCat}::{vtable_drop_shim}(_1: *mut (dyn Pettable))
+unsafe fn {impl Pettable for HouseCat}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Pettable))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Pettable + '0); // arg #1
@@ -247,7 +247,7 @@ impl Pettable for HouseCat {
 }
 
 // Full name: test_crate::{impl Cat for HouseCat}::meow
-fn {impl Cat for HouseCat}::meow<'_0>(_1: &'_0 HouseCat)
+fn {impl Cat for HouseCat}::meow<'_0>(self_1: &'_0 HouseCat)
 {
     let _0: (); // return
     let self_1: &'1 HouseCat; // arg #1
@@ -272,7 +272,7 @@ fn {impl Cat for HouseCat}::meow::{vtable_method}<'_0>(_1: &'_0 (dyn Cat))
 }
 
 // Full name: test_crate::{impl Cat for HouseCat}::{vtable_drop_shim}
-unsafe fn {impl Cat for HouseCat}::{vtable_drop_shim}(_1: *mut (dyn Cat))
+unsafe fn {impl Cat for HouseCat}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Cat))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Cat + '0); // arg #1

--- a/charon/tests/ui/simple/dyn-fn.out
+++ b/charon/tests/ui/simple/dyn-fn.out
@@ -98,7 +98,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::takes_fn
-fn takes_fn<'_0>(_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '_0))
+fn takes_fn<'_0>(f_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '_0))
 {
     let _0: (); // return
     let f_1: &'10 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '11); // arg #1
@@ -144,7 +144,7 @@ fn takes_fn<'_0>(_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent
 struct closure {}
 
 // Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}::call
-fn {impl Fn<(&'_ mut u32,)> for closure}::call<'_0, '_1>(_1: &'_1 closure, _2: (&'_0 mut u32,)) -> bool
+fn {impl Fn<(&'_ mut u32,)> for closure}::call<'_0, '_1>(_1: &'_1 closure, tupled_args_2: (&'_0 mut u32,)) -> bool
 {
     let _0: bool; // return
     let _1: &'1 closure; // arg #1
@@ -162,7 +162,7 @@ fn {impl Fn<(&'_ mut u32,)> for closure}::call<'_0, '_1>(_1: &'_1 closure, _2: (
 }
 
 // Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for closure}::call_mut
-fn {impl FnMut<(&'_ mut u32,)> for closure}::call_mut<'_0, '_1>(_1: &'_1 mut closure, _2: (&'_0 mut u32,)) -> bool
+fn {impl FnMut<(&'_ mut u32,)> for closure}::call_mut<'_0, '_1>(state_1: &'_1 mut closure, args_2: (&'_0 mut u32,)) -> bool
 {
     let _0: bool; // return
     let state_1: &'_1 mut closure; // arg #1

--- a/charon/tests/ui/simple/dyn-method-with-early-bound-lifetimes.out
+++ b/charon/tests/ui/simple/dyn-method-with-early-bound-lifetimes.out
@@ -28,7 +28,7 @@ where
     Self : 'a,
 = <method_without_default_body>
 
-fn test_crate::foo<'_0>(_1: &'_0 (dyn Trait + '_0))
+fn test_crate::foo<'_0>(x_1: &'_0 (dyn Trait + '_0))
 {
     let _0: (); // return
     let x_1: &'3 (dyn Trait + '4); // arg #1

--- a/charon/tests/ui/simple/extern-same-name-across-modules.out
+++ b/charon/tests/ui/simple/extern-same-name-across-modules.out
@@ -34,7 +34,7 @@ pub unsafe fn test_crate::second::nested::call() -> i32
     return
 }
 
-pub fn test_crate::local_impl::same_name(_1: i32) -> i32
+pub fn test_crate::local_impl::same_name(x_1: i32) -> i32
 {
     let _0: i32; // return
     let x_1: i32; // arg #1

--- a/charon/tests/ui/simple/extern-same-name-across-modules.out
+++ b/charon/tests/ui/simple/extern-same-name-across-modules.out
@@ -1,0 +1,55 @@
+# Final LLBC before serialization:
+
+unsafe fn test_crate::same_name(_1: i32) -> i32
+= <extern:same_name>
+
+// Full name: test_crate::call_root
+unsafe fn call_root() -> i32
+{
+    let _0: i32; // return
+
+    _0 = test_crate::same_name(const 0 : i32)
+    return
+}
+
+unsafe fn test_crate::first::same_name(_1: i32) -> i32
+= <extern:same_name>
+
+pub unsafe fn test_crate::first::call() -> i32
+{
+    let _0: i32; // return
+
+    _0 = test_crate::first::same_name(const 1 : i32)
+    return
+}
+
+unsafe fn test_crate::second::nested::same_name(_1: i32) -> i32
+= <extern:same_name>
+
+pub unsafe fn test_crate::second::nested::call() -> i32
+{
+    let _0: i32; // return
+
+    _0 = test_crate::second::nested::same_name(const 2 : i32)
+    return
+}
+
+pub fn test_crate::local_impl::same_name(_1: i32) -> i32
+{
+    let _0: i32; // return
+    let x_1: i32; // arg #1
+
+    _0 = copy x_1
+    return
+}
+
+pub fn test_crate::local_impl::call() -> i32
+{
+    let _0: i32; // return
+
+    _0 = test_crate::local_impl::same_name(const 3 : i32)
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/extern-same-name-across-modules.rs
+++ b/charon/tests/ui/simple/extern-same-name-across-modules.rs
@@ -1,0 +1,39 @@
+extern "C" {
+    fn same_name(x: i32) -> i32;
+}
+
+unsafe fn call_root() -> i32 {
+    unsafe { same_name(0) }
+}
+
+mod first {
+    unsafe extern "C" {
+        fn same_name(x: i32) -> i32;
+    }
+
+    pub unsafe fn call() -> i32 {
+        unsafe { same_name(1) }
+    }
+}
+
+mod second {
+    pub mod nested {
+        unsafe extern "C" {
+            fn same_name(x: i32) -> i32;
+        }
+
+        pub unsafe fn call() -> i32 {
+            unsafe { same_name(2) }
+        }
+    }
+}
+
+mod local_impl {
+    pub fn same_name(x: i32) -> i32 {
+        x
+    }
+
+    pub fn call() -> i32 {
+        same_name(3)
+    }
+}

--- a/charon/tests/ui/simple/gat-complex-lifetimes.out
+++ b/charon/tests/ui/simple/gat-complex-lifetimes.out
@@ -64,7 +64,7 @@ pub trait Bar<'a, Self>
 }
 
 // Full name: test_crate::bar
-pub fn bar<'x, 'y, 'z, T>(_1: @TraitClause1::Type) -> &'x &'y &'z ()
+pub fn bar<'x, 'y, 'z, T>(x_1: @TraitClause1::Type) -> &'x &'y &'z ()
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Bar<'x, T>,

--- a/charon/tests/ui/simple/gat-implied-clause.out
+++ b/charon/tests/ui/simple/gat-implied-clause.out
@@ -70,7 +70,7 @@ trait Trait<Self>
 }
 
 // Full name: test_crate::lifetime_gat_bound
-fn lifetime_gat_bound<'_0, X>(_1: @TraitClause1::LifetimeGat)
+fn lifetime_gat_bound<'_0, X>(x_1: @TraitClause1::LifetimeGat)
 where
     [@TraitClause0]: Sized<X>,
     [@TraitClause1]: Trait<X>,
@@ -94,7 +94,7 @@ where
 }
 
 // Full name: test_crate::non_lifetime_gat_bound
-fn non_lifetime_gat_bound<X>(_1: @TraitClause1::NonLifetimeGat)
+fn non_lifetime_gat_bound<X>(x_1: @TraitClause1::NonLifetimeGat)
 where
     [@TraitClause0]: Sized<X>,
     [@TraitClause1]: Trait<X>,

--- a/charon/tests/ui/simple/generic-cast-to-dyn.out
+++ b/charon/tests/ui/simple/generic-cast-to-dyn.out
@@ -48,7 +48,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::foo
-fn foo<'_0, T>(_1: &'_0 T) -> &'_0 (dyn Any + 'static)
+fn foo<'_0, T>(x_1: &'_0 T) -> &'_0 (dyn Any + 'static)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Any<T>,

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
@@ -30,7 +30,7 @@ pub trait BoolTrait<Self>
     vtable: test_crate::BoolTrait::{vtable}
 }
 
-pub fn test_crate::BoolTrait::foo<'_0, Self>(_1: &'_0 Self)
+pub fn test_crate::BoolTrait::foo<'_0, Self>(self_1: &'_0 Self)
 where
     [@TraitClause0]: BoolTrait<Self>,
 {
@@ -43,7 +43,7 @@ where
 }
 
 // Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::foo
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::foo<'_0, T>(_1: &'_0 Option<T>[@TraitClause0])
+pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::foo<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0])
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/generic-impl-with-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-method.out
@@ -26,7 +26,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for T}::method
-pub fn {impl Trait for T}::method<'_0, T>(_1: &'_0 T)
+pub fn {impl Trait for T}::method<'_0, T>(self_1: &'_0 T)
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
@@ -1,0 +1,86 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::clone::Clone
+#[lang_item("clone")]
+pub trait Clone<Self>
+{
+    parent_clause0 : [@TraitClause0]: Sized<Self>
+    fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
+    non-dyn-compatible
+}
+
+#[lang_item("clone_fn")]
+pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
+where
+    [@TraitClause0]: Clone<Self>,
+= <opaque>
+
+// Full name: core::clone::impls::{impl Clone for u8}::clone
+pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
+= <opaque>
+
+// Full name: core::clone::impls::{impl Clone for u8}
+impl Clone for u8 {
+    parent_clause0 = {built_in impl Sized for u8}
+    fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Copy
+#[lang_item("copy")]
+pub trait Copy<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Clone<Self>
+    non-dyn-compatible
+}
+
+pub fn core::intrinsics::wrapping_add<T>(_1: T, _2: T) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+= <intrinsic:wrapping_add>
+
+// Full name: core::marker::{impl Copy for u8}
+impl Copy for u8 {
+    parent_clause0 = {built_in impl MetaSized for u8}
+    parent_clause1 = {impl Clone for u8}
+    non-dyn-compatible
+}
+
+pub fn test_crate::first::nested::wrapping_add<T>(_1: T, _2: T) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+= <intrinsic:wrapping_add>
+
+pub fn test_crate::first::nested::call() -> u8
+{
+    let _0: u8; // return
+
+    _0 = test_crate::first::nested::wrapping_add<u8>[{built_in impl Sized for u8}, {impl Copy for u8}](const 1 : u8, const 2 : u8)
+    return
+}
+
+fn test_crate::call() -> u8
+{
+    let _0: u8; // return
+
+    _0 = core::intrinsics::wrapping_add<u8>[{built_in impl Sized for u8}, {impl Copy for u8}](const 3 : u8, const 4 : u8)
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
@@ -47,7 +47,7 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
-pub fn core::intrinsics::wrapping_add<T>(_1: T, _2: T) -> T
+pub fn core::intrinsics::wrapping_add<T>(a_1: T, b_2: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,
@@ -60,7 +60,7 @@ impl Copy for u8 {
     non-dyn-compatible
 }
 
-pub fn test_crate::first::nested::wrapping_add<T>(_1: T, _2: T) -> T
+pub fn test_crate::first::nested::wrapping_add<T>(lhs_1: T, rhs_2: T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Copy<T>,

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.rs
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.rs
@@ -5,7 +5,7 @@ mod first {
     pub mod nested {
         #[rustc_intrinsic]
         #[inline]
-        pub const fn wrapping_add<T: Copy>(x: T, y: T) -> T;
+        pub const fn wrapping_add<T: Copy>(lhs: T, rhs: T) -> T;
 
         pub fn call() -> u8 {
             unsafe { wrapping_add(1, 2) }

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.rs
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.rs
@@ -1,0 +1,18 @@
+#![feature(intrinsics)]
+#![feature(core_intrinsics)]
+
+mod first {
+    pub mod nested {
+        #[rustc_intrinsic]
+        #[inline]
+        pub const fn wrapping_add<T: Copy>(x: T, y: T) -> T;
+
+        pub fn call() -> u8 {
+            unsafe { wrapping_add(1, 2) }
+        }
+    }
+}
+
+fn call() -> u8 {
+    unsafe { std::intrinsics::wrapping_add(3, 4) }
+}

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -152,7 +152,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'_ T}]}::next
-pub fn {impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'_ T}]}::next<'a, 'b, T>(_1: &'b mut Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'b T>[{built_in impl Sized for &'b T}]
+pub fn {impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'_ T}]}::next<'a, 'b, T>(self_1: &'b mut Option<&'a T>[{built_in impl Sized for &'_ T}]) -> Option<&'b T>[{built_in impl Sized for &'b T}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -200,7 +200,7 @@ where
 }
 
 // Full name: test_crate::for_each
-pub fn for_each<I, T1>(_1: I, _2: T1)
+pub fn for_each<I, T1>(iter_1: I, f_2: T1)
 where
     [@TraitClause0]: Sized<I>,
     [@TraitClause1]: Sized<T1>,
@@ -267,7 +267,7 @@ struct closure<'_0> {
 }
 
 // Full name: test_crate::main::{impl FnMut<(&'_ i32,)> for closure<'_0>}::call_mut
-fn {impl FnMut<(&'_ i32,)> for closure<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0>, _2: (&'_1 i32,))
+fn {impl FnMut<(&'_ i32,)> for closure<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0>, tupled_args_2: (&'_1 i32,))
 {
     let _0: (); // return
     let _1: &'1 mut closure<'_0>; // arg #1

--- a/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
+++ b/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
@@ -58,7 +58,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method
-fn {impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method<'a>(_1: &'a u32) -> &'a [u8; 4 : usize]
+fn {impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method<'a>(self_1: &'a u32) -> &'a [u8; 4 : usize]
 {
     let _0: &'1 [u8; 4 : usize]; // return
     let self_1: &'3 u32; // arg #1
@@ -88,7 +88,7 @@ impl<'a> Convert<&'a [u8; 4 : usize]> for &'a u32 {
 }
 
 // Full name: test_crate::convert
-fn convert<T, U>(_1: T) -> U
+fn convert<T, U>(x_1: T) -> U
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<U>,
@@ -107,7 +107,7 @@ where
 }
 
 // Full name: test_crate::to_bytes_by_ref
-pub fn to_bytes_by_ref<'b>(_1: &'b u32) -> &'b [u8; 4 : usize]
+pub fn to_bytes_by_ref<'b>(s_1: &'b u32) -> &'b [u8; 4 : usize]
 {
     let _0: &'1 [u8; 4 : usize]; // return
     let s_1: &'3 u32; // arg #1

--- a/charon/tests/ui/simple/manual-drop-impl.out
+++ b/charon/tests/ui/simple/manual-drop-impl.out
@@ -72,7 +72,7 @@ where
 }
 
 // Full name: test_crate::{impl Drop for Foo<T>[@TraitClause0]}::drop
-pub fn {impl Drop for Foo<T>[@TraitClause0]}::drop<'_0, T>(_1: &'_0 mut Foo<T>[@TraitClause0])
+pub fn {impl Drop for Foo<T>[@TraitClause0]}::drop<'_0, T>(self_1: &'_0 mut Foo<T>[@TraitClause0])
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/metadata-without-marker-trait.out
+++ b/charon/tests/ui/simple/metadata-without-marker-trait.out
@@ -20,7 +20,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::wrap_shared_in_option
-pub fn wrap_shared_in_option<'a, T>(_1: &'a T) -> Option<&'a T>
+pub fn wrap_shared_in_option<'a, T>(x_1: &'a T) -> Option<&'a T>
 {
     let _0: Option<&'2 T>; // return
     let x_1: &'3 T; // arg #1

--- a/charon/tests/ui/simple/nested-closure-lifetime.out
+++ b/charon/tests/ui/simple/nested-closure-lifetime.out
@@ -128,7 +128,7 @@ where
 }
 
 // Full name: test_crate::foo::{impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, '_3, T>(_1: &'_3 test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+fn {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, '_3, T>(_1: &'_3 test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -142,7 +142,7 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<'a, T>(_1: &'a T) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+fn foo<'a, T>(x_1: &'a T) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -167,7 +167,7 @@ where
 }
 
 // Full name: test_crate::foo::{impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, '_3, T>(_1: &'_3 mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+fn {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], args_2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -262,7 +262,7 @@ where
 }
 
 // Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, T>(_1: &'_2 test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> &'_1 T
+fn {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, T>(_1: &'_2 test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> &'_1 T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -276,7 +276,7 @@ where
 }
 
 // Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, T>(_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> &'_1 T
+fn {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, T>(state_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], args_2: ()) -> &'_1 T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,

--- a/charon/tests/ui/simple/nested-closure-trait-ref.out
+++ b/charon/tests/ui/simple/nested-closure-trait-ref.out
@@ -145,7 +145,7 @@ where
 }
 
 // Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -160,7 +160,7 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<T>(_1: T) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+fn foo<T>(x_1: T) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -202,7 +202,7 @@ where
 }
 
 // Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], _2: ()) -> T
+fn {impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -220,7 +220,7 @@ where
 }
 
 // Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(_1: &'_0 mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], _2: ()) -> T
+fn {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], args_2: ()) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -129,7 +129,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> T
+fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_2 u32,)) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -158,7 +158,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
+fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -187,7 +187,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(_1: &'_6 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
+fn {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(_1: &'_6 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -205,7 +205,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures
-pub fn test_nested_closures<'a, 'b, T>(_1: &'a &'b T) -> T
+pub fn test_nested_closures<'a, 'b, T>(x_1: &'a &'b T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -292,7 +292,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(_1: &'_6 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
+fn {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(state_1: &'_6 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -387,7 +387,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
+fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(state_1: &'_5 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -482,7 +482,7 @@ where
 }
 
 // Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(_1: &'_3 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> T
+fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: (&'_2 u32,)) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,

--- a/charon/tests/ui/simple/non-lifetime-gats.out
+++ b/charon/tests/ui/simple/non-lifetime-gats.out
@@ -102,7 +102,7 @@ where
 pub struct BoxFamily {}
 
 // Full name: test_crate::{impl PointerFamily for BoxFamily}::new
-pub fn {impl PointerFamily for BoxFamily}::new<T>(_1: T) -> alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
+pub fn {impl PointerFamily for BoxFamily}::new<T>(value_1: T) -> alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -127,7 +127,7 @@ impl PointerFamily for BoxFamily {
 }
 
 // Full name: test_crate::make_pointer
-pub fn make_pointer<F, T>(_1: T) -> @TraitClause2::Pointer
+pub fn make_pointer<F, T>(x_1: T) -> @TraitClause2::Pointer
 where
     [@TraitClause0]: Sized<F>,
     [@TraitClause1]: Sized<T>,

--- a/charon/tests/ui/simple/opaque-vtable.out
+++ b/charon/tests/ui/simple/opaque-vtable.out
@@ -50,7 +50,7 @@ impl Trait for () {
 }
 
 // Full name: test_crate::use_debug
-fn use_debug<'_0>(_1: &'_0 (dyn Trait + '_0))
+fn use_debug<'_0>(_d_1: &'_0 (dyn Trait + '_0))
 {
     let _0: (); // return
     let _d_1: &'3 (dyn Trait + '4); // arg #1

--- a/charon/tests/ui/simple/partial-drop.out
+++ b/charon/tests/ui/simple/partial-drop.out
@@ -17,7 +17,7 @@ struct Foo {
 }
 
 // Full name: test_crate::foo
-fn foo(_1: Foo)
+fn foo(f_1: Foo)
 {
     let _0: (); // return
     let f_1: Foo; // arg #1

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -86,7 +86,7 @@ where
 = <opaque>
 
 // Full name: test_crate::flabada
-pub fn flabada<'a>(_1: &'a ()) -> &'a ()
+pub fn flabada<'a>(x_1: &'a ()) -> &'a ()
 {
     let _0: &'1 (); // return
     let x_1: &'2 (); // arg #1

--- a/charon/tests/ui/simple/promoted-closure-no-warns.out
+++ b/charon/tests/ui/simple/promoted-closure-no-warns.out
@@ -125,7 +125,7 @@ pub fn foo() -> &'static closure
 }
 
 // Full name: test_crate::foo::{impl Fn<(u32,)> for closure}::call
-fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u32,)) -> u32
+fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 closure; // arg #1
@@ -139,7 +139,7 @@ fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u32,)) -> u32
 }
 
 // Full name: test_crate::foo::{impl FnMut<(u32,)> for closure}::call_mut
-fn {impl FnMut<(u32,)> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,)> for closure}::call_mut<'_0>(state_1: &'_0 mut closure, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut closure; // arg #1

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -125,7 +125,7 @@ pub fn foo() -> &'static closure
 }
 
 // Full name: test_crate::foo::{impl Fn<(u32,)> for closure}::call
-fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u32,)) -> u32
+fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, tupled_args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 closure; // arg #1
@@ -139,7 +139,7 @@ fn {impl Fn<(u32,)> for closure}::call<'_0>(_1: &'_0 closure, _2: (u32,)) -> u32
 }
 
 // Full name: test_crate::foo::{impl FnMut<(u32,)> for closure}::call_mut
-fn {impl FnMut<(u32,)> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: (u32,)) -> u32
+fn {impl FnMut<(u32,)> for closure}::call_mut<'_0>(state_1: &'_0 mut closure, args_2: (u32,)) -> u32
 {
     let _0: u32; // return
     let state_1: &'_0 mut closure; // arg #1

--- a/charon/tests/ui/simple/promoted_in_closure.out
+++ b/charon/tests/ui/simple/promoted_in_closure.out
@@ -113,7 +113,7 @@ fn main()
 }
 
 // Full name: test_crate::main::{impl Fn<()> for closure}::call
-fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, _2: ())
+fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, tupled_args_2: ())
 {
     let _0: (); // return
     let _1: &'1 closure; // arg #1
@@ -138,7 +138,7 @@ fn {impl Fn<()> for closure}::call<'_0>(_1: &'_0 closure, _2: ())
 }
 
 // Full name: test_crate::main::{impl FnMut<()> for closure}::call_mut
-fn {impl FnMut<()> for closure}::call_mut<'_0>(_1: &'_0 mut closure, _2: ())
+fn {impl FnMut<()> for closure}::call_mut<'_0>(state_1: &'_0 mut closure, args_2: ())
 {
     let _0: (); // return
     let state_1: &'_0 mut closure; // arg #1

--- a/charon/tests/ui/simple/ptr-from-raw-parts.out
+++ b/charon/tests/ui/simple/ptr-from-raw-parts.out
@@ -250,7 +250,7 @@ pub trait Freeze<Self>
 pub trait Unpin<Self>
 
 // Full name: core::ptr::metadata::from_raw_parts
-pub fn from_raw_parts<T, T1>(_1: *const T1, _2: {built_in impl Pointee for T}::Metadata) -> *const T
+pub fn from_raw_parts<T, T1>(data_pointer_1: *const T1, metadata_2: {built_in impl Pointee for T}::Metadata) -> *const T
 where
     [@TraitClause0]: Sized<T1>,
     [@TraitClause1]: Thin<T1>,

--- a/charon/tests/ui/simple/range-iter.out
+++ b/charon/tests/ui/simple/range-iter.out
@@ -193,7 +193,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::iter
-fn iter(_1: usize)
+fn iter(n_1: usize)
 {
     let _0: (); // return
     let n_1: usize; // arg #1

--- a/charon/tests/ui/simple/remove-adt-clauses.out
+++ b/charon/tests/ui/simple/remove-adt-clauses.out
@@ -33,7 +33,7 @@ struct Foo<T, Clause1_Type> {
 }
 
 // Full name: test_crate::foo
-fn foo(_1: Foo<u32, bool>)
+fn foo(_x_1: Foo<u32, bool>)
 {
     let _0: (); // return
     let _x_1: Foo<u32, bool>; // arg #1

--- a/charon/tests/ui/simple/slice_increment.out
+++ b/charon/tests/ui/simple/slice_increment.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::incr
-pub fn incr<'_0>(_1: &'_0 mut [u32])
+pub fn incr<'_0>(s_1: &'_0 mut [u32])
 {
     let _0: (); // return
     let s_1: &'1 mut [u32]; // arg #1

--- a/charon/tests/ui/simple/slice_index.out
+++ b/charon/tests/ui/simple/slice_index.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: test_crate::first
-pub fn first<'_0>(_1: &'_0 [u32]) -> u32
+pub fn first<'_0>(s_1: &'_0 [u32]) -> u32
 {
     let _0: u32; // return
     let s_1: &'1 [u32]; // arg #1

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -71,7 +71,7 @@ fn UNIT_METADATA()
 // Full name: UNIT_METADATA
 const UNIT_METADATA: () = UNIT_METADATA()
 
-fn core::slice::index::slice_index_fail::do_panic::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic::runtime(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -171,7 +171,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(_1: usize, _2: usize)
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#1::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#1::runtime(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -271,7 +271,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(_1: usize, _2: usiz
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#2::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#2::runtime(start_1: usize, end_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -371,7 +371,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(_1: usize, _2: usiz
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#3::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#3::runtime(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -472,7 +472,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(_1: usize, _2: usiz
 }
 
 // Full name: core::panicking::panic_nounwind_fmt::compiletime
-fn compiletime<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+fn compiletime<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -506,7 +506,7 @@ where
 
 // Full name: core::ops::range::{RangeInclusive<Idx>[@TraitClause0]}::new
 #[lang_item("range_inclusive_new")]
-pub fn new<Idx>(_1: Idx, _2: Idx) -> RangeInclusive<Idx>[@TraitClause0]
+pub fn new<Idx>(start_1: Idx, end_2: Idx) -> RangeInclusive<Idx>[@TraitClause0]
 where
     [@TraitClause0]: Sized<Idx>,
 {
@@ -528,7 +528,7 @@ where
   Some(T),
 }
 
-fn core::slice::index::slice_index_fail::do_panic(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -537,7 +537,7 @@ fn core::slice::index::slice_index_fail::do_panic(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic::runtime(move start_1, move len_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#1(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#1(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -546,7 +546,7 @@ fn core::slice::index::slice_index_fail::do_panic#1(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move end_1, move len_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#2(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#2(start_1: usize, end_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -555,7 +555,7 @@ fn core::slice::index::slice_index_fail::do_panic#2(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move start_1, move end_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#3(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#3(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -565,7 +565,7 @@ fn core::slice::index::slice_index_fail::do_panic#3(_1: usize, _2: usize) -> !
 }
 
 // Full name: core::panicking::panic_nounwind_fmt
-pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
+pub fn panic_nounwind_fmt<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 {
     let _0: !; // return
     let fmt_1: Arguments<'1>; // arg #1
@@ -616,7 +616,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl Index<I> for [T]}::index
-pub fn {impl Index<I> for [T]}::index<'_0, T, I>(_1: &'_0 [T], _2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 @TraitClause2::Output
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
@@ -631,7 +631,7 @@ where
 }
 
 // Full name: core::slice::index::slice_index_fail
-fn slice_index_fail(_1: usize, _2: usize, _3: usize) -> !
+fn slice_index_fail(start_1: usize, end_2: usize, len_3: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -757,7 +757,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> &'_0 mut [T]
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> &'_0 mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -853,7 +853,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> &'_0 [T]
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> &'_0 [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -949,7 +949,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
-fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(_1: usize, _2: usize, _3: usize)
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(start_1: usize, end_2: usize, len_3: usize)
 {
     let _0: (); // return
     let start_1: usize; // arg #1
@@ -1016,7 +1016,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: *mut [T]) -> *mut [T]
+pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1070,7 +1070,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
-fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(_1: usize, _2: usize, _3: usize)
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(start_1: usize, end_2: usize, len_3: usize)
 {
     let _0: (); // return
     let start_1: usize; // arg #1
@@ -1137,7 +1137,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: *const [T]) -> *const [T]
+pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1191,7 +1191,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1281,7 +1281,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(_1: RangeInclusive<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
+pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1390,7 +1390,7 @@ where
 }
 
 // Full name: test_crate::slice_index_range
-pub fn slice_index_range<'_0>(_1: &'_0 [u8]) -> &'_0 [u8]
+pub fn slice_index_range<'_0>(slice_1: &'_0 [u8]) -> &'_0 [u8]
 {
     let _0: &'1 [u8]; // return
     let slice_1: &'2 [u8]; // arg #1

--- a/charon/tests/ui/simple/struct-with-drops.out
+++ b/charon/tests/ui/simple/struct-with-drops.out
@@ -98,7 +98,7 @@ struct A {
 }
 
 // Full name: test_crate::{impl Drop for B}::drop
-pub fn {impl Drop for B}::drop<'_0>(_1: &'_0 mut B)
+pub fn {impl Drop for B}::drop<'_0>(self_1: &'_0 mut B)
 {
     let _0: (); // return
     let self_1: &'1 mut B; // arg #1

--- a/charon/tests/ui/simple/trait-alias.out
+++ b/charon/tests/ui/simple/trait-alias.out
@@ -74,7 +74,7 @@ trait Trait<Self, T, Self_Item>
 struct Struct {}
 
 // Full name: test_crate::{impl Clone for Struct}::clone
-pub fn {impl Clone for Struct}::clone<'_0>(_1: &'_0 Struct) -> Struct
+pub fn {impl Clone for Struct}::clone<'_0>(self_1: &'_0 Struct) -> Struct
 {
     let _0: Struct; // return
     let self_1: &'1 Struct; // arg #1
@@ -127,7 +127,7 @@ where
 }
 
 // Full name: test_crate::takes_alias
-fn takes_alias<T>(_1: T)
+fn takes_alias<T>(x_1: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Alias<T, ()>,

--- a/charon/tests/ui/simple/trivial_generic_function.out
+++ b/charon/tests/ui/simple/trivial_generic_function.out
@@ -25,7 +25,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
 // Full name: test_crate::ignore
-fn ignore<T>(_1: T)
+fn ignore<T>(t_1: T)
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -201,7 +201,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push_mut
-pub fn push_mut<'_0, T, A>(_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], _2: T) -> &'_0 mut T
+pub fn push_mut<'_0, T, A>(self_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], value_2: T) -> &'_0 mut T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
@@ -266,7 +266,7 @@ where
 }
 
 // Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push
-pub fn push<'_0, T, A>(_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], _2: T)
+pub fn push<'_0, T, A>(self_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], value_2: T)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<A>,
@@ -285,7 +285,7 @@ where
 }
 
 // Full name: test_crate::vec
-fn vec<'_0>(_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
+fn vec<'_0>(x_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
     let x_1: &'1 mut Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]; // arg #1

--- a/charon/tests/ui/simple/vec-with-capacity.out
+++ b/charon/tests/ui/simple/vec-with-capacity.out
@@ -200,7 +200,7 @@ where
 
 // Full name: alloc::vec::{Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}::with_capacity
 #[lang_item("vec_with_capacity")]
-pub fn with_capacity<T>(_1: usize) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn with_capacity<T>(capacity_1: usize) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/simple/well-formedness-bound.out
+++ b/charon/tests/ui/simple/well-formedness-bound.out
@@ -35,7 +35,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::get
-pub fn get<'a>(_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'_ u32}]
+pub fn get<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'_ u32}]
 {
     let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
     let x_1: &'9 u32; // arg #1

--- a/charon/tests/ui/simple/wrapping-ops.out
+++ b/charon/tests/ui/simple/wrapping-ops.out
@@ -1,7 +1,7 @@
 # Final LLBC before serialization:
 
 // Full name: core::num::{u8}::wrapping_add
-pub fn wrapping_add(_1: u8, _2: u8) -> u8
+pub fn wrapping_add(self_1: u8, rhs_2: u8) -> u8
 {
     let _0: u8; // return
     let self_1: u8; // arg #1
@@ -12,7 +12,7 @@ pub fn wrapping_add(_1: u8, _2: u8) -> u8
 }
 
 // Full name: core::num::{u8}::wrapping_sub
-pub fn wrapping_sub(_1: u8, _2: u8) -> u8
+pub fn wrapping_sub(self_1: u8, rhs_2: u8) -> u8
 {
     let _0: u8; // return
     let self_1: u8; // arg #1
@@ -23,7 +23,7 @@ pub fn wrapping_sub(_1: u8, _2: u8) -> u8
 }
 
 // Full name: core::num::{u8}::wrapping_mul
-pub fn wrapping_mul(_1: u8, _2: u8) -> u8
+pub fn wrapping_mul(self_1: u8, rhs_2: u8) -> u8
 {
     let _0: u8; // return
     let self_1: u8; // arg #1

--- a/charon/tests/ui/skip-borrowck.out
+++ b/charon/tests/ui/skip-borrowck.out
@@ -25,7 +25,7 @@ fn UNIT_METADATA()
 const UNIT_METADATA: () = UNIT_METADATA()
 
 // Full name: test_crate::choose
-fn choose<'a, T>(_1: bool, _2: &'a mut T, _3: &'a mut T) -> &'a mut T
+fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -84,7 +84,7 @@ fn UNIT_METADATA()
 // Full name: UNIT_METADATA
 const UNIT_METADATA: () = UNIT_METADATA()
 
-fn core::slice::index::slice_index_fail::do_panic::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic::runtime(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -184,7 +184,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(_1: usize, _2: usize)
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#1::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#1::runtime(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -284,7 +284,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(_1: usize, _2: usiz
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#2::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#2::runtime(start_1: usize, end_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -384,7 +384,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(_1: usize, _2: usiz
     panic(core::panicking::panic_fmt)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#3::runtime(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#3::runtime(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -509,7 +509,7 @@ where
   Some(T),
 }
 
-fn core::slice::index::slice_index_fail::do_panic(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -518,7 +518,7 @@ fn core::slice::index::slice_index_fail::do_panic(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic::runtime(move start_1, move len_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#1(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#1(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -527,7 +527,7 @@ fn core::slice::index::slice_index_fail::do_panic#1(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move end_1, move len_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#2(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#2(start_1: usize, end_2: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -536,7 +536,7 @@ fn core::slice::index::slice_index_fail::do_panic#2(_1: usize, _2: usize) -> !
     _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move start_1, move end_2)
 }
 
-fn core::slice::index::slice_index_fail::do_panic#3(_1: usize, _2: usize) -> !
+fn core::slice::index::slice_index_fail::do_panic#3(end_1: usize, len_2: usize) -> !
 {
     let _0: !; // return
     let end_1: usize; // arg #1
@@ -580,7 +580,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl Index<I> for [T]}::index
-pub fn {impl Index<I> for [T]}::index<'_0, T, I>(_1: &'_0 [T], _2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 @TraitClause2::Output
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Sized<I>,
@@ -610,7 +610,7 @@ where
 }
 
 // Full name: core::slice::index::slice_index_fail
-fn slice_index_fail(_1: usize, _2: usize, _3: usize) -> !
+fn slice_index_fail(start_1: usize, end_2: usize, len_3: usize) -> !
 {
     let _0: !; // return
     let start_1: usize; // arg #1
@@ -736,7 +736,7 @@ where
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
-pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> &'_0 mut [T]
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> &'_0 mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -809,7 +809,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index
-pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> &'_0 [T]
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> &'_0 [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -882,7 +882,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check
-fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(_1: usize, _2: usize, _3: usize)
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check(start_1: usize, end_2: usize, len_3: usize)
 {
     let _0: (); // return
     let start_1: usize; // arg #1
@@ -949,7 +949,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
-pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: *mut [T]) -> *mut [T]
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: *mut [T]) -> *mut [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1001,7 +1001,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check
-fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(_1: usize, _2: usize, _3: usize)
+fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check(start_1: usize, end_2: usize, len_3: usize)
 {
     let _0: (); // return
     let start_1: usize; // arg #1
@@ -1068,7 +1068,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
-pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: *const [T]) -> *const [T]
+pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: *const [T]) -> *const [T]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1120,7 +1120,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
-pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -1198,7 +1198,7 @@ where
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
-pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
+pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
     [@TraitClause0]: Sized<T>,
 {

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -207,7 +207,7 @@ fn FOO() -> Foo
 static FOO: Foo = FOO()
 
 // Full name: test_crate::non_copy_static::{Foo}::method
-fn method<'_0>(_1: &'_0 Foo)
+fn method<'_0>(self_1: &'_0 Foo)
 {
     let _0: (); // return
     let self_1: &'1 Foo; // arg #1

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -175,7 +175,7 @@ where
     [@TraitClause0]: BoolTrait<Self>,
 = <method_without_default_body>
 
-pub fn test_crate::BoolTrait::ret_true<'_0, Self>(_1: &'_0 Self) -> bool
+pub fn test_crate::BoolTrait::ret_true<'_0, Self>(self_1: &'_0 Self) -> bool
 where
     [@TraitClause0]: BoolTrait<Self>,
 {
@@ -187,7 +187,7 @@ where
 }
 
 // Full name: test_crate::{impl BoolTrait for bool}::get_bool
-pub fn {impl BoolTrait for bool}::get_bool<'_0>(_1: &'_0 bool) -> bool
+pub fn {impl BoolTrait for bool}::get_bool<'_0>(self_1: &'_0 bool) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 bool; // arg #1
@@ -197,7 +197,7 @@ pub fn {impl BoolTrait for bool}::get_bool<'_0>(_1: &'_0 bool) -> bool
 }
 
 // Full name: test_crate::{impl BoolTrait for bool}::ret_true
-pub fn {impl BoolTrait for bool}::ret_true<'_0>(_1: &'_0 bool) -> bool
+pub fn {impl BoolTrait for bool}::ret_true<'_0>(self_1: &'_0 bool) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 bool; // arg #1
@@ -215,7 +215,7 @@ impl BoolTrait for bool {
 }
 
 // Full name: test_crate::test_bool_trait_bool
-pub fn test_bool_trait_bool(_1: bool) -> bool
+pub fn test_bool_trait_bool(x_1: bool) -> bool
 {
     let _0: bool; // return
     let x_1: bool; // arg #1
@@ -242,7 +242,7 @@ pub fn test_bool_trait_bool(_1: bool) -> bool
 }
 
 // Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::get_bool
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -262,7 +262,7 @@ where
 }
 
 // Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::ret_true
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::ret_true<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::ret_true<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -285,7 +285,7 @@ where
 }
 
 // Full name: test_crate::test_bool_trait_option
-pub fn test_bool_trait_option<T>(_1: Option<T>[@TraitClause0]) -> bool
+pub fn test_bool_trait_option<T>(x_1: Option<T>[@TraitClause0]) -> bool
 where
     [@TraitClause0]: Sized<T>,
 {
@@ -315,7 +315,7 @@ where
 }
 
 // Full name: test_crate::test_bool_trait
-pub fn test_bool_trait<T>(_1: T) -> bool
+pub fn test_bool_trait<T>(x_1: T) -> bool
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: BoolTrait<T>,
@@ -346,7 +346,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl ToU64 for u64}::to_u64
-pub fn {impl ToU64 for u64}::to_u64(_1: u64) -> u64
+pub fn {impl ToU64 for u64}::to_u64(self_1: u64) -> u64
 {
     let _0: u64; // return
     let self_1: u64; // arg #1
@@ -363,7 +363,7 @@ impl ToU64 for u64 {
 }
 
 // Full name: test_crate::{impl ToU64 for (A, A)}::to_u64
-pub fn {impl ToU64 for (A, A)}::to_u64<A>(_1: (A, A)) -> u64
+pub fn {impl ToU64 for (A, A)}::to_u64<A>(self_1: (A, A)) -> u64
 where
     [@TraitClause0]: Sized<A>,
     [@TraitClause1]: ToU64<A>,
@@ -406,7 +406,7 @@ where
     vtable: {impl ToU64 for (A, A)}::{vtable}<A>[@TraitClause0, @TraitClause1]
 }
 
-pub fn test_crate::f<T>(_1: (T, T)) -> u64
+pub fn test_crate::f<T>(x_1: (T, T)) -> u64
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToU64<T>,
@@ -424,7 +424,7 @@ where
 }
 
 // Full name: test_crate::g
-pub fn g<T>(_1: (T, T)) -> u64
+pub fn g<T>(x_1: (T, T)) -> u64
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToU64<(T, T)>,
@@ -442,7 +442,7 @@ where
 }
 
 // Full name: test_crate::h0
-pub fn h0(_1: u64) -> u64
+pub fn h0(x_1: u64) -> u64
 {
     let _0: u64; // return
     let x_1: u64; // arg #1
@@ -479,7 +479,7 @@ where
 }
 
 // Full name: test_crate::{impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64
-pub fn {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<T>(_1: Wrapper<T>[@TraitClause0]) -> u64
+pub fn {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<T>(self_1: Wrapper<T>[@TraitClause0]) -> u64
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToU64<T>,
@@ -508,7 +508,7 @@ where
 }
 
 // Full name: test_crate::h1
-pub fn h1(_1: Wrapper<u64>[{built_in impl Sized for u64}]) -> u64
+pub fn h1(x_1: Wrapper<u64>[{built_in impl Sized for u64}]) -> u64
 {
     let _0: u64; // return
     let x_1: Wrapper<u64>[{built_in impl Sized for u64}]; // arg #1
@@ -522,7 +522,7 @@ pub fn h1(_1: Wrapper<u64>[{built_in impl Sized for u64}]) -> u64
 }
 
 // Full name: test_crate::h2
-pub fn h2<T>(_1: Wrapper<T>[@TraitClause0]) -> u64
+pub fn h2<T>(x_1: Wrapper<T>[@TraitClause0]) -> u64
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToU64<T>,
@@ -554,7 +554,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl ToType<bool> for u64}::to_type
-pub fn {impl ToType<bool> for u64}::to_type(_1: u64) -> bool
+pub fn {impl ToType<bool> for u64}::to_type(self_1: u64) -> bool
 {
     let _0: bool; // return
     let self_1: u64; // arg #1
@@ -592,7 +592,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::h3
-pub fn h3<T1, T2>(_1: T2) -> T1
+pub fn h3<T1, T2>(y_1: T2) -> T1
 where
     [@TraitClause0]: Sized<T1>,
     [@TraitClause1]: Sized<T2>,
@@ -629,7 +629,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::h4
-pub fn h4<T1, T2>(_1: T2) -> T1
+pub fn h4<T1, T2>(y_1: T2) -> T1
 where
     [@TraitClause0]: Sized<T1>,
     [@TraitClause1]: Sized<T2>,
@@ -662,7 +662,7 @@ struct TestType1 {
 }
 
 // Full name: test_crate::{TestType<T>[@TraitClause0]}::test::{impl TestTrait for TestType1}::test
-fn {impl TestTrait for TestType1}::test<'_0>(_1: &'_0 TestType1) -> bool
+fn {impl TestTrait for TestType1}::test<'_0>(self_1: &'_0 TestType1) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 TestType1; // arg #1
@@ -675,7 +675,7 @@ fn {impl TestTrait for TestType1}::test<'_0>(_1: &'_0 TestType1) -> bool
     return
 }
 
-pub fn test_crate::{TestType<T>[@TraitClause0]}::test<'_0, T>(_1: &'_0 TestType<T>[@TraitClause0], _2: T) -> bool
+pub fn test_crate::{TestType<T>[@TraitClause0]}::test<'_0, T>(self_1: &'_0 TestType<T>[@TraitClause0], x_2: T) -> bool
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToU64<T>,
@@ -749,7 +749,7 @@ pub struct BoolWrapper {
 }
 
 // Full name: test_crate::{impl ToType<T> for BoolWrapper}::to_type
-pub fn {impl ToType<T> for BoolWrapper}::to_type<T>(_1: BoolWrapper) -> T
+pub fn {impl ToType<T> for BoolWrapper}::to_type<T>(self_1: BoolWrapper) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ToType<bool, T>,
@@ -880,7 +880,7 @@ where
 }
 
 // Full name: test_crate::use_with_const_ty3
-pub fn use_with_const_ty3<H, const LEN : usize>(_1: @TraitClause1::W) -> u64
+pub fn use_with_const_ty3<H, const LEN : usize>(x_1: @TraitClause1::W) -> u64
 where
     [@TraitClause0]: Sized<H>,
     [@TraitClause1]: WithConstTy<H, LEN>,
@@ -898,7 +898,7 @@ where
 }
 
 // Full name: test_crate::test_where1
-pub fn test_where1<'a, T>(_1: &'a T)
+pub fn test_where1<'a, T>(_x_1: &'a T)
 where
     [@TraitClause0]: Sized<T>,
     T : 'a,
@@ -912,7 +912,7 @@ where
 }
 
 // Full name: test_crate::test_where2
-pub fn test_where2<T>(_1: u32)
+pub fn test_where2<T>(_x_1: u32)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: WithConstTy<T, 32 : usize>,
@@ -965,7 +965,7 @@ pub trait ChildTrait<Self>
 }
 
 // Full name: test_crate::test_child_trait1
-pub fn test_child_trait1<'_0, T>(_1: &'_0 T) -> String
+pub fn test_child_trait1<'_0, T>(x_1: &'_0 T) -> String
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ChildTrait<T>,
@@ -982,7 +982,7 @@ where
 }
 
 // Full name: test_crate::test_child_trait2
-pub fn test_child_trait2<'_0, T>(_1: &'_0 T) -> @TraitClause1::parent_clause1::W
+pub fn test_child_trait2<'_0, T>(x_1: &'_0 T) -> @TraitClause1::parent_clause1::W
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: ChildTrait<T>,
@@ -1134,7 +1134,7 @@ impl ParentTrait2 for u32 {
 }
 
 // Full name: test_crate::{impl ChildTrait2 for u32}::convert
-pub fn {impl ChildTrait2 for u32}::convert(_1: u32) -> u32
+pub fn {impl ChildTrait2 for u32}::convert(x_1: u32) -> u32
 {
     let _0: u32; // return
     let x_1: u32; // arg #1
@@ -1213,7 +1213,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::test_get_trait
-pub fn test_get_trait<'_0, T>(_1: &'_0 T) -> @TraitClause1::W
+pub fn test_get_trait<'_0, T>(x_1: &'_0 T) -> @TraitClause1::W
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: GetTrait<T>,
@@ -1383,7 +1383,7 @@ impl RecursiveImpl for () {
 }
 
 // Full name: test_crate::flabada
-pub fn flabada<'a>(_1: &'a ()) -> Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}]
+pub fn flabada<'a>(_x_1: &'a ()) -> Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}]
 {
     let _0: Wrapper<(bool, &'9 ())>[{built_in impl Sized for (bool, &'9 ())}]; // return
     let _x_1: &'12 (); // arg #1

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -41,7 +41,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl From<&'_0 bool> for bool}::from
-pub fn {impl From<&'_0 bool> for bool}::from<'_0>(_1: &'_0 bool) -> Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
+pub fn {impl From<&'_0 bool> for bool}::from<'_0>(v_1: &'_0 bool) -> Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 {
     let _0: Result<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]; // return
     let v_1: &'1 bool; // arg #1

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -225,7 +225,7 @@ impl Hash for () {
 }
 
 pub unsafe fn core::intrinsics::assume(_1: bool)
-= <opaque>
+= <intrinsic:assume>
 
 // Full name: core::marker::Send
 #[lang_item("Send")]

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -224,7 +224,7 @@ impl Hash for () {
     non-dyn-compatible
 }
 
-pub unsafe fn core::intrinsics::assume(_1: bool)
+pub unsafe fn core::intrinsics::assume(b_1: bool)
 = <intrinsic:assume>
 
 // Full name: core::marker::Send

--- a/charon/tests/ui/vtable-simple.out
+++ b/charon/tests/ui/vtable-simple.out
@@ -75,7 +75,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify
-fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(_1: &'_0 mut i32, _2: &'_1 T) -> T
+fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(self_1: &'_0 mut i32, arg_2: &'_1 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -114,7 +114,7 @@ where
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}<T>(_1: *mut (dyn Modifiable<T>))
+unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -167,7 +167,7 @@ where
 }
 
 // Full name: test_crate::modify_trait_object
-fn modify_trait_object<'_0, T>(_1: &'_0 T) -> T
+fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,

--- a/charon/tests/ui/vtable_drop.out
+++ b/charon/tests/ui/vtable_drop.out
@@ -136,7 +136,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify
-fn {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0, '_1, T>(_1: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}], _2: &'_1 T) -> T
+fn {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0, '_1, T>(self_1: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}], arg_2: &'_1 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -196,7 +196,7 @@ where
 }
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}<T>(_1: *mut (dyn Modifiable<T>))
+unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -256,7 +256,7 @@ where
 }
 
 // Full name: test_crate::modify_trait_object
-fn modify_trait_object<'_0, T>(_1: &'_0 T) -> T
+fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -204,7 +204,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Super<i32> for i32}::super_method
-fn {impl Super<i32> for i32}::super_method<'_0>(_1: &'_0 i32, _2: i32) -> i32
+fn {impl Super<i32> for i32}::super_method<'_0>(self_1: &'_0 i32, arg_2: i32) -> i32
 {
     let _0: i32; // return
     let self_1: &'1 i32; // arg #1
@@ -240,7 +240,7 @@ fn {impl Super<i32> for i32}::super_method::{vtable_method}<'_0>(_1: &'_0 (dyn S
 }
 
 // Full name: test_crate::{impl Super<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Super<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn Super<i32>))
+unsafe fn {impl Super<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Super<i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Super<i32> + '0); // arg #1
@@ -279,7 +279,7 @@ impl Super<i32> for i32 {
 }
 
 // Full name: test_crate::{impl Checkable<i32> for i32}::check
-fn {impl Checkable<i32> for i32}::check<'_0>(_1: &'_0 i32) -> bool
+fn {impl Checkable<i32> for i32}::check<'_0>(self_1: &'_0 i32) -> bool
 {
     let _0: bool; // return
     let self_1: &'1 i32; // arg #1
@@ -310,7 +310,7 @@ fn {impl Checkable<i32> for i32}::check::{vtable_method}<'_0>(_1: &'_0 (dyn Chec
 }
 
 // Full name: test_crate::{impl Checkable<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Checkable<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn Checkable<i32>))
+unsafe fn {impl Checkable<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Checkable<i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Checkable<i32> + '0); // arg #1
@@ -374,7 +374,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl NoParam for i32}::dummy
-fn {impl NoParam for i32}::dummy<'_0>(_1: &'_0 i32)
+fn {impl NoParam for i32}::dummy<'_0>(self_1: &'_0 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -405,7 +405,7 @@ impl NoParam for i32 {
 }
 
 // Full name: test_crate::to_dyn_obj
-fn to_dyn_obj<'_0, T>(_1: &'_0 T) -> &'_0 (dyn NoParam + '_0)
+fn to_dyn_obj<'_0, T>(arg_1: &'_0 T) -> &'_0 (dyn NoParam + '_0)
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: NoParam<T>,
@@ -452,7 +452,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify
-fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(_1: &'_0 mut i32, _2: &'_1 T) -> T
+fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(self_1: &'_0 mut i32, arg_2: &'_1 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -491,7 +491,7 @@ where
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable_drop_shim}
-unsafe fn {impl Modifiable<T> for i32}::{vtable_drop_shim}<T>(_1: *mut (dyn Modifiable<T>))
+unsafe fn {impl Modifiable<T> for i32}::{vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -544,7 +544,7 @@ where
 }
 
 // Full name: test_crate::modify_trait_object
-fn modify_trait_object<'_0, T>(_1: &'_0 T) -> T
+fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
     [@TraitClause0]: Sized<T>,
     [@TraitClause1]: Clone<T>,
@@ -622,7 +622,7 @@ trait Both32And64<Self>
     vtable: test_crate::Both32And64::{vtable}
 }
 
-fn test_crate::Both32And64::both_operate<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 i32, _3: &'_2 i64)
+fn test_crate::Both32And64::both_operate<'_0, '_1, '_2, Self>(self_1: &'_0 Self, t32_2: &'_1 i32, t64_3: &'_2 i64)
 where
     [@TraitClause0]: Both32And64<Self>,
 {
@@ -661,7 +661,7 @@ where
 }
 
 // Full name: test_crate::{impl BaseOn<i32> for i32}::operate_on
-fn {impl BaseOn<i32> for i32}::operate_on<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i32)
+fn {impl BaseOn<i32> for i32}::operate_on<'_0, '_1>(self_1: &'_0 i32, t_2: &'_1 i32)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -706,7 +706,7 @@ fn {impl BaseOn<i32> for i32}::operate_on::{vtable_method}<'_0, '_1>(_1: &'_0 (d
 }
 
 // Full name: test_crate::{impl BaseOn<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl BaseOn<i32> for i32}::{vtable_drop_shim}(_1: *mut (dyn BaseOn<i32>))
+unsafe fn {impl BaseOn<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn BaseOn<i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn BaseOn<i32> + '0); // arg #1
@@ -745,7 +745,7 @@ impl BaseOn<i32> for i32 {
 }
 
 // Full name: test_crate::{impl BaseOn<i64> for i32}::operate_on
-fn {impl BaseOn<i64> for i32}::operate_on<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i64)
+fn {impl BaseOn<i64> for i32}::operate_on<'_0, '_1>(self_1: &'_0 i32, t_2: &'_1 i64)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -794,7 +794,7 @@ fn {impl BaseOn<i64> for i32}::operate_on::{vtable_method}<'_0, '_1>(_1: &'_0 (d
 }
 
 // Full name: test_crate::{impl BaseOn<i64> for i32}::{vtable_drop_shim}
-unsafe fn {impl BaseOn<i64> for i32}::{vtable_drop_shim}(_1: *mut (dyn BaseOn<i64>))
+unsafe fn {impl BaseOn<i64> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn BaseOn<i64>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn BaseOn<i64> + '0); // arg #1
@@ -833,7 +833,7 @@ impl BaseOn<i64> for i32 {
 }
 
 // Full name: test_crate::{impl Both32And64 for i32}::{vtable_drop_shim}
-unsafe fn {impl Both32And64 for i32}::{vtable_drop_shim}(_1: *mut (dyn Both32And64))
+unsafe fn {impl Both32And64 for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Both32And64))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Both32And64 + '0); // arg #1
@@ -870,7 +870,7 @@ fn {impl Both32And64 for i32}::{vtable}() -> test_crate::Both32And64::{vtable}
 static {impl Both32And64 for i32}::{vtable}: test_crate::Both32And64::{vtable} = {impl Both32And64 for i32}::{vtable}()
 
 // Full name: test_crate::{impl Both32And64 for i32}::both_operate
-fn {impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(_1: &'_0 i32, _2: &'_1 i32, _3: &'_2 i64)
+fn {impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(self_1: &'_0 i32, t32_2: &'_1 i32, t64_3: &'_2 i64)
 {
     let _0: (); // return
     let self_1: &'1 i32; // arg #1
@@ -947,7 +947,7 @@ where
 = <method_without_default_body>
 
 // Full name: test_crate::{impl LifetimeTrait for i32}::lifetime_method
-fn {impl LifetimeTrait for i32}::lifetime_method<'a, '_1>(_1: &'_1 i32, _2: &'a i32) -> &'a i32
+fn {impl LifetimeTrait for i32}::lifetime_method<'a, '_1>(self_1: &'_1 i32, arg_2: &'a i32) -> &'a i32
 {
     let _0: &'1 i32; // return
     let self_1: &'2 i32; // arg #1
@@ -990,7 +990,7 @@ fn {impl LifetimeTrait for i32}::lifetime_method::{vtable_method}<'a, '_1>(_1: &
 }
 
 // Full name: test_crate::{impl LifetimeTrait for i32}::{vtable_drop_shim}
-unsafe fn {impl LifetimeTrait for i32}::{vtable_drop_shim}(_1: *mut (dyn LifetimeTrait<Ty = i32>))
+unsafe fn {impl LifetimeTrait for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn LifetimeTrait<Ty = i32>))
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn LifetimeTrait<Ty = i32> + '0); // arg #1
@@ -1030,7 +1030,7 @@ impl LifetimeTrait for i32 {
 }
 
 // Full name: test_crate::use_lifetime_trait
-fn use_lifetime_trait<'a, '_1>(_1: &'_1 (dyn LifetimeTrait<Ty = i32> + '_1), _2: &'a i32) -> &'a i32
+fn use_lifetime_trait<'a, '_1>(x_1: &'_1 (dyn LifetimeTrait<Ty = i32> + '_1), y_2: &'a i32) -> &'a i32
 {
     let _0: &'1 i32; // return
     let x_1: &'5 (dyn LifetimeTrait<Ty = i32> + '6); // arg #1
@@ -1053,7 +1053,7 @@ fn use_lifetime_trait<'a, '_1>(_1: &'_1 (dyn LifetimeTrait<Ty = i32> + '_1), _2:
 }
 
 // Full name: test_crate::use_alias
-fn use_alias<'_0>(_1: &'_0 (dyn Both32And64 + '_0))
+fn use_alias<'_0>(x_1: &'_0 (dyn Both32And64 + '_0))
 {
     let _0: (); // return
     let x_1: &'3 (dyn Both32And64 + '4); // arg #1


### PR DESCRIPTION
Add two variants to `Body`: `Extern(string)` and `Intrinsic(string)`! On the OCaml side, a body isn't just a `'body option` anymore: we instead properly translate the `Body` enum, to give more information to the client.

For now intrinsics are just strings rather than an enum, as I don't have the time to do that part. There is also the question of [how we make this enum make sense](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Intrinsics.20lowered.20to.20MIR/with/580679106): some intrinsics actually never get lowered into a function call, and a few of them disappear through the compilation pipeline. 

One thing we lose with this change is that we can't get the name of the intrinsic's arguments. This isn't a big deal but in Soteria I [generate intrinsic definitions](https://github.com/soteria-tools/soteria/blob/9f496145ceb6fa898244440e22447de60981036d/soteria-rust/lib/builtins/intrinsics_intf.ml#L735-L743) from the ULLBC output, and having names for the arguments is super useful. Maybe we could make a new `Argument` type that stores a type, optional name (and an ArgAbi?) to keep this information? And then `FunSig.inputs` would be a `Vec<Arg>` instead. Let me know.

Fixes #982 
First step towards #864

ci: use https://github.com/AeneasVerif/aeneas/pull/919
ci: use https://github.com/AeneasVerif/eurydice/pull/395