### PR TITLE
Support multi-target compilation

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.178"
+let supported_charon_version = "0.1.179"

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -47,7 +47,7 @@ type target_info = { target_pointer_size : int; is_little_endian : bool }
 type 'fun_body gcrate = {
   name : string;
   options : cli_options;
-  target_information : target_info;
+  target_information : (string * target_info) list;
   declarations : declaration_group list;
   type_decls : type_decl TypeDeclId.Map.t;
   fun_decls : 'fun_body gfun_decl FunDeclId.Map.t;

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -112,7 +112,11 @@ and gtranslated_crate_of_json
 
         let* crate_name = string_of_json ctx crate_name in
         let* options = cli_options_of_json ctx options in
-        let* target_information = target_info_of_json ctx target_info in
+        let* target_information =
+          list_of_json
+            (key_value_pair_of_json string_of_json target_info_of_json)
+            ctx target_info
+        in
         let* _item_names =
           list_of_json
             (key_value_pair_of_json item_id_of_json name_of_json)

--- a/charon-ml/src/GAstOfJson.ml
+++ b/charon-ml/src/GAstOfJson.ml
@@ -144,7 +144,9 @@ and gtranslated_crate_of_json
         in
         let* unit_metadata = global_decl_ref_of_json ctx unit_metadata in
         let* ordered_decls =
-          list_of_json declaration_group_of_json ctx ordered_decls
+          option_of_json
+            (list_of_json declaration_group_of_json)
+            ctx ordered_decls
         in
 
         let type_decls = TypeDeclId.map_of_indexed_list type_decls in
@@ -152,6 +154,7 @@ and gtranslated_crate_of_json
         let global_decls = GlobalDeclId.map_of_indexed_list global_decls in
         let trait_decls = TraitDeclId.map_of_indexed_list trait_decls in
         let trait_impls = TraitImplId.map_of_indexed_list trait_impls in
+        let ordered_decls = Option.value ordered_decls ~default:[] in
 
         Ok
           {

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -2,6 +2,12 @@ open Types
 open TypesUtils
 open GAst
 
+let get_target_information crate =
+  match crate.target_information with
+  | [ (_, info) ] -> info
+  | _ ->
+      failwith "`get_target_information` can't be used in a multi-layout crate"
+
 (** Small utility: list the transitive parents of a region var group. We don't
     do that in an efficient manner, but it doesn't matter.
 

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -153,7 +153,11 @@ class ['self] map_crate =
       in
       let name = self#visit_string env name in
       let options = self#visit_cli_options env options in
-      let target_information = self#visit_target_info env target_information in
+      let target_information =
+        List.map
+          (fun (name, info) -> (name, self#visit_target_info env info))
+          target_information
+      in
       let declarations =
         List.map (self#visit_declaration_group env) declarations
       in

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -978,7 +978,7 @@ and path_elem_with_generic_args_to_pattern (ctx : 'fun_body ctx)
       | Some args -> [ PIdent (s, d, args) ]
     end
   | PeImpl impl -> [ impl_elem_to_pattern ctx c impl ]
-  | PeInstantiated _ ->
+  | PeInstantiated _ | PeTarget _ ->
       (* In pattern generation, we skip monomorphized elements since patterns
          are meant to match the logical structure, not the instantiation details *)
       []

--- a/charon-ml/src/PrintTypes.ml
+++ b/charon-ml/src/PrintTypes.ml
@@ -480,6 +480,7 @@ and path_elem_to_string (env : 'a fmt_env) (e : path_elem) : string =
       let env = fmt_env_push_generics_and_preds env binder.binder_params in
       let explicits, _ = generic_args_to_strings env binder.binder_value in
       "<" ^ String.concat ", " explicits ^ ">"
+  | PeTarget target -> target
 
 and name_to_string (env : 'a fmt_env) (n : name) : string =
   let name = List.map (path_elem_to_string env) n in

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -320,7 +320,11 @@ let generic_params_lengths (args : generic_params) : int * int * int * int =
     variant[TagEncoding::Niche::untagged_variant]. *)
 let get_variant_from_tag ptr_size ty_decl (tag : Values.scalar_value) =
   let ( let* ) = Option.bind in
-  let* layout = ty_decl.layout in
+  let layout =
+    match ty_decl.layout with
+    | [ (_, layout) ] -> layout
+    | _ -> failwith "get_variant_from_tag can't be used in a multi-layout crate"
+  in
   let* discr_layout = layout.discriminant_layout in
   match ty_decl.kind with
   | Enum variants -> begin

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -402,6 +402,10 @@ type cli_options = {
       (** The MIR stage to extract. This is only relevant for the current crate;
           for dpendencies only MIR optimized is available. *)
   rustc_args : string list;  (** Extra flags to pass to rustc. *)
+  targets : string list;
+      (** A list of target architectures to translate for. Charon will run the
+          compiler once for each target and aggregate the results, which is
+          useful if the code includes [#[cfg(..)]] filters. *)
   monomorphize : bool;
       (** Monomorphize the items encountered when possible. Generic items found
           in the crate are skipped. To only translate a particular call graph,

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -405,7 +405,8 @@ type cli_options = {
   targets : string list;
       (** A list of target architectures to translate for. Charon will run the
           compiler once for each target and aggregate the results, which is
-          useful if the code includes [#[cfg(..)]] filters. *)
+          useful if the code includes [#[cfg(..)]] filters. Warning: this is an
+          initial implementation which is extremely slow. *)
   monomorphize : bool;
       (** Monomorphize the items encountered when possible. Generic items found
           in the crate are skipped. To only translate a particular call graph,

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1006,17 +1006,17 @@ and generic_args_of_json (ctx : of_json_ctx) (js : json) :
           ("trait_refs", trait_refs);
         ] ->
         let* regions =
-          index_map_of_json region_id_of_json region_of_json ctx regions
+          indexed_map_of_json region_id_of_json region_of_json ctx regions
         in
         let* types =
-          index_map_of_json type_var_id_of_json ty_of_json ctx types
+          indexed_map_of_json type_var_id_of_json ty_of_json ctx types
         in
         let* const_generics =
-          index_map_of_json const_generic_var_id_of_json constant_expr_of_json
+          indexed_map_of_json const_generic_var_id_of_json constant_expr_of_json
             ctx const_generics
         in
         let* trait_refs =
-          index_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
             trait_refs
         in
         Ok ({ regions; types; const_generics; trait_refs } : generic_args)
@@ -1037,17 +1037,17 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
           ("trait_type_constraints", trait_type_constraints);
         ] ->
         let* regions =
-          index_map_of_json region_id_of_json region_param_of_json ctx regions
+          indexed_map_of_json region_id_of_json region_param_of_json ctx regions
         in
         let* types =
-          index_map_of_json type_var_id_of_json type_param_of_json ctx types
+          indexed_map_of_json type_var_id_of_json type_param_of_json ctx types
         in
         let* const_generics =
-          index_map_of_json const_generic_var_id_of_json
+          indexed_map_of_json const_generic_var_id_of_json
             const_generic_param_of_json ctx const_generics
         in
         let* trait_clauses =
-          index_map_of_json trait_clause_id_of_json trait_param_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_param_of_json ctx
             trait_clauses
         in
         let* regions_outlive =
@@ -1063,7 +1063,7 @@ and generic_params_of_json (ctx : of_json_ctx) (js : json) :
             ctx types_outlive
         in
         let* trait_type_constraints =
-          index_map_of_json trait_type_constraint_id_of_json
+          indexed_map_of_json trait_type_constraint_id_of_json
             (region_binder_of_json trait_type_constraint_of_json)
             ctx trait_type_constraints
         in
@@ -1156,7 +1156,7 @@ and impl_elem_of_json (ctx : of_json_ctx) (js : json) :
         Ok (ImplElemTrait trait)
     | _ -> Error "")
 
-and index_map_of_json :
+and indexed_map_of_json :
     'a0 'a1.
     (of_json_ctx -> json -> ('a0, string) result) ->
     (of_json_ctx -> json -> ('a1, string) result) ->
@@ -1169,6 +1169,21 @@ and index_map_of_json :
     | json ->
         let* list = list_of_json (option_of_json arg1_of_json) ctx json in
         Ok (List.filter_map (fun x -> x) list)
+    | _ -> Error "")
+
+and index_map_of_json :
+    'a0 'a1 'a2.
+    (of_json_ctx -> json -> ('a0, string) result) ->
+    (of_json_ctx -> json -> ('a1, string) result) ->
+    (of_json_ctx -> json -> ('a2, string) result) ->
+    of_json_ctx ->
+    json ->
+    (('a0 * 'a1) list, string) result =
+ fun arg0_of_json arg1_of_json arg2_of_json ctx js ->
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | json ->
+        list_of_json (key_value_pair_of_json arg0_of_json arg1_of_json) ctx json
     | _ -> Error "")
 
 and index_vec_of_json :
@@ -1314,7 +1329,7 @@ and item_source_of_json (ctx : of_json_ctx) (js : json) :
           index_vec_of_json field_id_of_json v_table_field_of_json ctx field_map
         in
         let* supertrait_map =
-          index_map_of_json trait_clause_id_of_json
+          indexed_map_of_json trait_clause_id_of_json
             (option_of_json field_id_of_json)
             ctx supertrait_map
         in
@@ -1671,7 +1686,7 @@ and region_binder_of_json :
     (match js with
     | `Assoc [ ("regions", regions); ("skip_binder", skip_binder) ] ->
         let* binder_regions =
-          index_map_of_json region_id_of_json region_param_of_json ctx regions
+          indexed_map_of_json region_id_of_json region_param_of_json ctx regions
         in
         let* binder_value = arg0_of_json ctx skip_binder in
         Ok ({ binder_regions; binder_value } : _ region_binder)
@@ -1884,7 +1899,7 @@ and trait_assoc_ty_of_json (ctx : of_json_ctx) (js : json) :
         let* attr_info = attr_info_of_json ctx attr_info in
         let* default = option_of_json trait_assoc_ty_impl_of_json ctx default in
         let* implied_clauses =
-          index_map_of_json trait_clause_id_of_json trait_param_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_param_of_json ctx
             implied_clauses
         in
         Ok ({ name; attr_info; default; implied_clauses } : trait_assoc_ty)
@@ -1925,7 +1940,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* item_meta = item_meta_of_json ctx item_meta in
         let* generics = generic_params_of_json ctx generics in
         let* implied_clauses =
-          index_map_of_json trait_clause_id_of_json trait_param_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_param_of_json ctx
             implied_clauses
         in
         let* consts = list_of_json trait_assoc_const_of_json ctx consts in
@@ -1988,7 +2003,7 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
         let* impl_trait = trait_decl_ref_of_json ctx impl_trait in
         let* generics = generic_params_of_json ctx generics in
         let* implied_trait_refs =
-          index_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
             implied_trait_refs
         in
         let* consts =
@@ -2131,7 +2146,7 @@ and trait_ref_kind_of_json (ctx : of_json_ctx) (js : json) :
         ] ->
         let* builtin_data = builtin_impl_data_of_json ctx builtin_data in
         let* parent_trait_refs =
-          index_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
+          indexed_map_of_json trait_clause_id_of_json trait_ref_of_json ctx
             parent_trait_refs
         in
         let* types =
@@ -2244,7 +2259,9 @@ and type_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* generics = generic_params_of_json ctx generics in
         let* src = item_source_of_json ctx src in
         let* kind = type_decl_kind_of_json ctx kind in
-        let* layout = option_of_json layout_of_json ctx layout in
+        let* layout =
+          index_map_of_json string_of_json layout_of_json int_of_json ctx layout
+        in
         let* ptr_metadata = ptr_metadata_of_json ctx ptr_metadata in
         let* repr = option_of_json repr_options_of_json ctx repr in
         Ok

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -1553,6 +1553,9 @@ and path_elem_of_json (ctx : of_json_ctx) (js : json) :
           box_of_json (binder_of_json generic_args_of_json) ctx instantiated
         in
         Ok (PeInstantiated instantiated)
+    | `Assoc [ ("Target", target) ] ->
+        let* target = string_of_json ctx target in
+        Ok (PeTarget target)
     | _ -> Error "")
 
 and place_of_json (ctx : of_json_ctx) (js : json) : (place, string) result =

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -414,6 +414,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("skip_borrowck", skip_borrowck);
           ("mir", mir);
           ("rustc_args", rustc_args);
+          ("targets", targets);
           ("monomorphize", monomorphize);
           ("monomorphize_mut", monomorphize_mut);
           ("start_from", start_from);
@@ -456,6 +457,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* skip_borrowck = bool_of_json ctx skip_borrowck in
         let* mir = option_of_json mir_level_of_json ctx mir in
         let* rustc_args = list_of_json string_of_json ctx rustc_args in
+        let* targets = list_of_json string_of_json ctx targets in
         let* monomorphize = bool_of_json ctx monomorphize in
         let* monomorphize_mut =
           option_of_json monomorphize_mut_of_json ctx monomorphize_mut
@@ -515,6 +517,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              skip_borrowck;
              mir;
              rustc_args;
+             targets;
              monomorphize;
              monomorphize_mut;
              start_from;

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -995,6 +995,9 @@ and path_elem =
       (** This item was obtained by instantiating its parent with the given
           args. The binder binds the parameters of the new items. If the binder
           binds nothing then this is a monomorphization. *)
+  | PeTarget of string
+      (** This item is only available on the given target. Only appears in
+          multi-target mode. *)
 
 (** The metadata stored in a pointer. That's the information stored in pointers
     alongside their address. It's empty for [Sized] types, and interesting for

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -1070,10 +1070,10 @@ and type_decl = {
       (** The context of the type: distinguishes top-level items from
           closure-related items. *)
   kind : type_decl_kind;  (** The type kind: enum, struct, or opaque. *)
-  layout : layout option;
-      (** The layout of the type. Information may be partial because of generics
-          or dynamically- sized types. If rustc cannot compute a layout, it is
-          [None]. *)
+  layout : (string * layout) list;
+      (** The layout of the type for each target. Information may be partial
+          because of generics or dynamically-sized types. If we cannot compute a
+          layout, the target has no entry. *)
   ptr_metadata : ptr_metadata;
       (** The metadata associated with a pointer to the type. *)
   repr : repr_options option;

--- a/charon-ml/tests/Test_Deserialize.ml
+++ b/charon-ml/tests/Test_Deserialize.ml
@@ -65,7 +65,9 @@ let run_tests (folder : string) : unit =
               | Some v -> "Some " ^ PrintValues.scalar_value_to_string v
               | None -> "None"
             in
-            let ptr_size = m.target_information.target_pointer_size in
+            let ptr_size =
+              (snd (List.hd m.target_information)).target_pointer_size
+            in
             Types.TypeDeclId.Map.iter
               (fun _ (ty_decl : Types.type_decl) ->
                 match (ty_decl.kind, ty_decl.Types.layout) with

--- a/charon-ml/tests/Test_Deserialize.ml
+++ b/charon-ml/tests/Test_Deserialize.ml
@@ -71,7 +71,7 @@ let run_tests (folder : string) : unit =
             Types.TypeDeclId.Map.iter
               (fun _ (ty_decl : Types.type_decl) ->
                 match (ty_decl.kind, ty_decl.Types.layout) with
-                | Enum _, Some layout
+                | Enum _, [ (_, layout) ]
                   when Option.is_some layout.discriminant_layout -> begin
                     let name =
                       PrintTypes.name_to_string print_ctx ty_decl.item_meta.name

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.178"
+version = "0.1.179"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -78,6 +78,7 @@ smallvec = "1.15.1"
 stacker = "0.1"
 strip-ansi-escapes = "0.2.1"
 take_mut = "0.2.2"
+tempfile = "3"
 tar = { version = "0.4.42", optional = true }
 toml = { version = "0.8", features = ["parse"] }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "fmt", ] }

--- a/charon/rust-toolchain
+++ b/charon/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly-2026-02-07"
 components = [ "rustc-dev", "llvm-tools-preview", "rust-src", "miri" ]
-targets = [ "x86_64-apple-darwin", "i686-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "riscv64gc-unknown-none-elf" ]
+targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "i686-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "riscv64gc-unknown-none-elf" ]

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -688,6 +688,8 @@ pub struct ConstantExpr {
 /// TODO: we should prefix the type variants with "R" or "Rv", this would avoid collisions
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     EnumToGetters,
     EnumAsGetters,
@@ -788,7 +790,17 @@ pub enum Rvalue {
 /// initialization, `ls` is initialized to `⊥`, then this `⊥` is expanded to
 /// `Cons (⊥, ⊥)` upon the first assignment, at which point we can initialize
 /// the field 0, etc.).
-#[derive(Debug, Clone, VariantIndexArity, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    VariantIndexArity,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[charon::variants_prefix("Aggregated")]
 pub enum AggregateKind {
     /// A struct, enum or union aggregate. The `VariantId`, if present, indicates this is an enum

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -197,7 +197,6 @@ pub enum VTableField {
 /// A function definition
 #[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct FunDecl {
-    #[drive(skip)]
     pub def_id: FunDeclId,
     /// The meta data associated with the declaration.
     pub item_meta: ItemMeta,
@@ -240,7 +239,6 @@ pub enum GlobalKind {
 /// A global variable definition (constant or static).
 #[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct GlobalDecl {
-    #[drive(skip)]
     pub def_id: GlobalDeclId,
     /// The meta data associated with the declaration.
     pub item_meta: ItemMeta,
@@ -317,7 +315,6 @@ pub struct TraitItemName(pub ustr::Ustr);
 #[allow(clippy::type_complexity)]
 #[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitDecl {
-    #[drive(skip)]
     pub def_id: TraitDeclId,
     pub item_meta: ItemMeta,
     pub generics: GenericParams,
@@ -402,7 +399,6 @@ pub struct TraitMethod {
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitImpl {
-    #[drive(skip)]
     pub def_id: TraitImplId,
     pub item_meta: ItemMeta,
     /// The information about the implemented trait.

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -11,7 +11,7 @@ use serde_state::DeserializeState;
 use serde_state::SerializeState;
 
 /// A variable
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Local {
     /// Unique index identifying the variable
     pub index: LocalId,
@@ -31,7 +31,9 @@ pub type Var = Local;
 pub type VarId = LocalId;
 
 /// The local variables of a body.
-#[derive(Debug, Default, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug, PartialEq, Eq, Default, Clone, SerializeState, DeserializeState, Drive, DriveMut,
+)]
 pub struct Locals {
     /// The number of local variables used for the input arguments.
     #[drive(skip)]
@@ -47,7 +49,7 @@ pub struct Locals {
 /// An expression body.
 /// TODO: arg_count should be stored in GFunDecl below. But then,
 ///       the print is obfuscated and Aeneas may need some refactoring.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("GexprBody")]
 pub struct GExprBody<T> {
     pub span: Span,
@@ -69,6 +71,8 @@ pub struct GExprBody<T> {
 /// The body of a function.
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     SerializeState,
     DeserializeState,
@@ -191,7 +195,7 @@ pub enum VTableField {
 }
 
 /// A function definition
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct FunDecl {
     #[drive(skip)]
     pub def_id: FunDeclId,
@@ -220,7 +224,7 @@ pub struct FunDeclRef {
     pub generics: BoxedArgs,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum GlobalKind {
     /// A static.
     Static,
@@ -234,7 +238,7 @@ pub enum GlobalKind {
 }
 
 /// A global variable definition (constant or static).
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct GlobalDecl {
     #[drive(skip)]
     pub def_id: GlobalDeclId,
@@ -311,7 +315,7 @@ pub struct TraitItemName(pub ustr::Ustr);
 /// Of course, this forbids other useful use cases such as visitors implemented
 /// by means of traits.
 #[allow(clippy::type_complexity)]
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitDecl {
     #[drive(skip)]
     pub def_id: TraitDeclId,
@@ -351,7 +355,7 @@ pub struct TraitDecl {
 }
 
 /// An associated constant in a trait.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitAssocConst {
     pub name: TraitItemName,
     #[drive(skip)]
@@ -362,7 +366,7 @@ pub struct TraitAssocConst {
 }
 
 /// An associated type in a trait.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitAssocTy {
     pub name: TraitItemName,
     #[drive(skip)]
@@ -374,7 +378,7 @@ pub struct TraitAssocTy {
 }
 
 /// A trait method.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitMethod {
     pub name: TraitItemName,
     #[drive(skip)]
@@ -396,7 +400,7 @@ pub struct TraitMethod {
 ///   fn baz(...) { ... }
 /// }
 /// ```
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct TraitImpl {
     #[drive(skip)]
     pub def_id: TraitImplId,
@@ -432,7 +436,7 @@ pub struct TraitAssocTyImpl {
 /// A function operand is used in function calls.
 /// It either designates a top-level function, or a place in case
 /// we are using function pointers stored in local variables.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::variants_prefix("FnOp")]
 pub enum FnOperand {
     /// Regular case: call to a top-level function, trait method, etc.
@@ -441,14 +445,14 @@ pub enum FnOperand {
     Dynamic(Operand),
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Call {
     pub func: FnOperand,
     pub args: Vec<Operand>,
     pub dest: Place,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct CopyNonOverlapping {
     pub src: Operand,
     pub dst: Operand,
@@ -459,7 +463,7 @@ pub struct CopyNonOverlapping {
 /// by `reconstruct_fallible_operations` because they're implicit in the semantics of (U)LLBC.
 /// This kind should only be used for error-reporting purposes, as the check itself
 /// is performed in the instructions preceding the assert.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum BuiltinAssertKind {
     BoundsCheck { len: Operand, index: Operand },
     Overflow(BinOp, Operand, Operand),
@@ -476,7 +480,7 @@ pub enum BuiltinAssertKind {
 /// - Panic
 /// - Undefined behavior (caused by an "assume")
 /// - Unwind termination
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum AbortKind {
     /// A built-in panicking function, or a panic due to a failed built-in check (e.g. for out-of-bounds accesses).
     Panic(Option<Name>),
@@ -489,7 +493,7 @@ pub enum AbortKind {
 /// A `Drop` statement/terminator can mean two things, depending on what MIR phase we retrieved
 /// from rustc: it could be a real drop, or it could be a "conditional drop", which is where drop
 /// may happen depending on whether the borrow-checker determines a drop is needed.
-#[derive(Debug, Clone, Copy, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, SerializeState, DeserializeState, Drive, DriveMut)]
 pub enum DropKind {
     /// A real drop. This calls `<T as Destruct>::drop_in_place(&raw mut place)` and marks the
     /// place as moved-out-of. Use `--desugar-drops` to transform all such drops to an actual
@@ -522,7 +526,7 @@ pub enum DropKind {
 /// instance) to this. We then eliminate them in [crate::transform::resugar::reconstruct_fallible_operations],
 /// because they're implicit in the semantics of our array accesses etc. Finally we introduce new asserts in
 /// [crate::transform::resugar::reconstruct_asserts].
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("Assertion")]
 pub struct Assert {
     pub cond: Operand,
@@ -535,7 +539,7 @@ pub struct Assert {
 }
 
 /// A generic `*DeclRef`-shaped struct, used when we're generic over the type of item.
-#[derive(Debug, Clone, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, Drive, DriveMut)]
 pub struct DeclRef<Id> {
     pub id: Id,
     pub generics: BoxedArgs,

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -1,5 +1,6 @@
 //! Definitions common to [crate::ullbc_ast] and [crate::llbc_ast]
 use crate::ast::*;
+use crate::common::serialize_map_to_array::SeqHashMapToArray;
 use crate::ids::IndexMap;
 use crate::ids::IndexVec;
 use crate::llbc_ast;
@@ -82,12 +83,20 @@ pub struct GExprBody<T> {
     EnumAsGetters,
     EnumToGetters,
 )]
+#[serde_state(state_implements = HashConsSerializerState)]
 pub enum Body {
     /// Body represented as a CFG. This is what ullbc is made of, and what we get after translating MIR.
     Unstructured(ullbc_ast::ExprBody),
     /// Body represented with structured control flow. This is what llbc is made of. We restructure
     /// the control flow in the `ullbc_to_llbc` pass.
     Structured(llbc_ast::ExprBody),
+    /// A façade body that dispatches to one of several per-target function bodies. Created during
+    /// multi-target merging for functions with the same signature but different bodies across
+    /// targets.
+    TargetDispatch(
+        #[serde(with = "SeqHashMapToArray::<TargetTriple, FunDeclRef>")]
+        SeqHashMap<TargetTriple, FunDeclRef>,
+    ),
     /// The body of the function item we add for each trait method declaration, if the trait
     /// doesn't provide a default for that method.
     TraitMethodWithoutDefault,

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -14,9 +14,11 @@ impl Body {
     pub fn has_contents(&self) -> bool {
         match self {
             Body::Unstructured(..) | Body::Structured(..) => true,
-            Body::TraitMethodWithoutDefault | Body::Opaque | Body::Missing | Body::Error(..) => {
-                false
-            }
+            Body::TraitMethodWithoutDefault
+            | Body::Opaque
+            | Body::Missing
+            | Body::Error(..)
+            | Body::TargetDispatch(..) => false,
         }
     }
 

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -90,7 +90,9 @@ impl TryFrom<ItemId> for FunId {
 }
 
 /// A translated item.
-#[derive(Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut)]
+#[derive(
+    Debug, PartialEq, Eq, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut,
+)]
 pub enum ItemByVal {
     Type(TypeDecl),
     Fun(FunDecl),
@@ -112,7 +114,9 @@ pub enum ItemRef<'ctx> {
 }
 
 /// A mutable reference to a translated item.
-#[derive(Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut)]
+#[derive(
+    Debug, PartialEq, Eq, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut,
+)]
 pub enum ItemRefMut<'ctx> {
     Type(&'ctx mut TypeDecl),
     Fun(&'ctx mut FunDecl),

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -269,14 +269,15 @@ impl TranslatedCrate {
         }
     }
     /// Set the item to the corresponding slot, and record its name in the name map.
-    pub fn set_new_item_slot(&mut self, id: ItemId, item: ItemByVal) {
+    pub fn set_new_item_slot(&mut self, id: ItemId, item: impl Into<ItemByVal>) {
+        let item = item.into();
         self.item_names
             .insert(id, item.as_ref().item_meta().name.clone());
         self.set_item_slot(id, item);
     }
     /// Set the item to the corresponding slot.
-    pub fn set_item_slot(&mut self, id: ItemId, item: ItemByVal) {
-        match item {
+    pub fn set_item_slot(&mut self, id: ItemId, item: impl Into<ItemByVal>) {
+        match item.into() {
             ItemByVal::Type(decl) => self.type_decls.set_slot(*id.as_type().unwrap(), decl),
             ItemByVal::Fun(decl) => self.fun_decls.set_slot(*id.as_fun().unwrap(), decl),
             ItemByVal::Global(decl) => self.global_decls.set_slot(*id.as_global().unwrap(), decl),

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -254,6 +254,12 @@ impl TranslatedCrate {
         }
     }
     pub fn remove_item(&mut self, trans_id: ItemId) -> Option<ItemByVal> {
+        self.short_names.swap_remove(&trans_id);
+        self.item_names.swap_remove(&trans_id);
+        self.remove_item_temporarily(trans_id)
+    }
+    /// Remove the item without touching the name maps.
+    pub fn remove_item_temporarily(&mut self, trans_id: ItemId) -> Option<ItemByVal> {
         match trans_id {
             ItemId::Type(id) => self.type_decls.remove(id).map(ItemByVal::Type),
             ItemId::Fun(id) => self.fun_decls.remove(id).map(ItemByVal::Fun),
@@ -262,6 +268,13 @@ impl TranslatedCrate {
             ItemId::TraitImpl(id) => self.trait_impls.remove(id).map(ItemByVal::TraitImpl),
         }
     }
+    /// Set the item to the corresponding slot, and record its name in the name map.
+    pub fn set_new_item_slot(&mut self, id: ItemId, item: ItemByVal) {
+        self.item_names
+            .insert(id, item.as_ref().item_meta().name.clone());
+        self.set_item_slot(id, item);
+    }
+    /// Set the item to the corresponding slot.
     pub fn set_item_slot(&mut self, id: ItemId, item: ItemByVal) {
         match item {
             ItemByVal::Type(decl) => self.type_decls.set_slot(*id.as_type().unwrap(), decl),
@@ -350,7 +363,7 @@ impl<'ctx> ItemRef<'ctx> {
         }
     }
 
-    pub fn to_item_by_val(&self) -> ItemByVal {
+    pub fn to_owned(&self) -> ItemByVal {
         match *self {
             Self::Type(d) => ItemByVal::Type(d.clone()),
             Self::Fun(d) => ItemByVal::Fun(d.clone()),

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use derive_generic_visitor::{ControlFlow, Drive, DriveMut};
 use index_vec::Idx;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_state::{DeserializeState, SerializeState};
 
@@ -158,7 +159,11 @@ pub enum DeclarationGroup {
 
 pub type DeclarationsGroups = Vec<DeclarationGroup>;
 
-#[derive(Default, Clone, Drive, DriveMut, Serialize, Deserialize)]
+/// A target triple, e.g. `x86_64-unknown-linux-gnu`.
+pub type TargetTriple = String;
+
+#[derive(Clone, Drive, DriveMut, SerializeState, DeserializeState)]
+#[serde_state(stateless)]
 pub struct TargetInfo {
     /// The pointer size of the target in bytes.
     pub target_pointer_size: types::ByteCount,
@@ -181,10 +186,11 @@ pub struct TranslatedCrate {
     #[serde_state(stateless)]
     pub options: crate::options::CliOpts,
 
-    /// Information about the target platform for which rustc is called on for the crate.
+    /// Information about each target platform. When translating a crate normally this will have a
+    /// single entry; when using `--targets` this will have one entry per chosen target.
     #[drive(skip)]
-    #[serde_state(stateless)]
-    pub target_information: TargetInfo,
+    #[serde(with = "SeqHashMapToArray::<TargetTriple, TargetInfo>")]
+    pub target_information: SeqHashMap<TargetTriple, TargetInfo>,
 
     /// The names of all registered items. Available so we can know the names even of items that
     /// failed to translate.
@@ -299,6 +305,16 @@ impl TranslatedCrate {
     }
     pub fn all_items_with_ids(&self) -> impl Iterator<Item = (ItemId, ItemRef<'_>)> {
         self.all_items().map(|item| (item.id(), item))
+    }
+
+    /// When translating without `--target`, there's only one target information; this method
+    /// retrieves it.
+    pub fn the_target_information(&self) -> &TargetInfo {
+        self.target_information
+            .values()
+            .exactly_one()
+            .ok()
+            .expect("called `the_target_information` on a multi-target crate")
     }
 }
 

--- a/charon/src/ast/llbc_ast.rs
+++ b/charon/src/ast/llbc_ast.rs
@@ -17,6 +17,8 @@ generate_index_type!(StatementId);
 /// A raw statement: a statement without meta data.
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     EnumIsA,
     EnumToGetters,
@@ -85,7 +87,7 @@ pub enum StatementKind {
     Error(String),
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Statement {
     pub span: Span,
     /// Integer uniquely identifying this statement among the statmeents in the current body. To
@@ -99,7 +101,16 @@ pub struct Statement {
     pub comments_before: Vec<String>,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+/// Ignores statement ids.
+impl PartialEq for Statement {
+    fn eq(&self, other: &Self) -> bool {
+        self.span == other.span
+            && self.kind == other.kind
+            && self.comments_before == other.comments_before
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Block {
     pub span: Span,
@@ -108,6 +119,8 @@ pub struct Block {
 
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     EnumIsA,
     EnumToGetters,

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -24,6 +24,7 @@ generate_index_type!(FileId);
     Drive,
     DriveMut,
 )]
+#[drive(skip)]
 pub struct Loc {
     /// The (1-based) line number.
     pub line: usize,
@@ -59,7 +60,6 @@ pub struct SpanData {
     Drive,
     DriveMut,
 )]
-#[drive(skip)]
 #[serde_state(stateless)]
 pub struct Span {
     /// The source code span.

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -143,7 +143,7 @@ pub struct RawAttribute {
 }
 
 /// Information about the attributes and visibility of an item, field or variant..
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Serialize, Deserialize, Drive, DriveMut)]
 pub struct AttrInfo {
     /// Attributes (`#[...]`).
     pub attributes: Vec<Attribute>,
@@ -210,7 +210,7 @@ pub enum ItemOpacity {
 }
 
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[serde_state(stateless)]
 pub struct ItemMeta {
     #[serde_state(stateful)]

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -12,6 +12,7 @@ generate_index_type!(Disambiguator);
     Clone,
     PartialEq,
     Eq,
+    Hash,
     SerializeState,
     DeserializeState,
     Drive,
@@ -40,7 +41,7 @@ pub enum PathElem {
 ///   impl<T> PartialEq for List<T> { ...}
 ///   ```
 /// We distinguish the two.
-#[derive(Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::variants_prefix("ImplElem")]
 pub enum ImplElem {
     Ty(Box<Binder<Ty>>),
@@ -83,7 +84,7 @@ pub enum ImplElem {
 ///
 /// Also note that the first path element in the name is always the crate name.
 #[derive(
-    Debug, Default, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut,
+    Debug, Default, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut,
 )]
 #[serde(transparent)]
 pub struct Name {

--- a/charon/src/ast/names.rs
+++ b/charon/src/ast/names.rs
@@ -29,6 +29,9 @@ pub enum PathElem {
     /// the parameters of the new items. If the binder binds nothing then this is a
     /// monomorphization.
     Instantiated(Box<Binder<GenericArgs>>),
+    /// This item is only available on the given target. Only appears in multi-target mode.
+    #[serde_state(stateless)]
+    Target(#[drive(skip)] TargetTriple),
 }
 
 /// There are two kinds of `impl` blocks:

--- a/charon/src/ast/names_utils.rs
+++ b/charon/src/ast/names_utils.rs
@@ -43,6 +43,19 @@ impl Name {
         self.name.last()?.as_monomorphized()
     }
 
+    /// Strip the trailing `PathElem::Target` from a name, if any.
+    pub fn strip_target_suffix(&self) -> Option<(Name, TargetTriple)> {
+        match self.name.last() {
+            Some(PathElem::Target(target)) => {
+                let target = target.clone();
+                let mut base = self.clone();
+                base.name.pop();
+                Some((base, target))
+            }
+            _ => None,
+        }
+    }
+
     /// Compare the name to a constant array.
     /// This ignores disambiguators.
     ///

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -1,4 +1,5 @@
 use crate::ast::*;
+use crate::common::serialize_map_to_array::SeqHashMapToArray;
 use crate::ids::{IndexMap, IndexVec};
 use derive_generic_visitor::*;
 use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
@@ -401,7 +402,20 @@ pub struct DiscriminantLayout {
 /// Does not include information about niches.
 /// If the type does not have a fully known layout (e.g. it is ?Sized)
 /// some of the layout parts are not available.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
+#[serde_state(stateless)]
 pub struct Layout {
     /// The size of the type in bytes.
     #[drive(skip)]
@@ -504,10 +518,10 @@ pub struct TypeDecl {
     pub src: ItemSource,
     /// The type kind: enum, struct, or opaque.
     pub kind: TypeDeclKind,
-    /// The layout of the type. Information may be partial because of generics or dynamically-
-    /// sized types. If rustc cannot compute a layout, it is `None`.
-    #[serde_state(stateless)]
-    pub layout: Option<Layout>,
+    /// The layout of the type for each target. Information may be partial because of generics or
+    /// dynamically-sized types. If we cannot compute a layout, the target has no entry.
+    #[serde(with = "SeqHashMapToArray::<TargetTriple, Layout>")]
+    pub layout: SeqHashMap<TargetTriple, Layout>,
     /// The metadata associated with a pointer to the type.
     pub ptr_metadata: PtrMetadata,
     /// The representation options of this type declaration as annotated by the user.

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -509,7 +509,6 @@ pub struct ReprOptions {
 #[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[serde_state(state_implements = HashConsSerializerState)]
 pub struct TypeDecl {
-    #[drive(skip)]
     pub def_id: TypeDeclId,
     /// Meta information associated with the item.
     pub item_meta: ItemMeta,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -492,7 +492,8 @@ pub struct ReprOptions {
 ///
 /// A type can only be an ADT (structure or enumeration), as type aliases are
 /// inlined in MIR.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[serde_state(state_implements = HashConsSerializerState)]
 pub struct TypeDecl {
     #[drive(skip)]
     pub def_id: TypeDeclId,
@@ -520,7 +521,16 @@ generate_index_type!(VariantId, "Variant");
 generate_index_type!(FieldId, "Field");
 
 #[derive(
-    Debug, Clone, EnumIsA, EnumAsGetters, SerializeState, DeserializeState, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    EnumAsGetters,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub enum TypeDeclKind {
     Struct(IndexVec<FieldId, Field>),
@@ -540,7 +550,7 @@ pub enum TypeDeclKind {
     Error(String),
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[serde_state(stateless)]
 pub struct Variant {
     pub span: Span,
@@ -557,7 +567,7 @@ pub struct Variant {
     pub discriminant: Literal,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[serde_state(stateless)]
 pub struct Field {
     pub span: Span,

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -334,19 +334,21 @@ impl<T: AstVisitable> Binder<Binder<T>> {
             types_outlive,
             trait_type_constraints,
         } = &inner_params;
-        outer_params.regions.extend_from_slice(regions);
-        outer_params.types.extend_from_slice(types);
+        outer_params.regions.clone_extend_from_other(regions);
+        outer_params.types.clone_extend_from_other(types);
         outer_params
             .const_generics
-            .extend_from_slice(const_generics);
-        outer_params.trait_clauses.extend_from_slice(trait_clauses);
+            .clone_extend_from_other(const_generics);
+        outer_params
+            .trait_clauses
+            .clone_extend_from_other(trait_clauses);
         outer_params
             .regions_outlive
             .extend_from_slice(regions_outlive);
         outer_params.types_outlive.extend_from_slice(types_outlive);
         outer_params
             .trait_type_constraints
-            .extend_from_slice(trait_type_constraints);
+            .clone_extend_from_other(trait_type_constraints);
 
         Binder {
             params: outer_params,
@@ -498,10 +500,10 @@ impl GenericArgs {
             const_generics,
             trait_refs,
         } = other;
-        self.regions.extend_from_slice(regions);
-        self.types.extend_from_slice(types);
-        self.const_generics.extend_from_slice(const_generics);
-        self.trait_refs.extend_from_slice(trait_refs);
+        self.regions.clone_extend_from_other(regions);
+        self.types.clone_extend_from_other(types);
+        self.const_generics.clone_extend_from_other(const_generics);
+        self.trait_refs.clone_extend_from_other(trait_refs);
         self
     }
 }

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1435,8 +1435,12 @@ impl TypeDecl {
     ///
     /// If the `tag` does not correspond to any valid discriminant but there is a niche,
     /// the resulting `VariantId` will be for the untagged variant [`TagEncoding::Niche::untagged_variant`].
-    pub fn get_variant_from_tag(&self, tag: ScalarValue) -> Option<VariantId> {
-        let layout = self.layout.as_ref()?;
+    pub fn get_variant_from_tag(
+        &self,
+        target: &TargetTriple,
+        tag: ScalarValue,
+    ) -> Option<VariantId> {
+        let layout = self.layout.get(target)?;
         if layout.uninhabited {
             return None;
         };

--- a/charon/src/ast/ullbc_ast.rs
+++ b/charon/src/ast/ullbc_ast.rs
@@ -19,6 +19,8 @@ pub type ExprBody = GExprBody<BodyContents>;
 /// A raw statement: a statement without meta data.
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     EnumIsA,
     EnumAsGetters,
@@ -62,7 +64,7 @@ pub enum StatementKind {
     Nop,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Statement {
     pub span: Span,
     pub kind: StatementKind,
@@ -74,6 +76,8 @@ pub struct Statement {
 
 #[derive(
     Debug,
+    PartialEq,
+    Eq,
     Clone,
     EnumIsA,
     EnumAsGetters,
@@ -96,7 +100,16 @@ pub enum SwitchTargets {
 
 /// A raw terminator: a terminator without meta data.
 #[derive(
-    Debug, Clone, EnumIsA, EnumAsGetters, SerializeState, DeserializeState, Drive, DriveMut,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumIsA,
+    EnumAsGetters,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub enum TerminatorKind {
     Goto {
@@ -138,7 +151,7 @@ pub enum TerminatorKind {
     UnwindResume,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Terminator {
     pub span: Span,
     pub kind: TerminatorKind,
@@ -148,7 +161,7 @@ pub struct Terminator {
     pub comments_before: Vec<String>,
 }
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
 #[charon::rename("Block")]
 pub struct BlockData {
     pub statements: Vec<Statement>,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -3,14 +3,15 @@
 //! everywhere in the ast.
 //!
 //! The crate defines two traits:
-/// - `AstVisitable` is a trait implemented by all the types that can be visited by this;
-/// - `VisitAst[Mut]` is a (pair of) visitor trait(s) that can be implemented by visitors.
-///   To define a visitor, implement `VisitAst[Mut]` and override the methods you need. Calling
-///   `x.drive[_mut](&mut visitor)` will then traverse `x`, calling the visitor methods on all the
-///   subvalues encountered.
-///
-/// Underneath it all, this uses `derive_generic_visitor::Drive[Mut]` to do the actual visiting.
-use std::{any::Any, collections::HashMap};
+//! - `AstVisitable` is a trait implemented by all the types that can be visited by this;
+//! - `VisitAst[Mut]` is a (pair of) visitor trait(s) that can be implemented by visitors.
+//!   To define a visitor, implement `VisitAst[Mut]` and override the methods you need. Calling
+//!   `x.drive[_mut](&mut visitor)` will then traverse `x`, calling the visitor methods on all the
+//!   subvalues encountered.
+//!
+//! Underneath it all, this uses `derive_generic_visitor::Drive[Mut]` to do the actual visiting.
+use std::mem;
+use std::{any::Any, hash::Hash};
 
 use crate::ast::*;
 use crate::ids::{Idx, IndexVec};
@@ -47,13 +48,13 @@ use derive_generic_visitor::*;
         Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
         FnOperand, FunId, FnPtrKind, FunSig, ImplElem, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
-        Locals, NullOp, Operand, PathElem, PlaceKind, ProjectionElem, ConstantExprKind,
+        Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ProjectionElem, ConstantExprKind,
         RefKind, RegionId, RegionParam, ScalarValue, TraitItemName,
         TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypeVarId, llbc_ast::StatementId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
         ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
         UnOp, UnsizingMetadata, Local, Variant, VariantId, LocalId, CopyNonOverlapping, Layout, VariantLayout, PtrMetadata,
-        TraitAssocTy, TraitAssocConst, TraitMethod, TraitAssocTyImpl,
+        SpanData, TraitAssocTy, TraitAssocConst, TraitMethod, TraitAssocTyImpl,
         ItemByVal, VTableField,
         for<Id: AstVisitable> DeclRef<Id>, ItemId,
         for<T: AstVisitable> Box<T>,
@@ -79,7 +80,7 @@ use derive_generic_visitor::*;
         llbc_block: llbc_ast::Block, llbc_statement: llbc_ast::Statement,
         ullbc_statement: ullbc_ast::Statement, ullbc_terminator: ullbc_ast::Terminator,
         AggregateKind, FnPtr, ItemSource, ItemMeta, Name, Span, ConstantExpr,
-        FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId,
+        FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId, FileId,
         FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
     )
 )]
@@ -98,33 +99,20 @@ pub trait AstVisitable: Any {
     }
 }
 
-/// Manual impl that only visits the values
-impl<K: Any, T: AstVisitable> AstVisitable for HashMap<K, T> {
+/// Manual impl that visits the keys and values
+impl<K: AstVisitable + Hash + Eq, T: AstVisitable> AstVisitable for SeqHashMap<K, T> {
     fn drive<V: VisitAst>(&self, v: &mut V) -> ControlFlow<V::Break> {
-        for x in self.values() {
+        for (k, x) in self {
+            v.visit(k)?;
             v.visit(x)?;
         }
         Continue(())
     }
     fn drive_mut<V: VisitAstMut>(&mut self, v: &mut V) -> ControlFlow<V::Break> {
-        for x in self.values_mut() {
-            v.visit(x)?;
-        }
-        Continue(())
-    }
-}
-
-/// Manual impl that only visits the values
-impl<K: Any, T: AstVisitable> AstVisitable for SeqHashMap<K, T> {
-    fn drive<V: VisitAst>(&self, v: &mut V) -> ControlFlow<V::Break> {
-        for x in self.values() {
-            v.visit(x)?;
-        }
-        Continue(())
-    }
-    fn drive_mut<V: VisitAstMut>(&mut self, v: &mut V) -> ControlFlow<V::Break> {
-        for x in self.values_mut() {
-            v.visit(x)?;
+        for (mut k, mut x) in mem::take(self) {
+            v.visit(&mut k)?;
+            v.visit(&mut x)?;
+            self.insert(k, x);
         }
         Continue(())
     }

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -46,9 +46,9 @@ use derive_generic_visitor::*;
         AbortKind, Assert, BinOp, BorrowKind, BuiltinAssertKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy,
         Call, CastKind, ClosureInfo, ClosureKind, ConstGenericParam, ConstGenericVarId,
         Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
-        FnOperand, FunId, FnPtrKind, FunSig, ImplElem, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
+        FnOperand, FunId, FnPtrKind, FunSig, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
-        Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ProjectionElem, ConstantExprKind,
+        Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ConstantExprKind,
         RefKind, RegionId, RegionParam, ScalarValue, TraitItemName,
         TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypeVarId, llbc_ast::StatementId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
@@ -72,14 +72,14 @@ use derive_generic_visitor::*;
     // type but can be overridden.
     override(
         DeBruijnId, Ty, TyKind, Region, TraitRef, TraitRefContents, TraitRefKind,
-        TypeDeclRef, FunDeclRef, TraitMethodRef, GlobalDeclRef, TraitDeclRef, TraitImplRef,
+        TypeDeclRef, FunDeclRef, TraitMethodRef, GlobalDeclRef, TraitDeclRef, TraitImplRef, ImplElem,
         GenericArgs, GenericParams, TraitParam, TraitClauseId, TraitTypeConstraint, Place, Rvalue, Body,
         for<T: AstVisitable + Idx> DeBruijnVar<T>,
         for<T: AstVisitable> RegionBinder<T>,
         for<T: AstVisitable> Binder<T>,
         llbc_block: llbc_ast::Block, llbc_statement: llbc_ast::Statement,
         ullbc_statement: ullbc_ast::Statement, ullbc_terminator: ullbc_ast::Terminator,
-        AggregateKind, FnPtr, ItemSource, ItemMeta, Name, Span, ConstantExpr,
+        AggregateKind, FnPtr, ItemSource, ItemMeta, Name, Span, ConstantExpr, ProjectionElem,
         FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId, FileId,
         FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
     )

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -117,6 +117,23 @@ impl<K: AstVisitable + Hash + Eq, T: AstVisitable> AstVisitable for SeqHashMap<K
         Continue(())
     }
 }
+impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMap<K, T> {
+    fn drive_body<V: VisitBody>(&self, v: &mut V) -> ControlFlow<V::Break> {
+        for (k, x) in self {
+            v.visit(k)?;
+            v.visit(x)?;
+        }
+        Continue(())
+    }
+    fn drive_body_mut<V: VisitBodyMut>(&mut self, v: &mut V) -> ControlFlow<V::Break> {
+        for (mut k, mut x) in mem::take(self) {
+            v.visit(&mut k)?;
+            v.visit(&mut x)?;
+            self.insert(k, x);
+        }
+        Continue(())
+    }
+}
 
 /// A smaller visitor group just for function bodies. This explores statements, places and
 /// operands, but does not recurse into types.
@@ -137,7 +154,7 @@ impl<K: AstVisitable + Hash + Eq, T: AstVisitable> AstVisitable for SeqHashMap<K
     // Types that are ignored when encountered.
     skip(
         AbortKind, BinOp, BorrowKind, BuiltinAssertKind, ConstantExpr, FieldId, FieldProjKind,
-        TypeDeclRef, FunDeclId, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
+        TypeDeclRef, FunDeclId, FunDeclRef, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId,
         TraitRef, LiteralTy, Literal, RegionId, (), String, bool,
     ),

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -47,7 +47,7 @@ use derive_generic_visitor::*;
         Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
         FnOperand, FunId, FnPtrKind, FunSig, ImplElem, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
-        Locals, Name, NullOp, Operand, PathElem, PlaceKind, ProjectionElem, ConstantExprKind,
+        Locals, NullOp, Operand, PathElem, PlaceKind, ProjectionElem, ConstantExprKind,
         RefKind, RegionId, RegionParam, ScalarValue, TraitItemName,
         TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypeVarId, llbc_ast::StatementId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
@@ -78,7 +78,7 @@ use derive_generic_visitor::*;
         for<T: AstVisitable> Binder<T>,
         llbc_block: llbc_ast::Block, llbc_statement: llbc_ast::Statement,
         ullbc_statement: ullbc_ast::Statement, ullbc_terminator: ullbc_ast::Terminator,
-        AggregateKind, FnPtr, ItemSource, ItemMeta, Span, ConstantExpr,
+        AggregateKind, FnPtr, ItemSource, ItemMeta, Name, Span, ConstantExpr,
         FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId,
         FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
     )

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -39,7 +39,7 @@ use derive_generic_visitor::*;
     visitor(drive(&VisitAst)),
     visitor(drive_mut(&mut VisitAstMut)),
     // Types that we ignore.
-    skip(()),
+    skip((), String, bool),
     // Types that we unconditionally explore.
     drive(
         AbortKind, Assert, BinOp, BorrowKind, BuiltinAssertKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy,
@@ -151,7 +151,7 @@ impl<K: Any, T: AstVisitable> AstVisitable for SeqHashMap<K, T> {
         AbortKind, BinOp, BorrowKind, BuiltinAssertKind, ConstantExpr, FieldId, FieldProjKind,
         TypeDeclRef, FunDeclId, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId,
-        TraitRef, LiteralTy, Literal, RegionId, ()
+        TraitRef, LiteralTy, Literal, RegionId, (), String, bool,
     ),
     // Types that we unconditionally explore.
     drive(

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -2,7 +2,8 @@
 use crate::CharonFailure;
 use crate::translate::translate_crate;
 use charon_lib::common::arg_value;
-use charon_lib::options::CliOpts;
+use charon_lib::errors::ErrorCtx;
+use charon_lib::options::{self, CliOpts};
 use charon_lib::transform::TransformCtx;
 use itertools::Itertools;
 use rustc_driver::{Callbacks, Compilation};
@@ -88,7 +89,7 @@ fn setup_compiler(config: &mut Config, options: &CliOpts, do_translate: bool) {
 /// Run the rustc driver with our custom hooks. Returns `None` if the crate was not compiled with
 /// charon (e.g. because it was a dependency). Otherwise returns the translated crate, ready for
 /// post-processing transformations.
-pub fn run_rustc_driver(options: &CliOpts) -> Result<Option<TransformCtx>, CharonFailure> {
+pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailure> {
     // Retreive the command-line arguments pased to `charon_driver`. The first arg is the path to
     // the current executable, we skip it.
     let mut compiler_args: Vec<String> = env::args().skip(1).collect();
@@ -117,22 +118,45 @@ pub fn run_rustc_driver(options: &CliOpts) -> Result<Option<TransformCtx>, Charo
     let output = if !is_selected_crate {
         trace!("Skipping charon; running compiler normally instead.");
         // Run the compiler normally.
-        run_compiler_with_callbacks(compiler_args, &mut RunCompilerNormallyCallbacks { options })?;
+        run_compiler_with_callbacks(compiler_args, &mut RunCompilerNormallyCallbacks)?;
         None
     } else {
+        let mut error_ctx = ErrorCtx::new();
+
+        // Retrieve the Charon options by deserializing them from the environment variable
+        // (cargo-charon serialized the arguments and stored them in a specific environment
+        // variable before calling cargo with RUSTC_WRAPPER=charon-driver).
+        let mut options: options::CliOpts = match env::var(options::CHARON_ARGS) {
+            Ok(opts) => serde_json::from_str(opts.as_str()).unwrap(),
+            Err(_) => {
+                register_error!(
+                    error_ctx,
+                    no_crate,
+                    "environment variable `CHARON_ARGS` not set; \
+                    don't call `charon-driver` directly, call `charon rustc` instead"
+                );
+                return Err(CharonFailure::CharonError(1));
+            }
+        };
+        options.apply_preset();
+
+        error_ctx.continue_on_failure = !options.abort_on_error;
+        error_ctx.error_on_warnings = options.error_on_warnings;
+
         for extra_flag in options.rustc_args.iter().cloned() {
             compiler_args.push(extra_flag);
         }
 
         // Call the Rust compiler with our custom callback.
         let mut callback = CharonCallbacks {
-            options,
+            options: &options,
+            error_ctx: Some(error_ctx),
             transform_ctx: None,
         };
         run_compiler_with_callbacks(compiler_args, &mut callback)?;
         // If `transform_ctx` is not set here, there was a fatal error.
         let ctx = callback.transform_ctx.ok_or(CharonFailure::RustcError)?;
-        Some(ctx)
+        Some((ctx, options))
     };
     Ok(output)
 }
@@ -140,6 +164,8 @@ pub fn run_rustc_driver(options: &CliOpts) -> Result<Option<TransformCtx>, Charo
 /// The callbacks for Charon
 pub struct CharonCallbacks<'a> {
     options: &'a CliOpts,
+    /// Context for errors; `take()`n by translation.
+    error_ctx: Option<ErrorCtx>,
     /// This is to be filled during the extraction; it contains the translated crate. `None` at the
     /// start or if we couldn't translate anything.
     transform_ctx: Option<TransformCtx>,
@@ -159,8 +185,9 @@ impl<'a> Callbacks for CharonCallbacks<'a> {
             .swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
 
         self.transform_ctx = translate_crate::translate(
-            self.options,
             tcx,
+            self.options,
+            self.error_ctx.take().unwrap(),
             compiler.sess.opts.sysroot.path().to_owned(),
         )
         .ok();
@@ -174,12 +201,11 @@ impl<'a> Callbacks for CharonCallbacks<'a> {
 }
 
 /// Dummy callbacks used to run the compiler normally when we shouldn't be analyzing the crate.
-pub struct RunCompilerNormallyCallbacks<'a> {
-    options: &'a CliOpts,
-}
-impl<'a> Callbacks for RunCompilerNormallyCallbacks<'a> {
+pub struct RunCompilerNormallyCallbacks;
+
+impl Callbacks for RunCompilerNormallyCallbacks {
     fn config(&mut self, config: &mut Config) {
-        setup_compiler(config, self.options, false);
+        setup_compiler(config, &Default::default(), false);
     }
 }
 

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -36,13 +36,13 @@ mod translate;
 
 use charon_lib::{
     export, logger,
-    options::{self, CliOpts},
+    options::CliOpts,
     transform::{
         FINAL_CLEANUP_PASSES, INITIAL_CLEANUP_PASSES, LLBC_PASSES, Pass, PrintCtxPass,
         SHARED_FINALIZING_PASSES, ULLBC_PASSES,
     },
 };
-use std::{env, fmt, panic};
+use std::{fmt, panic};
 
 pub enum CharonFailure {
     /// The usize is the number of errors.
@@ -112,9 +112,9 @@ pub fn transformation_passes(options: &CliOpts) -> Vec<Pass> {
 }
 
 /// Run charon. Returns the number of warnings generated.
-fn run_charon(options: CliOpts) -> Result<usize, CharonFailure> {
+fn run_charon() -> Result<usize, CharonFailure> {
     // Run the driver machinery.
-    let Some(mut ctx) = driver::run_rustc_driver(&options)? else {
+    let Some((mut ctx, options)) = driver::run_rustc_driver()? else {
         // We didn't run charon.
         return Ok(0);
     };
@@ -158,17 +158,8 @@ fn main() {
     // Initialize the logger
     logger::initialize_logger();
 
-    // Retrieve the Charon options by deserializing them from the environment variable
-    // (cargo-charon serialized the arguments and stored them in a specific environment
-    // variable before calling cargo with RUSTC_WRAPPER=charon-driver).
-    let mut options: options::CliOpts = match env::var(options::CHARON_ARGS) {
-        Ok(opts) => serde_json::from_str(opts.as_str()).unwrap(),
-        Err(_) => Default::default(),
-    };
-    options.apply_preset();
-
     // Catch any and all panics coming from charon to display a clear error.
-    let res = panic::catch_unwind(move || run_charon(options))
+    let res = panic::catch_unwind(run_charon)
         .map_err(|_| CharonFailure::Panic)
         .and_then(|x| x);
 

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -130,19 +130,9 @@ fn run_charon() -> Result<usize, CharonFailure> {
 
     // # Final step: generate the files.
     if !options.no_serialize {
-        let crate_data = export::CrateData::new(ctx);
-        let dest_file = match options.dest_file.clone() {
-            Some(f) => f,
-            None => {
-                let mut target_filename = options.dest_dir.clone().unwrap_or_default();
-                let crate_name = &crate_data.translated.crate_name;
-                let extension = if options.ullbc { "ullbc" } else { "llbc" };
-                target_filename.push(format!("{crate_name}.{extension}"));
-                target_filename
-            }
-        };
+        let dest_file = options.target_filename(&ctx.translated.crate_name);
         trace!("Target file: {:?}", dest_file);
-        crate_data
+        export::CrateData::new(ctx)
             .serialize_to_file(&dest_file)
             .map_err(|()| CharonFailure::Serialize)?;
     }

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -399,7 +399,7 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
 
         let tcx = self.hax_state.base().tcx;
         let local_decls = self.local_decls;
-        let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
+        let ptr_size = self.translated.the_target_information().target_pointer_size;
 
         let mut place_ty: mir::PlaceTy = mir::Place::from(mir_place.local).ty(local_decls, tcx);
         let var_id = self.translate_local(&mir_place.local).unwrap();
@@ -826,7 +826,7 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
                     .iter()
                     .map(|op| self.translate_operand(span, op))
                     .try_collect()?;
-                let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
+                let ptr_size = self.translated.the_target_information().target_pointer_size;
 
                 match aggregate_kind {
                     mir::AggregateKind::Array(ty) => {

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -685,13 +685,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     }
 }
 
-#[tracing::instrument(skip(tcx))]
+#[tracing::instrument(skip(tcx, error_ctx))]
 pub fn translate<'tcx>(
-    cli_options: &CliOpts,
     tcx: TyCtxt<'tcx>,
+    cli_options: &CliOpts,
+    mut error_ctx: ErrorCtx,
     sysroot: PathBuf,
 ) -> Result<TransformCtx, Error> {
-    let mut error_ctx = ErrorCtx::new(!cli_options.abort_on_error, cli_options.error_on_warnings);
     let translate_options = TranslateOptions::new(&mut error_ctx, cli_options);
 
     let hax_state = hax::state::State::new(

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -339,10 +339,12 @@ impl<'tcx> TranslateCtx<'tcx> {
 
     pub(crate) fn register_target_info(&mut self) {
         let target_data = &self.tcx.data_layout;
-        self.translated.target_information = krate::TargetInfo {
+        let triple = self.tcx.sess.opts.target_triple.tuple().to_owned();
+        let info = krate::TargetInfo {
             target_pointer_size: target_data.pointer_size().bytes(),
             is_little_endian: matches!(target_data.endian, rustc_abi::Endian::Little),
-        }
+        };
+        self.translated.target_information.insert(triple, info);
     }
 }
 

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -339,7 +339,7 @@ impl<'tcx> TranslateCtx<'tcx> {
 
     pub(crate) fn register_target_info(&mut self) {
         let target_data = &self.tcx.data_layout;
-        let triple = self.tcx.sess.opts.target_triple.tuple().to_owned();
+        let triple = self.get_target_triple();
         let info = krate::TargetInfo {
             target_pointer_size: target_data.pointer_size().bytes(),
             is_little_endian: matches!(target_data.endian, rustc_abi::Endian::Little),

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -146,6 +146,10 @@ impl<'tcx> TranslateCtx<'tcx> {
             .span_err(&self.translated, span, msg, level)
     }
 
+    pub fn get_target_triple(&self) -> TargetTriple {
+        self.tcx.sess.opts.target_triple.tuple().to_owned()
+    }
+
     /// Translates `T` into `U` using `hax`'s `SInto` trait, catching any hax panics.
     pub fn catch_sinto<S, T, U>(&mut self, s: &S, span: Span, x: &T) -> Result<U, Error>
     where

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -504,7 +504,11 @@ impl ItemTransCtx<'_, '_> {
             Ok(kind) => kind,
             Err(err) => TypeDeclKind::Error(err.msg),
         };
-        let layout = self.translate_layout(def.this());
+        let layout = self
+            .translate_layout(def.this())
+            .into_iter()
+            .map(|l| (self.get_target_triple(), l))
+            .collect();
         let ptr_metadata = self.translate_ptr_metadata(span, def.this())?;
         let type_def = TypeDecl {
             def_id: trans_id,

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -582,7 +582,7 @@ impl ItemTransCtx<'_, '_> {
                 .map(|_| None)
                 .collect();
         let (mut kind, layout) = if item_meta.opacity.with_private_contents().is_opaque() {
-            (TypeDeclKind::Opaque, None)
+            (TypeDeclKind::Opaque, SeqHashMap::default())
         } else {
             // First construct fields that use the real method signatures (which may use the `Self`
             // type). We fixup the types and generics below.
@@ -590,7 +590,7 @@ impl ItemTransCtx<'_, '_> {
             let fields = self.gen_vtable_struct_fields(span, &self_trait_ref, &vtable_data)?;
 
             let kind = TypeDeclKind::Struct(fields);
-            let layout = self.generate_naive_layout(span, &kind)?;
+            let l = self.generate_naive_layout(span, &kind)?;
             supertrait_map = vtable_data.supertrait_map;
             field_map = vtable_data.fields.map_ref(|tr_field| match *tr_field {
                 TrVTableField::Size => VTableField::Size,
@@ -599,7 +599,8 @@ impl ItemTransCtx<'_, '_> {
                 TrVTableField::Method(name, ..) => VTableField::Method(name),
                 TrVTableField::SuperTrait(clause_id, ..) => VTableField::SuperTrait(clause_id),
             });
-            (kind, Some(layout))
+            let layout = [(self.get_target_triple(), l)].into();
+            (kind, layout)
         };
 
         let mut generics = Default::default();

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -565,7 +565,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     .as_ref()
                     .expect("No discriminant layout for enum?")
                     .tag_ty;
-                let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
+                let ptr_size = self.translated.the_target_information().target_pointer_size;
                 let tag_size = r_abi::Size::from_bytes(tag_ty.target_size(ptr_size));
 
                 for (id, variant_layout) in variants.iter_enumerated() {
@@ -622,7 +622,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             TypeDeclKind::Struct(fields) => {
                 let mut size = 0;
                 let mut align = 0;
-                let ptr_size = self.t_ctx.translated.target_information.target_pointer_size;
+                let ptr_size = self.translated.the_target_information().target_pointer_size;
                 let field_offsets = fields.map_ref(|field| {
                     let offset = size;
                     let size_of_ty = match field.ty.kind() {

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -29,14 +29,16 @@
 //! them in a specific environment variable, so that charon-driver can
 //! deserialize them later and use them to guide the extraction in the
 //! callbacks.
-use anyhow::Result;
+use anyhow::{Context, Result};
 use charon_lib::{
     common::arg_value,
+    export::{CrateData, multi_target},
     logger,
     options::{CHARON_ARGS, CliOpts},
 };
 use clap::Parser;
 use cli::{Charon, Cli};
+use itertools::Itertools;
 use std::{env, process::ExitStatus};
 use toolchain::toolchain_path;
 
@@ -59,11 +61,32 @@ pub fn main() -> Result<()> {
             println!("{krate}");
             ExitStatus::default()
         }
-        Charon::Cargo(subcmd_cargo) => translate_with_cargo(subcmd_cargo.opts, subcmd_cargo.cargo)?,
+        Charon::Cargo(subcmd_cargo) => {
+            let mut options = subcmd_cargo.opts;
+            let targets = std::mem::take(&mut options.targets);
+            if targets.is_empty() {
+                translate_with_cargo(options, subcmd_cargo.cargo)?
+            } else {
+                translate_multi_target(targets, options, |opts: CliOpts, target: &str| {
+                    let mut cargo_args = subcmd_cargo.cargo.clone();
+                    cargo_args.extend(["--target".to_owned(), target.to_owned()]);
+                    translate_with_cargo(opts, cargo_args)
+                })?
+            }
+        }
         Charon::Rustc(mut subcmd_rustc) => {
             let mut options = subcmd_rustc.opts;
             options.rustc_args.append(&mut subcmd_rustc.rustc);
-            translate_without_cargo(options)?
+            let targets = std::mem::take(&mut options.targets);
+            if targets.is_empty() {
+                translate_without_cargo(options)?
+            } else {
+                translate_multi_target(targets, options, |mut opts: CliOpts, target: &str| {
+                    opts.rustc_args
+                        .extend(["--target".to_owned(), target.to_owned()]);
+                    translate_without_cargo(opts)
+                })?
+            }
         }
         Charon::ToolchainPath(_) => {
             let path = toolchain_path()?;
@@ -77,6 +100,73 @@ pub fn main() -> Result<()> {
     };
 
     handle_exit_status(exit_status)
+}
+
+/// Run translation once per target (in parallel), then merge the results.
+fn translate_multi_target(
+    targets: Vec<String>,
+    options: CliOpts,
+    translate_one: impl Fn(CliOpts, &str) -> anyhow::Result<ExitStatus> + Sync,
+) -> anyhow::Result<ExitStatus> {
+    let temp_dir = tempfile::tempdir().context("failed to create temp dir")?;
+
+    // Translate each target in its own thread.
+    let krates: Vec<_> = std::thread::scope(|scope| {
+        let options = &options;
+        let translate_one = &translate_one;
+        let temp_dir = temp_dir.path();
+        let handles: Vec<_> = targets
+            .iter()
+            .enumerate()
+            .map(|(i, target)| {
+                scope.spawn(move || -> anyhow::Result<_> {
+                    let mut opts = options.clone();
+                    let temp_file = temp_dir.join(format!("target_{i}.json"));
+                    opts.dest_file = Some(temp_file.clone());
+                    // Don't recurse into multi-target.
+                    opts.targets.clear();
+                    // Suppress per-target printing; we'll print the merged result.
+                    opts.print_ullbc = false;
+                    opts.print_llbc = false;
+                    // Ensure serialization so we can load the result.
+                    opts.no_serialize = false;
+
+                    let status = translate_one(opts, target)?;
+                    if !status.success() {
+                        eprintln!("translation for target {target} failed with status {status}");
+                        handle_exit_status(status)?;
+                    }
+
+                    let krate =
+                        CrateData::deserialize_from_file(&temp_file).with_context(|| {
+                            format!("failed to load translation result for target {target}")
+                        })?;
+                    Ok(krate)
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("target translation thread panicked"))
+            .try_collect()
+    })?;
+
+    // Merge all crates.
+    let merged = multi_target::merge(options.clone(), krates);
+
+    if options.print_llbc || options.print_ullbc {
+        println!("{}", merged.translated);
+    }
+
+    // Serialize the merged result unless --no-serialize was passed.
+    if !options.no_serialize {
+        let target_filename = options.target_filename(&merged.translated.crate_name);
+        merged
+            .serialize_to_file(&target_filename)
+            .map_err(|()| anyhow::anyhow!("failed to serialize merged crate"))?;
+    }
+
+    Ok(ExitStatus::default())
 }
 
 fn translate_with_cargo(

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -28,6 +28,7 @@ fn repr_name(_crate_data: &TranslatedCrate, n: &Name) -> String {
             PathElem::Ident(i, _) => i.clone(),
             PathElem::Impl(..) => "<impl>".to_string(),
             PathElem::Instantiated(..) => "<mono>".to_string(),
+            PathElem::Target(target) => target.clone(),
         })
         .join("::")
 }

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -222,6 +222,11 @@ fn type_to_ocaml_call(ctx: &GenerateCtx, ty: &Ty) -> String {
                     if first == "ustr" {
                         first = "string".to_string();
                     }
+                    if first == "index_map" {
+                        // That's the `indexmap::IndexMap` case. Pass something dummy for the
+                        // `RandomState` parameter.
+                        expr[2] = "int_of_json".to_string();
+                    }
                     expr.insert(0, first + "_of_json");
                 }
                 TypeId::Builtin(BuiltinTy::Box) => expr.insert(0, "box_of_json".to_owned()),
@@ -298,9 +303,14 @@ fn type_to_ocaml_name(ctx: &GenerateCtx, ty: &Ty) -> String {
                     if base_ty == "ustr" {
                         base_ty = "string".to_string();
                     }
-                    if base_ty == "index_map" || base_ty == "index_vec" {
+                    if base_ty == "indexed_map" || base_ty == "index_vec" {
                         base_ty = "list".to_string();
                         args.remove(0); // Remove the index generic param
+                    }
+                    if base_ty == "index_map" {
+                        // That's the `indexmap::IndexMap` case. Translate as a list of pairs.
+                        base_ty = "list".to_string();
+                        args = vec![format!("( {} * {} )", args[0], args[1])]
                     }
                     let args = match args.as_slice() {
                         [] => String::new(),
@@ -1068,11 +1078,12 @@ fn generate_ml(
         ),
     ];
     let manual_json_impls = &[
+        // Hand-written because we interpret it as a list.
         (
             "charon_lib::ids::index_vec::IndexVec",
             "list_of_json arg1_of_json ctx json",
         ),
-        // Hand-written because we filter out `None` values.
+        // Hand-written because we interpret it as a list.
         (
             "charon_lib::ids::index_map::IndexMap",
             indoc!(
@@ -1081,6 +1092,11 @@ fn generate_ml(
                 Ok (List.filter_map (fun x -> x) list)
                 "#
             ),
+        ),
+        // Hand-written because we turn it into a list of pairs.
+        (
+            "indexmap::map::IndexMap",
+            "list_of_json (key_value_pair_of_json arg0_of_json arg1_of_json) ctx json",
         ),
         // Hand-written because we replace the `FileId` with the corresponding file name.
         (
@@ -1137,7 +1153,8 @@ fn generate_ml(
 
     // Compute type sets for json deserializers.
     let (gast_types, llbc_types, ullbc_types) = {
-        let all_types: HashSet<_> = ctx.children_of("TranslatedCrate");
+        let mut all_types: HashSet<_> = ctx.children_of("TranslatedCrate");
+        all_types.insert(ctx.id_from_name("indexmap::map::IndexMap")); // Add this one foreign type
 
         // (u)llbc types are those that are dominated by the entrypoint of the corresponding
         // module, i.e. those that can't be reached if you remove these entrypoints.

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -285,7 +285,7 @@ pub mod serialize_map_to_array {
             Ok(map)
         }
         /// Deserializes from an array of named key-values.
-        pub fn deserialize_state<'de, D, State>(
+        pub fn deserialize_state<'de, D, State: ?Sized>(
             state: &State,
             deserializer: D,
         ) -> Result<SeqHashMap<K, V, U>, D::Error>
@@ -295,9 +295,12 @@ pub mod serialize_map_to_array {
             U: BuildHasher + Default,
             D: Deserializer<'de>,
         {
-            struct SeqHashMapToArrayVisitor<'a, State, K, V, U>(&'a State, PhantomData<(K, V, U)>);
+            struct SeqHashMapToArrayVisitor<'a, State: ?Sized, K, V, U>(
+                &'a State,
+                PhantomData<(K, V, U)>,
+            );
 
-            impl<'de, State, K, V, U> Visitor<'de> for SeqHashMapToArrayVisitor<'_, State, K, V, U>
+            impl<'de, State: ?Sized, K, V, U> Visitor<'de> for SeqHashMapToArrayVisitor<'_, State, K, V, U>
             where
                 K: DeserializeState<'de, State> + Eq + Hash,
                 V: DeserializeState<'de, State>,

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -34,7 +34,7 @@ pub use register_error;
 #[macro_export]
 macro_rules! raise_error {
     ($($tokens:tt)*) => {{
-        return Err(register_error!($($tokens)*))?;
+        return Err(register_error!($($tokens)*));
     }};
 }
 pub use raise_error;

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -19,6 +19,10 @@ macro_rules! register_error {
         let msg = format!($($fmt)*);
         $ctx.span_err($krate, $span, &msg, $crate::errors::Level::WARNING)
     }};
+    ($ctx:expr, no_crate, $($fmt:tt)*) => {{
+        let msg = format!($($fmt)*);
+        $ctx.span_err(&Default::default(), Default::default(), &msg, $crate::errors::Level::WARNING)
+    }};
     ($ctx:expr, $span: expr, $($fmt:tt)*) => {{
         let msg = format!($($fmt)*);
         $ctx.span_err($span, &msg, $crate::errors::Level::WARNING)
@@ -30,7 +34,7 @@ pub use register_error;
 #[macro_export]
 macro_rules! raise_error {
     ($($tokens:tt)*) => {{
-        return Err(register_error!($($tokens)*));
+        return Err(register_error!($($tokens)*))?;
     }};
 }
 pub use raise_error;
@@ -215,10 +219,10 @@ pub struct ErrorCtx {
 }
 
 impl ErrorCtx {
-    pub fn new(continue_on_failure: bool, error_on_warnings: bool) -> Self {
+    pub fn new() -> Self {
         Self {
-            continue_on_failure,
-            error_on_warnings,
+            continue_on_failure: true,
+            error_on_warnings: false,
             external_decls_with_errors: HashSet::new(),
             external_dep_graph: DepGraph::new(),
             def_id: None,

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -77,7 +77,7 @@ macro_rules! sanity_check {
 pub use sanity_check;
 
 /// Common error used during the translation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Error {
     pub span: Span,
     pub msg: String,

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -1,3 +1,5 @@
+pub mod multi_target;
+
 use crate::ast::*;
 use crate::transform::TransformCtx;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -119,5 +121,22 @@ impl CrateData {
             info!("Generated the file: {}", target_filename.to_str().unwrap());
         }
         Ok(())
+    }
+
+    pub fn deserialize_from_file(path: &std::path::Path) -> anyhow::Result<Self> {
+        use crate::export::CrateData;
+        use anyhow::Context;
+        use serde::Deserialize;
+        use std::fs::File;
+        use std::io::BufReader;
+        let file = File::open(path)
+            .with_context(|| format!("Failed to read llbc file {}", path.display()))?;
+        let reader = BufReader::new(file);
+        let mut deserializer = serde_json::Deserializer::from_reader(reader);
+        // Deserialize without recursion limit.
+        deserializer.disable_recursion_limit();
+        // Grow stack space as needed.
+        let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+        Ok(CrateData::deserialize(deserializer)?)
     }
 }

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -22,7 +22,7 @@ pub fn merge(options: CliOpts, krates: Vec<CrateData>) -> CrateData {
 
     let mut merged = CrateMerger::process(options, krates);
 
-    ItemDeduplicator::dedup(&mut merged.translated);
+    ItemDeduplicator::dedup(&mut merged.translated, &mut error_ctx);
 
     // Recompute declaration order on the merged crate.
     let mut ctx = TransformCtx {
@@ -196,8 +196,6 @@ generate_index_type!(TargetGroupId, "TargetGroup");
 /// A set of items that share the same base name and item kind.
 /// These are candidates for merging into a single cross-target item.
 struct TargetGroup {
-    name: Name,
-    kind: std::mem::Discriminant<ItemId>,
     ids: SeqHashMap<TargetTriple, ItemId>,
 }
 
@@ -221,7 +219,7 @@ impl TargetGroup {
 
     /// Whether this group is a group of function items.
     fn is_function_group(&self) -> bool {
-        self.kind == std::mem::discriminant(&ItemId::Fun(FunDeclId::from_raw(0)))
+        self.canonical_id().is_fun()
     }
 
     /// Compare the items of this group under the provided id mapping.
@@ -231,17 +229,25 @@ impl TargetGroup {
         remap: &HashMap<ItemId, ItemId>,
     ) -> MergeDecision {
         let canonical_id = self.canonical_id();
-        let items = self
+        let items: Vec<Option<ItemByVal>> = self
             .ids
             .values()
-            .filter_map(|&id| {
-                let item = krate.get_item(id)?.to_owned();
-                Some(normalize_item(item, canonical_id, remap))
+            .map(|&id| {
+                krate
+                    .get_item(id)
+                    .map(|item| normalize_item(item.to_owned(), canonical_id, remap))
             })
             .collect_vec();
-        if items.len() != self.ids.len() {
-            return MergeDecision::Skip;
+
+        // Items that don't exist in the crate can't be compared; if they're all missing we can
+        // still merge them tho.
+        if items.iter().all(|i| i.is_none()) {
+            return MergeDecision::Dedup;
         }
+        let items: Vec<_> = match items.into_iter().collect::<Option<Vec<_>>>() {
+            Some(items) => items,
+            None => return MergeDecision::Skip,
+        };
 
         if items.iter().all_equal() {
             MergeDecision::Dedup
@@ -261,6 +267,10 @@ impl TargetGroup {
     /// Yields `(non_canonical_id, canonical_id)` pairs for building an ID remap.
     fn remap_entries<'a>(&'a self) -> impl Iterator<Item = (ItemId, ItemId)> + 'a {
         self.ids.values().map(|&id| (id, self.canonical_id()))
+    }
+    fn into_remap_entries(self) -> impl Iterator<Item = (ItemId, ItemId)> {
+        let canonical_id = self.canonical_id();
+        self.ids.into_values().map(move |id| (id, canonical_id))
     }
 
     /// Build a façade `FunDecl` for a group of functions with matching signatures but different
@@ -282,7 +292,8 @@ impl TargetGroup {
             .collect();
 
         let mut item_meta = canonical.item_meta.clone();
-        item_meta.name = self.name.clone();
+        // Remove the target suffix (and do a little sanity check).
+        item_meta.name.name.pop().unwrap().as_target().unwrap();
 
         FunDecl {
             def_id,
@@ -296,6 +307,36 @@ impl TargetGroup {
     }
 }
 
+/// Normalize a name for grouping across targets; returns the target.
+fn normalize_name_for_grouping(
+    name: &Name,
+    krate: &TranslatedCrate,
+) -> Option<(Name, TargetTriple)> {
+    let (mut name, target) = name.strip_target_suffix()?;
+    for elem in &mut name.name {
+        if let PathElem::Impl(ImplElem::Trait(id)) = elem {
+            // Replace ipl block references with something that contains the implemented trait
+            // predicate instead. That way, comparing names for equality compares trait predicates
+            // instead.
+            if let Some(timpl) = krate.trait_impls.get(*id) {
+                let mut params = GenericParams::default();
+                params.trait_clauses.push(TraitParam {
+                    clause_id: TraitClauseId::ZERO,
+                    span: None,
+                    origin: PredicateOrigin::WhereClauseOnImpl,
+                    trait_: RegionBinder::empty(timpl.impl_trait.clone()),
+                });
+                *elem = PathElem::Impl(ImplElem::Ty(Box::new(Binder {
+                    params,
+                    skip_binder: Ty::mk_unit(),
+                    kind: BinderKind::Other,
+                })));
+            }
+        }
+    }
+    Some((name, target))
+}
+
 /// Orchestrates deduplication of items across compilation targets.
 struct ItemDeduplicator<'a> {
     krate: &'a mut TranslatedCrate,
@@ -304,8 +345,8 @@ struct ItemDeduplicator<'a> {
 
 impl<'a> ItemDeduplicator<'a> {
     /// Entrypoint: deduplicate items that are the same across targets.
-    pub fn dedup(krate: &'a mut TranslatedCrate) {
-        let groups = Self::discover_groups(krate);
+    pub fn dedup(krate: &'a mut TranslatedCrate, errors: &mut ErrorCtx) {
+        let groups = Self::discover_groups(krate, errors);
         if groups.is_empty() {
             return;
         }
@@ -315,33 +356,64 @@ impl<'a> ItemDeduplicator<'a> {
     }
 
     /// Group items by (base_name, item_kind), keeping only groups that have items in all targets.
-    fn discover_groups(krate: &TranslatedCrate) -> IndexVec<TargetGroupId, TargetGroup> {
+    fn discover_groups(
+        krate: &TranslatedCrate,
+        _errors: &mut ErrorCtx,
+    ) -> IndexVec<TargetGroupId, TargetGroup> {
         let num_targets = krate.target_information.len();
-        let mut groups: HashMap<
+        let mut groups_map: SeqHashMap<
             (Name, std::mem::Discriminant<ItemId>),
             SeqHashMap<TargetTriple, ItemId>,
-        > = HashMap::new();
+        > = SeqHashMap::new();
         for (&item_id, name) in &krate.item_names {
-            if let Some((base_name, target)) = name.strip_target_suffix() {
+            if let Some((base_name, target)) = normalize_name_for_grouping(name, krate) {
                 let key = (base_name, std::mem::discriminant(&item_id));
-                let per_target = groups.entry(key).or_default();
+                let per_target = groups_map.entry(key).or_default();
                 if per_target.contains_key(&target) {
-                    // Name collision within the same target — skip this group entirely.
+                    // Name collision within the same target: skip this group entirely.
                     per_target.clear();
                 } else {
                     per_target.insert(target, item_id);
                 }
             }
         }
+        // We do a fixpoint: merging a group may lead to detecting that some names are actually the
+        // same (because the names refer to impls/types).
+        loop {
+            let prev_len = groups_map.len();
+            let remap: HashMap<ItemId, ItemId> = groups_map
+                .values()
+                .cloned()
+                .map(|ids| TargetGroup { ids })
+                .flat_map(|g| g.into_remap_entries())
+                .filter(|(x, y)| x != y)
+                .collect();
+            for ((mut name, kind), ids) in mem::take(&mut groups_map) {
+                name.drive_mut(&mut IdRefMapperVisitor::new(&remap));
+                let key = (name, kind);
+                let per_target = groups_map.entry(key).or_default();
+                for (target, item_id) in ids {
+                    if per_target.contains_key(&target) {
+                        // Name collision within the same target: skip this group entirely.
+                        per_target.clear();
+                        break;
+                    } else {
+                        per_target.insert(target, item_id);
+                    }
+                }
+            }
+            groups_map.retain(|_, v| v.len() == num_targets);
+            if prev_len == groups_map.len() {
+                break;
+            }
+        }
+        let groups: IndexVec<TargetGroupId, TargetGroup> = groups_map
+            .values()
+            .filter(|&per_target| per_target.len() == num_targets)
+            .cloned()
+            .map(|ids| TargetGroup { ids })
+            .collect();
         groups
-            .into_iter()
-            .filter(|(_, per_target)| per_target.len() == num_targets)
-            .map(|((base_name, item_kind), per_target)| TargetGroup {
-                name: base_name,
-                kind: item_kind,
-                ids: per_target,
-            })
-            .collect()
     }
 
     /// Decide how to merge each group. Skipped groups are not included in the output.
@@ -426,11 +498,13 @@ impl<'a> ItemDeduplicator<'a> {
         let group = &self.groups[idx];
         let canonical = group.canonical_id();
 
-        // Rename the canonical copy (strip target suffix).
-        self.krate.item_names.insert(canonical, group.name.clone());
+        // Remove the target suffix (and do a little sanity check).
+        let mut name = self.krate.item_names.get(&canonical).cloned().unwrap();
+        name.name.pop().unwrap().as_target().unwrap();
         if let Some(mut canonical_item) = self.krate.get_item_mut(canonical) {
-            canonical_item.item_meta().name = group.name.clone();
+            canonical_item.item_meta().name = name.clone();
         }
+        self.krate.item_names.insert(canonical, name);
 
         // Merge per-target layouts into the canonical type.
         if let ItemId::Type(canonical_type_id) = canonical {
@@ -517,11 +591,6 @@ impl VisitAstMut for IdRefMapperVisitor<'_> {
     fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
         self.map(&mut x.id);
     }
-    fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
-        if let FnPtrKind::Fun(FunId::Regular(id)) = &mut *x.kind {
-            self.map(id);
-        }
-    }
     fn enter_global_decl_ref(&mut self, x: &mut GlobalDeclRef) {
         self.map(&mut x.id);
     }
@@ -530,5 +599,41 @@ impl VisitAstMut for IdRefMapperVisitor<'_> {
     }
     fn enter_trait_impl_ref(&mut self, x: &mut TraitImplRef) {
         self.map(&mut x.id);
+    }
+
+    fn enter_projection_elem(&mut self, x: &mut ProjectionElem) {
+        if let ProjectionElem::Field(proj, _) = x
+            && let FieldProjKind::Adt(id, _) = proj
+        {
+            self.map(id);
+        }
+    }
+    fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
+        match &mut *x.kind {
+            FnPtrKind::Fun(FunId::Regular(id)) => self.map(id),
+            FnPtrKind::Trait(_, _, id) => self.map(id),
+            _ => {}
+        }
+    }
+    fn enter_trait_method_ref(&mut self, x: &mut TraitMethodRef) {
+        self.map(&mut x.method_decl_id);
+    }
+    fn enter_item_source(&mut self, x: &mut ItemSource) {
+        if let ItemSource::VTableMethodPreShim(id, _, _) = x {
+            self.map(id);
+        }
+    }
+    fn enter_global_decl(&mut self, x: &mut GlobalDecl) {
+        self.map(&mut x.init);
+    }
+    fn enter_fun_decl(&mut self, x: &mut FunDecl) {
+        if let Some(id) = &mut x.is_global_initializer {
+            self.map(id);
+        }
+    }
+    fn enter_impl_elem(&mut self, x: &mut ImplElem) {
+        if let ImplElem::Trait(id) = x {
+            self.map(id);
+        }
     }
 }

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -1,0 +1,179 @@
+//! Merging multiple [`CrateData`]s from different compilation targets into one.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+use crate::errors::ErrorCtx;
+use crate::ids::IndexVec;
+use crate::options::TranslateOptions;
+use crate::transform::TransformCtx;
+use crate::transform::ctx::TransformPass;
+use crate::{ast::*, options::CliOpts};
+
+use super::{CharonVersion, CrateData};
+
+/// Merge per-target [`CrateData`]s into a single [`CrateData`].
+pub fn merge(options: CliOpts, krates: Vec<CrateData>) -> CrateData {
+    let mut error_ctx = ErrorCtx::new();
+    let tr_options = TranslateOptions::new(&mut error_ctx, &options);
+
+    let mut merged = CrateMerger::process(options, krates);
+
+    // Recompute declaration order on the merged crate.
+    let mut ctx = TransformCtx {
+        options: tr_options,
+        translated: merged.translated,
+        errors: RefCell::new(error_ctx),
+    };
+    crate::transform::add_missing_info::reorder_decls::Transform.transform_ctx(&mut ctx);
+    merged.translated = ctx.translated;
+
+    merged
+}
+
+struct CrateMerger {
+    merged: CrateData,
+    file_name_to_id: HashMap<FileName, FileId>,
+}
+
+impl CrateMerger {
+    fn process(options: CliOpts, krates: Vec<CrateData>) -> CrateData {
+        let mut translated = TranslatedCrate::default();
+        translated.options = options;
+        let mut merger = CrateMerger {
+            merged: CrateData {
+                charon_version: CharonVersion(crate::VERSION.to_owned()),
+                translated,
+                has_errors: false,
+            },
+            file_name_to_id: HashMap::new(),
+        };
+        for krate in krates {
+            merger.add_one(krate);
+        }
+
+        merger.merged
+    }
+
+    fn add_one(&mut self, krate: CrateData) {
+        let CrateData {
+            charon_version: _, // Checked by deserialization already
+            translated: mut krate,
+            has_errors,
+        } = krate;
+        self.merged.has_errors |= has_errors;
+        let target = krate
+            .target_information
+            .keys()
+            .exactly_one()
+            .ok()
+            .unwrap()
+            .clone();
+
+        // Remap all ids inside `krate`.
+        krate.drive_mut(&mut {
+            let file_id_map = krate.files.map_ref(|file| {
+                if let Some(&existing_id) = self.file_name_to_id.get(&file.name) {
+                    existing_id
+                } else {
+                    let new_id = self.merged.translated.files.push(file.clone());
+                    self.file_name_to_id.insert(file.name.clone(), new_id);
+                    new_id
+                }
+            });
+            RemapIdsVisitor {
+                target,
+                file_id_map,
+                type_offset: self.merged.translated.type_decls.slot_count(),
+                fun_offset: self.merged.translated.fun_decls.slot_count(),
+                global_offset: self.merged.translated.global_decls.slot_count(),
+                trait_decl_offset: self.merged.translated.trait_decls.slot_count(),
+                trait_impl_offset: self.merged.translated.trait_impls.slot_count(),
+            }
+        });
+
+        let TranslatedCrate {
+            crate_name,
+            options: _, // We discard the per-target options we made
+            target_information,
+            item_names,
+            short_names: _, // TODO
+            files: _,       // Done above
+            type_decls,
+            fun_decls,
+            global_decls,
+            trait_decls,
+            trait_impls,
+            unit_metadata,
+            ordered_decls: _, // Recomputed on the merged crate
+        } = krate;
+        if self.merged.translated.crate_name.is_empty() {
+            self.merged.translated.crate_name = crate_name;
+        }
+        self.merged
+            .translated
+            .target_information
+            .extend(target_information);
+        self.merged.translated.item_names.extend(item_names);
+        self.merged
+            .translated
+            .type_decls
+            .extend_from_other(type_decls);
+        self.merged
+            .translated
+            .fun_decls
+            .extend_from_other(fun_decls);
+        self.merged
+            .translated
+            .global_decls
+            .extend_from_other(global_decls);
+        self.merged
+            .translated
+            .trait_decls
+            .extend_from_other(trait_decls);
+        self.merged
+            .translated
+            .trait_impls
+            .extend_from_other(trait_impls);
+        if self.merged.translated.unit_metadata.is_none() {
+            self.merged.translated.unit_metadata = unit_metadata;
+        }
+    }
+}
+
+#[derive(Visitor)]
+struct RemapIdsVisitor {
+    target: TargetTriple,
+    file_id_map: IndexVec<FileId, FileId>,
+    type_offset: usize,
+    fun_offset: usize,
+    global_offset: usize,
+    trait_decl_offset: usize,
+    trait_impl_offset: usize,
+}
+
+impl VisitAstMut for RemapIdsVisitor {
+    fn enter_file_id(&mut self, id: &mut FileId) {
+        *id = self.file_id_map[*id];
+    }
+    fn enter_type_decl_id(&mut self, id: &mut TypeDeclId) {
+        *id += self.type_offset;
+    }
+    fn enter_fun_decl_id(&mut self, id: &mut FunDeclId) {
+        *id += self.fun_offset;
+    }
+    fn enter_global_decl_id(&mut self, id: &mut GlobalDeclId) {
+        *id += self.global_offset;
+    }
+    fn enter_trait_decl_id(&mut self, id: &mut TraitDeclId) {
+        *id += self.trait_decl_offset;
+    }
+    fn enter_trait_impl_id(&mut self, id: &mut TraitImplId) {
+        *id += self.trait_impl_offset;
+    }
+    fn enter_name(&mut self, name: &mut Name) {
+        name.name.push(PathElem::Target(self.target.clone()));
+    }
+}

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -1,7 +1,8 @@
 //! Merging multiple [`CrateData`]s from different compilation targets into one.
-
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::mem;
 
 use itertools::Itertools;
 
@@ -21,6 +22,8 @@ pub fn merge(options: CliOpts, krates: Vec<CrateData>) -> CrateData {
 
     let mut merged = CrateMerger::process(options, krates);
 
+    ItemDeduplicator::dedup(&mut merged.translated);
+
     // Recompute declaration order on the merged crate.
     let mut ctx = TransformCtx {
         options: tr_options,
@@ -32,6 +35,10 @@ pub fn merge(options: CliOpts, krates: Vec<CrateData>) -> CrateData {
 
     merged
 }
+
+// =============================================================================================
+// Step 1: Merge a set of crates into one, remembering the source target in the names.
+// =============================================================================================
 
 struct CrateMerger {
     merged: CrateData,
@@ -83,6 +90,42 @@ impl CrateMerger {
                     new_id
                 }
             });
+
+            #[derive(Visitor)]
+            struct RemapIdsVisitor {
+                target: TargetTriple,
+                file_id_map: IndexVec<FileId, FileId>,
+                type_offset: usize,
+                fun_offset: usize,
+                global_offset: usize,
+                trait_decl_offset: usize,
+                trait_impl_offset: usize,
+            }
+
+            impl VisitAstMut for RemapIdsVisitor {
+                fn enter_file_id(&mut self, id: &mut FileId) {
+                    *id = self.file_id_map[*id];
+                }
+                fn enter_type_decl_id(&mut self, id: &mut TypeDeclId) {
+                    *id += self.type_offset;
+                }
+                fn enter_fun_decl_id(&mut self, id: &mut FunDeclId) {
+                    *id += self.fun_offset;
+                }
+                fn enter_global_decl_id(&mut self, id: &mut GlobalDeclId) {
+                    *id += self.global_offset;
+                }
+                fn enter_trait_decl_id(&mut self, id: &mut TraitDeclId) {
+                    *id += self.trait_decl_offset;
+                }
+                fn enter_trait_impl_id(&mut self, id: &mut TraitImplId) {
+                    *id += self.trait_impl_offset;
+                }
+                fn enter_name(&mut self, name: &mut Name) {
+                    name.name.push(PathElem::Target(self.target.clone()));
+                }
+            }
+
             RemapIdsVisitor {
                 target,
                 file_id_map,
@@ -143,37 +186,349 @@ impl CrateMerger {
     }
 }
 
-#[derive(Visitor)]
-struct RemapIdsVisitor {
-    target: TargetTriple,
-    file_id_map: IndexVec<FileId, FileId>,
-    type_offset: usize,
-    fun_offset: usize,
-    global_offset: usize,
-    trait_decl_offset: usize,
-    trait_impl_offset: usize,
+// =============================================================================================
+// Step 2: Deduplicates items that don't differ across targets and create façades for
+// target-dependent functions
+// =============================================================================================
+
+generate_index_type!(TargetGroupId, "TargetGroup");
+
+/// A set of items that share the same base name and item kind.
+/// These are candidates for merging into a single cross-target item.
+struct TargetGroup {
+    name: Name,
+    kind: std::mem::Discriminant<ItemId>,
+    ids: SeqHashMap<TargetTriple, ItemId>,
 }
 
-impl VisitAstMut for RemapIdsVisitor {
-    fn enter_file_id(&mut self, id: &mut FileId) {
-        *id = self.file_id_map[*id];
+/// How a `TargetGroup` should be merged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergeDecision {
+    /// Don't merge this group.
+    Skip,
+    /// All the items are the same; merge them into one.
+    Dedup,
+    /// Function signatures match but bodies diffe; create a façade that dispatches to the
+    /// per-target items.
+    Facade,
+}
+
+impl TargetGroup {
+    /// Deterministically chosen representative id.
+    fn canonical_id(&self) -> ItemId {
+        self.ids.values().next().copied().unwrap()
     }
-    fn enter_type_decl_id(&mut self, id: &mut TypeDeclId) {
-        *id += self.type_offset;
+
+    /// Whether this group is a group of function items.
+    fn is_function_group(&self) -> bool {
+        self.kind == std::mem::discriminant(&ItemId::Fun(FunDeclId::from_raw(0)))
     }
-    fn enter_fun_decl_id(&mut self, id: &mut FunDeclId) {
-        *id += self.fun_offset;
+
+    /// Compare the items of this group under the provided id mapping.
+    fn decide_merge(
+        &self,
+        krate: &TranslatedCrate,
+        remap: &HashMap<ItemId, ItemId>,
+    ) -> MergeDecision {
+        let canonical_id = self.canonical_id();
+        let items = self
+            .ids
+            .values()
+            .filter_map(|&id| {
+                let item = krate.get_item(id)?.to_owned();
+                Some(normalize_item(item, canonical_id, remap))
+            })
+            .collect_vec();
+        if items.len() != self.ids.len() {
+            return MergeDecision::Skip;
+        }
+
+        if items.iter().all_equal() {
+            MergeDecision::Dedup
+        } else if self.is_function_group()
+            && items
+                .iter()
+                .map(|item| item.as_fun().unwrap())
+                .map(|d| (&d.generics, &d.signature))
+                .all_equal()
+        {
+            MergeDecision::Facade
+        } else {
+            MergeDecision::Skip
+        }
     }
-    fn enter_global_decl_id(&mut self, id: &mut GlobalDeclId) {
-        *id += self.global_offset;
+
+    /// Yields `(non_canonical_id, canonical_id)` pairs for building an ID remap.
+    fn remap_entries<'a>(&'a self) -> impl Iterator<Item = (ItemId, ItemId)> + 'a {
+        self.ids.values().map(|&id| (id, self.canonical_id()))
     }
-    fn enter_trait_decl_id(&mut self, id: &mut TraitDeclId) {
-        *id += self.trait_decl_offset;
+
+    /// Build a façade `FunDecl` for a group of functions with matching signatures but different
+    /// bodies. The `def_id` is set to a placeholder and must be fixed up on insertion.
+    fn build_facade_decl(&self, def_id: FunDeclId, krate: &TranslatedCrate) -> FunDecl {
+        let canonical_fun_id = *self.canonical_id().as_fun().unwrap();
+        let canonical = krate.fun_decls.get(canonical_fun_id).unwrap();
+
+        let dispatch_map = self
+            .ids
+            .iter()
+            .map(|(target, &id)| {
+                let fun_decl_ref = FunDeclRef {
+                    id: *id.as_fun().unwrap(),
+                    generics: Box::new(canonical.generics.identity_args()),
+                };
+                (target.clone(), fun_decl_ref)
+            })
+            .collect();
+
+        let mut item_meta = canonical.item_meta.clone();
+        item_meta.name = self.name.clone();
+
+        FunDecl {
+            def_id,
+            item_meta,
+            generics: canonical.generics.clone(),
+            signature: canonical.signature.clone(),
+            src: canonical.src.clone(),
+            is_global_initializer: canonical.is_global_initializer,
+            body: Body::TargetDispatch(dispatch_map),
+        }
     }
-    fn enter_trait_impl_id(&mut self, id: &mut TraitImplId) {
-        *id += self.trait_impl_offset;
+}
+
+/// Orchestrates deduplication of items across compilation targets.
+struct ItemDeduplicator<'a> {
+    krate: &'a mut TranslatedCrate,
+    groups: IndexVec<TargetGroupId, TargetGroup>,
+}
+
+impl<'a> ItemDeduplicator<'a> {
+    /// Entrypoint: deduplicate items that are the same across targets.
+    pub fn dedup(krate: &'a mut TranslatedCrate) {
+        let groups = Self::discover_groups(krate);
+        if groups.is_empty() {
+            return;
+        }
+        let mut this = Self { krate, groups };
+        let decisions = this.decide_group_mergings();
+        this.apply_merge_decisions(decisions);
     }
-    fn enter_name(&mut self, name: &mut Name) {
-        name.name.push(PathElem::Target(self.target.clone()));
+
+    /// Group items by (base_name, item_kind), keeping only groups that have items in all targets.
+    fn discover_groups(krate: &TranslatedCrate) -> IndexVec<TargetGroupId, TargetGroup> {
+        let num_targets = krate.target_information.len();
+        let mut groups: HashMap<
+            (Name, std::mem::Discriminant<ItemId>),
+            SeqHashMap<TargetTriple, ItemId>,
+        > = HashMap::new();
+        for (&item_id, name) in &krate.item_names {
+            if let Some((base_name, target)) = name.strip_target_suffix() {
+                let key = (base_name, std::mem::discriminant(&item_id));
+                let per_target = groups.entry(key).or_default();
+                if per_target.contains_key(&target) {
+                    // Name collision within the same target — skip this group entirely.
+                    per_target.clear();
+                } else {
+                    per_target.insert(target, item_id);
+                }
+            }
+        }
+        groups
+            .into_iter()
+            .filter(|(_, per_target)| per_target.len() == num_targets)
+            .map(|((base_name, item_kind), per_target)| TargetGroup {
+                name: base_name,
+                kind: item_kind,
+                ids: per_target,
+            })
+            .collect()
+    }
+
+    /// Decide how to merge each group. Skipped groups are not included in the output.
+    fn decide_group_mergings(&self) -> Vec<(TargetGroupId, MergeDecision)> {
+        // Start with all groups as candidates.
+        let mut candidates: Vec<(TargetGroupId, MergeDecision)> = self
+            .groups
+            .indices()
+            .map(|id| (id, MergeDecision::Skip))
+            .collect();
+
+        // Fixpoint: assume that all included groups are mapped to a single item; keep the groups
+        // that can be merged under such a mapping. Iterate until fixpoint.
+        loop {
+            let remap = self.build_remap(candidates.iter().map(|(id, _)| id));
+            let prev_len = candidates.len();
+            candidates.retain_mut(|(idx, decision)| {
+                *decision = self.groups[*idx].decide_merge(self.krate, &remap);
+                *decision != MergeDecision::Skip
+            });
+            if candidates.len() == prev_len {
+                break;
+            }
+        }
+
+        candidates
+    }
+
+    /// Build an id remap: for each candidate group, map non-canonical IDs → canonical ID.
+    fn build_remap<'b>(
+        &self,
+        candidate_indices: impl IntoIterator<Item = &'b TargetGroupId>,
+    ) -> HashMap<ItemId, ItemId> {
+        candidate_indices
+            .into_iter()
+            .flat_map(|&idx| self.groups[idx].remap_entries())
+            .filter(|(x, y)| x != y)
+            .collect()
+    }
+
+    fn apply_merge_decisions(&mut self, decisions: Vec<(TargetGroupId, MergeDecision)>) {
+        if decisions.is_empty() {
+            return;
+        }
+
+        let mut remap = HashMap::new();
+        let mut facade_decls: Vec<FunDecl> = Vec::new();
+        for &(idx, decision) in &decisions {
+            let mut group = &self.groups[idx];
+            let target_id = match decision {
+                MergeDecision::Skip => unreachable!(),
+                MergeDecision::Dedup => {
+                    self.dedup_group(idx); // takes mutable borrow; invalidates `group`
+                    group = &self.groups[idx];
+                    group.canonical_id()
+                }
+                MergeDecision::Facade => {
+                    let facade_id = self.krate.fun_decls.reserve_slot();
+                    // Insert facade decls later because the id remapping would mess up the
+                    // dispatch maps.
+                    facade_decls.push(group.build_facade_decl(facade_id, self.krate));
+                    ItemId::Fun(facade_id)
+                }
+            };
+            for &id in group.ids.values() {
+                if id != target_id {
+                    remap.insert(id, target_id);
+                }
+            }
+        }
+
+        // Remap all ids.
+        self.krate.drive_mut(&mut IdRefMapperVisitor::new(&remap));
+
+        for decl in facade_decls {
+            self.krate
+                .set_new_item_slot(ItemId::Fun(decl.def_id), ItemByVal::Fun(decl));
+        }
+    }
+
+    fn dedup_group(&mut self, idx: TargetGroupId) {
+        let group = &self.groups[idx];
+        let canonical = group.canonical_id();
+
+        // Rename the canonical copy (strip target suffix).
+        self.krate.item_names.insert(canonical, group.name.clone());
+        if let Some(mut canonical_item) = self.krate.get_item_mut(canonical) {
+            canonical_item.item_meta().name = group.name.clone();
+        }
+
+        // Merge per-target layouts into the canonical type.
+        if let ItemId::Type(canonical_type_id) = canonical {
+            let layouts = group
+                .ids
+                .values()
+                .map(|&id| *id.as_type().unwrap())
+                .flat_map(|id| {
+                    self.krate
+                        .type_decls
+                        .get_mut(id)
+                        .map(|tdecl| mem::take(&mut tdecl.layout))
+                        .into_iter()
+                        .flatten()
+                })
+                .collect();
+            if let Some(dest) = self.krate.type_decls.get_mut(canonical_type_id) {
+                dest.layout = layouts;
+            }
+        }
+
+        // Remove non-canonical copies.
+        for &id in group.ids.values() {
+            if id != canonical {
+                self.krate.remove_item(id);
+            }
+        }
+    }
+}
+
+// =============================================================================================
+// Utilities
+// =============================================================================================
+
+/// Normalize an item for cross-target comparison.
+fn normalize_item(
+    mut item: ItemByVal,
+    canonical_id: ItemId,
+    remap: &HashMap<ItemId, ItemId>,
+) -> ItemByVal {
+    item.as_mut().drive_mut(&mut IdRefMapperVisitor::new(remap));
+    item.as_mut().set_id(canonical_id);
+    item.as_mut()
+        .item_meta()
+        .name
+        .name
+        .retain(|elem| !matches!(elem, PathElem::Target(_)));
+    if let ItemByVal::Type(ty_decl) = &mut item {
+        // Layouts are allowed to differ per-target.
+        ty_decl.layout.clear();
+    }
+    item
+}
+
+/// Visitor that remaps references to the given items.
+#[derive(Visitor)]
+struct IdRefMapperVisitor<'a> {
+    map: &'a HashMap<ItemId, ItemId>,
+}
+
+impl<'a> IdRefMapperVisitor<'a> {
+    fn new(remap: &'a HashMap<ItemId, ItemId>) -> Self {
+        Self { map: remap }
+    }
+
+    fn map<Id>(&self, id: &mut Id)
+    where
+        Id: Copy,
+        Id: Into<ItemId>,
+        ItemId: TryInto<Id, Error: Debug>,
+    {
+        if let Some(&new) = self.map.get(&(*id).into()) {
+            *id = new.try_into().unwrap();
+        }
+    }
+}
+
+impl VisitAstMut for IdRefMapperVisitor<'_> {
+    fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
+        if let TypeId::Adt(id) = &mut x.id {
+            self.map(id);
+        }
+    }
+    fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
+        self.map(&mut x.id);
+    }
+    fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
+        if let FnPtrKind::Fun(FunId::Regular(id)) = &mut *x.kind {
+            self.map(id);
+        }
+    }
+    fn enter_global_decl_ref(&mut self, x: &mut GlobalDeclRef) {
+        self.map(&mut x.id);
+    }
+    fn enter_trait_decl_ref(&mut self, x: &mut TraitDeclRef) {
+        self.map(&mut x.id);
+    }
+    fn enter_trait_impl_ref(&mut self, x: &mut TraitImplRef) {
+        self.map(&mut x.id);
     }
 }

--- a/charon/src/ids/index_map.rs
+++ b/charon/src/ids/index_map.rs
@@ -18,6 +18,7 @@ use derive_generic_visitor::*;
 /// To prevent accidental id reuse, the vector supports reserving a slot to be filled later. Use
 /// `IndexVec` if this is not needed.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[charon::rename("IndexedMap")]
 pub struct IndexMap<I, T>
 where
     I: Idx,

--- a/charon/src/ids/index_map.rs
+++ b/charon/src/ids/index_map.rs
@@ -148,7 +148,11 @@ where
         self.push_all(it).for_each(|_| ())
     }
 
-    pub fn extend_from_slice(&mut self, other: &Self)
+    pub fn extend_from_other(&mut self, other: Self) {
+        self.vector.extend(other.vector);
+        self.elem_count += other.elem_count;
+    }
+    pub fn clone_extend_from_other(&mut self, other: &Self)
     where
         T: Clone,
     {

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -57,17 +57,5 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Read a `.llbc` file.
 pub fn deserialize_llbc(path: &std::path::Path) -> anyhow::Result<ast::TranslatedCrate> {
     use crate::export::CrateData;
-    use anyhow::Context;
-    use serde::Deserialize;
-    use std::fs::File;
-    use std::io::BufReader;
-    let file =
-        File::open(path).with_context(|| format!("Failed to read llbc file {}", path.display()))?;
-    let reader = BufReader::new(file);
-    let mut deserializer = serde_json::Deserializer::from_reader(reader);
-    // Deserialize without recursion limit.
-    deserializer.disable_recursion_limit();
-    // Grow stack space as needed.
-    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
-    Ok(CrateData::deserialize(deserializer)?.translated)
+    Ok(CrateData::deserialize_from_file(path)?.translated)
 }

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -59,6 +59,12 @@ pub struct CliOpts {
     #[clap(long = "rustc-arg")]
     #[serde(default)]
     pub rustc_args: Vec<String>,
+    /// A list of target architectures to translate for. Charon will run the compiler once for each
+    /// target and aggregate the results, which is useful if the code includes `#[cfg(..)]`
+    /// filters.
+    #[clap(long, value_delimiter = ',')]
+    #[serde(default)]
+    pub targets: Vec<String>,
 
     /// Monomorphize the items encountered when possible. Generic items found in the crate are
     /// skipped. To only translate a particular call graph, use `--start-from`. Note: this doesn't

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -62,6 +62,7 @@ pub struct CliOpts {
     /// A list of target architectures to translate for. Charon will run the compiler once for each
     /// target and aggregate the results, which is useful if the code includes `#[cfg(..)]`
     /// filters.
+    /// Warning: this is an initial implementation which is extremely slow.
     #[clap(long, value_delimiter = ',')]
     #[serde(default)]
     pub targets: Vec<String>,

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -415,6 +415,18 @@ impl CliOpts {
         }
         Ok(())
     }
+
+    pub fn target_filename(&self, crate_name: &str) -> PathBuf {
+        match self.dest_file.clone() {
+            Some(f) => f,
+            None => {
+                let mut target_filename = self.dest_dir.clone().unwrap_or_default();
+                let extension = if self.ullbc { "ullbc" } else { "llbc" };
+                target_filename.push(format!("{crate_name}.{extension}"));
+                target_filename
+            }
+        }
+    }
 }
 
 /// Predicates that determine wihch items to use as starting point for translation.

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -504,15 +504,10 @@ pub struct TranslateOptions {
 
 impl TranslateOptions {
     pub fn new(error_ctx: &mut ErrorCtx, options: &CliOpts) -> Self {
-        let mut parse_pattern = |s: &str| match NamePattern::parse(s) {
-            Ok(p) => Ok(p),
-            Err(e) => {
-                raise_error!(
-                    error_ctx,
-                    crate(&TranslatedCrate::default()),
-                    Span::dummy(),
-                    "failed to parse pattern `{s}` ({e})"
-                )
+        let mut parse_pattern = |s: &str| -> Result<_, Error> {
+            match NamePattern::parse(s) {
+                Ok(p) => Ok(p),
+                Err(e) => raise_error!(error_ctx, no_crate, "failed to parse pattern `{s}` ({e})"),
             }
         };
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1158,6 +1158,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for PathElem {
                     binder.skip_binder.fmt_explicits(ctx).format(", ")
                 )
             }
+            PathElem::Target(target) => write!(f, "{target}"),
         }
     }
 }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -254,6 +254,14 @@ impl<C: AstFormatter> FmtWithCtx<C> for gast::Body {
             Body::Opaque => write!(f, "= <opaque>"),
             Body::Missing => write!(f, "= <missing>"),
             Body::Error(error) => write!(f, "= error(\"{}\")", error.msg),
+            Body::TargetDispatch(targets) => {
+                writeln!(f, "= target_dispatch {{")?;
+                for (target, fun) in targets {
+                    let fun = fun.with_ctx(ctx);
+                    writeln!(f, "{tab}{TAB_INCR}{target} => {fun},")?;
+                }
+                write!(f, "{tab}}}")
+            }
         }
     }
 }

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -151,6 +151,9 @@ pub struct DepsForItem<'a> {
     ctx: &'a TransformCtx,
     deps: &'a mut Deps,
     current_id: ItemId,
+    // Each item countains its own id; we dont' want to count that as a self-reference. Hence the
+    // first time we see its own id, we skip.
+    seen_current_id: bool,
     // We use this to track the trait impl block the current item belongs to
     // (if relevant).
     //
@@ -208,6 +211,7 @@ impl Deps {
         let mut for_item = DepsForItem {
             ctx,
             deps: self,
+            seen_current_id: false,
             current_id,
             parent_trait_impl: None,
             parent_trait_decl: None,
@@ -238,6 +242,12 @@ impl DepsForItem<'_> {
     }
     fn insert_edge(&mut self, tgt: impl Into<ItemId>) {
         let tgt = tgt.into();
+        if tgt == self.current_id && !self.seen_current_id {
+            // Each item contains its own id; this is a hack to avoid considering that as a self
+            // loop.
+            self.seen_current_id = true;
+            return;
+        }
         self.insert_node(tgt);
         // Only add translated items.
         if self.ctx.translated.get_item(tgt).is_some() {
@@ -320,7 +330,7 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
             }
             ItemRef::Fun(d) => {
                 let FunDecl {
-                    def_id: _,
+                    def_id,
                     item_meta: _,
                     generics,
                     signature,
@@ -328,6 +338,7 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
                     is_global_initializer: _,
                     body,
                 } = d;
+                let _ = def_id.drive(&mut visitor); // For `seen_current_id`
                 // Skip `d.is_global_initializer` to avoid incorrect mutual dependencies.
                 // TODO: add `is_global_initializer` to `ItemSource`.
                 let _ = generics.drive(&mut visitor);
@@ -339,7 +350,7 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
             }
             ItemRef::TraitDecl(d) => {
                 let TraitDecl {
-                    def_id: _,
+                    def_id,
                     item_meta: _,
                     generics,
                     implied_clauses: parent_clauses,
@@ -348,6 +359,7 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
                     methods,
                     vtable,
                 } = d;
+                let _ = def_id.drive(&mut visitor); // For `seen_current_id`
                 // Visit the traits referenced in the generics
                 let _ = generics.drive(&mut visitor);
 

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -195,7 +195,7 @@ impl TransformCtx {
     /// each item before iterating over it. Items added during traversal will not be iterated over.
     pub fn for_each_item_mut(&mut self, mut f: impl for<'a> FnMut(&'a mut Self, ItemRefMut<'a>)) {
         for id in self.translated.all_ids() {
-            if let Some(mut decl) = self.translated.remove_item(id) {
+            if let Some(mut decl) = self.translated.remove_item_temporarily(id) {
                 f(self, decl.as_mut());
                 self.translated.set_item_slot(id, decl);
             }

--- a/charon/src/transform/normalize/partial_monomorphization.rs
+++ b/charon/src/transform/normalize/partial_monomorphization.rs
@@ -447,7 +447,7 @@ impl<'a> PartialMonomorphizer<'a> {
             .translated
             .get_item(*orig_id)
             .unwrap()
-            .to_item_by_val()
+            .to_owned()
             .substitute_with_self(&shape.skip_binder, &TraitRefKind::SelfId);
 
         let mut decl_mut = decl.as_mut();
@@ -533,7 +533,7 @@ impl TransformPass for Transform {
             } else {
                 // Take the item out so we can modify it. Warning: don't look up other items in the
                 // meantime as this would break in recursive cases.
-                match visitor.ctx.translated.remove_item(id) {
+                match visitor.ctx.translated.remove_item_temporarily(id) {
                     Some(decl) => decl,
                     None => continue,
                 }

--- a/charon/tests/cargo.rs
+++ b/charon/tests/cargo.rs
@@ -163,6 +163,16 @@ fn main() -> Result<(), Box<dyn Error>> {
             &[],
             Success,
         ),
+        mktest(
+            "multi-targets",
+            root.join("multi-targets"),
+            &[
+                "--targets=i686-unknown-linux-gnu,x86_64-apple-darwin,riscv64gc-unknown-none-elf"
+                    .to_owned(),
+            ],
+            &[],
+            Success,
+        ),
     ];
 
     let args = libtest_mimic::Arguments::from_args();

--- a/charon/tests/cargo/multi-targets.out
+++ b/charon/tests/cargo/multi-targets.out
@@ -1,0 +1,67 @@
+pub fn multi_targets::no_os::riscv64gc-unknown-none-elf(_1: u64, _2: u64) -> u64
+{
+    let _0: u64; // return
+    let left_1: u64; // arg #1
+    let right_2: u64; // arg #2
+    let _3: u64; // anonymous local
+    let _4: u64; // anonymous local
+    let _5: (u64, bool); // anonymous local
+
+    storage_live(_5)
+    storage_live(_3)
+    _3 = copy left_1
+    storage_live(_4)
+    _4 = copy right_2
+    _5 = copy _3 checked.+ copy _4
+    assert(move _5.1 == false) (overflow) else panic
+    _0 = move _5.0
+    storage_dead(_4)
+    storage_dead(_3)
+    return
+}
+
+pub fn multi_targets::on_unix::i686-unknown-linux-gnu(_1: u64, _2: u64) -> u64
+{
+    let _0: u64; // return
+    let left_1: u64; // arg #1
+    let right_2: u64; // arg #2
+    let _3: u64; // anonymous local
+    let _4: u64; // anonymous local
+    let _5: (u64, bool); // anonymous local
+
+    storage_live(_5)
+    storage_live(_3)
+    _3 = copy left_1
+    storage_live(_4)
+    _4 = copy right_2
+    _5 = copy _3 checked.+ copy _4
+    assert(move _5.1 == false) (overflow) else panic
+    _0 = move _5.0
+    storage_dead(_4)
+    storage_dead(_3)
+    return
+}
+
+pub fn multi_targets::on_unix::x86_64-apple-darwin(_1: u64, _2: u64) -> u64
+{
+    let _0: u64; // return
+    let left_1: u64; // arg #1
+    let right_2: u64; // arg #2
+    let _3: u64; // anonymous local
+    let _4: u64; // anonymous local
+    let _5: (u64, bool); // anonymous local
+
+    storage_live(_5)
+    storage_live(_3)
+    _3 = copy left_1
+    storage_live(_4)
+    _4 = copy right_2
+    _5 = copy _3 checked.+ copy _4
+    assert(move _5.1 == false) (overflow) else panic
+    _0 = move _5.0
+    storage_dead(_4)
+    storage_dead(_3)
+    return
+}
+
+

--- a/charon/tests/cli.rs
+++ b/charon/tests/cli.rs
@@ -125,8 +125,6 @@ fn charon_cargo_features() -> Result<()> {
 
 #[test]
 fn charon_cargo_target() -> Result<()> {
-    let target = "riscv64gc-unknown-none-elf";
-
     let dir = "tests/cargo/multi-targets";
 
     #[cfg(target_family = "unix")]
@@ -149,6 +147,7 @@ fn charon_cargo_target() -> Result<()> {
         Ok(())
     })?;
 
+    let target = "riscv64gc-unknown-none-elf";
     let args = &["cargo", "--print-llbc", "--", "--target", target];
     charon(args, dir, |stdout, cmd| {
         let main = "multi_targets::no_os";
@@ -208,38 +207,6 @@ fn put_options_after_subcommand() -> Result<()> {
     let output = Command::cargo_bin("charon")?.args(args).output()?;
     assert!(!output.status.success());
     Ok(())
-}
-
-#[test]
-fn charon_rust_target() -> Result<()> {
-    let target = "riscv64gc-unknown-none-elf";
-
-    let path = "tests/cargo/multi-targets/src/lib.rs";
-    let args = &[
-        "rustc",
-        "--print-llbc",
-        "--",
-        "--crate-type=lib",
-        path,
-        "--crate-name",
-        "multi_targets",
-        "--target",
-        target,
-    ];
-    let [stdout, rustc_cmd] = charon(args, ".", |stdout, cmd| Ok([stdout, cmd]))?;
-
-    let dir = "tests/cargo/multi-targets";
-    let args = &["cargo", "--print-llbc", "--", "--target", target];
-    // Suppose outputs from cargo and rustc queries are the same...
-    charon(args, dir, |desired, cargo_cmd| {
-        ensure!(
-            desired == stdout,
-            "LLBC output differs between `charon cargo` and `charon rustc`\n\
-            `{cargo_cmd}` emits:\n{desired:?}\n\
-            `{rustc_cmd}` emits:\n{stdout:?}"
-        );
-        Ok(())
-    })
 }
 
 #[test]

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -33,7 +33,7 @@ Options:
           Extra flags to pass to rustc
 
       --targets <TARGETS>
-          A list of target architectures to translate for. Charon will run the compiler once for each target and aggregate the results, which is useful if the code includes `#[cfg(..)]` filters
+          A list of target architectures to translate for. Charon will run the compiler once for each target and aggregate the results, which is useful if the code includes `#[cfg(..)]` filters. Warning: this is an initial implementation which is extremely slow
 
       --monomorphize
           Monomorphize the items encountered when possible. Generic items found in the crate are skipped. To only translate a particular call graph, use `--start-from`. Note: this doesn't currently support `dyn Trait`

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -32,6 +32,9 @@ Options:
       --rustc-arg <RUSTC_ARGS>
           Extra flags to pass to rustc
 
+      --targets <TARGETS>
+          A list of target architectures to translate for. Charon will run the compiler once for each target and aggregate the results, which is useful if the code includes `#[cfg(..)]` filters
+
       --monomorphize
           Monomorphize the items encountered when possible. Generic items found in the crate are skipped. To only translate a particular call graph, use `--start-from`. Note: this doesn't currently support `dyn Trait`
           

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -157,8 +157,10 @@ fn type_layout() -> anyhow::Result<()> {
         &[],
     )?;
 
+    // Check whether niche discriminant computations are correct, i.e. reversible.
+    let the_target = crate_data.target_information.keys().next().unwrap().clone();
     for tdecl in crate_data.type_decls.iter() {
-        if let Some(layout) = tdecl.layout.as_ref()
+        if let Some(layout) = tdecl.layout.get(&the_target)
             && layout.discriminant_layout.is_some()
         {
             let name = repr_name(&crate_data, &tdecl.item_meta.name);
@@ -174,7 +176,7 @@ fn type_layout() -> anyhow::Result<()> {
                     match tag {
                         None => (), // Must be the untagged variant
                         Some(tag) => {
-                            let roundtrip_var_id = tdecl.get_variant_from_tag(tag);
+                            let roundtrip_var_id = tdecl.get_variant_from_tag(&the_target, tag);
                             assert_eq!(
                                 Some(var_id),
                                 roundtrip_var_id,
@@ -197,7 +199,7 @@ fn type_layout() -> anyhow::Result<()> {
                 return None;
             }
             let name = repr_name(&crate_data, &tdecl.item_meta.name);
-            Some((name, tdecl.layout.clone()))
+            Some((name, tdecl.layout.get(&the_target).cloned()))
         })
         .collect();
     let layouts_str = serde_json::to_string_pretty(&layouts)?;

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1705:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1706:13:
 Could not determine method index for drop in vtable
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `core::fmt::Display`.
@@ -11,7 +11,7 @@ note: the error occurred when translating `core::fmt::Display::{vtable_drop_pres
 12 |     let _ = dyn_to_string(&str);
    |                           ----
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1583:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1584:13:
 Could not determine method index for method_fmt in vtable
 error: Thread panicked when extracting item `core::fmt::Display`.
  --> /rustc/library/core/src/fmt/mod.rs:1186:1

--- a/charon/tests/ui/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target-from-symcrypt.out
@@ -165,14 +165,7 @@ where
 = <opaque>
 
 #[lang_item("Ordering")]
-pub enum core::cmp::Ordering::x86_64-apple-darwin {
-  Less,
-  Equal,
-  Greater,
-}
-
-#[lang_item("Ordering")]
-pub enum core::cmp::Ordering::aarch64-apple-darwin {
+pub enum core::cmp::Ordering {
   Less,
   Equal,
   Greater,
@@ -213,13 +206,13 @@ pub trait core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>
 }
 
 #[lang_item("cmp_partialord_cmp")]
-pub fn core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering::x86_64-apple-darwin}]
+pub fn core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering}]
 where
     [@TraitClause0]: core::cmp::PartialOrd::x86_64-apple-darwin<Self, Rhs>,
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
-pub fn core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering::aarch64-apple-darwin}]
+pub fn core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering}]
 where
     [@TraitClause0]: core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>,
 = <opaque>
@@ -242,7 +235,7 @@ impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize {
     vtable: core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::{vtable}::aarch64-apple-darwin
 }
 
-pub fn core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering::x86_64-apple-darwin}]
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering}]
 = <opaque>
 
 // Full name: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
@@ -252,7 +245,7 @@ impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize {
     vtable: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::{vtable}::x86_64-apple-darwin
 }
 
-pub fn core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering::aarch64-apple-darwin}]
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering}]
 = <opaque>
 
 // Full name: core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
@@ -456,10 +449,7 @@ where
     [@TraitClause0]: core::iter::traits::iterator::Iterator::aarch64-apple-darwin<Self>,
 = <opaque>
 
-pub fn core::num::{u16}::wrapping_add::x86_64-apple-darwin(_1: u16, _2: u16) -> u16
-= <opaque>
-
-pub fn core::num::{u16}::wrapping_add::aarch64-apple-darwin(_1: u16, _2: u16) -> u16
+pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
 = <opaque>
 
 pub fn core::slice::{[T]}::as_ptr::x86_64-apple-darwin<'_0, T>(_1: &'_0 [T]) -> *const T
@@ -791,7 +781,7 @@ fn test_crate::ntt_layer_generic::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u1
         storage_live(_19)
         _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
         _13 = copy (*_19)
-        _10 = core::num::{u16}::wrapping_add::x86_64-apple-darwin(move _11, move _13)
+        _10 = core::num::{u16}::wrapping_add(move _11, move _13)
         storage_dead(_13)
         storage_dead(_11)
         storage_live(_15)
@@ -885,7 +875,7 @@ fn test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u
         storage_live(_19)
         _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
         _13 = copy (*_19)
-        _10 = core::num::{u16}::wrapping_add::aarch64-apple-darwin(move _11, move _13)
+        _10 = core::num::{u16}::wrapping_add(move _11, move _13)
         storage_dead(_13)
         storage_dead(_11)
         storage_live(_15)
@@ -910,6 +900,12 @@ fn test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u
     storage_dead(iter_5)
     storage_dead(_3)
     return
+}
+
+fn test_crate::ntt_layer_generic<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+= target_dispatch {
+    x86_64-apple-darwin => test_crate::ntt_layer_generic::x86_64-apple-darwin<'_0, '_1>,
+    aarch64-apple-darwin => test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>,
 }
 
 fn test_crate::ntt_layer_vec128::x86_64-apple-darwin<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
@@ -1036,6 +1032,12 @@ fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin() -> u32
     return
 }
 
+fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2() -> u32
+= target_dispatch {
+    x86_64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin,
+    aarch64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin,
+}
+
 const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin()
 
 const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin()
@@ -1056,20 +1058,17 @@ fn test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin() -> u32
     return
 }
 
+fn test_crate::SYMCRYPT_CPU_FEATURE_NEON() -> u32
+= target_dispatch {
+    x86_64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin,
+    aarch64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin,
+}
+
 const test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin()
 
 const test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin()
 
-fn test_crate::cpu_features_present::x86_64-apple-darwin(_1: u32) -> bool
-{
-    let _0: bool; // return
-    let _mask_1: u32; // arg #1
-
-    _0 = const true
-    return
-}
-
-fn test_crate::cpu_features_present::aarch64-apple-darwin(_1: u32) -> bool
+fn test_crate::cpu_features_present(_1: u32) -> bool
 {
     let _0: bool; // return
     let _mask_1: u32; // arg #1
@@ -1093,7 +1092,7 @@ fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mu
 
     _0 = ()
     storage_live(_3)
-    _3 = test_crate::cpu_features_present::x86_64-apple-darwin(copy test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin)
+    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin)
     if move _3 {
         storage_live(_4)
         storage_live(_5)
@@ -1111,7 +1110,7 @@ fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mu
         _8 = &two-phase-mut (*a_1)
         storage_live(_9)
         _9 = &(*b_2)
-        _7 = test_crate::ntt_layer_generic::x86_64-apple-darwin<'14, '15>(move _8, move _9)
+        _7 = test_crate::ntt_layer_generic<'14, '15>(move _8, move _9)
         storage_dead(_9)
         storage_dead(_8)
         storage_dead(_7)
@@ -1136,7 +1135,7 @@ fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 m
 
     _0 = ()
     storage_live(_3)
-    _3 = test_crate::cpu_features_present::aarch64-apple-darwin(copy test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin)
+    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin)
     if move _3 {
         storage_live(_4)
         storage_live(_5)
@@ -1154,7 +1153,7 @@ fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 m
         _8 = &two-phase-mut (*a_1)
         storage_live(_9)
         _9 = &(*b_2)
-        _7 = test_crate::ntt_layer_generic::aarch64-apple-darwin<'14, '15>(move _8, move _9)
+        _7 = test_crate::ntt_layer_generic<'14, '15>(move _8, move _9)
         storage_dead(_9)
         storage_dead(_8)
         storage_dead(_7)
@@ -1162,6 +1161,12 @@ fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 m
     }
     storage_dead(_3)
     return
+}
+
+fn test_crate::poly_element_ntt_layer<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+= target_dispatch {
+    x86_64-apple-darwin => test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>,
+    aarch64-apple-darwin => test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>,
 }
 
 

--- a/charon/tests/ui/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target-from-symcrypt.out
@@ -1,0 +1,1167 @@
+pub opaque type core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+
+pub unsafe fn core::core_arch::aarch64::neon::generated::vld1q_u16::aarch64-apple-darwin(_1: *const u16) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+= <opaque>
+
+pub unsafe fn core::core_arch::aarch64::neon::generated::vst1q_u16::aarch64-apple-darwin(_1: *mut u16, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
+= <opaque>
+
+pub unsafe fn core::core_arch::arm_shared::neon::generated::vaddq_u16::aarch64-apple-darwin(_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+= <opaque>
+
+#[lang_item("meta_sized")]
+pub trait core::marker::MetaSized::x86_64-apple-darwin<Self>
+
+#[lang_item("sized")]
+pub trait core::marker::Sized::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
+    non-dyn-compatible
+}
+
+#[lang_item("clone")]
+pub trait core::clone::Clone::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Self>
+    fn clone<'_0_1> = core::clone::Clone::clone::x86_64-apple-darwin<'_0_1, Self>[Self]
+    non-dyn-compatible
+}
+
+#[lang_item("copy")]
+pub trait core::marker::Copy::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone::x86_64-apple-darwin<Self>
+    non-dyn-compatible
+}
+
+pub opaque type core::core_arch::x86::__m128i::x86_64-apple-darwin
+
+pub fn core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0>(_1: &'_0 core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+= <opaque>
+
+// Full name: core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    fn clone<'_0_1> = core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: core::core_arch::x86::{impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    parent_clause1 = core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+    non-dyn-compatible
+}
+
+#[lang_item("meta_sized")]
+pub trait core::marker::MetaSized::aarch64-apple-darwin<Self>
+
+#[lang_item("sized")]
+pub trait core::marker::Sized::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
+    non-dyn-compatible
+}
+
+#[lang_item("clone")]
+pub trait core::clone::Clone::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Self>
+    fn clone<'_0_1> = core::clone::Clone::clone::aarch64-apple-darwin<'_0_1, Self>[Self]
+    non-dyn-compatible
+}
+
+#[lang_item("copy")]
+pub trait core::marker::Copy::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone::aarch64-apple-darwin<Self>
+    non-dyn-compatible
+}
+
+pub fn core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0>(_1: &'_0 core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+= <opaque>
+
+// Full name: core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    fn clone<'_0_1> = core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: core::core_arch::arm_shared::neon::{impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    parent_clause1 = core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+    non-dyn-compatible
+}
+
+pub unsafe fn core::core_arch::x86::sse2::_mm_add_epi16::x86_64-apple-darwin(_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+= <opaque>
+
+pub unsafe fn core::core_arch::x86::sse2::_mm_loadu_si128::x86_64-apple-darwin(_1: *const core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+= <opaque>
+
+pub unsafe fn core::core_arch::x86::sse2::_mm_storeu_si128::x86_64-apple-darwin(_1: *mut core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
+= <opaque>
+
+#[lang_item("clone_fn")]
+pub fn core::clone::Clone::clone::x86_64-apple-darwin<'_0, Self>(_1: &'_0 Self) -> Self
+where
+    [@TraitClause0]: core::clone::Clone::x86_64-apple-darwin<Self>,
+= <opaque>
+
+#[lang_item("clone_fn")]
+pub fn core::clone::Clone::clone::aarch64-apple-darwin<'_0, Self>(_1: &'_0 Self) -> Self
+where
+    [@TraitClause0]: core::clone::Clone::aarch64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::clone::x86_64-apple-darwin<'_0>(_1: &'_0 usize) -> usize
+= <opaque>
+
+// Full name: core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::x86_64-apple-darwin
+impl core::clone::Clone::x86_64-apple-darwin for usize {
+    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for usize}
+    fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::clone::x86_64-apple-darwin<'_0_1>
+    non-dyn-compatible
+}
+
+pub fn core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::clone::aarch64-apple-darwin<'_0>(_1: &'_0 usize) -> usize
+= <opaque>
+
+// Full name: core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::aarch64-apple-darwin
+impl core::clone::Clone::aarch64-apple-darwin for usize {
+    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for usize}
+    fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::clone::aarch64-apple-darwin<'_0_1>
+    non-dyn-compatible
+}
+
+#[lang_item("eq")]
+pub trait core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>
+{
+    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq::x86_64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialEq::{vtable}::x86_64-apple-darwin<Rhs>
+}
+
+#[lang_item("eq")]
+pub trait core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>
+{
+    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq::aarch64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialEq::{vtable}::aarch64-apple-darwin<Rhs>
+}
+
+#[lang_item("cmp_partialeq_eq")]
+pub fn core::cmp::PartialEq::eq::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>,
+= <opaque>
+
+#[lang_item("cmp_partialeq_eq")]
+pub fn core::cmp::PartialEq::eq::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
+where
+    [@TraitClause0]: core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>,
+= <opaque>
+
+#[lang_item("Ordering")]
+pub enum core::cmp::Ordering::x86_64-apple-darwin {
+  Less,
+  Equal,
+  Greater,
+}
+
+#[lang_item("Ordering")]
+pub enum core::cmp::Ordering::aarch64-apple-darwin {
+  Less,
+  Equal,
+  Greater,
+}
+
+#[lang_item("Option")]
+pub enum core::option::Option::x86_64-apple-darwin<T>
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+{
+  None,
+  Some(T),
+}
+
+#[lang_item("partial_ord")]
+pub trait core::cmp::PartialOrd::x86_64-apple-darwin<Self, Rhs>
+{
+    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialOrd::{vtable}::x86_64-apple-darwin<Rhs>
+}
+
+#[lang_item("Option")]
+pub enum core::option::Option::aarch64-apple-darwin<T>
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
+{
+  None,
+  Some(T),
+}
+
+#[lang_item("partial_ord")]
+pub trait core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>
+{
+    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialOrd::{vtable}::aarch64-apple-darwin<Rhs>
+}
+
+#[lang_item("cmp_partialord_cmp")]
+pub fn core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering::x86_64-apple-darwin}]
+where
+    [@TraitClause0]: core::cmp::PartialOrd::x86_64-apple-darwin<Self, Rhs>,
+= <opaque>
+
+#[lang_item("cmp_partialord_cmp")]
+pub fn core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering::aarch64-apple-darwin}]
+where
+    [@TraitClause0]: core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>,
+= <opaque>
+
+pub fn core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::eq::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
+= <opaque>
+
+// Full name: core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
+impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize {
+    fn eq<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::eq::x86_64-apple-darwin<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::{vtable}::x86_64-apple-darwin
+}
+
+pub fn core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::eq::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
+= <opaque>
+
+// Full name: core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
+impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize {
+    fn eq<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::eq::aarch64-apple-darwin<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::{vtable}::aarch64-apple-darwin
+}
+
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering::x86_64-apple-darwin}]
+= <opaque>
+
+// Full name: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
+impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize {
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::{vtable}::x86_64-apple-darwin
+}
+
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering::aarch64-apple-darwin}]
+= <opaque>
+
+// Full name: core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
+impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize {
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::{vtable}::aarch64-apple-darwin
+}
+
+#[lang_item("range_step")]
+pub trait core::iter::range::Step::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone::x86_64-apple-darwin<Self>
+    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd::x86_64-apple-darwin<Self, Self>
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between::x86_64-apple-darwin<'_0_1, '_1_1, Self>[Self]
+    fn forward_checked = core::iter::range::Step::forward_checked::x86_64-apple-darwin<Self>[Self]
+    fn backward_checked = core::iter::range::Step::backward_checked::x86_64-apple-darwin<Self>[Self]
+    non-dyn-compatible
+}
+
+#[lang_item("range_step")]
+pub trait core::iter::range::Step::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone::aarch64-apple-darwin<Self>
+    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd::aarch64-apple-darwin<Self, Self>
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between::aarch64-apple-darwin<'_0_1, '_1_1, Self>[Self]
+    fn forward_checked = core::iter::range::Step::forward_checked::aarch64-apple-darwin<Self>[Self]
+    fn backward_checked = core::iter::range::Step::backward_checked::aarch64-apple-darwin<Self>[Self]
+    non-dyn-compatible
+}
+
+pub fn core::iter::range::Step::steps_between::x86_64-apple-darwin<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}])
+where
+    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::steps_between::aarch64-apple-darwin<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}])
+where
+    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::forward_checked::x86_64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::x86_64-apple-darwin<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::forward_checked::aarch64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::aarch64-apple-darwin<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::backward_checked::x86_64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::x86_64-apple-darwin<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::Step::backward_checked::aarch64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::aarch64-apple-darwin<Self>[@TraitClause0::parent_clause0]
+where
+    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::backward_checked::x86_64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]
+= <opaque>
+
+pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::forward_checked::x86_64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]
+= <opaque>
+
+pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::steps_between::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}])
+= <opaque>
+
+// Full name: core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin
+impl core::iter::range::Step::x86_64-apple-darwin for usize {
+    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for usize}
+    parent_clause1 = core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::x86_64-apple-darwin
+    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::steps_between::x86_64-apple-darwin<'_0_1, '_1_1>
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::forward_checked::x86_64-apple-darwin
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::backward_checked::x86_64-apple-darwin
+    non-dyn-compatible
+}
+
+pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::backward_checked::aarch64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]
+= <opaque>
+
+pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::forward_checked::aarch64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]
+= <opaque>
+
+pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::steps_between::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}])
+= <opaque>
+
+// Full name: core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin
+impl core::iter::range::Step::aarch64-apple-darwin for usize {
+    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for usize}
+    parent_clause1 = core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::aarch64-apple-darwin
+    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::steps_between::aarch64-apple-darwin<'_0_1, '_1_1>
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::forward_checked::aarch64-apple-darwin
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::backward_checked::aarch64-apple-darwin
+    non-dyn-compatible
+}
+
+#[lang_item("Range")]
+pub struct core::ops::range::Range::x86_64-apple-darwin<Idx>
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Idx>,
+{
+  start: Idx,
+  end: Idx,
+}
+
+#[lang_item("iterator")]
+pub trait core::iter::traits::iterator::Iterator::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized::x86_64-apple-darwin<Self::Item>
+    type Item
+    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next::x86_64-apple-darwin<'_0_1, Self>[Self]
+    vtable: core::iter::traits::iterator::Iterator::{vtable}::x86_64-apple-darwin<Self::Item>
+}
+
+pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'_0, A>(_1: &'_0 mut core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]) -> core::option::Option::x86_64-apple-darwin<A>[@TraitClause0]
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<A>,
+    [@TraitClause1]: core::iter::range::Step::x86_64-apple-darwin<A>,
+= <opaque>
+
+// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::x86_64-apple-darwin
+impl<A> core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<A>,
+    [@TraitClause1]: core::iter::range::Step::x86_64-apple-darwin<A>,
+{
+    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}
+    parent_clause1 = @TraitClause0
+    type Item = A
+    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'_0_1, A>[@TraitClause0, @TraitClause1]
+    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::{vtable}::x86_64-apple-darwin<A>[@TraitClause0, @TraitClause1]
+}
+
+#[lang_item("Range")]
+pub struct core::ops::range::Range::aarch64-apple-darwin<Idx>
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Idx>,
+{
+  start: Idx,
+  end: Idx,
+}
+
+#[lang_item("iterator")]
+pub trait core::iter::traits::iterator::Iterator::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized::aarch64-apple-darwin<Self::Item>
+    type Item
+    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next::aarch64-apple-darwin<'_0_1, Self>[Self]
+    vtable: core::iter::traits::iterator::Iterator::{vtable}::aarch64-apple-darwin<Self::Item>
+}
+
+pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'_0, A>(_1: &'_0 mut core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]) -> core::option::Option::aarch64-apple-darwin<A>[@TraitClause0]
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<A>,
+    [@TraitClause1]: core::iter::range::Step::aarch64-apple-darwin<A>,
+= <opaque>
+
+// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::aarch64-apple-darwin
+impl<A> core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<A>,
+    [@TraitClause1]: core::iter::range::Step::aarch64-apple-darwin<A>,
+{
+    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}
+    parent_clause1 = @TraitClause0
+    type Item = A
+    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'_0_1, A>[@TraitClause0, @TraitClause1]
+    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::{vtable}::aarch64-apple-darwin<A>[@TraitClause0, @TraitClause1]
+}
+
+pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::x86_64-apple-darwin for I}::into_iter::x86_64-apple-darwin<I>(_1: I) -> I
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator::x86_64-apple-darwin<I>,
+= <opaque>
+
+pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::aarch64-apple-darwin for I}::into_iter::aarch64-apple-darwin<I>(_1: I) -> I
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator::aarch64-apple-darwin<I>,
+= <opaque>
+
+#[lang_item("next")]
+pub fn core::iter::traits::iterator::Iterator::next::x86_64-apple-darwin<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option::x86_64-apple-darwin<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator::x86_64-apple-darwin<Self>,
+= <opaque>
+
+#[lang_item("next")]
+pub fn core::iter::traits::iterator::Iterator::next::aarch64-apple-darwin<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option::aarch64-apple-darwin<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+where
+    [@TraitClause0]: core::iter::traits::iterator::Iterator::aarch64-apple-darwin<Self>,
+= <opaque>
+
+pub fn core::num::{u16}::wrapping_add::x86_64-apple-darwin(_1: u16, _2: u16) -> u16
+= <opaque>
+
+pub fn core::num::{u16}::wrapping_add::aarch64-apple-darwin(_1: u16, _2: u16) -> u16
+= <opaque>
+
+pub fn core::slice::{[T]}::as_ptr::x86_64-apple-darwin<'_0, T>(_1: &'_0 [T]) -> *const T
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+= <opaque>
+
+pub fn core::slice::{[T]}::as_ptr::aarch64-apple-darwin<'_0, T>(_1: &'_0 [T]) -> *const T
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
+= <opaque>
+
+pub fn core::slice::{[T]}::as_mut_ptr::x86_64-apple-darwin<'_0, T>(_1: &'_0 mut [T]) -> *mut T
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+= <opaque>
+
+pub fn core::slice::{[T]}::as_mut_ptr::aarch64-apple-darwin<'_0, T>(_1: &'_0 mut [T]) -> *mut T
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
+= <opaque>
+
+fn UNIT_METADATA::x86_64-apple-darwin()
+{
+    let _0: (); // return
+
+    _0 = ()
+    return
+}
+
+fn UNIT_METADATA::aarch64-apple-darwin()
+{
+    let _0: (); // return
+
+    _0 = ()
+    return
+}
+
+const UNIT_METADATA::x86_64-apple-darwin: () = UNIT_METADATA::x86_64-apple-darwin()
+
+const UNIT_METADATA::aarch64-apple-darwin: () = UNIT_METADATA::aarch64-apple-darwin()
+
+trait test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized::x86_64-apple-darwin<Self::Vec128>
+    parent_clause2 : [@TraitClause2]: core::marker::Copy::x86_64-apple-darwin<Self::Vec128>
+    type Vec128
+    fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load::x86_64-apple-darwin<'_0_1, Self>[Self]
+    fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store::x86_64-apple-darwin<'_0_1, Self>[Self]
+    fn vec128_add = test_crate::NttIntrinsicsInterface::vec128_add::x86_64-apple-darwin<Self>[Self]
+    non-dyn-compatible
+}
+
+trait test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>
+{
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized::aarch64-apple-darwin<Self::Vec128>
+    parent_clause2 : [@TraitClause2]: core::marker::Copy::aarch64-apple-darwin<Self::Vec128>
+    type Vec128
+    fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load::aarch64-apple-darwin<'_0_1, Self>[Self]
+    fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store::aarch64-apple-darwin<'_0_1, Self>[Self]
+    fn vec128_add = test_crate::NttIntrinsicsInterface::vec128_add::aarch64-apple-darwin<Self>[Self]
+    non-dyn-compatible
+}
+
+fn test_crate::NttIntrinsicsInterface::vec128_load::x86_64-apple-darwin<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
+= <method_without_default_body>
+
+fn test_crate::NttIntrinsicsInterface::vec128_load::aarch64-apple-darwin<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
+= <method_without_default_body>
+
+fn test_crate::NttIntrinsicsInterface::vec128_store::x86_64-apple-darwin<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
+= <method_without_default_body>
+
+fn test_crate::NttIntrinsicsInterface::vec128_store::aarch64-apple-darwin<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
+= <method_without_default_body>
+
+fn test_crate::NttIntrinsicsInterface::vec128_add::x86_64-apple-darwin<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
+= <method_without_default_body>
+
+fn test_crate::NttIntrinsicsInterface::vec128_add::aarch64-apple-darwin<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
+where
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
+= <method_without_default_body>
+
+pub struct test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {}
+
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin(_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+{
+    let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
+    let a_1: core::core_arch::x86::__m128i::x86_64-apple-darwin; // arg #1
+    let b_2: core::core_arch::x86::__m128i::x86_64-apple-darwin; // arg #2
+    let _3: core::core_arch::x86::__m128i::x86_64-apple-darwin; // anonymous local
+    let _4: core::core_arch::x86::__m128i::x86_64-apple-darwin; // anonymous local
+
+    storage_live(_3)
+    _3 = copy a_1
+    storage_live(_4)
+    _4 = copy b_2
+    _0 = core::core_arch::x86::sse2::_mm_add_epi16::x86_64-apple-darwin(move _3, move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
+{
+    let _0: (); // return
+    let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let val_2: core::core_arch::x86::__m128i::x86_64-apple-darwin; // arg #2
+    let _3: *mut core::core_arch::x86::__m128i::x86_64-apple-darwin; // anonymous local
+    let _4: *mut u16; // anonymous local
+    let _5: &'3 mut [u16]; // anonymous local
+    let _6: &'4 mut [u16; 8 : usize]; // anonymous local
+    let _7: core::core_arch::x86::__m128i::x86_64-apple-darwin; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    storage_live(_6)
+    _6 = &two-phase-mut (*dst_1)
+    _5 = @ArrayToSliceMut<'_, u16, 8 : usize>(move _6)
+    storage_dead(_6)
+    _4 = core::slice::{[T]}::as_mut_ptr::x86_64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::x86_64-apple-darwin for u16}](move _5)
+    storage_dead(_5)
+    _3 = cast<*mut u16, *mut core::core_arch::x86::__m128i::x86_64-apple-darwin>(move _4)
+    storage_dead(_4)
+    storage_live(_7)
+    _7 = copy val_2
+    _0 = core::core_arch::x86::sse2::_mm_storeu_si128::x86_64-apple-darwin(move _3, move _7)
+    storage_dead(_7)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+{
+    let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
+    let src_1: &'1 [u16; 8 : usize]; // arg #1
+    let _2: *const core::core_arch::x86::__m128i::x86_64-apple-darwin; // anonymous local
+    let _3: *const u16; // anonymous local
+    let _4: &'3 [u16]; // anonymous local
+    let _5: &'4 [u16; 8 : usize]; // anonymous local
+
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*src_1)
+    _4 = @ArrayToSliceShared<'_, u16, 8 : usize>(move _5)
+    storage_dead(_5)
+    _3 = core::slice::{[T]}::as_ptr::x86_64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::x86_64-apple-darwin for u16}](move _4)
+    storage_dead(_4)
+    _2 = cast<*const u16, *const core::core_arch::x86::__m128i::x86_64-apple-darwin>(move _3)
+    storage_dead(_3)
+    _0 = core::core_arch::x86::sse2::_mm_loadu_si128::x86_64-apple-darwin(move _2)
+    storage_dead(_2)
+    return
+}
+
+// Full name: test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin
+impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}
+    parent_clause1 = {built_in impl core::marker::Sized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    parent_clause2 = core::core_arch::x86::{impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+    type Vec128 = core::core_arch::x86::__m128i::x86_64-apple-darwin
+    fn vec128_load<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0_1>
+    fn vec128_store<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0_1>
+    fn vec128_add = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin
+    non-dyn-compatible
+}
+
+pub struct test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {}
+
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin(_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+{
+    let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
+    let a_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // arg #1
+    let b_2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // arg #2
+    let _3: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // anonymous local
+    let _4: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // anonymous local
+
+    storage_live(_3)
+    _3 = copy a_1
+    storage_live(_4)
+    _4 = copy b_2
+    _0 = core::core_arch::arm_shared::neon::generated::vaddq_u16::aarch64-apple-darwin(move _3, move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
+{
+    let _0: (); // return
+    let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let val_2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // arg #2
+    let _3: *mut u16; // anonymous local
+    let _4: &'3 mut [u16]; // anonymous local
+    let _5: &'4 mut [u16; 8 : usize]; // anonymous local
+    let _6: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &two-phase-mut (*dst_1)
+    _4 = @ArrayToSliceMut<'_, u16, 8 : usize>(move _5)
+    storage_dead(_5)
+    _3 = core::slice::{[T]}::as_mut_ptr::aarch64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::aarch64-apple-darwin for u16}](move _4)
+    storage_dead(_4)
+    storage_live(_6)
+    _6 = copy val_2
+    _0 = core::core_arch::aarch64::neon::generated::vst1q_u16::aarch64-apple-darwin(move _3, move _6)
+    storage_dead(_6)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+{
+    let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
+    let src_1: &'1 [u16; 8 : usize]; // arg #1
+    let _2: *const u16; // anonymous local
+    let _3: &'3 [u16]; // anonymous local
+    let _4: &'4 [u16; 8 : usize]; // anonymous local
+
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = &(*src_1)
+    _3 = @ArrayToSliceShared<'_, u16, 8 : usize>(move _4)
+    storage_dead(_4)
+    _2 = core::slice::{[T]}::as_ptr::aarch64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::aarch64-apple-darwin for u16}](move _3)
+    storage_dead(_3)
+    _0 = core::core_arch::aarch64::neon::generated::vld1q_u16::aarch64-apple-darwin(move _2)
+    storage_dead(_2)
+    return
+}
+
+// Full name: test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin
+impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}
+    parent_clause1 = {built_in impl core::marker::Sized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    parent_clause2 = core::core_arch::arm_shared::neon::{impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+    type Vec128 = core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+    fn vec128_load<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0_1>
+    fn vec128_store<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0_1>
+    fn vec128_add = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin
+    non-dyn-compatible
+}
+
+fn test_crate::ntt_layer_generic::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let _3: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
+    let _4: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
+    let iter_5: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // local
+    let _6: core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
+    let _7: &'5 mut core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
+    let _8: &'6 mut core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
+    let i_9: usize; // local
+    let _10: u16; // anonymous local
+    let _11: u16; // anonymous local
+    let _12: usize; // anonymous local
+    let _13: u16; // anonymous local
+    let _14: usize; // anonymous local
+    let _15: usize; // anonymous local
+    let _16: &'_ [u16; 8 : usize]; // anonymous local
+    let _17: &'_ u16; // anonymous local
+    let _18: &'_ [u16; 8 : usize]; // anonymous local
+    let _19: &'_ u16; // anonymous local
+    let _20: &'_ mut [u16; 8 : usize]; // anonymous local
+    let _21: &'_ mut u16; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    storage_live(_4)
+    _4 = core::ops::range::Range::x86_64-apple-darwin { start: const 0 : usize, end: const 8 : usize }
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::x86_64-apple-darwin for I}::into_iter::x86_64-apple-darwin<core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin]](move _4)
+    storage_dead(_4)
+    storage_live(iter_5)
+    iter_5 = move _3
+    loop {
+        storage_live(_6)
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &mut iter_5
+        _7 = &two-phase-mut (*_8)
+        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'8, usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin](move _7)
+        storage_dead(_7)
+        match _6 {
+            core::option::Option::x86_64-apple-darwin::None => {
+                break 0
+            },
+            core::option::Option::x86_64-apple-darwin::Some => {
+            },
+        }
+        storage_live(i_9)
+        i_9 = copy (_6 as variant core::option::Option::x86_64-apple-darwin::Some).0
+        storage_live(_10)
+        storage_live(_11)
+        storage_live(_12)
+        _12 = copy i_9
+        storage_live(_16)
+        _16 = &(*a_1)
+        storage_live(_17)
+        _17 = @ArrayIndexShared<'_, u16, 8 : usize>(move _16, copy _12)
+        _11 = copy (*_17)
+        storage_live(_13)
+        storage_live(_14)
+        _14 = copy i_9
+        storage_live(_18)
+        _18 = &(*b_2)
+        storage_live(_19)
+        _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
+        _13 = copy (*_19)
+        _10 = core::num::{u16}::wrapping_add::x86_64-apple-darwin(move _11, move _13)
+        storage_dead(_13)
+        storage_dead(_11)
+        storage_live(_15)
+        _15 = copy i_9
+        storage_live(_20)
+        _20 = &mut (*a_1)
+        storage_live(_21)
+        _21 = @ArrayIndexMut<'_, u16, 8 : usize>(move _20, copy _15)
+        (*_21) = move _10
+        storage_dead(_10)
+        storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_12)
+        storage_dead(i_9)
+        storage_dead(_8)
+        storage_dead(_6)
+        continue 0
+    }
+    _0 = ()
+    storage_dead(_8)
+    storage_dead(_6)
+    storage_dead(iter_5)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let _3: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
+    let _4: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
+    let iter_5: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // local
+    let _6: core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
+    let _7: &'5 mut core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
+    let _8: &'6 mut core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
+    let i_9: usize; // local
+    let _10: u16; // anonymous local
+    let _11: u16; // anonymous local
+    let _12: usize; // anonymous local
+    let _13: u16; // anonymous local
+    let _14: usize; // anonymous local
+    let _15: usize; // anonymous local
+    let _16: &'_ [u16; 8 : usize]; // anonymous local
+    let _17: &'_ u16; // anonymous local
+    let _18: &'_ [u16; 8 : usize]; // anonymous local
+    let _19: &'_ u16; // anonymous local
+    let _20: &'_ mut [u16; 8 : usize]; // anonymous local
+    let _21: &'_ mut u16; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    storage_live(_4)
+    _4 = core::ops::range::Range::aarch64-apple-darwin { start: const 0 : usize, end: const 8 : usize }
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::aarch64-apple-darwin for I}::into_iter::aarch64-apple-darwin<core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin]](move _4)
+    storage_dead(_4)
+    storage_live(iter_5)
+    iter_5 = move _3
+    loop {
+        storage_live(_6)
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &mut iter_5
+        _7 = &two-phase-mut (*_8)
+        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'8, usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin](move _7)
+        storage_dead(_7)
+        match _6 {
+            core::option::Option::aarch64-apple-darwin::None => {
+                break 0
+            },
+            core::option::Option::aarch64-apple-darwin::Some => {
+            },
+        }
+        storage_live(i_9)
+        i_9 = copy (_6 as variant core::option::Option::aarch64-apple-darwin::Some).0
+        storage_live(_10)
+        storage_live(_11)
+        storage_live(_12)
+        _12 = copy i_9
+        storage_live(_16)
+        _16 = &(*a_1)
+        storage_live(_17)
+        _17 = @ArrayIndexShared<'_, u16, 8 : usize>(move _16, copy _12)
+        _11 = copy (*_17)
+        storage_live(_13)
+        storage_live(_14)
+        _14 = copy i_9
+        storage_live(_18)
+        _18 = &(*b_2)
+        storage_live(_19)
+        _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
+        _13 = copy (*_19)
+        _10 = core::num::{u16}::wrapping_add::aarch64-apple-darwin(move _11, move _13)
+        storage_dead(_13)
+        storage_dead(_11)
+        storage_live(_15)
+        _15 = copy i_9
+        storage_live(_20)
+        _20 = &mut (*a_1)
+        storage_live(_21)
+        _21 = @ArrayIndexMut<'_, u16, 8 : usize>(move _20, copy _15)
+        (*_21) = move _10
+        storage_dead(_10)
+        storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_12)
+        storage_dead(i_9)
+        storage_dead(_8)
+        storage_dead(_6)
+        continue 0
+    }
+    _0 = ()
+    storage_dead(_8)
+    storage_dead(_6)
+    storage_dead(iter_5)
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::ntt_layer_vec128::x86_64-apple-darwin<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+where
+    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+    [@TraitClause1]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<T>,
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let va_3: @TraitClause1::Vec128; // local
+    let _4: &'4 [u16; 8 : usize]; // anonymous local
+    let vb_5: @TraitClause1::Vec128; // local
+    let _6: &'5 [u16; 8 : usize]; // anonymous local
+    let vr_7: @TraitClause1::Vec128; // local
+    let _8: @TraitClause1::Vec128; // anonymous local
+    let _9: @TraitClause1::Vec128; // anonymous local
+    let _10: (); // anonymous local
+    let _11: &'6 mut [u16; 8 : usize]; // anonymous local
+    let _12: @TraitClause1::Vec128; // anonymous local
+
+    _0 = ()
+    storage_live(va_3)
+    storage_live(_4)
+    _4 = &(*a_1)
+    va_3 = @TraitClause1::vec128_load<'8>(move _4)
+    storage_dead(_4)
+    storage_live(vb_5)
+    storage_live(_6)
+    _6 = &(*b_2)
+    vb_5 = @TraitClause1::vec128_load<'10>(move _6)
+    storage_dead(_6)
+    storage_live(vr_7)
+    storage_live(_8)
+    _8 = copy va_3
+    storage_live(_9)
+    _9 = copy vb_5
+    vr_7 = @TraitClause1::vec128_add(move _8, move _9)
+    storage_dead(_9)
+    storage_dead(_8)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = &two-phase-mut (*a_1)
+    storage_live(_12)
+    _12 = copy vr_7
+    _10 = @TraitClause1::vec128_store<'12>(move _11, move _12)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_dead(_10)
+    _0 = ()
+    storage_dead(vr_7)
+    storage_dead(vb_5)
+    storage_dead(va_3)
+    return
+}
+
+fn test_crate::ntt_layer_vec128::aarch64-apple-darwin<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+where
+    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
+    [@TraitClause1]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<T>,
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let va_3: @TraitClause1::Vec128; // local
+    let _4: &'4 [u16; 8 : usize]; // anonymous local
+    let vb_5: @TraitClause1::Vec128; // local
+    let _6: &'5 [u16; 8 : usize]; // anonymous local
+    let vr_7: @TraitClause1::Vec128; // local
+    let _8: @TraitClause1::Vec128; // anonymous local
+    let _9: @TraitClause1::Vec128; // anonymous local
+    let _10: (); // anonymous local
+    let _11: &'6 mut [u16; 8 : usize]; // anonymous local
+    let _12: @TraitClause1::Vec128; // anonymous local
+
+    _0 = ()
+    storage_live(va_3)
+    storage_live(_4)
+    _4 = &(*a_1)
+    va_3 = @TraitClause1::vec128_load<'8>(move _4)
+    storage_dead(_4)
+    storage_live(vb_5)
+    storage_live(_6)
+    _6 = &(*b_2)
+    vb_5 = @TraitClause1::vec128_load<'10>(move _6)
+    storage_dead(_6)
+    storage_live(vr_7)
+    storage_live(_8)
+    _8 = copy va_3
+    storage_live(_9)
+    _9 = copy vb_5
+    vr_7 = @TraitClause1::vec128_add(move _8, move _9)
+    storage_dead(_9)
+    storage_dead(_8)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = &two-phase-mut (*a_1)
+    storage_live(_12)
+    _12 = copy vr_7
+    _10 = @TraitClause1::vec128_store<'12>(move _11, move _12)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_dead(_10)
+    _0 = ()
+    storage_dead(vr_7)
+    storage_dead(vb_5)
+    storage_dead(va_3)
+    return
+}
+
+fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 1 : u32
+    return
+}
+
+fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 1 : u32
+    return
+}
+
+const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin()
+
+const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin()
+
+fn test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 2 : u32
+    return
+}
+
+fn test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 2 : u32
+    return
+}
+
+const test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin()
+
+const test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin()
+
+fn test_crate::cpu_features_present::x86_64-apple-darwin(_1: u32) -> bool
+{
+    let _0: bool; // return
+    let _mask_1: u32; // arg #1
+
+    _0 = const true
+    return
+}
+
+fn test_crate::cpu_features_present::aarch64-apple-darwin(_1: u32) -> bool
+{
+    let _0: bool; // return
+    let _mask_1: u32; // arg #1
+
+    _0 = const true
+    return
+}
+
+fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let _3: bool; // anonymous local
+    let _4: (); // anonymous local
+    let _5: &'4 mut [u16; 8 : usize]; // anonymous local
+    let _6: &'5 [u16; 8 : usize]; // anonymous local
+    let _7: (); // anonymous local
+    let _8: &'6 mut [u16; 8 : usize]; // anonymous local
+    let _9: &'7 [u16; 8 : usize]; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    _3 = test_crate::cpu_features_present::x86_64-apple-darwin(copy test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin)
+    if move _3 {
+        storage_live(_4)
+        storage_live(_5)
+        _5 = &two-phase-mut (*a_1)
+        storage_live(_6)
+        _6 = &(*b_2)
+        _4 = test_crate::ntt_layer_vec128::x86_64-apple-darwin<'10, '11, test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}, test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin](move _5, move _6)
+        storage_dead(_6)
+        storage_dead(_5)
+        storage_dead(_4)
+        _0 = ()
+    } else {
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &two-phase-mut (*a_1)
+        storage_live(_9)
+        _9 = &(*b_2)
+        _7 = test_crate::ntt_layer_generic::x86_64-apple-darwin<'14, '15>(move _8, move _9)
+        storage_dead(_9)
+        storage_dead(_8)
+        storage_dead(_7)
+        _0 = ()
+    }
+    storage_dead(_3)
+    return
+}
+
+fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let _3: bool; // anonymous local
+    let _4: (); // anonymous local
+    let _5: &'4 mut [u16; 8 : usize]; // anonymous local
+    let _6: &'5 [u16; 8 : usize]; // anonymous local
+    let _7: (); // anonymous local
+    let _8: &'6 mut [u16; 8 : usize]; // anonymous local
+    let _9: &'7 [u16; 8 : usize]; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    _3 = test_crate::cpu_features_present::aarch64-apple-darwin(copy test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin)
+    if move _3 {
+        storage_live(_4)
+        storage_live(_5)
+        _5 = &two-phase-mut (*a_1)
+        storage_live(_6)
+        _6 = &(*b_2)
+        _4 = test_crate::ntt_layer_vec128::aarch64-apple-darwin<'10, '11, test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}, test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin](move _5, move _6)
+        storage_dead(_6)
+        storage_dead(_5)
+        storage_dead(_4)
+        _0 = ()
+    } else {
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &two-phase-mut (*a_1)
+        storage_live(_9)
+        _9 = &(*b_2)
+        _7 = test_crate::ntt_layer_generic::aarch64-apple-darwin<'14, '15>(move _8, move _9)
+        storage_dead(_9)
+        storage_dead(_8)
+        storage_dead(_7)
+        _0 = ()
+    }
+    storage_dead(_3)
+    return
+}
+
+

--- a/charon/tests/ui/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target-from-symcrypt.out
@@ -10,90 +10,64 @@ pub unsafe fn core::core_arch::arm_shared::neon::generated::vaddq_u16::aarch64-a
 = <opaque>
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::x86_64-apple-darwin<Self>
+pub trait core::marker::MetaSized<Self>
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::x86_64-apple-darwin<Self>
+pub trait core::marker::Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
     non-dyn-compatible
 }
 
 #[lang_item("clone")]
-pub trait core::clone::Clone::x86_64-apple-darwin<Self>
+pub trait core::clone::Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Self>
-    fn clone<'_0_1> = core::clone::Clone::clone::x86_64-apple-darwin<'_0_1, Self>[Self]
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
+    fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
 
 #[lang_item("copy")]
-pub trait core::marker::Copy::x86_64-apple-darwin<Self>
+pub trait core::marker::Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone::x86_64-apple-darwin<Self>
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
     non-dyn-compatible
 }
 
 pub opaque type core::core_arch::x86::__m128i::x86_64-apple-darwin
 
-pub fn core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0>(_1: &'_0 core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+pub fn core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0>(_1: &'_0 core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
 = <opaque>
 
-// Full name: core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
-impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
-    fn clone<'_0_1> = core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0_1>
+// Full name: core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+impl core::clone::Clone for core::core_arch::x86::__m128i::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    fn clone<'_0_1> = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i::x86_64-apple-darwin}::clone::x86_64-apple-darwin<'_0_1>
     non-dyn-compatible
 }
 
-// Full name: core::core_arch::x86::{impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
-impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
-    parent_clause1 = core::core_arch::x86::{impl core::clone::Clone::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+// Full name: core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+impl core::marker::Copy for core::core_arch::x86::__m128i::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    parent_clause1 = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
     non-dyn-compatible
 }
 
-#[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::aarch64-apple-darwin<Self>
-
-#[lang_item("sized")]
-pub trait core::marker::Sized::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
-    non-dyn-compatible
-}
-
-#[lang_item("clone")]
-pub trait core::clone::Clone::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Self>
-    fn clone<'_0_1> = core::clone::Clone::clone::aarch64-apple-darwin<'_0_1, Self>[Self]
-    non-dyn-compatible
-}
-
-#[lang_item("copy")]
-pub trait core::marker::Copy::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone::aarch64-apple-darwin<Self>
-    non-dyn-compatible
-}
-
-pub fn core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0>(_1: &'_0 core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+pub fn core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0>(_1: &'_0 core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
 = <opaque>
 
-// Full name: core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
-impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
-    fn clone<'_0_1> = core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0_1>
+// Full name: core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    fn clone<'_0_1> = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::clone::aarch64-apple-darwin<'_0_1>
     non-dyn-compatible
 }
 
-// Full name: core::core_arch::arm_shared::neon::{impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
-impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
-    parent_clause1 = core::core_arch::arm_shared::neon::{impl core::clone::Clone::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+// Full name: core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    parent_clause1 = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
     non-dyn-compatible
 }
 
@@ -107,61 +81,32 @@ pub unsafe fn core::core_arch::x86::sse2::_mm_storeu_si128::x86_64-apple-darwin(
 = <opaque>
 
 #[lang_item("clone_fn")]
-pub fn core::clone::Clone::clone::x86_64-apple-darwin<'_0, Self>(_1: &'_0 Self) -> Self
+pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: core::clone::Clone::x86_64-apple-darwin<Self>,
+    [@TraitClause0]: core::clone::Clone<Self>,
 = <opaque>
 
-#[lang_item("clone_fn")]
-pub fn core::clone::Clone::clone::aarch64-apple-darwin<'_0, Self>(_1: &'_0 Self) -> Self
-where
-    [@TraitClause0]: core::clone::Clone::aarch64-apple-darwin<Self>,
+pub fn core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 = <opaque>
 
-pub fn core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::clone::x86_64-apple-darwin<'_0>(_1: &'_0 usize) -> usize
-= <opaque>
-
-// Full name: core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::x86_64-apple-darwin
-impl core::clone::Clone::x86_64-apple-darwin for usize {
-    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for usize}
-    fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::clone::x86_64-apple-darwin<'_0_1>
-    non-dyn-compatible
-}
-
-pub fn core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::clone::aarch64-apple-darwin<'_0>(_1: &'_0 usize) -> usize
-= <opaque>
-
-// Full name: core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::aarch64-apple-darwin
-impl core::clone::Clone::aarch64-apple-darwin for usize {
-    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for usize}
-    fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::clone::aarch64-apple-darwin<'_0_1>
+// Full name: core::clone::impls::{impl core::clone::Clone for usize}
+impl core::clone::Clone for usize {
+    parent_clause0 = {built_in impl core::marker::Sized for usize}
+    fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0_1>
     non-dyn-compatible
 }
 
 #[lang_item("eq")]
-pub trait core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>
+pub trait core::cmp::PartialEq<Self, Rhs>
 {
-    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq::x86_64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
-    vtable: core::cmp::PartialEq::{vtable}::x86_64-apple-darwin<Rhs>
-}
-
-#[lang_item("eq")]
-pub trait core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>
-{
-    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq::aarch64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
-    vtable: core::cmp::PartialEq::{vtable}::aarch64-apple-darwin<Rhs>
+    fn eq<'_0_1, '_1_1> = core::cmp::PartialEq::eq<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialEq::{vtable}<Rhs>
 }
 
 #[lang_item("cmp_partialeq_eq")]
-pub fn core::cmp::PartialEq::eq::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
+pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>,
-= <opaque>
-
-#[lang_item("cmp_partialeq_eq")]
-pub fn core::cmp::PartialEq::eq::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
-where
-    [@TraitClause0]: core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>,
+    [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>,
 = <opaque>
 
 #[lang_item("Ordering")]
@@ -172,307 +117,158 @@ pub enum core::cmp::Ordering {
 }
 
 #[lang_item("Option")]
-pub enum core::option::Option::x86_64-apple-darwin<T>
+pub enum core::option::Option<T>
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+    [@TraitClause0]: core::marker::Sized<T>,
 {
   None,
   Some(T),
 }
 
 #[lang_item("partial_ord")]
-pub trait core::cmp::PartialOrd::x86_64-apple-darwin<Self, Rhs>
+pub trait core::cmp::PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq::x86_64-apple-darwin<Self, Rhs>
-    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
-    vtable: core::cmp::PartialOrd::{vtable}::x86_64-apple-darwin<Rhs>
-}
-
-#[lang_item("Option")]
-pub enum core::option::Option::aarch64-apple-darwin<T>
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
-{
-  None,
-  Some(T),
-}
-
-#[lang_item("partial_ord")]
-pub trait core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>
-{
-    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq::aarch64-apple-darwin<Self, Rhs>
-    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0_1, '_1_1, Self, Rhs>[Self]
-    vtable: core::cmp::PartialOrd::{vtable}::aarch64-apple-darwin<Rhs>
+    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
+    vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
 
 #[lang_item("cmp_partialord_cmp")]
-pub fn core::cmp::PartialOrd::partial_cmp::x86_64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering}]
+pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option<core::cmp::Ordering>[{built_in impl core::marker::Sized for core::cmp::Ordering}]
 where
-    [@TraitClause0]: core::cmp::PartialOrd::x86_64-apple-darwin<Self, Rhs>,
+    [@TraitClause0]: core::cmp::PartialOrd<Self, Rhs>,
 = <opaque>
 
-#[lang_item("cmp_partialord_cmp")]
-pub fn core::cmp::PartialOrd::partial_cmp::aarch64-apple-darwin<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering}]
-where
-    [@TraitClause0]: core::cmp::PartialOrd::aarch64-apple-darwin<Self, Rhs>,
+pub fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}::eq<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
 = <opaque>
 
-pub fn core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::eq::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
-= <opaque>
-
-// Full name: core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
-impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize {
-    fn eq<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::eq::x86_64-apple-darwin<'_0_1, '_1_1>
-    vtable: core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::{vtable}::x86_64-apple-darwin
+// Full name: core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
+impl core::cmp::PartialEq<usize> for usize {
+    fn eq<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}::eq<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}::{vtable}
 }
 
-pub fn core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::eq::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
+pub fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_cmp<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option<core::cmp::Ordering>[{built_in impl core::marker::Sized for core::cmp::Ordering}]
 = <opaque>
 
-// Full name: core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
-impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize {
-    fn eq<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::eq::aarch64-apple-darwin<'_0_1, '_1_1>
-    vtable: core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::{vtable}::aarch64-apple-darwin
-}
-
-pub fn core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::x86_64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::cmp::Ordering}]
-= <opaque>
-
-// Full name: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
-impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
-    fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::partial_cmp::x86_64-apple-darwin<'_0_1, '_1_1>
-    vtable: core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::{vtable}::x86_64-apple-darwin
-}
-
-pub fn core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> core::option::Option::aarch64-apple-darwin<core::cmp::Ordering>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::cmp::Ordering}]
-= <opaque>
-
-// Full name: core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
-impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
-    fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::partial_cmp::aarch64-apple-darwin<'_0_1, '_1_1>
-    vtable: core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::{vtable}::aarch64-apple-darwin
+// Full name: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
+impl core::cmp::PartialOrd<usize> for usize {
+    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
+    fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
+    vtable: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::{vtable}
 }
 
 #[lang_item("range_step")]
-pub trait core::iter::range::Step::x86_64-apple-darwin<Self>
+pub trait core::iter::range::Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone::x86_64-apple-darwin<Self>
-    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd::x86_64-apple-darwin<Self, Self>
-    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between::x86_64-apple-darwin<'_0_1, '_1_1, Self>[Self]
-    fn forward_checked = core::iter::range::Step::forward_checked::x86_64-apple-darwin<Self>[Self]
-    fn backward_checked = core::iter::range::Step::backward_checked::x86_64-apple-darwin<Self>[Self]
+    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
+    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
+    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd<Self, Self>
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
+    fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
+    fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
     non-dyn-compatible
 }
 
-#[lang_item("range_step")]
-pub trait core::iter::range::Step::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone::aarch64-apple-darwin<Self>
-    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd::aarch64-apple-darwin<Self, Self>
-    fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between::aarch64-apple-darwin<'_0_1, '_1_1, Self>[Self]
-    fn forward_checked = core::iter::range::Step::forward_checked::aarch64-apple-darwin<Self>[Self]
-    fn backward_checked = core::iter::range::Step::backward_checked::aarch64-apple-darwin<Self>[Self]
-    non-dyn-compatible
-}
-
-pub fn core::iter::range::Step::steps_between::x86_64-apple-darwin<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}])
+pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option<usize>[{built_in impl core::marker::Sized for usize}])
 where
-    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+    [@TraitClause0]: core::iter::range::Step<Self>,
 = <opaque>
 
-pub fn core::iter::range::Step::steps_between::aarch64-apple-darwin<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}])
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
 where
-    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+    [@TraitClause0]: core::iter::range::Step<Self>,
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked::x86_64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::x86_64-apple-darwin<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
 where
-    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+    [@TraitClause0]: core::iter::range::Step<Self>,
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked::aarch64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::aarch64-apple-darwin<Self>[@TraitClause0::parent_clause0]
-where
-    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+pub fn core::iter::range::{impl core::iter::range::Step for usize}::backward_checked(_1: usize, _2: usize) -> core::option::Option<usize>[{built_in impl core::marker::Sized for usize}]
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked::x86_64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::x86_64-apple-darwin<Self>[@TraitClause0::parent_clause0]
-where
-    [@TraitClause0]: core::iter::range::Step::x86_64-apple-darwin<Self>,
+pub fn core::iter::range::{impl core::iter::range::Step for usize}::forward_checked(_1: usize, _2: usize) -> core::option::Option<usize>[{built_in impl core::marker::Sized for usize}]
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked::aarch64-apple-darwin<Self>(_1: Self, _2: usize) -> core::option::Option::aarch64-apple-darwin<Self>[@TraitClause0::parent_clause0]
-where
-    [@TraitClause0]: core::iter::range::Step::aarch64-apple-darwin<Self>,
+pub fn core::iter::range::{impl core::iter::range::Step for usize}::steps_between<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, core::option::Option<usize>[{built_in impl core::marker::Sized for usize}])
 = <opaque>
 
-pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::backward_checked::x86_64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]
-= <opaque>
-
-pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::forward_checked::x86_64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]
-= <opaque>
-
-pub fn core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::steps_between::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}])
-= <opaque>
-
-// Full name: core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin
-impl core::iter::range::Step::x86_64-apple-darwin for usize {
-    parent_clause0 = {built_in impl core::marker::Sized::x86_64-apple-darwin for usize}
-    parent_clause1 = core::clone::impls::{impl core::clone::Clone::x86_64-apple-darwin for usize}::x86_64-apple-darwin
-    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd::x86_64-apple-darwin<usize> for usize}::x86_64-apple-darwin
-    fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::steps_between::x86_64-apple-darwin<'_0_1, '_1_1>
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::forward_checked::x86_64-apple-darwin
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::backward_checked::x86_64-apple-darwin
-    non-dyn-compatible
-}
-
-pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::backward_checked::aarch64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]
-= <opaque>
-
-pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::forward_checked::aarch64-apple-darwin(_1: usize, _2: usize) -> core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]
-= <opaque>
-
-pub fn core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::steps_between::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> (usize, core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}])
-= <opaque>
-
-// Full name: core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin
-impl core::iter::range::Step::aarch64-apple-darwin for usize {
-    parent_clause0 = {built_in impl core::marker::Sized::aarch64-apple-darwin for usize}
-    parent_clause1 = core::clone::impls::{impl core::clone::Clone::aarch64-apple-darwin for usize}::aarch64-apple-darwin
-    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd::aarch64-apple-darwin<usize> for usize}::aarch64-apple-darwin
-    fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::steps_between::aarch64-apple-darwin<'_0_1, '_1_1>
-    fn forward_checked = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::forward_checked::aarch64-apple-darwin
-    fn backward_checked = core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::backward_checked::aarch64-apple-darwin
+// Full name: core::iter::range::{impl core::iter::range::Step for usize}
+impl core::iter::range::Step for usize {
+    parent_clause0 = {built_in impl core::marker::Sized for usize}
+    parent_clause1 = core::clone::impls::{impl core::clone::Clone for usize}
+    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
+    fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step for usize}::steps_between<'_0_1, '_1_1>
+    fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}::forward_checked
+    fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}::backward_checked
     non-dyn-compatible
 }
 
 #[lang_item("Range")]
-pub struct core::ops::range::Range::x86_64-apple-darwin<Idx>
+pub struct core::ops::range::Range<Idx>
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<Idx>,
+    [@TraitClause0]: core::marker::Sized<Idx>,
 {
   start: Idx,
   end: Idx,
 }
 
 #[lang_item("iterator")]
-pub trait core::iter::traits::iterator::Iterator::x86_64-apple-darwin<Self>
+pub trait core::iter::traits::iterator::Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized::x86_64-apple-darwin<Self::Item>
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
     type Item
-    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next::x86_64-apple-darwin<'_0_1, Self>[Self]
-    vtable: core::iter::traits::iterator::Iterator::{vtable}::x86_64-apple-darwin<Self::Item>
+    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
+    vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'_0, A>(_1: &'_0 mut core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]) -> core::option::Option::x86_64-apple-darwin<A>[@TraitClause0]
+pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut core::ops::range::Range<A>[@TraitClause0]) -> core::option::Option<A>[@TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<A>,
-    [@TraitClause1]: core::iter::range::Step::x86_64-apple-darwin<A>,
+    [@TraitClause0]: core::marker::Sized<A>,
+    [@TraitClause1]: core::iter::range::Step<A>,
 = <opaque>
 
-// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::x86_64-apple-darwin
-impl<A> core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]
+// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}
+impl<A> core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<A>,
-    [@TraitClause1]: core::iter::range::Step::x86_64-apple-darwin<A>,
+    [@TraitClause0]: core::marker::Sized<A>,
+    [@TraitClause1]: core::iter::range::Step<A>,
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}
+    parent_clause0 = {built_in impl core::marker::MetaSized for core::ops::range::Range<A>[@TraitClause0]}
     parent_clause1 = @TraitClause0
     type Item = A
-    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::{vtable}::x86_64-apple-darwin<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
+    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
 }
 
-#[lang_item("Range")]
-pub struct core::ops::range::Range::aarch64-apple-darwin<Idx>
+pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<Idx>,
-{
-  start: Idx,
-  end: Idx,
-}
-
-#[lang_item("iterator")]
-pub trait core::iter::traits::iterator::Iterator::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized::aarch64-apple-darwin<Self::Item>
-    type Item
-    fn next<'_0_1> = core::iter::traits::iterator::Iterator::next::aarch64-apple-darwin<'_0_1, Self>[Self]
-    vtable: core::iter::traits::iterator::Iterator::{vtable}::aarch64-apple-darwin<Self::Item>
-}
-
-pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'_0, A>(_1: &'_0 mut core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]) -> core::option::Option::aarch64-apple-darwin<A>[@TraitClause0]
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<A>,
-    [@TraitClause1]: core::iter::range::Step::aarch64-apple-darwin<A>,
-= <opaque>
-
-// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::aarch64-apple-darwin
-impl<A> core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<A>,
-    [@TraitClause1]: core::iter::range::Step::aarch64-apple-darwin<A>,
-{
-    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
-    type Item = A
-    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::{vtable}::aarch64-apple-darwin<A>[@TraitClause0, @TraitClause1]
-}
-
-pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::x86_64-apple-darwin for I}::into_iter::x86_64-apple-darwin<I>(_1: I) -> I
-where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator::x86_64-apple-darwin<I>,
-= <opaque>
-
-pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::aarch64-apple-darwin for I}::into_iter::aarch64-apple-darwin<I>(_1: I) -> I
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator::aarch64-apple-darwin<I>,
+    [@TraitClause0]: core::marker::Sized<I>,
+    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next::x86_64-apple-darwin<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option::x86_64-apple-darwin<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
 where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator::x86_64-apple-darwin<Self>,
-= <opaque>
-
-#[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next::aarch64-apple-darwin<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option::aarch64-apple-darwin<@TraitClause0::Item>[@TraitClause0::parent_clause1]
-where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator::aarch64-apple-darwin<Self>,
+    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
 = <opaque>
 
 pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
 = <opaque>
 
-pub fn core::slice::{[T]}::as_ptr::x86_64-apple-darwin<'_0, T>(_1: &'_0 [T]) -> *const T
+pub fn core::slice::{[T]}::as_ptr<'_0, T>(_1: &'_0 [T]) -> *const T
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
+    [@TraitClause0]: core::marker::Sized<T>,
 = <opaque>
 
-pub fn core::slice::{[T]}::as_ptr::aarch64-apple-darwin<'_0, T>(_1: &'_0 [T]) -> *const T
+pub fn core::slice::{[T]}::as_mut_ptr<'_0, T>(_1: &'_0 mut [T]) -> *mut T
 where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
+    [@TraitClause0]: core::marker::Sized<T>,
 = <opaque>
 
-pub fn core::slice::{[T]}::as_mut_ptr::x86_64-apple-darwin<'_0, T>(_1: &'_0 mut [T]) -> *mut T
-where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
-= <opaque>
-
-pub fn core::slice::{[T]}::as_mut_ptr::aarch64-apple-darwin<'_0, T>(_1: &'_0 mut [T]) -> *mut T
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
-= <opaque>
-
-fn UNIT_METADATA::x86_64-apple-darwin()
+fn UNIT_METADATA()
 {
     let _0: (); // return
 
@@ -480,75 +276,38 @@ fn UNIT_METADATA::x86_64-apple-darwin()
     return
 }
 
-fn UNIT_METADATA::aarch64-apple-darwin()
+const UNIT_METADATA: () = UNIT_METADATA()
+
+trait test_crate::NttIntrinsicsInterface<Self>
 {
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-const UNIT_METADATA::x86_64-apple-darwin: () = UNIT_METADATA::x86_64-apple-darwin()
-
-const UNIT_METADATA::aarch64-apple-darwin: () = UNIT_METADATA::aarch64-apple-darwin()
-
-trait test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::x86_64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized::x86_64-apple-darwin<Self::Vec128>
-    parent_clause2 : [@TraitClause2]: core::marker::Copy::x86_64-apple-darwin<Self::Vec128>
+    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Vec128>
+    parent_clause2 : [@TraitClause2]: core::marker::Copy<Self::Vec128>
     type Vec128
-    fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load::x86_64-apple-darwin<'_0_1, Self>[Self]
-    fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store::x86_64-apple-darwin<'_0_1, Self>[Self]
-    fn vec128_add = test_crate::NttIntrinsicsInterface::vec128_add::x86_64-apple-darwin<Self>[Self]
+    fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load<'_0_1, Self>[Self]
+    fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store<'_0_1, Self>[Self]
+    fn vec128_add = test_crate::NttIntrinsicsInterface::vec128_add<Self>[Self]
     non-dyn-compatible
 }
 
-trait test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>
-{
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::aarch64-apple-darwin<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized::aarch64-apple-darwin<Self::Vec128>
-    parent_clause2 : [@TraitClause2]: core::marker::Copy::aarch64-apple-darwin<Self::Vec128>
-    type Vec128
-    fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load::aarch64-apple-darwin<'_0_1, Self>[Self]
-    fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store::aarch64-apple-darwin<'_0_1, Self>[Self]
-    fn vec128_add = test_crate::NttIntrinsicsInterface::vec128_add::aarch64-apple-darwin<Self>[Self]
-    non-dyn-compatible
-}
-
-fn test_crate::NttIntrinsicsInterface::vec128_load::x86_64-apple-darwin<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
+fn test_crate::NttIntrinsicsInterface::vec128_load<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
 = <method_without_default_body>
 
-fn test_crate::NttIntrinsicsInterface::vec128_load::aarch64-apple-darwin<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
+fn test_crate::NttIntrinsicsInterface::vec128_store<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
 = <method_without_default_body>
 
-fn test_crate::NttIntrinsicsInterface::vec128_store::x86_64-apple-darwin<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
+fn test_crate::NttIntrinsicsInterface::vec128_add<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
-= <method_without_default_body>
-
-fn test_crate::NttIntrinsicsInterface::vec128_store::aarch64-apple-darwin<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
-where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
-= <method_without_default_body>
-
-fn test_crate::NttIntrinsicsInterface::vec128_add::x86_64-apple-darwin<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
-where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<Self>,
-= <method_without_default_body>
-
-fn test_crate::NttIntrinsicsInterface::vec128_add::aarch64-apple-darwin<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
-where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<Self>,
+    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
 = <method_without_default_body>
 
 pub struct test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {}
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin(_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin(_1: core::core_arch::x86::__m128i::x86_64-apple-darwin, _2: core::core_arch::x86::__m128i::x86_64-apple-darwin) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
 {
     let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
     let a_1: core::core_arch::x86::__m128i::x86_64-apple-darwin; // arg #1
@@ -566,7 +325,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-d
     return
 }
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::x86::__m128i::x86_64-apple-darwin)
 {
     let _0: (); // return
     let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -585,7 +344,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-d
     _6 = &two-phase-mut (*dst_1)
     _5 = @ArrayToSliceMut<'_, u16, 8 : usize>(move _6)
     storage_dead(_6)
-    _4 = core::slice::{[T]}::as_mut_ptr::x86_64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::x86_64-apple-darwin for u16}](move _5)
+    _4 = core::slice::{[T]}::as_mut_ptr<'7, u16>[{built_in impl core::marker::Sized for u16}](move _5)
     storage_dead(_5)
     _3 = cast<*mut u16, *mut core::core_arch::x86::__m128i::x86_64-apple-darwin>(move _4)
     storage_dead(_4)
@@ -597,7 +356,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-d
     return
 }
 
-fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
+fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::x86::__m128i::x86_64-apple-darwin
 {
     let _0: core::core_arch::x86::__m128i::x86_64-apple-darwin; // return
     let src_1: &'1 [u16; 8 : usize]; // arg #1
@@ -613,7 +372,7 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-d
     _5 = &(*src_1)
     _4 = @ArrayToSliceShared<'_, u16, 8 : usize>(move _5)
     storage_dead(_5)
-    _3 = core::slice::{[T]}::as_ptr::x86_64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::x86_64-apple-darwin for u16}](move _4)
+    _3 = core::slice::{[T]}::as_ptr<'7, u16>[{built_in impl core::marker::Sized for u16}](move _4)
     storage_dead(_4)
     _2 = cast<*const u16, *const core::core_arch::x86::__m128i::x86_64-apple-darwin>(move _3)
     storage_dead(_3)
@@ -622,21 +381,21 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-d
     return
 }
 
-// Full name: test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin
-impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::MetaSized::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}
-    parent_clause1 = {built_in impl core::marker::Sized::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}
-    parent_clause2 = core::core_arch::x86::{impl core::marker::Copy::x86_64-apple-darwin for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
+// Full name: test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin
+impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}
+    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i::x86_64-apple-darwin}
+    parent_clause2 = core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i::x86_64-apple-darwin}::x86_64-apple-darwin
     type Vec128 = core::core_arch::x86::__m128i::x86_64-apple-darwin
-    fn vec128_load<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0_1>
-    fn vec128_store<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0_1>
-    fn vec128_add = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin
+    fn vec128_load<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_load::x86_64-apple-darwin<'_0_1>
+    fn vec128_store<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_store::x86_64-apple-darwin<'_0_1>
+    fn vec128_add = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::vec128_add::x86_64-apple-darwin
     non-dyn-compatible
 }
 
 pub struct test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {}
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin(_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin(_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin, _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
 {
     let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
     let a_1: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // arg #1
@@ -654,7 +413,7 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple
     return
 }
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0>(_1: &'_0 mut [u16; 8 : usize], _2: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin)
 {
     let _0: (); // return
     let dst_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -671,7 +430,7 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple
     _5 = &two-phase-mut (*dst_1)
     _4 = @ArrayToSliceMut<'_, u16, 8 : usize>(move _5)
     storage_dead(_5)
-    _3 = core::slice::{[T]}::as_mut_ptr::aarch64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::aarch64-apple-darwin for u16}](move _4)
+    _3 = core::slice::{[T]}::as_mut_ptr<'7, u16>[{built_in impl core::marker::Sized for u16}](move _4)
     storage_dead(_4)
     storage_live(_6)
     _6 = copy val_2
@@ -681,7 +440,7 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple
     return
 }
 
-fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
+fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0>(_1: &'_0 [u16; 8 : usize]) -> core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
 {
     let _0: core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin; // return
     let src_1: &'1 [u16; 8 : usize]; // arg #1
@@ -695,223 +454,123 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple
     _4 = &(*src_1)
     _3 = @ArrayToSliceShared<'_, u16, 8 : usize>(move _4)
     storage_dead(_4)
-    _2 = core::slice::{[T]}::as_ptr::aarch64-apple-darwin<'7, u16>[{built_in impl core::marker::Sized::aarch64-apple-darwin for u16}](move _3)
+    _2 = core::slice::{[T]}::as_ptr<'7, u16>[{built_in impl core::marker::Sized for u16}](move _3)
     storage_dead(_3)
     _0 = core::core_arch::aarch64::neon::generated::vld1q_u16::aarch64-apple-darwin(move _2)
     storage_dead(_2)
     return
 }
 
-// Full name: test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin
-impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {
-    parent_clause0 = {built_in impl core::marker::MetaSized::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}
-    parent_clause1 = {built_in impl core::marker::Sized::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
-    parent_clause2 = core::core_arch::arm_shared::neon::{impl core::marker::Copy::aarch64-apple-darwin for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
+// Full name: test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin
+impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin {
+    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}
+    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}
+    parent_clause2 = core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin}::aarch64-apple-darwin
     type Vec128 = core::core_arch::arm_shared::neon::uint16x8_t::aarch64-apple-darwin
-    fn vec128_load<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0_1>
-    fn vec128_store<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0_1>
-    fn vec128_add = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin
+    fn vec128_load<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_load::aarch64-apple-darwin<'_0_1>
+    fn vec128_store<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_store::aarch64-apple-darwin<'_0_1>
+    fn vec128_add = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::vec128_add::aarch64-apple-darwin
     non-dyn-compatible
 }
 
-fn test_crate::ntt_layer_generic::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
-{
-    let _0: (); // return
-    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
-    let b_2: &'3 [u16; 8 : usize]; // arg #2
-    let _3: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
-    let _4: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
-    let iter_5: core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // local
-    let _6: core::option::Option::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
-    let _7: &'5 mut core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
-    let _8: &'6 mut core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]; // anonymous local
-    let i_9: usize; // local
-    let _10: u16; // anonymous local
-    let _11: u16; // anonymous local
-    let _12: usize; // anonymous local
-    let _13: u16; // anonymous local
-    let _14: usize; // anonymous local
-    let _15: usize; // anonymous local
-    let _16: &'_ [u16; 8 : usize]; // anonymous local
-    let _17: &'_ u16; // anonymous local
-    let _18: &'_ [u16; 8 : usize]; // anonymous local
-    let _19: &'_ u16; // anonymous local
-    let _20: &'_ mut [u16; 8 : usize]; // anonymous local
-    let _21: &'_ mut u16; // anonymous local
-
-    _0 = ()
-    storage_live(_3)
-    storage_live(_4)
-    _4 = core::ops::range::Range::x86_64-apple-darwin { start: const 0 : usize, end: const 8 : usize }
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::x86_64-apple-darwin for I}::into_iter::x86_64-apple-darwin<core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]>[{built_in impl core::marker::Sized::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::x86_64-apple-darwin<usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin]](move _4)
-    storage_dead(_4)
-    storage_live(iter_5)
-    iter_5 = move _3
-    loop {
-        storage_live(_6)
-        storage_live(_7)
-        storage_live(_8)
-        _8 = &mut iter_5
-        _7 = &two-phase-mut (*_8)
-        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator::x86_64-apple-darwin for core::ops::range::Range::x86_64-apple-darwin<A>[@TraitClause0]}::next::x86_64-apple-darwin<'8, usize>[{built_in impl core::marker::Sized::x86_64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::x86_64-apple-darwin for usize}::x86_64-apple-darwin](move _7)
-        storage_dead(_7)
-        match _6 {
-            core::option::Option::x86_64-apple-darwin::None => {
-                break 0
-            },
-            core::option::Option::x86_64-apple-darwin::Some => {
-            },
-        }
-        storage_live(i_9)
-        i_9 = copy (_6 as variant core::option::Option::x86_64-apple-darwin::Some).0
-        storage_live(_10)
-        storage_live(_11)
-        storage_live(_12)
-        _12 = copy i_9
-        storage_live(_16)
-        _16 = &(*a_1)
-        storage_live(_17)
-        _17 = @ArrayIndexShared<'_, u16, 8 : usize>(move _16, copy _12)
-        _11 = copy (*_17)
-        storage_live(_13)
-        storage_live(_14)
-        _14 = copy i_9
-        storage_live(_18)
-        _18 = &(*b_2)
-        storage_live(_19)
-        _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
-        _13 = copy (*_19)
-        _10 = core::num::{u16}::wrapping_add(move _11, move _13)
-        storage_dead(_13)
-        storage_dead(_11)
-        storage_live(_15)
-        _15 = copy i_9
-        storage_live(_20)
-        _20 = &mut (*a_1)
-        storage_live(_21)
-        _21 = @ArrayIndexMut<'_, u16, 8 : usize>(move _20, copy _15)
-        (*_21) = move _10
-        storage_dead(_10)
-        storage_dead(_15)
-        storage_dead(_14)
-        storage_dead(_12)
-        storage_dead(i_9)
-        storage_dead(_8)
-        storage_dead(_6)
-        continue 0
-    }
-    _0 = ()
-    storage_dead(_8)
-    storage_dead(_6)
-    storage_dead(iter_5)
-    storage_dead(_3)
-    return
-}
-
-fn test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
-{
-    let _0: (); // return
-    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
-    let b_2: &'3 [u16; 8 : usize]; // arg #2
-    let _3: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
-    let _4: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
-    let iter_5: core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // local
-    let _6: core::option::Option::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
-    let _7: &'5 mut core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
-    let _8: &'6 mut core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]; // anonymous local
-    let i_9: usize; // local
-    let _10: u16; // anonymous local
-    let _11: u16; // anonymous local
-    let _12: usize; // anonymous local
-    let _13: u16; // anonymous local
-    let _14: usize; // anonymous local
-    let _15: usize; // anonymous local
-    let _16: &'_ [u16; 8 : usize]; // anonymous local
-    let _17: &'_ u16; // anonymous local
-    let _18: &'_ [u16; 8 : usize]; // anonymous local
-    let _19: &'_ u16; // anonymous local
-    let _20: &'_ mut [u16; 8 : usize]; // anonymous local
-    let _21: &'_ mut u16; // anonymous local
-
-    _0 = ()
-    storage_live(_3)
-    storage_live(_4)
-    _4 = core::ops::range::Range::aarch64-apple-darwin { start: const 0 : usize, end: const 8 : usize }
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator::aarch64-apple-darwin for I}::into_iter::aarch64-apple-darwin<core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]>[{built_in impl core::marker::Sized::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::aarch64-apple-darwin<usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin]](move _4)
-    storage_dead(_4)
-    storage_live(iter_5)
-    iter_5 = move _3
-    loop {
-        storage_live(_6)
-        storage_live(_7)
-        storage_live(_8)
-        _8 = &mut iter_5
-        _7 = &two-phase-mut (*_8)
-        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator::aarch64-apple-darwin for core::ops::range::Range::aarch64-apple-darwin<A>[@TraitClause0]}::next::aarch64-apple-darwin<'8, usize>[{built_in impl core::marker::Sized::aarch64-apple-darwin for usize}, core::iter::range::{impl core::iter::range::Step::aarch64-apple-darwin for usize}::aarch64-apple-darwin](move _7)
-        storage_dead(_7)
-        match _6 {
-            core::option::Option::aarch64-apple-darwin::None => {
-                break 0
-            },
-            core::option::Option::aarch64-apple-darwin::Some => {
-            },
-        }
-        storage_live(i_9)
-        i_9 = copy (_6 as variant core::option::Option::aarch64-apple-darwin::Some).0
-        storage_live(_10)
-        storage_live(_11)
-        storage_live(_12)
-        _12 = copy i_9
-        storage_live(_16)
-        _16 = &(*a_1)
-        storage_live(_17)
-        _17 = @ArrayIndexShared<'_, u16, 8 : usize>(move _16, copy _12)
-        _11 = copy (*_17)
-        storage_live(_13)
-        storage_live(_14)
-        _14 = copy i_9
-        storage_live(_18)
-        _18 = &(*b_2)
-        storage_live(_19)
-        _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
-        _13 = copy (*_19)
-        _10 = core::num::{u16}::wrapping_add(move _11, move _13)
-        storage_dead(_13)
-        storage_dead(_11)
-        storage_live(_15)
-        _15 = copy i_9
-        storage_live(_20)
-        _20 = &mut (*a_1)
-        storage_live(_21)
-        _21 = @ArrayIndexMut<'_, u16, 8 : usize>(move _20, copy _15)
-        (*_21) = move _10
-        storage_dead(_10)
-        storage_dead(_15)
-        storage_dead(_14)
-        storage_dead(_12)
-        storage_dead(i_9)
-        storage_dead(_8)
-        storage_dead(_6)
-        continue 0
-    }
-    _0 = ()
-    storage_dead(_8)
-    storage_dead(_6)
-    storage_dead(iter_5)
-    storage_dead(_3)
-    return
-}
-
 fn test_crate::ntt_layer_generic<'_0, '_1>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
-= target_dispatch {
-    x86_64-apple-darwin => test_crate::ntt_layer_generic::x86_64-apple-darwin<'_0, '_1>,
-    aarch64-apple-darwin => test_crate::ntt_layer_generic::aarch64-apple-darwin<'_0, '_1>,
+{
+    let _0: (); // return
+    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
+    let b_2: &'3 [u16; 8 : usize]; // arg #2
+    let _3: core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]; // anonymous local
+    let _4: core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]; // anonymous local
+    let iter_5: core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]; // local
+    let _6: core::option::Option<usize>[{built_in impl core::marker::Sized for usize}]; // anonymous local
+    let _7: &'5 mut core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]; // anonymous local
+    let _8: &'6 mut core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]; // anonymous local
+    let i_9: usize; // local
+    let _10: u16; // anonymous local
+    let _11: u16; // anonymous local
+    let _12: usize; // anonymous local
+    let _13: u16; // anonymous local
+    let _14: usize; // anonymous local
+    let _15: usize; // anonymous local
+    let _16: &'_ [u16; 8 : usize]; // anonymous local
+    let _17: &'_ u16; // anonymous local
+    let _18: &'_ [u16; 8 : usize]; // anonymous local
+    let _19: &'_ u16; // anonymous local
+    let _20: &'_ mut [u16; 8 : usize]; // anonymous local
+    let _21: &'_ mut u16; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    storage_live(_4)
+    _4 = core::ops::range::Range { start: const 0 : usize, end: const 8 : usize }
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]>[{built_in impl core::marker::Sized for core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}<usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}]](move _4)
+    storage_dead(_4)
+    storage_live(iter_5)
+    iter_5 = move _3
+    loop {
+        storage_live(_6)
+        storage_live(_7)
+        storage_live(_8)
+        _8 = &mut iter_5
+        _7 = &two-phase-mut (*_8)
+        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'8, usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}](move _7)
+        storage_dead(_7)
+        match _6 {
+            core::option::Option::None => {
+                break 0
+            },
+            core::option::Option::Some => {
+            },
+        }
+        storage_live(i_9)
+        i_9 = copy (_6 as variant core::option::Option::Some).0
+        storage_live(_10)
+        storage_live(_11)
+        storage_live(_12)
+        _12 = copy i_9
+        storage_live(_16)
+        _16 = &(*a_1)
+        storage_live(_17)
+        _17 = @ArrayIndexShared<'_, u16, 8 : usize>(move _16, copy _12)
+        _11 = copy (*_17)
+        storage_live(_13)
+        storage_live(_14)
+        _14 = copy i_9
+        storage_live(_18)
+        _18 = &(*b_2)
+        storage_live(_19)
+        _19 = @ArrayIndexShared<'_, u16, 8 : usize>(move _18, copy _14)
+        _13 = copy (*_19)
+        _10 = core::num::{u16}::wrapping_add(move _11, move _13)
+        storage_dead(_13)
+        storage_dead(_11)
+        storage_live(_15)
+        _15 = copy i_9
+        storage_live(_20)
+        _20 = &mut (*a_1)
+        storage_live(_21)
+        _21 = @ArrayIndexMut<'_, u16, 8 : usize>(move _20, copy _15)
+        (*_21) = move _10
+        storage_dead(_10)
+        storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_12)
+        storage_dead(i_9)
+        storage_dead(_8)
+        storage_dead(_6)
+        continue 0
+    }
+    _0 = ()
+    storage_dead(_8)
+    storage_dead(_6)
+    storage_dead(iter_5)
+    storage_dead(_3)
+    return
 }
 
-fn test_crate::ntt_layer_vec128::x86_64-apple-darwin<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
+fn test_crate::ntt_layer_vec128<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
 where
-    [@TraitClause0]: core::marker::Sized::x86_64-apple-darwin<T>,
-    [@TraitClause1]: test_crate::NttIntrinsicsInterface::x86_64-apple-darwin<T>,
+    [@TraitClause0]: core::marker::Sized<T>,
+    [@TraitClause1]: test_crate::NttIntrinsicsInterface<T>,
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1
@@ -959,114 +618,28 @@ where
     storage_dead(vr_7)
     storage_dead(vb_5)
     storage_dead(va_3)
-    return
-}
-
-fn test_crate::ntt_layer_vec128::aarch64-apple-darwin<'_0, '_1, T>(_1: &'_0 mut [u16; 8 : usize], _2: &'_1 [u16; 8 : usize])
-where
-    [@TraitClause0]: core::marker::Sized::aarch64-apple-darwin<T>,
-    [@TraitClause1]: test_crate::NttIntrinsicsInterface::aarch64-apple-darwin<T>,
-{
-    let _0: (); // return
-    let a_1: &'1 mut [u16; 8 : usize]; // arg #1
-    let b_2: &'3 [u16; 8 : usize]; // arg #2
-    let va_3: @TraitClause1::Vec128; // local
-    let _4: &'4 [u16; 8 : usize]; // anonymous local
-    let vb_5: @TraitClause1::Vec128; // local
-    let _6: &'5 [u16; 8 : usize]; // anonymous local
-    let vr_7: @TraitClause1::Vec128; // local
-    let _8: @TraitClause1::Vec128; // anonymous local
-    let _9: @TraitClause1::Vec128; // anonymous local
-    let _10: (); // anonymous local
-    let _11: &'6 mut [u16; 8 : usize]; // anonymous local
-    let _12: @TraitClause1::Vec128; // anonymous local
-
-    _0 = ()
-    storage_live(va_3)
-    storage_live(_4)
-    _4 = &(*a_1)
-    va_3 = @TraitClause1::vec128_load<'8>(move _4)
-    storage_dead(_4)
-    storage_live(vb_5)
-    storage_live(_6)
-    _6 = &(*b_2)
-    vb_5 = @TraitClause1::vec128_load<'10>(move _6)
-    storage_dead(_6)
-    storage_live(vr_7)
-    storage_live(_8)
-    _8 = copy va_3
-    storage_live(_9)
-    _9 = copy vb_5
-    vr_7 = @TraitClause1::vec128_add(move _8, move _9)
-    storage_dead(_9)
-    storage_dead(_8)
-    storage_live(_10)
-    storage_live(_11)
-    _11 = &two-phase-mut (*a_1)
-    storage_live(_12)
-    _12 = copy vr_7
-    _10 = @TraitClause1::vec128_store<'12>(move _11, move _12)
-    storage_dead(_12)
-    storage_dead(_11)
-    storage_dead(_10)
-    _0 = ()
-    storage_dead(vr_7)
-    storage_dead(vb_5)
-    storage_dead(va_3)
-    return
-}
-
-fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin() -> u32
-{
-    let _0: u32; // return
-
-    _0 = const 1 : u32
-    return
-}
-
-fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin() -> u32
-{
-    let _0: u32; // return
-
-    _0 = const 1 : u32
     return
 }
 
 fn test_crate::SYMCRYPT_CPU_FEATURE_SSE2() -> u32
-= target_dispatch {
-    x86_64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin,
-    aarch64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin,
-}
-
-const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin()
-
-const test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2::aarch64-apple-darwin()
-
-fn test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin() -> u32
 {
     let _0: u32; // return
 
-    _0 = const 2 : u32
+    _0 = const 1 : u32
     return
 }
 
-fn test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin() -> u32
-{
-    let _0: u32; // return
-
-    _0 = const 2 : u32
-    return
-}
+const test_crate::SYMCRYPT_CPU_FEATURE_SSE2: u32 = test_crate::SYMCRYPT_CPU_FEATURE_SSE2()
 
 fn test_crate::SYMCRYPT_CPU_FEATURE_NEON() -> u32
-= target_dispatch {
-    x86_64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin,
-    aarch64-apple-darwin => test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin,
+{
+    let _0: u32; // return
+
+    _0 = const 2 : u32
+    return
 }
 
-const test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::x86_64-apple-darwin()
-
-const test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin()
+const test_crate::SYMCRYPT_CPU_FEATURE_NEON: u32 = test_crate::SYMCRYPT_CPU_FEATURE_NEON()
 
 fn test_crate::cpu_features_present(_1: u32) -> bool
 {
@@ -1092,14 +665,14 @@ fn test_crate::poly_element_ntt_layer::x86_64-apple-darwin<'_0, '_1>(_1: &'_0 mu
 
     _0 = ()
     storage_live(_3)
-    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_SSE2::x86_64-apple-darwin)
+    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_SSE2)
     if move _3 {
         storage_live(_4)
         storage_live(_5)
         _5 = &two-phase-mut (*a_1)
         storage_live(_6)
         _6 = &(*b_2)
-        _4 = test_crate::ntt_layer_vec128::x86_64-apple-darwin<'10, '11, test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin>[{built_in impl core::marker::Sized::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}, test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface::x86_64-apple-darwin for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin](move _5, move _6)
+        _4 = test_crate::ntt_layer_vec128<'10, '11, test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin>[{built_in impl core::marker::Sized for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}, test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm::x86_64-apple-darwin}::x86_64-apple-darwin](move _5, move _6)
         storage_dead(_6)
         storage_dead(_5)
         storage_dead(_4)
@@ -1135,14 +708,14 @@ fn test_crate::poly_element_ntt_layer::aarch64-apple-darwin<'_0, '_1>(_1: &'_0 m
 
     _0 = ()
     storage_live(_3)
-    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_NEON::aarch64-apple-darwin)
+    _3 = test_crate::cpu_features_present(copy test_crate::SYMCRYPT_CPU_FEATURE_NEON)
     if move _3 {
         storage_live(_4)
         storage_live(_5)
         _5 = &two-phase-mut (*a_1)
         storage_live(_6)
         _6 = &(*b_2)
-        _4 = test_crate::ntt_layer_vec128::aarch64-apple-darwin<'10, '11, test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin>[{built_in impl core::marker::Sized::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}, test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface::aarch64-apple-darwin for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin](move _5, move _6)
+        _4 = test_crate::ntt_layer_vec128<'10, '11, test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin>[{built_in impl core::marker::Sized for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}, test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon::aarch64-apple-darwin}::aarch64-apple-darwin](move _5, move _6)
         storage_dead(_6)
         storage_dead(_5)
         storage_dead(_4)

--- a/charon/tests/ui/multi-target-from-symcrypt.rs
+++ b/charon/tests/ui/multi-target-from-symcrypt.rs
@@ -1,0 +1,106 @@
+//@ charon-args=--targets=x86_64-apple-darwin,aarch64-apple-darwin
+#![allow(unused, non_camel_case_types)]
+
+// ── Trait abstracting over platform SIMD intrinsics ────────────────────
+
+trait NttIntrinsicsInterface {
+    type Vec128: Copy;
+
+    fn vec128_load(src: &[u16; 8]) -> Self::Vec128;
+    fn vec128_store(dst: &mut [u16; 8], val: Self::Vec128);
+    fn vec128_add(a: Self::Vec128, b: Self::Vec128) -> Self::Vec128;
+}
+
+// ── x86_64 backend ────────────────────────────────────────────────────
+
+#[cfg(target_arch = "x86_64")]
+mod ntt_xmm {
+    use super::NttIntrinsicsInterface;
+    use core::arch::x86_64::*;
+
+    pub struct NttIntrinsicsXmm;
+
+    impl NttIntrinsicsInterface for NttIntrinsicsXmm {
+        type Vec128 = __m128i;
+
+        fn vec128_load(src: &[u16; 8]) -> __m128i {
+            unsafe { _mm_loadu_si128(src.as_ptr() as *const __m128i) }
+        }
+        fn vec128_store(dst: &mut [u16; 8], val: __m128i) {
+            unsafe { _mm_storeu_si128(dst.as_mut_ptr() as *mut __m128i, val) }
+        }
+        fn vec128_add(a: __m128i, b: __m128i) -> __m128i {
+            unsafe { _mm_add_epi16(a, b) }
+        }
+    }
+}
+
+// ── aarch64 backend ───────────────────────────────────────────────────
+
+#[cfg(target_arch = "aarch64")]
+mod ntt_neon {
+    use super::NttIntrinsicsInterface;
+    use core::arch::aarch64::*;
+
+    pub struct NttIntrinsicsNeon;
+
+    impl NttIntrinsicsInterface for NttIntrinsicsNeon {
+        type Vec128 = uint16x8_t;
+
+        fn vec128_load(src: &[u16; 8]) -> uint16x8_t {
+            unsafe { vld1q_u16(src.as_ptr()) }
+        }
+        fn vec128_store(dst: &mut [u16; 8], val: uint16x8_t) {
+            unsafe { vst1q_u16(dst.as_mut_ptr(), val) }
+        }
+        fn vec128_add(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
+            unsafe { vaddq_u16(a, b) }
+        }
+    }
+}
+
+// ── Generic (scalar) fallback ─────────────────────────────────────────
+
+fn ntt_layer_generic(a: &mut [u16; 8], b: &[u16; 8]) {
+    for i in 0..8 {
+        a[i] = a[i].wrapping_add(b[i]);
+    }
+}
+
+// ── Vectorised implementation, generic over the intrinsics trait ──────
+
+fn ntt_layer_vec128<T: NttIntrinsicsInterface>(a: &mut [u16; 8], b: &[u16; 8]) {
+    let va = T::vec128_load(a);
+    let vb = T::vec128_load(b);
+    let vr = T::vec128_add(va, vb);
+    T::vec128_store(a, vr);
+}
+
+// ── Portable entry point: cfg-dispatched ──────────────────────────────
+
+const SYMCRYPT_CPU_FEATURE_SSE2: u32 = 0x01;
+const SYMCRYPT_CPU_FEATURE_NEON: u32 = 0x02;
+
+fn cpu_features_present(_mask: u32) -> bool {
+    true
+}
+
+fn poly_element_ntt_layer(a: &mut [u16; 8], b: &[u16; 8]) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if cpu_features_present(SYMCRYPT_CPU_FEATURE_SSE2) {
+            ntt_layer_vec128::<ntt_xmm::NttIntrinsicsXmm>(a, b);
+        } else {
+            ntt_layer_generic(a, b);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if cpu_features_present(SYMCRYPT_CPU_FEATURE_NEON) {
+            ntt_layer_vec128::<ntt_neon::NttIntrinsicsNeon>(a, b);
+        } else {
+            ntt_layer_generic(a, b);
+        }
+    }
+}

--- a/charon/tests/ui/multi-targets.out
+++ b/charon/tests/ui/multi-targets.out
@@ -1,0 +1,71 @@
+pub fn test_crate::f1::i686-unknown-linux-gnu() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 0 : u64
+    return
+}
+
+pub fn test_crate::f1::x86_64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 0 : u64
+    return
+}
+
+pub fn test_crate::f2_per_target::i686-unknown-linux-gnu() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 1 : u64
+    return
+}
+
+pub fn test_crate::f2_per_target::x86_64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 2 : u64
+    return
+}
+
+fn test_crate::foo::i686-unknown-linux-gnu() -> u64
+{
+    let _0: u64; // return
+    let _1: u64; // anonymous local
+    let _2: u64; // anonymous local
+    let _3: u64; // anonymous local
+
+    storage_live(_3)
+    storage_live(_1)
+    _1 = test_crate::f1::i686-unknown-linux-gnu()
+    storage_live(_2)
+    _2 = test_crate::f2_per_target::i686-unknown-linux-gnu()
+    _3 = copy _1 panic.+ copy _2
+    _0 = move _3
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+fn test_crate::foo::x86_64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+    let _1: u64; // anonymous local
+    let _2: u64; // anonymous local
+    let _3: u64; // anonymous local
+
+    storage_live(_3)
+    storage_live(_1)
+    _1 = test_crate::f1::x86_64-apple-darwin()
+    storage_live(_2)
+    _2 = test_crate::f2_per_target::x86_64-apple-darwin()
+    _3 = copy _1 panic.+ copy _2
+    _0 = move _3
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+

--- a/charon/tests/ui/multi-targets.out
+++ b/charon/tests/ui/multi-targets.out
@@ -1,4 +1,30 @@
-pub fn test_crate::f1::i686-unknown-linux-gnu() -> u64
+pub struct test_crate::StructTargetIndep::i686-unknown-linux-gnu {
+  x: u64,
+  y: u64,
+}
+
+pub struct test_crate::StructTargetIndep::x86_64-apple-darwin {
+  x: u64,
+  y: u64,
+}
+
+fn test_crate::make_pair_same::i686-unknown-linux-gnu() -> test_crate::StructTargetIndep::i686-unknown-linux-gnu
+{
+    let _0: test_crate::StructTargetIndep::i686-unknown-linux-gnu; // return
+
+    _0 = test_crate::StructTargetIndep::i686-unknown-linux-gnu { x: const 1 : u64, y: const 2 : u64 }
+    return
+}
+
+fn test_crate::make_pair_same::x86_64-apple-darwin() -> test_crate::StructTargetIndep::x86_64-apple-darwin
+{
+    let _0: test_crate::StructTargetIndep::x86_64-apple-darwin; // return
+
+    _0 = test_crate::StructTargetIndep::x86_64-apple-darwin { x: const 1 : u64, y: const 2 : u64 }
+    return
+}
+
+pub fn test_crate::f1_same::i686-unknown-linux-gnu() -> u64
 {
     let _0: u64; // return
 
@@ -6,7 +32,7 @@ pub fn test_crate::f1::i686-unknown-linux-gnu() -> u64
     return
 }
 
-pub fn test_crate::f1::x86_64-apple-darwin() -> u64
+pub fn test_crate::f1_same::x86_64-apple-darwin() -> u64
 {
     let _0: u64; // return
 
@@ -14,15 +40,38 @@ pub fn test_crate::f1::x86_64-apple-darwin() -> u64
     return
 }
 
-pub fn test_crate::f2_per_target::i686-unknown-linux-gnu() -> u64
+fn test_crate::f2_same::i686-unknown-linux-gnu() -> u64
 {
     let _0: u64; // return
 
-    _0 = const 1 : u64
+    _0 = test_crate::f1_same::i686-unknown-linux-gnu()
     return
 }
 
-pub fn test_crate::f2_per_target::x86_64-apple-darwin() -> u64
+fn test_crate::f2_same::x86_64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+
+    _0 = test_crate::f1_same::x86_64-apple-darwin()
+    return
+}
+
+pub fn test_crate::f3_different::i686-unknown-linux-gnu() -> u64
+{
+    let _0: u64; // return
+    let _1: u64; // anonymous local
+    let _2: u64; // anonymous local
+
+    storage_live(_2)
+    storage_live(_1)
+    _1 = test_crate::f2_same::i686-unknown-linux-gnu()
+    _2 = const 1 : u64 panic.+ copy _1
+    _0 = move _2
+    storage_dead(_1)
+    return
+}
+
+pub fn test_crate::f3_different::x86_64-apple-darwin() -> u64
 {
     let _0: u64; // return
 
@@ -30,7 +79,7 @@ pub fn test_crate::f2_per_target::x86_64-apple-darwin() -> u64
     return
 }
 
-fn test_crate::foo::i686-unknown-linux-gnu() -> u64
+fn test_crate::foo_same::i686-unknown-linux-gnu() -> u64
 {
     let _0: u64; // return
     let _1: u64; // anonymous local
@@ -39,9 +88,9 @@ fn test_crate::foo::i686-unknown-linux-gnu() -> u64
 
     storage_live(_3)
     storage_live(_1)
-    _1 = test_crate::f1::i686-unknown-linux-gnu()
+    _1 = test_crate::f2_same::i686-unknown-linux-gnu()
     storage_live(_2)
-    _2 = test_crate::f2_per_target::i686-unknown-linux-gnu()
+    _2 = test_crate::f3_different::i686-unknown-linux-gnu()
     _3 = copy _1 panic.+ copy _2
     _0 = move _3
     storage_dead(_2)
@@ -49,7 +98,7 @@ fn test_crate::foo::i686-unknown-linux-gnu() -> u64
     return
 }
 
-fn test_crate::foo::x86_64-apple-darwin() -> u64
+fn test_crate::foo_same::x86_64-apple-darwin() -> u64
 {
     let _0: u64; // return
     let _1: u64; // anonymous local
@@ -58,9 +107,9 @@ fn test_crate::foo::x86_64-apple-darwin() -> u64
 
     storage_live(_3)
     storage_live(_1)
-    _1 = test_crate::f1::x86_64-apple-darwin()
+    _1 = test_crate::f2_same::x86_64-apple-darwin()
     storage_live(_2)
-    _2 = test_crate::f2_per_target::x86_64-apple-darwin()
+    _2 = test_crate::f3_different::x86_64-apple-darwin()
     _3 = copy _1 panic.+ copy _2
     _0 = move _3
     storage_dead(_2)

--- a/charon/tests/ui/multi-targets.out
+++ b/charon/tests/ui/multi-targets.out
@@ -1,30 +1,17 @@
-pub struct test_crate::StructTargetIndep::i686-unknown-linux-gnu {
+pub struct test_crate::StructTargetIndep {
   x: u64,
   y: u64,
 }
 
-pub struct test_crate::StructTargetIndep::x86_64-apple-darwin {
-  x: u64,
-  y: u64,
-}
-
-fn test_crate::make_pair_same::i686-unknown-linux-gnu() -> test_crate::StructTargetIndep::i686-unknown-linux-gnu
+fn test_crate::make_pair_same() -> test_crate::StructTargetIndep
 {
-    let _0: test_crate::StructTargetIndep::i686-unknown-linux-gnu; // return
+    let _0: test_crate::StructTargetIndep; // return
 
-    _0 = test_crate::StructTargetIndep::i686-unknown-linux-gnu { x: const 1 : u64, y: const 2 : u64 }
+    _0 = test_crate::StructTargetIndep { x: const 1 : u64, y: const 2 : u64 }
     return
 }
 
-fn test_crate::make_pair_same::x86_64-apple-darwin() -> test_crate::StructTargetIndep::x86_64-apple-darwin
-{
-    let _0: test_crate::StructTargetIndep::x86_64-apple-darwin; // return
-
-    _0 = test_crate::StructTargetIndep::x86_64-apple-darwin { x: const 1 : u64, y: const 2 : u64 }
-    return
-}
-
-pub fn test_crate::f1_same::i686-unknown-linux-gnu() -> u64
+pub fn test_crate::f1_same() -> u64
 {
     let _0: u64; // return
 
@@ -32,27 +19,11 @@ pub fn test_crate::f1_same::i686-unknown-linux-gnu() -> u64
     return
 }
 
-pub fn test_crate::f1_same::x86_64-apple-darwin() -> u64
+fn test_crate::f2_same() -> u64
 {
     let _0: u64; // return
 
-    _0 = const 0 : u64
-    return
-}
-
-fn test_crate::f2_same::i686-unknown-linux-gnu() -> u64
-{
-    let _0: u64; // return
-
-    _0 = test_crate::f1_same::i686-unknown-linux-gnu()
-    return
-}
-
-fn test_crate::f2_same::x86_64-apple-darwin() -> u64
-{
-    let _0: u64; // return
-
-    _0 = test_crate::f1_same::x86_64-apple-darwin()
+    _0 = test_crate::f1_same()
     return
 }
 
@@ -64,7 +35,7 @@ pub fn test_crate::f3_different::i686-unknown-linux-gnu() -> u64
 
     storage_live(_2)
     storage_live(_1)
-    _1 = test_crate::f2_same::i686-unknown-linux-gnu()
+    _1 = test_crate::f2_same()
     _2 = const 1 : u64 panic.+ copy _1
     _0 = move _2
     storage_dead(_1)
@@ -79,26 +50,13 @@ pub fn test_crate::f3_different::x86_64-apple-darwin() -> u64
     return
 }
 
-fn test_crate::foo_same::i686-unknown-linux-gnu() -> u64
-{
-    let _0: u64; // return
-    let _1: u64; // anonymous local
-    let _2: u64; // anonymous local
-    let _3: u64; // anonymous local
-
-    storage_live(_3)
-    storage_live(_1)
-    _1 = test_crate::f2_same::i686-unknown-linux-gnu()
-    storage_live(_2)
-    _2 = test_crate::f3_different::i686-unknown-linux-gnu()
-    _3 = copy _1 panic.+ copy _2
-    _0 = move _3
-    storage_dead(_2)
-    storage_dead(_1)
-    return
+pub fn test_crate::f3_different() -> u64
+= target_dispatch {
+    i686-unknown-linux-gnu => test_crate::f3_different::i686-unknown-linux-gnu,
+    x86_64-apple-darwin => test_crate::f3_different::x86_64-apple-darwin,
 }
 
-fn test_crate::foo_same::x86_64-apple-darwin() -> u64
+fn test_crate::foo_same() -> u64
 {
     let _0: u64; // return
     let _1: u64; // anonymous local
@@ -107,9 +65,9 @@ fn test_crate::foo_same::x86_64-apple-darwin() -> u64
 
     storage_live(_3)
     storage_live(_1)
-    _1 = test_crate::f2_same::x86_64-apple-darwin()
+    _1 = test_crate::f2_same()
     storage_live(_2)
-    _2 = test_crate::f3_different::x86_64-apple-darwin()
+    _2 = test_crate::f3_different()
     _3 = copy _1 panic.+ copy _2
     _0 = move _3
     storage_dead(_2)

--- a/charon/tests/ui/multi-targets.rs
+++ b/charon/tests/ui/multi-targets.rs
@@ -1,18 +1,31 @@
 //@ charon-args=--targets=i686-unknown-linux-gnu,x86_64-apple-darwin
-pub fn f1() -> u64 {
+pub struct StructTargetIndep {
+    pub x: u64,
+    pub y: u64,
+}
+
+fn make_pair_same() -> StructTargetIndep {
+    StructTargetIndep { x: 1, y: 2 }
+}
+
+pub fn f1_same() -> u64 {
     0
 }
 
+fn f2_same() -> u64 {
+    f1_same()
+}
+
 #[cfg(target_os = "linux")]
-pub fn f2_per_target() -> u64 {
-    1
+pub fn f3_different() -> u64 {
+    1 + f2_same()
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn f2_per_target() -> u64 {
+pub fn f3_different() -> u64 {
     2
 }
 
-fn foo() -> u64 {
-    f1() + f2_per_target()
+fn foo_same() -> u64 {
+    f2_same() + f3_different()
 }

--- a/charon/tests/ui/multi-targets.rs
+++ b/charon/tests/ui/multi-targets.rs
@@ -1,0 +1,18 @@
+//@ charon-args=--targets=i686-unknown-linux-gnu,x86_64-apple-darwin
+pub fn f1() -> u64 {
+    0
+}
+
+#[cfg(target_os = "linux")]
+pub fn f2_per_target() -> u64 {
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn f2_per_target() -> u64 {
+    2
+}
+
+fn foo() -> u64 {
+    f1() + f2_per_target()
+}

--- a/charon/tests/util/mod.rs
+++ b/charon/tests/util/mod.rs
@@ -120,6 +120,7 @@ pub fn repr_name(crate_data: &TranslatedCrate, n: &Name) -> String {
                 ImplElem::Ty(..) => "<inherent impl>".to_string(),
             },
             PathElem::Instantiated(..) => "<mono>".to_string(),
+            PathElem::Target(target) => target.clone(),
         })
         .join("::")
 }


### PR DESCRIPTION
Fixes #1081, albeit with a non-optimal implementation (we do a fixpoint that passes over all items, substitutes identifies, and compares them across targets again and again). The output is pretty nice tho.

ci: use https://github.com/AeneasVerif/aeneas/pull/941