### PR TITLE
Build charon-linux-aarch64 artifacts on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: charon-linux-x86_64
+          - os: ubuntu-24.04-arm
+            artifact_name: charon-linux-aarch64
           - os: macos-15-intel
             artifact_name: charon-macos-x86_64
           - os: macos-latest


### PR DESCRIPTION
This matches the released artifacts for Aeneas.