### PR TITLE
Add some options to speed up translation

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.181"
+let supported_charon_version = "0.1.182"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -518,6 +518,7 @@ type cli_options = {
       (** Don't deduplicate values (types, trait refs) in the .(u)llbc file.
           This makes the file easier to inspect. *)
   no_serialize : bool;  (** Don't serialize the final (U)LLBC to a file. *)
+  no_typecheck : bool;  (** Skip the typecheck passes. *)
   abort_on_error : bool;
       (** Panic on the first error. This is useful for debugging. *)
   error_on_warnings : bool;  (** Consider any warnings to be errors. *)

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -519,6 +519,7 @@ type cli_options = {
           This makes the file easier to inspect. *)
   no_serialize : bool;  (** Don't serialize the final (U)LLBC to a file. *)
   no_typecheck : bool;  (** Skip the typecheck passes. *)
+  no_normalize : bool;  (** Don't normalize associated types. *)
   abort_on_error : bool;
       (** Panic on the first error. This is useful for debugging. *)
   error_on_warnings : bool;  (** Consider any warnings to be errors. *)
@@ -586,6 +587,7 @@ and preset =
   | RawMir
       (** Emit the MIR as unmodified as possible. This is very imperfect for
           now, we should make more passes optional. *)
+  | Fast  (** Skip as many optional transformations as possible. *)
   | Aeneas
   | Eurydice
   | Soteria

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -449,6 +449,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("no_dedup_serialized_ast", no_dedup_serialized_ast);
           ("no_serialize", no_serialize);
           ("no_typecheck", no_typecheck);
+          ("no_normalize", no_normalize);
           ("abort_on_error", abort_on_error);
           ("error_on_warnings", error_on_warnings);
           ("preset", preset);
@@ -509,6 +510,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         in
         let* no_serialize = bool_of_json ctx no_serialize in
         let* no_typecheck = bool_of_json ctx no_typecheck in
+        let* no_normalize = bool_of_json ctx no_normalize in
         let* abort_on_error = bool_of_json ctx abort_on_error in
         let* error_on_warnings = bool_of_json ctx error_on_warnings in
         let* preset = option_of_json preset_of_json ctx preset in
@@ -554,6 +556,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              no_dedup_serialized_ast;
              no_serialize;
              no_typecheck;
+             no_normalize;
              abort_on_error;
              error_on_warnings;
              preset;
@@ -1594,6 +1597,7 @@ and preset_of_json (ctx : of_json_ctx) (js : json) : (preset, string) result =
     (match js with
     | `String "OldDefaults" -> Ok OldDefaults
     | `String "RawMir" -> Ok RawMir
+    | `String "Fast" -> Ok Fast
     | `String "Aeneas" -> Ok Aeneas
     | `String "Eurydice" -> Ok Eurydice
     | `String "Soteria" -> Ok Soteria

--- a/charon-ml/src/generated/Generated_GAstOfJson.ml
+++ b/charon-ml/src/generated/Generated_GAstOfJson.ml
@@ -448,6 +448,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("dest_file", dest_file);
           ("no_dedup_serialized_ast", no_dedup_serialized_ast);
           ("no_serialize", no_serialize);
+          ("no_typecheck", no_typecheck);
           ("abort_on_error", abort_on_error);
           ("error_on_warnings", error_on_warnings);
           ("preset", preset);
@@ -507,6 +508,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           bool_of_json ctx no_dedup_serialized_ast
         in
         let* no_serialize = bool_of_json ctx no_serialize in
+        let* no_typecheck = bool_of_json ctx no_typecheck in
         let* abort_on_error = bool_of_json ctx abort_on_error in
         let* error_on_warnings = bool_of_json ctx error_on_warnings in
         let* preset = option_of_json preset_of_json ctx preset in
@@ -551,6 +553,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              dest_file;
              no_dedup_serialized_ast;
              no_serialize;
+             no_typecheck;
              abort_on_error;
              error_on_warnings;
              preset;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.181"
+version = "0.1.182"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charon"
-version = "0.1.181"
+version = "0.1.182"
 authors = [
     "Son Ho <hosonmarc@gmail.com>",
     "Guillaume Boisseau <nadrieril+git@gmail.com>",

--- a/charon/src/ast/hash_cons.rs
+++ b/charon/src/ast/hash_cons.rs
@@ -40,6 +40,7 @@ pub struct HashConsId(usize);
 // equality on `HashCons` to be broken.
 mod intern_table {
     use indexmap::IndexSet as SeqHashSet;
+    use std::borrow::Borrow;
     use std::sync::{Arc, LazyLock, RwLock};
 
     use super::{HashConsId, HashConsable, HashConsed};
@@ -58,7 +59,13 @@ mod intern_table {
     }
     static INTERNED: LazyLock<RwLock<TypeMap<InternMapper>>> = LazyLock::new(Default::default);
 
-    pub fn intern<T: HashConsable>(inner: T) -> HashConsed<T> {
+    // The excessive generality is to make it work for both `U = T` and `U = Arc<T>`.
+    pub fn intern<T: HashConsable, U>(inner: U) -> HashConsed<T>
+    where
+        Arc<T>: Borrow<U>,
+        U: Into<Arc<T>> + std::hash::Hash,
+        U: indexmap::Equivalent<Arc<T>>,
+    {
         // Fast read-only check.
         #[expect(irrefutable_let_patterns)] // https://github.com/rust-lang/rust/issues/139369
         let arc = if let read_guard = INTERNED.read().unwrap()
@@ -73,12 +80,47 @@ mod intern_table {
             if let Some(arc) = set.get(&inner) {
                 arc.clone()
             } else {
-                let arc: Arc<T> = Arc::new(inner);
+                let arc: Arc<T> = inner.into();
                 set.insert(arc.clone());
                 arc
             }
         };
         HashConsed(HashByAddr(arc))
+    }
+
+    /// Mutate the contents in-place if possible.
+    pub fn mutate_in_place<T: HashConsable, R, F: FnOnce(&mut T) -> R>(
+        x: &mut HashConsed<T>,
+        f: F,
+    ) -> Result<R, F> {
+        let arc = &mut x.0.0;
+        // Every value has at least two pointers: the current value and the one stored in the
+        // global map. If there are exactly two, we may mutate directly by discarding the one in
+        // the global map temporarily.
+        if Arc::strong_count(arc) != 2 {
+            return Err(f);
+        }
+        {
+            // Take the write guard just long enough to drop the other `Arc` to this value.
+            let mut write_guard = INTERNED.write().unwrap();
+            if let Some(other_arc) = write_guard.or_default::<T>().swap_take(&*arc) {
+                drop(other_arc);
+            } else {
+                // Nothing was removed, early return.
+                return Err(f);
+            }
+            // The Arc was removed from the map; `x` is invalid as interning the same value would
+            // result in a different pointer. NO MORE EARLY RETURN until we fix that.
+        }
+        // If we are still the sole owner, we can now mutate in-place.
+        let ret = match Arc::get_mut(arc) {
+            Some(val) => Ok(f(val)),
+            None => Err(f),
+        };
+        // Re-establish the interning invariant. If the same value was added to the map in the
+        // meantime, we'll get a pointer to that.
+        *x = HashConsed::from_arc(arc.clone());
+        ret
     }
 
     /// Identify this value uniquely amongst values of its type. The id depends on insertion
@@ -105,15 +147,24 @@ where
     pub fn new(inner: T) -> Self {
         intern_table::intern(inner)
     }
+    /// Rarely used: in case we already have an `Arc`, may avoid an allocation.
+    pub fn from_arc(inner: Arc<T>) -> Self {
+        intern_table::intern(inner)
+    }
 
     /// Clones if needed to get mutable access to the inner value.
     pub fn with_inner_mut<R>(&mut self, f: impl FnOnce(&mut T) -> R) -> R {
-        // The value is behind a shared `Arc`, we clone it in order to mutate it.
-        let mut value = self.inner().clone();
-        let ret = f(&mut value);
-        // Re-intern the new value.
-        *self = Self::new(value);
-        ret
+        match intern_table::mutate_in_place(self, f) {
+            Ok(r) => r,
+            Err(f) => {
+                // The value is behind a shared `Arc`, we clone it in order to mutate it.
+                let mut value = self.inner().clone();
+                let ret = f(&mut value);
+                // Re-intern the new value.
+                *self = Self::new(value);
+                ret
+            }
+        }
     }
 
     pub fn id(&self) -> HashConsId {

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -270,6 +270,10 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub no_typecheck: bool,
+    /// Don't normalize associated types.
+    #[clap(long)]
+    #[serde(default)]
+    pub no_normalize: bool,
     /// Panic on the first error. This is useful for debugging.
     #[clap(long)]
     #[serde(default)]
@@ -312,6 +316,8 @@ pub enum Preset {
     /// Emit the MIR as unmodified as possible. This is very imperfect for now, we should make more
     /// passes optional.
     RawMir,
+    /// Skip as many optional transformations as possible.
+    Fast,
     Aeneas,
     Eurydice,
     Soteria,
@@ -346,6 +352,13 @@ impl CliOpts {
                     self.extract_opaque_bodies = true;
                     self.raw_consts = true;
                     self.ullbc = true;
+                }
+                Preset::Fast => {
+                    self.ullbc = true;
+                    self.no_typecheck = true;
+                    self.no_normalize = true;
+                    self.hide_marker_traits = true;
+                    self.raw_consts = true;
                 }
                 Preset::Aeneas => {
                     self.lift_associated_types.push("*".to_owned());
@@ -520,6 +533,8 @@ pub struct TranslateOptions {
     pub lift_associated_types: Vec<NamePattern>,
     /// Skip the typecheck passes.
     pub no_typecheck: bool,
+    /// Don't normalize associated types.
+    pub no_normalize: bool,
     /// Transform Drop to Call drop_in_place
     pub desugar_drops: bool,
     /// Add `Destruct` bounds to all generic params.
@@ -640,6 +655,7 @@ impl TranslateOptions {
             unbind_item_vars: options.unbind_item_vars,
             translate_all_methods: options.translate_all_methods,
             no_typecheck: options.no_typecheck,
+            no_normalize: options.no_normalize,
             desugar_drops: options.desugar_drops,
             add_destruct_bounds: options.precise_drops,
             translate_poly_drop_glue: options.precise_drops,

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -266,6 +266,10 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub no_serialize: bool,
+    /// Skip the typecheck passes.
+    #[clap(long)]
+    #[serde(default)]
+    pub no_typecheck: bool,
     /// Panic on the first error. This is useful for debugging.
     #[clap(long)]
     #[serde(default)]
@@ -514,6 +518,8 @@ pub struct TranslateOptions {
     pub item_opacities: Vec<(NamePattern, ItemOpacity)>,
     /// List of traits for which we transform associated types to type parameters.
     pub lift_associated_types: Vec<NamePattern>,
+    /// Skip the typecheck passes.
+    pub no_typecheck: bool,
     /// Transform Drop to Call drop_in_place
     pub desugar_drops: bool,
     /// Add `Destruct` bounds to all generic params.
@@ -633,6 +639,7 @@ impl TranslateOptions {
             lift_associated_types,
             unbind_item_vars: options.unbind_item_vars,
             translate_all_methods: options.translate_all_methods,
+            no_typecheck: options.no_typecheck,
             desugar_drops: options.desugar_drops,
             add_destruct_bounds: options.precise_drops,
             translate_poly_drop_glue: options.precise_drops,

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -53,12 +53,11 @@ pub trait UllbcPass: Sync {
     /// Log that the pass is about to be run on this body.
     fn log_before_body(&self, ctx: &TransformCtx, name: &Name, body: &Body) {
         let fmt_ctx = &ctx.into_fmt();
-        let body_str = body.to_string_with_ctx(fmt_ctx);
         trace!(
             "# About to run pass [{}] on `{}`:\n{}",
             self.name(),
             name.with_ctx(fmt_ctx),
-            body_str,
+            body.with_ctx(fmt_ctx),
         );
     }
 }

--- a/charon/src/transform/normalize/desugar_drops.rs
+++ b/charon/src/transform/normalize/desugar_drops.rs
@@ -73,10 +73,10 @@ impl<'a> UllbcStatementTransformCtx<'a> {
 pub struct Transform;
 
 impl UllbcPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        options.desugar_drops
+    }
     fn transform_function(&self, ctx: &mut TransformCtx, decl: &mut FunDecl) {
-        if !ctx.options.desugar_drops {
-            return;
-        }
         decl.transform_ullbc_terminators(ctx, |ctx, term| {
             ctx.transform_drop_to_call(term);
         });

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1272,6 +1272,9 @@ impl VisitAstMut for UpdateItemBody<'_> {
 
 pub struct Transform;
 impl TransformPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        !(options.lift_associated_types.is_empty() && options.no_normalize)
+    }
     fn transform_ctx(&self, ctx: &mut TransformCtx) {
         // Compute all the necessary type info to be able to replace and normalize associated
         // types.

--- a/charon/src/transform/resugar/reconstruct_boxes.rs
+++ b/charon/src/transform/resugar/reconstruct_boxes.rs
@@ -20,11 +20,10 @@ pub struct Transform;
 ///
 /// We reconstruct this into a call to `Box::new(x)`.
 impl UllbcPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        options.treat_box_as_builtin
+    }
     fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
-        if !ctx.options.treat_box_as_builtin {
-            return;
-        }
-
         // We need to find a block that has exchange_malloc as the terminator:
         // ```text
         // @4 := alloc::alloc::exchange_malloc(..)

--- a/charon/src/transform/simplify_output/lift_associated_item_clauses.rs
+++ b/charon/src/transform/simplify_output/lift_associated_item_clauses.rs
@@ -9,6 +9,9 @@ use crate::transform::{TransformCtx, ctx::TransformPass};
 
 pub struct Transform;
 impl TransformPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        !options.no_normalize
+    }
     fn transform_ctx(&self, ctx: &mut TransformCtx) {
         // For each trait, we move the item-local clauses to be top-level parent clauses, and
         // record the mapping from the old to the new ids.

--- a/charon/src/transform/simplify_output/simplify_constants.rs
+++ b/charon/src/transform/simplify_output/simplify_constants.rs
@@ -27,23 +27,7 @@ fn transform_constant_expr(
     mut val: Box<ConstantExpr>,
 ) -> Operand {
     let rval = match val.kind {
-        ConstantExprKind::Literal(_)
-        | ConstantExprKind::Var(_)
-        | ConstantExprKind::RawMemory(..)
-        | ConstantExprKind::TraitConst(..)
-        | ConstantExprKind::FnDef(..)
-        | ConstantExprKind::Opaque(_) => {
-            // Nothing to do
-            // TODO: for trait const: might come from a top-level impl, so we might
-            // want to introduce an intermediate statement to be able to evaluate
-            // it as a function call, like for globals.
-            return Operand::Const(val);
-        }
-        // Here we use a copy, rather than a move -- moving a global would leave it uninitialized,
-        // which would e.g. make the following code fail:
-        //     const GLOBAL: usize = 0;
-        //     let x = GLOBAL;
-        //     let y = GLOBAL; // if moving, at this point GLOBAL would be uninitialized
+        // Here we use a copy, rather than a move -- moving a global would leave it uninitialized.
         ConstantExprKind::Global(global_ref) => {
             return Operand::Copy(Place::new_global(global_ref, val.ty));
         }
@@ -66,7 +50,7 @@ fn transform_constant_expr(
             let (rk, bval, metadata) = match cexpr {
                 ConstantExprKind::Ref(bval, metadata) => (None, bval, metadata),
                 ConstantExprKind::Ptr(rk, bval, metadata) => (Some(rk), bval, metadata),
-                _ => unreachable!("Unexpected constant expr kind in ref/ptr"),
+                _ => unreachable!(),
             };
 
             // As the value is originally an argument, it must be Sized, hence no metadata
@@ -121,27 +105,19 @@ fn transform_constant_expr(
             let aggregate_kind = AggregateKind::Adt(tref.clone(), variant, None);
             Rvalue::Aggregate(aggregate_kind, fields)
         }
-        ConstantExprKind::Array(fields) => {
+        ConstantExprKind::Array(fields) if let TyKind::Array(ty, _) = val.ty.kind() => {
             let fields = fields
                 .into_iter()
                 .map(|x| transform_constant_expr(ctx, Box::new(x)))
                 .collect_vec();
-
             let len =
                 ConstantExpr::mk_usize(ScalarValue::Unsigned(UIntTy::Usize, fields.len() as u128));
-            let TyKind::Array(ty, _) = val.ty.kind() else {
-                unreachable!("Non array type in array constant");
-            };
             Rvalue::Aggregate(AggregateKind::Array(ty.clone(), Box::new(len)), fields)
         }
-        ConstantExprKind::FnPtr(fptr) => {
-            let TyKind::FnPtr(sig) = val.ty.kind() else {
-                unreachable!("FnPtr constant must have FnPtr type");
-            };
+        ConstantExprKind::FnPtr(fptr) if let TyKind::FnPtr(sig) = val.ty.kind() => {
             let from_ty =
                 TyKind::FnDef(sig.clone().map(|_| fptr.clone().move_under_binder())).into_ty();
             let to_ty = TyKind::FnPtr(sig.clone()).into_ty();
-
             Rvalue::UnaryOp(
                 UnOp::Cast(CastKind::FnPtr(from_ty.clone(), to_ty)),
                 Operand::Const(Box::new(ConstantExpr {
@@ -164,7 +140,7 @@ fn transform_constant_expr(
             // Normalize further into a place access.
             return transform_constant_expr(ctx, val);
         }
-        ConstantExprKind::VTableRef(..) => return Operand::Const(val),
+        _ => return Operand::Const(val),
     };
     Operand::Move(ctx.rval_to_place(rval, val.ty.clone()))
 }

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -607,6 +607,9 @@ impl Check {
 }
 
 impl TransformPass for Check {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        !options.no_typecheck
+    }
     fn transform_ctx(&self, ctx: &mut TransformCtx) {
         ctx.for_each_item_mut(|ctx, mut item| {
             let mut visitor = TypeCheckVisitor {

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -161,6 +161,9 @@ Options:
       --no-typecheck
           Skip the typecheck passes
 
+      --no-normalize
+          Don't normalize associated types
+
       --abort-on-error
           Panic on the first error. This is useful for debugging
 
@@ -173,6 +176,7 @@ Options:
           Possible values:
           - old-defaults: The default translation used before May 2025. After that, many passes were made optional and disabled by default
           - raw-mir:      Emit the MIR as unmodified as possible. This is very imperfect for now, we should make more passes optional
+          - fast:         Skip as many optional transformations as possible
           - aeneas
           - eurydice
           - soteria

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -158,6 +158,9 @@ Options:
       --no-serialize
           Don't serialize the final (U)LLBC to a file
 
+      --no-typecheck
+          Skip the typecheck passes
+
       --abort-on-error
           Panic on the first error. This is useful for debugging
 


### PR DESCRIPTION
Using `--preset=fast` will enable them all and should be the fastest way to get a ullbc file out of Charon.