### PR TITLE
feat: add a node for char values

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.191"
+let supported_charon_version = "0.1.192"

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -74,6 +74,9 @@ let big_int_of_json _ (js : json) : (big_int, string) result =
     | `String is -> Ok (Z.of_string is)
     | _ -> Error "")
 
+let char_value_of_json : of_json_ctx -> json -> (char_value, string) result =
+  char_of_json
+
 let opt_indexed_map_of_json :
     'a0 'a1.
     (of_json_ctx -> json -> ('a0, string) result) ->
@@ -804,7 +807,7 @@ and literal_of_json (ctx : of_json_ctx) (js : json) : (literal, string) result =
         let* bool_ = bool_of_json ctx bool_ in
         Ok (VBool bool_)
     | `Assoc [ ("Char", char_) ] ->
-        let* char_ = char_of_json ctx char_ in
+        let* char_ = char_value_of_json ctx char_ in
         Ok (VChar char_)
     | `Assoc [ ("ByteStr", byte_str) ] ->
         let* byte_str = list_of_json int_of_json ctx byte_str in

--- a/charon-ml/src/generated/Generated_Values.ml
+++ b/charon-ml/src/generated/Generated_Values.ml
@@ -3,6 +3,36 @@ include BigInt
 
 include Uchar
 
+(** A char value *)
+type char_value = (Uchar.t[@visitors.opaque]) [@@deriving show, eq, ord]
+
+(* Ancestors for the literal visitors *)
+class ['self] iter_literal_base =
+  object (self : 'self)
+    inherit [_] iter_big_int
+    method visit_char_value : 'env -> char_value -> unit = fun _ _ -> ()
+  end
+
+class ['self] map_literal_base =
+  object (self : 'self)
+    inherit [_] map_big_int
+    method visit_char_value : 'env -> char_value -> char_value = fun _ x -> x
+  end
+
+class virtual ['self] reduce_literal_base =
+  object (self : 'self)
+    inherit [_] reduce_big_int
+    method visit_char_value : 'env -> char_value -> 'a = fun _ _ -> self#zero
+  end
+
+class virtual ['self] mapreduce_literal_base =
+  object (self : 'self)
+    inherit [_] mapreduce_big_int
+
+    method visit_char_value : 'env -> char_value -> char_value * 'a =
+      fun _ x -> (x, self#zero)
+  end
+
 type float_type = F16 | F32 | F64 | F128
 
 (** This is simlar to the Scalar value above. However, instead of storing the
@@ -21,7 +51,7 @@ and literal =
   | VScalar of scalar_value
   | VFloat of float_value
   | VBool of bool
-  | VChar of (Uchar.t[@visitors.opaque])
+  | VChar of char_value
   | VByteStr of int list
   | VStr of string
 
@@ -48,7 +78,7 @@ and u_int_ty = Usize | U8 | U16 | U32 | U64 | U128
       name = "iter_literal";
       monomorphic = [ "env" ];
       variety = "iter";
-      ancestors = [ "iter_big_int" ];
+      ancestors = [ "iter_literal_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     },
   visitors
@@ -56,7 +86,7 @@ and u_int_ty = Usize | U8 | U16 | U32 | U64 | U128
       name = "map_literal";
       monomorphic = [ "env" ];
       variety = "map";
-      ancestors = [ "map_big_int" ];
+      ancestors = [ "map_literal_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     },
   visitors
@@ -64,7 +94,7 @@ and u_int_ty = Usize | U8 | U16 | U32 | U64 | U128
       name = "reduce_literal";
       monomorphic = [ "env" ];
       variety = "reduce";
-      ancestors = [ "reduce_big_int" ];
+      ancestors = [ "reduce_literal_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     },
   visitors
@@ -72,6 +102,6 @@ and u_int_ty = Usize | U8 | U16 | U32 | U64 | U128
       name = "mapreduce_literal";
       monomorphic = [ "env" ];
       variety = "mapreduce";
-      ancestors = [ "mapreduce_big_int" ];
+      ancestors = [ "mapreduce_literal_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     }]

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.191"
+version = "0.1.192"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.191"
+version = "0.1.192"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -264,7 +264,7 @@ fn generate_ml(
                     ancestors: &["big_int"],
                     name: "literal",
                     reduce: true,
-                    extra_types: &[],
+                    extra_types: &["char_value"],
                 })), &[
                     "Literal",
                     "IntegerTy",

--- a/charon/src/bin/generate-ml/of_json.rs
+++ b/charon/src/bin/generate-ml/of_json.rs
@@ -121,7 +121,7 @@ impl<'a> GenerateCtx<'a> {
     fn type_to_ocaml_call(&self, ty: &Ty) -> String {
         match ty.kind() {
             TyKind::Literal(LiteralTy::Bool) => "bool_of_json".to_string(),
-            TyKind::Literal(LiteralTy::Char) => "char_of_json".to_string(),
+            TyKind::Literal(LiteralTy::Char) => "char_value_of_json".to_string(),
             TyKind::Literal(LiteralTy::Int(int_ty)) => match int_ty {
                 // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
                 IntTy::I128 => "big_int_of_json".to_string(),

--- a/charon/src/bin/generate-ml/templates/OfJson.ml
+++ b/charon/src/bin/generate-ml/templates/OfJson.ml
@@ -75,6 +75,9 @@ let big_int_of_json _ (js : json) : (big_int, string) result =
       | `String is -> Ok (Z.of_string is)
       | _ -> Error "")
 
+let char_value_of_json : of_json_ctx -> json -> (char_value, string) result =
+  char_of_json
+
 let opt_indexed_map_of_json :
     'a0 'a1.
     (of_json_ctx -> json -> ('a0, string) result) ->

--- a/charon/src/bin/generate-ml/templates/Values.ml
+++ b/charon/src/bin/generate-ml/templates/Values.ml
@@ -2,4 +2,7 @@
 include BigInt
 include Uchar
 
+(** A char value *)
+type char_value = Uchar.t [@visitors.opaque] [@@deriving show, eq, ord]
+
 (* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/util.rs
+++ b/charon/src/bin/generate-ml/util.rs
@@ -126,7 +126,7 @@ impl<'a> GenerateCtx<'a> {
     pub fn type_to_ocaml_name(&self, ty: &Ty) -> String {
         match ty.kind() {
             TyKind::Literal(LiteralTy::Bool) => "bool".to_string(),
-            TyKind::Literal(LiteralTy::Char) => "(Uchar.t [@visitors.opaque])".to_string(),
+            TyKind::Literal(LiteralTy::Char) => "char_value".to_string(),
             TyKind::Literal(LiteralTy::Int(int_ty)) => match int_ty {
                 // Even though OCaml ints are only 63 bits, only scalars with their 128 bits should be able to become too large
                 IntTy::I128 => "big_int".to_string(),


### PR DESCRIPTION
This PR adds a wrapper around char values. It is used by https://github.com/AeneasVerif/aeneas/pull/917. In Aeneas, it allows handling char values without exposing the internal representation as a `UChar.t`