### PR TITLE
Fix: handle dangling references left by `--remove-adt-clauses`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.187"
+let supported_charon_version = "0.1.188"

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -286,6 +286,7 @@ and builtin_impl_data_of_json (ctx : of_json_ctx) (js : json) :
     | `String "FnOnce" -> Ok BuiltinFnOnce
     | `String "Copy" -> Ok BuiltinCopy
     | `String "Clone" -> Ok BuiltinClone
+    | `String "RemovedAdtClause" -> Ok BuiltinRemovedAdtClause
     | _ -> Error "")
 
 and builtin_index_op_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -226,6 +226,11 @@ and builtin_impl_data =
   | BuiltinFnOnce
   | BuiltinCopy
   | BuiltinClone
+  | BuiltinRemovedAdtClause
+      (** Placeholder used by the [--remove-adt-clauses] pass when it strips a
+          trait clause from a type declaration. References to the removed clause
+          are rewritten as
+          [BuiltinOrAuto { builtin_data: RemovedAdtClause, .. }]. *)
 
 (** One of 8 built-in indexing operations. *)
 and builtin_index_op = {
@@ -623,6 +628,12 @@ and trait_ref_kind =
       (** A trait implementation that is computed by the compiler, such as for
           built-in trait [Sized]. This morally points to an invisible [impl]
           block; as such it contains the information we may need from one.
+
+          Also used as a placeholder for trait clauses that were stripped by the
+          [--remove-adt-clauses] pass: the original [Clause] reference is
+          replaced with a
+          [BuiltinOrAuto { builtin_data: RemovedAdtClause, .. }]. See
+          [[BuiltinImplData::RemovedAdtClause]].
 
           Fields:
           - [builtin_data]

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.187"
+version = "0.1.188"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.187"
+version = "0.1.188"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -110,6 +110,11 @@ pub enum TraitRefKind {
     /// A trait implementation that is computed by the compiler, such as for built-in trait
     /// `Sized`. This morally points to an invisible `impl` block; as such it contains
     /// the information we may need from one.
+    ///
+    /// Also used as a placeholder for trait clauses that were stripped by the
+    /// `--remove-adt-clauses` pass: the original `Clause` reference is replaced with a
+    /// `BuiltinOrAuto { builtin_data: RemovedAdtClause, .. }`. See
+    /// [`BuiltinImplData::RemovedAdtClause`].
     BuiltinOrAuto {
         #[drive(skip)]
         builtin_data: BuiltinImplData,
@@ -155,6 +160,10 @@ pub enum BuiltinImplData {
     FnOnce,
     Copy,
     Clone,
+    /// Placeholder used by the `--remove-adt-clauses` pass when it strips a trait clause from a
+    /// type declaration. References to the removed clause are rewritten as
+    /// `BuiltinOrAuto { builtin_data: RemovedAdtClause, .. }`.
+    RemovedAdtClause,
 }
 
 /// A reference to a trait.

--- a/charon/src/transform/simplify_output/remove_adt_clauses.rs
+++ b/charon/src/transform/simplify_output/remove_adt_clauses.rs
@@ -1,19 +1,158 @@
+//! `--remove-adt-clauses` strips trait clauses from type declarations when it's possible to do so.
+//! Because it's not possible to recover associated type information when we remove clauses,
+//! we don't remove clauses if any of them have associated types. For that reason,
+//! this flag is best used with `--lift-associated-types`.
+//!
+//! Every reference to a clause removed in this way is replaced with a `TraitRefKind::BuiltinOrAuto
+//! { builtin_data: RemovedAdtClause, .. }`.
+
+use std::collections::HashSet;
+
+use derive_generic_visitor::*;
+
 use crate::ast::*;
+use crate::common::CycleDetector;
+use crate::ids::{IndexMap, IndexVec};
 use crate::transform::{TransformCtx, ctx::TransformPass};
 
-#[derive(Visitor)]
-struct RemoveAdtClausesVisitor;
+/// Compute whether a trait has associated types, even through supertraits.
+fn has_assoc_types(
+    translated: &TranslatedCrate,
+    cache: &mut IndexMap<TraitDeclId, CycleDetector<bool>>,
+    id: TraitDeclId,
+) -> bool {
+    if cache[id].start_processing() {
+        let result = match translated.trait_decls.get(id) {
+            Some(tdecl) => {
+                !tdecl.types.is_empty()
+                    || tdecl
+                        .implied_clauses
+                        .iter()
+                        .any(|p| has_assoc_types(translated, cache, p.trait_.skip_binder.id))
+            }
+            None => false,
+        };
+        cache[id].done_processing(result);
+    }
+    match &cache[id] {
+        CycleDetector::Processed(b) => *b,
+        CycleDetector::Cyclic | CycleDetector::Processing => false,
+        CycleDetector::Unprocessed => unreachable!(),
+    }
+}
 
-impl VisitAstMut for RemoveAdtClausesVisitor {
+/// ADTs that have at least one trait clause pointing at a trait with associated types
+/// (transitively). We leave these ADTs entirely untouched.
+fn untouchable_adts(translated: &TranslatedCrate) -> HashSet<TypeDeclId> {
+    let mut cache: IndexMap<TraitDeclId, CycleDetector<bool>> = translated
+        .trait_decls
+        .map_ref_opt(|_| Some(CycleDetector::Unprocessed));
+    translated
+        .type_decls
+        .iter()
+        .filter(|d| {
+            d.generics
+                .trait_clauses
+                .iter()
+                .any(|c| has_assoc_types(translated, &mut cache, c.trait_.skip_binder.id))
+        })
+        .map(|d| d.def_id)
+        .collect()
+}
+
+#[derive(Visitor)]
+struct RemoveAdtClausesVisitor<'a> {
+    translated: &'a TranslatedCrate,
+    untouchable_adts: &'a HashSet<TypeDeclId>,
+    binder_stack: BindingStack<GenericParams>,
+}
+
+impl VisitorWithBinderStack for RemoveAdtClausesVisitor<'_> {
+    fn binder_stack_mut(&mut self) -> &mut BindingStack<GenericParams> {
+        &mut self.binder_stack
+    }
+}
+
+impl VisitAstMut for RemoveAdtClausesVisitor<'_> {
+    fn visit<T: AstVisitable>(&mut self, x: &mut T) -> ::std::ops::ControlFlow<Self::Break> {
+        VisitWithBinderStack::new(self).visit(x)?;
+        ::std::ops::ControlFlow::Continue(())
+    }
+
     fn enter_type_decl(&mut self, decl: &mut TypeDecl) {
+        if self.untouchable_adts.contains(&decl.def_id) {
+            return;
+        }
         decl.generics.trait_clauses.clear();
         decl.generics.trait_type_constraints.clear();
+        // The wrapper has already pushed the (uncleared) generic params onto the binder stack.
+        // Replace the top with the cleared version so dangling-clause detection works as we
+        // descend into the body.
+        *self.binder_stack.innermost_mut() = decl.generics.clone();
     }
 
     fn enter_type_decl_ref(&mut self, tref: &mut TypeDeclRef) {
-        if matches!(tref.id, TypeId::Adt(_)) {
+        if let TypeId::Adt(id) = tref.id
+            && !self.untouchable_adts.contains(&id)
+        {
             tref.generics.trait_refs.clear();
         }
+    }
+
+    fn enter_trait_ref(&mut self, tref: &mut TraitRef) {
+        let TraitRefKind::Clause(var) = &tref.kind else {
+            return;
+        };
+        if self
+            .binder_stack
+            .get_var::<_, GenericParams>(*var)
+            .is_some()
+        {
+            return;
+        }
+        let new_kind = build_removed_clause_placeholder(self.translated, &tref.trait_decl_ref);
+        tref.with_contents_mut(|contents| contents.kind = new_kind);
+    }
+}
+
+/// Build a `BuiltinOrAuto { builtin_data: RemovedAdtClause, .. }` kind whose `parent_trait_refs`
+/// recursively mirror the trait's implied clauses (each parent itself a `RemovedAdtClause`
+/// placeholder).
+///
+/// Substitution into the parents' `trait_decl_ref`s uses a stub placeholder kind for `Self`
+/// rather than the original (dangling) `Clause(var)`: otherwise we'd embed dangling clause refs
+/// inside the synthesized parents, and the visitor never re-enters them.
+fn build_removed_clause_placeholder(
+    translated: &TranslatedCrate,
+    trait_decl_ref: &PolyTraitDeclRef,
+) -> TraitRefKind {
+    let trait_id = trait_decl_ref.skip_binder.id;
+    let stub_tref = TraitRef::new(
+        TraitRefKind::BuiltinOrAuto {
+            builtin_data: BuiltinImplData::RemovedAdtClause,
+            parent_trait_refs: Default::default(),
+            types: Default::default(),
+        },
+        trait_decl_ref.clone(),
+    );
+    let parent_trait_refs: IndexVec<TraitClauseId, TraitRef> = translated
+        .trait_decls
+        .get(trait_id)
+        .map(|tdecl| {
+            Substituted::new_for_trait_ref(&tdecl.implied_clauses, &stub_tref)
+                .iter()
+                .map(|s| {
+                    let parent: TraitParam = s.substitute();
+                    let kind = build_removed_clause_placeholder(translated, &parent.trait_);
+                    TraitRef::new(kind, parent.trait_)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    TraitRefKind::BuiltinOrAuto {
+        builtin_data: BuiltinImplData::RemovedAdtClause,
+        parent_trait_refs,
+        types: Default::default(),
     }
 }
 
@@ -23,6 +162,13 @@ impl TransformPass for Transform {
         if !ctx.options.remove_adt_clauses {
             return;
         }
-        let _ = ctx.translated.drive_mut(&mut RemoveAdtClausesVisitor);
+        let untouchable = untouchable_adts(&ctx.translated);
+        ctx.for_each_item_mut(|ctx, mut item| {
+            let _ = item.drive_mut(&mut RemoveAdtClausesVisitor {
+                translated: &ctx.translated,
+                untouchable_adts: &untouchable,
+                binder_stack: BindingStack::empty(),
+            });
+        });
     }
 }

--- a/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
+++ b/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
@@ -1,0 +1,379 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::clone::Clone
+#[lang_item("clone")]
+pub trait Clone<Self>
+{
+    parent_clause0 : [@TraitClause0]: Sized<Self>
+    fn clone<'_0_1> = clone<'_0_1, Self>[Self]
+    non-dyn-compatible
+}
+
+// Full name: core::clone::Clone::clone
+#[lang_item("clone_fn")]
+pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
+where
+    [@TraitClause0]: Clone<Self>,
+= <opaque>
+
+// Full name: core::marker::Copy
+#[lang_item("copy")]
+pub trait Copy<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Clone<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = core::marker::Destruct::drop_in_place<Self>
+    non-dyn-compatible
+}
+
+unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
+= <opaque>
+
+// Full name: core::marker::Tuple
+#[lang_item("tuple_trait")]
+pub trait Tuple<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::ops::function::FnOnce
+#[lang_item("fn_once")]
+pub trait FnOnce<Self, Args, Self_Output>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Args>
+    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
+}
+
+// Full name: core::ops::function::FnMut
+#[lang_item("fn_mut")]
+pub trait FnMut<Self, Args, Self_Clause1_Output>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
+    parent_clause2 : [@TraitClause2]: Sized<Args>
+    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
+}
+
+// Full name: core::ops::function::Fn
+#[lang_item("fn")]
+pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
+    parent_clause2 : [@TraitClause2]: Sized<Args>
+    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
+    vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
+}
+
+pub fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
+where
+    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+= <opaque>
+
+pub fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
+where
+    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+= <opaque>
+
+pub fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
+where
+    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+= <opaque>
+
+struct test_crate::f::closure<'_0, T> {
+  &'_0 T,
+}
+
+// Full name: test_crate::f
+fn f<'_0, T>(x_1: &'_0 T)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: (); // return
+    let x_1: &'1 T; // arg #1
+    let _c_2: test_crate::f::closure<'3, T>; // local
+    let _3: &'4 T; // anonymous local
+
+    _0 = ()
+    storage_live(_c_2)
+    storage_live(_3)
+    _3 = &(*x_1)
+    _c_2 = test_crate::f::closure { 0: move _3 }
+    storage_dead(_3)
+    _0 = ()
+    storage_dead(_c_2)
+    return
+}
+
+// Full name: test_crate::f::closure::{impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place
+unsafe fn {impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>(_1: *mut test_crate::f::closure<'_0, T>)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+= <missing>
+
+// Full name: test_crate::f::{impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call
+fn {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '_1, T>(_1: &'_1 test_crate::f::closure<'_0, T>, tupled_args_2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let _1: &'1 test_crate::f::closure<'_0, T>; // arg #1
+    let tupled_args_2: (); // arg #2
+
+    _0 = copy (*((*_1)).0)
+    return
+}
+
+// Full name: test_crate::f::{impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut
+fn {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::f::closure<'_0, T>, args_2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let state_1: &'_1 mut test_crate::f::closure<'_0, T>; // arg #1
+    let args_2: (); // arg #2
+    let _3: &'0 test_crate::f::closure<'_0, T>; // anonymous local
+
+    storage_live(_3)
+    _3 = &(*state_1)
+    _0 = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    return
+}
+
+// Full name: test_crate::f::{impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once
+fn {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once<'_0, T>(_1: test_crate::f::closure<'_0, T>, _2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let _1: test_crate::f::closure<'_0, T>; // arg #1
+    let _2: (); // arg #2
+    let _3: &'1 mut test_crate::f::closure<'_0, T>; // anonymous local
+
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '5, T>[@TraitClause0, @TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    return
+}
+
+// Full name: test_crate::f::{impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}
+impl<'_0, T> FnOnce<(), T> for test_crate::f::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    parent_clause1 = {built_in impl Sized for ()}
+    parent_clause2 = {built_in impl Tuple for ()}
+    parent_clause3 = @TraitClause0
+    fn call_once = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once<'_0, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::f::{impl FnMut<(), T> for test_crate::f::closure<'_0, T>}
+impl<'_0, T> FnMut<(), T> for test_crate::f::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    parent_clause1 = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
+    parent_clause2 = {built_in impl Sized for ()}
+    parent_clause3 = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::f::{impl Fn<(), T> for test_crate::f::closure<'_0, T>}
+impl<'_0, T> Fn<(), T> for test_crate::f::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    parent_clause1 = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
+    parent_clause2 = {built_in impl Sized for ()}
+    parent_clause3 = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::f::closure::{impl Destruct for test_crate::f::closure<'_0, T>}
+impl<'_0, T> Destruct for test_crate::f::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    fn drop_in_place = {impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+struct test_crate::g::closure<'_0, T> {
+  &'_0 T,
+}
+
+// Full name: test_crate::g
+fn g<T>(x_1: T)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: (); // return
+    let x_1: T; // arg #1
+    let _c_2: test_crate::g::closure<'1, T>; // local
+    let _3: &'3 T; // anonymous local
+
+    _0 = ()
+    storage_live(_c_2)
+    storage_live(_3)
+    _3 = &x_1
+    _c_2 = test_crate::g::closure { 0: move _3 }
+    storage_dead(_3)
+    _0 = ()
+    storage_dead(_c_2)
+    return
+}
+
+// Full name: test_crate::g::closure::{impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place
+unsafe fn {impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>(_1: *mut test_crate::g::closure<'_0, T>)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+= <missing>
+
+// Full name: test_crate::g::{impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call
+fn {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '_1, T>(_1: &'_1 test_crate::g::closure<'_0, T>, tupled_args_2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let _1: &'1 test_crate::g::closure<'_0, T>; // arg #1
+    let tupled_args_2: (); // arg #2
+
+    _0 = copy (*((*_1)).0)
+    return
+}
+
+// Full name: test_crate::g::{impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut
+fn {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::g::closure<'_0, T>, args_2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let state_1: &'_1 mut test_crate::g::closure<'_0, T>; // arg #1
+    let args_2: (); // arg #2
+    let _3: &'0 test_crate::g::closure<'_0, T>; // anonymous local
+
+    storage_live(_3)
+    _3 = &(*state_1)
+    _0 = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    return
+}
+
+// Full name: test_crate::g::{impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once
+fn {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once<'_0, T>(_1: test_crate::g::closure<'_0, T>, _2: ()) -> T
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    let _0: T; // return
+    let _1: test_crate::g::closure<'_0, T>; // arg #1
+    let _2: (); // arg #2
+    let _3: &'1 mut test_crate::g::closure<'_0, T>; // anonymous local
+
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '5, T>[@TraitClause0, @TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    return
+}
+
+// Full name: test_crate::g::{impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}
+impl<'_0, T> FnOnce<(), T> for test_crate::g::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    parent_clause1 = {built_in impl Sized for ()}
+    parent_clause2 = {built_in impl Tuple for ()}
+    parent_clause3 = @TraitClause0
+    fn call_once = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once<'_0, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::g::{impl FnMut<(), T> for test_crate::g::closure<'_0, T>}
+impl<'_0, T> FnMut<(), T> for test_crate::g::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    parent_clause1 = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
+    parent_clause2 = {built_in impl Sized for ()}
+    parent_clause3 = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::g::{impl Fn<(), T> for test_crate::g::closure<'_0, T>}
+impl<'_0, T> Fn<(), T> for test_crate::g::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    parent_clause1 = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
+    parent_clause2 = {built_in impl Sized for ()}
+    parent_clause3 = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::g::closure::{impl Destruct for test_crate::g::closure<'_0, T>}
+impl<'_0, T> Destruct for test_crate::g::closure<'_0, T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Copy<T>,
+{
+    fn drop_in_place = {impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/simple/closure-with-remove-adt-clauses.rs
+++ b/charon/tests/ui/simple/closure-with-remove-adt-clauses.rs
@@ -1,0 +1,12 @@
+//@ charon-args=--remove-adt-clauses
+//@ charon-args=--remove-associated-types=*
+// Regression test: closure ADTs reference trait impls (FnOnce/FnMut/Fn) that depend on
+// trait clauses inherited from the parent function. Stripping all ADT clauses would invalidate
+// those references, so closure ADTs must keep their clauses.
+fn f<T: Copy>(x: &T) {
+    let _c = || *x;
+}
+
+fn g<T: Copy>(x: T) {
+    let _c = || x;
+}

--- a/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
@@ -1,0 +1,114 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = drop_in_place<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct::drop_in_place
+unsafe fn drop_in_place<Self>(_1: *mut Self)
+= <opaque>
+
+// Full name: core::marker::Tuple
+#[lang_item("tuple_trait")]
+pub trait Tuple<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::ops::function::FnOnce
+#[lang_item("fn_once")]
+pub trait FnOnce<Self, Args>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Args>
+    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    type Output
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+pub fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+where
+    [@TraitClause0]: FnOnce<Self, Args>,
+= <opaque>
+
+// Full name: test_crate::HasAssoc
+trait HasAssoc<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Output>
+    type Output
+    vtable: test_crate::HasAssoc::{vtable}<Self::Output>
+}
+
+// Full name: test_crate::make_closure::closure
+struct closure<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{}
+
+// Full name: test_crate::make_closure
+fn make_closure<T>(x_1: T) -> closure<T>[@TraitClause0, @TraitClause1]
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{
+    let _0: closure<T>[@TraitClause0, @TraitClause1]; // return
+    let x_1: T; // arg #1
+
+    _0 = closure {  }
+    conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
+    return
+}
+
+// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once
+fn {impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ())
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{
+    let _0: (); // return
+    let _1: closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let tupled_args_2: (); // arg #2
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}
+impl<T> FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for closure<T>[@TraitClause0, @TraitClause1]}
+    parent_clause1 = {built_in impl Sized for ()}
+    parent_clause2 = {built_in impl Tuple for ()}
+    parent_clause3 = {built_in impl Sized for ()}
+    type Output = ()
+    fn call_once = {impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.rs
+++ b/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.rs
@@ -1,0 +1,24 @@
+//@ charon-args=--remove-adt-clauses
+//@ charon-args=--remove-associated-types=__no_match__
+// `--remove-associated-types` is passed a non-matching pattern so the trait associated types
+// stay in place, exercising the "preserve" path.
+//
+// Regression test (companion to `remove-adt-clauses-supertrait.rs`): when a closure inherits a
+// clause to a trait with associated types, the closure ADT itself becomes "untouchable" --
+// its clauses are preserved and no dangling `Clause(var)` refs appear inside its
+// `ItemSource::Closure { info }`. So `enter_trait_ref`'s rewrite path is *not* exercised for
+// this closure, and the FnOnce trait_impl signature retains its original `Clause(var)`
+// references intact.
+//
+// `remove-adt-clauses-supertrait.rs` covers the symmetric case (closure with a no-assoc-types
+// clause, where dangling refs *do* get rewritten); together they pin both branches.
+
+trait HasAssoc {
+    type Output;
+}
+
+fn make_closure<T: HasAssoc>(x: T) -> impl FnOnce() {
+    move || {
+        let _ = x;
+    }
+}

--- a/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
@@ -1,0 +1,165 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = core::marker::Destruct::drop_in_place<Self>
+    non-dyn-compatible
+}
+
+unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
+= <opaque>
+
+// Full name: test_crate::HasAssoc
+trait HasAssoc<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Output>
+    type Output
+    vtable: test_crate::HasAssoc::{vtable}<Self::Output>
+}
+
+// Full name: test_crate::Direct
+struct Direct<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{
+  T,
+}
+
+// Full name: test_crate::Direct::{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut Direct<T>[@TraitClause0, @TraitClause1])
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+= <missing>
+
+// Full name: test_crate::Direct::{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}
+impl<T> Destruct for Direct<T>[@TraitClause0, @TraitClause1]
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: HasAssoc<T>,
+{
+    fn drop_in_place = {impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::BaseWithAssoc
+trait BaseWithAssoc<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    type Item
+    vtable: test_crate::BaseWithAssoc::{vtable}<Self::Item>
+}
+
+// Full name: test_crate::DerivedNoAssoc
+trait DerivedNoAssoc<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: BaseWithAssoc<Self>
+    vtable: test_crate::DerivedNoAssoc::{vtable}<Self::parent_clause1::Item>
+}
+
+// Full name: test_crate::Transitive
+struct Transitive<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: DerivedNoAssoc<T>,
+{
+  T,
+}
+
+// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut Transitive<T>[@TraitClause0, @TraitClause1])
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: DerivedNoAssoc<T>,
+= <missing>
+
+// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}
+impl<T> Destruct for Transitive<T>[@TraitClause0, @TraitClause1]
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: DerivedNoAssoc<T>,
+{
+    fn drop_in_place = {impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::MarkerParent
+trait MarkerParent<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    vtable: test_crate::MarkerParent::{vtable}
+}
+
+// Full name: test_crate::MarkerChild
+trait MarkerChild<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: MarkerParent<Self>
+    vtable: test_crate::MarkerChild::{vtable}
+}
+
+// Full name: test_crate::Marker
+struct Marker<T> {
+  T,
+}
+
+// Full name: test_crate::Marker::{impl Destruct for Marker<T>}::drop_in_place
+unsafe fn {impl Destruct for Marker<T>}::drop_in_place<T>(_1: *mut Marker<T>)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: MarkerChild<T>,
+= <missing>
+
+// Full name: test_crate::Marker::{impl Destruct for Marker<T>}
+impl<T> Destruct for Marker<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: MarkerChild<T>,
+{
+    fn drop_in_place = {impl Destruct for Marker<T>}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::use_all
+fn use_all<T, U, V>(_x_1: Direct<T>[@TraitClause0, @TraitClause3], _y_2: Transitive<U>[@TraitClause1, @TraitClause4], _z_3: Marker<V>)
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Sized<U>,
+    [@TraitClause2]: Sized<V>,
+    [@TraitClause3]: HasAssoc<T>,
+    [@TraitClause4]: DerivedNoAssoc<U>,
+    [@TraitClause5]: MarkerChild<V>,
+{
+    let _0: (); // return
+    let _x_1: Direct<T>[@TraitClause0, @TraitClause3]; // arg #1
+    let _y_2: Transitive<U>[@TraitClause1, @TraitClause4]; // arg #2
+    let _z_3: Marker<V>; // arg #3
+
+    _0 = ()
+    _0 = ()
+    conditional_drop[{impl Destruct for Marker<T>}::drop_in_place<V>[@TraitClause2, @TraitClause5]] _z_3
+    conditional_drop[{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<U>[@TraitClause1, @TraitClause4]] _y_2
+    conditional_drop[{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause3]] _x_1
+    return
+}
+
+
+

--- a/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.rs
+++ b/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.rs
@@ -1,0 +1,41 @@
+//@ charon-args=--remove-adt-clauses
+//@ charon-args=--remove-associated-types=__no_match__
+// `--remove-associated-types` is passed a non-matching pattern: it's required to be non-empty
+// by `--remove-adt-clauses`'s validation, but here we want to leave the trait associated types
+// alone so we can test the "preserve clause when trait has assoc types" path.
+//
+// Regression test: `--remove-adt-clauses` must NOT strip a clause when the trait it points at
+// has an associated type (directly or via a transitive supertrait). Otherwise we'd have no way
+// to synthesize a placeholder value for the associated type. We leave the whole ADT untouched.
+//
+// The marker trait at the bottom has no associated types anywhere in its supertrait chain, so
+// its clause should still be stripped.
+
+trait HasAssoc {
+    type Output;
+}
+
+// `HasAssoc` has a direct associated type, so this clause must be kept.
+struct Direct<T: HasAssoc>(T);
+
+trait BaseWithAssoc {
+    type Item;
+}
+trait DerivedNoAssoc: BaseWithAssoc {}
+
+// `DerivedNoAssoc` has no direct associated type, but inherits one from `BaseWithAssoc` via the
+// supertrait. The clause must still be kept (transitive case).
+struct Transitive<T: DerivedNoAssoc>(T);
+
+trait MarkerParent {}
+trait MarkerChild: MarkerParent {}
+
+// Pure marker inheritance, no associated types: this clause may safely be stripped.
+struct Marker<T: MarkerChild>(T);
+
+fn use_all<T: HasAssoc, U: DerivedNoAssoc, V: MarkerChild>(
+    _x: Direct<T>,
+    _y: Transitive<U>,
+    _z: Marker<V>,
+) {
+}

--- a/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
@@ -1,0 +1,122 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = drop_in_place<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct::drop_in_place
+unsafe fn drop_in_place<Self>(_1: *mut Self)
+= <opaque>
+
+// Full name: core::marker::Tuple
+#[lang_item("tuple_trait")]
+pub trait Tuple<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::ops::function::FnOnce
+#[lang_item("fn_once")]
+pub trait FnOnce<Self, Args, Self_Output>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Sized<Args>
+    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
+}
+
+pub fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
+where
+    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+= <opaque>
+
+// Full name: test_crate::GrandParent
+trait GrandParent<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    vtable: test_crate::GrandParent::{vtable}
+}
+
+// Full name: test_crate::Parent
+trait Parent<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: GrandParent<Self>
+    vtable: test_crate::Parent::{vtable}
+}
+
+// Full name: test_crate::Child
+trait Child<Self>
+{
+    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    parent_clause1 : [@TraitClause1]: Parent<Self>
+    vtable: test_crate::Child::{vtable}
+}
+
+// Full name: test_crate::make::closure
+struct closure<T> {}
+
+// Full name: test_crate::make
+fn make<T>(x_1: T) -> closure<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Child<T>,
+{
+    let _0: closure<T>; // return
+    let x_1: T; // arg #1
+
+    _0 = closure {  }
+    conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
+    return
+}
+
+// Full name: test_crate::make::{impl FnOnce<(), ()> for closure<T>}::call_once
+fn {impl FnOnce<(), ()> for closure<T>}::call_once<T>(_1: closure<T>, tupled_args_2: ())
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Child<T>,
+{
+    let _0: (); // return
+    let _1: closure<T>; // arg #1
+    let tupled_args_2: (); // arg #2
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::make::{impl FnOnce<(), ()> for closure<T>}
+impl<T> FnOnce<(), ()> for closure<T>
+where
+    [@TraitClause0]: Sized<T>,
+    [@TraitClause1]: Child<T>,
+{
+    parent_clause0 = {built_in impl MetaSized for closure<T>}
+    parent_clause1 = {built_in impl Sized for ()}
+    parent_clause2 = {built_in impl Tuple for ()}
+    parent_clause3 = {built_in impl Sized for ()}
+    fn call_once = {impl FnOnce<(), ()> for closure<T>}::call_once<T>[@TraitClause0, @TraitClause1]
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/simple/remove-adt-clauses-supertrait.rs
+++ b/charon/tests/ui/simple/remove-adt-clauses-supertrait.rs
@@ -1,0 +1,20 @@
+//@ charon-args=--remove-adt-clauses
+//@ charon-args=--remove-associated-types=*
+// Regression test: when `--remove-adt-clauses` strips a clause to a trait with supertraits, the
+// synthesized `BuiltinOrAuto[RemovedAdtClause]` placeholder must include a recursive
+// `RemovedAdtClause` parent ref for each supertrait, so the placeholder matches the trait's
+// shape. The post-transformation typechecker checks this; if the recursion were missing or the
+// counts wrong, this test would fail there.
+
+trait GrandParent {}
+trait Parent: GrandParent {}
+trait Child: Parent {}
+
+// The closure inherits `T: Child` from `make`, so after stripping, references to that clause
+// inside the closure ADT become dangling and get rewritten to `RemovedAdtClause`. The recursive
+// parent fill is exercised because `Child: Parent: GrandParent`.
+fn make<T: Child>(x: T) -> impl FnOnce() {
+    move || {
+        let _ = x;
+    }
+}


### PR DESCRIPTION
Fixes #1120 

This is a claude implementation for the design from https://github.com/AeneasVerif/charon/issues/1120#issuecomment-4378918055