### PR TITLE
Remove unit_metadata hack

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.185"
+let supported_charon_version = "0.1.186"

--- a/charon-ml/src/ExpressionsUtils.ml
+++ b/charon-ml/src/ExpressionsUtils.ml
@@ -1,4 +1,5 @@
 open Types
+open TypesUtils
 open Expressions
 
 let unop_can_fail : unop -> bool = function
@@ -14,3 +15,5 @@ let binop_can_fail : binop -> bool = function
   | Shr OWrap
   | AddChecked | SubChecked | MulChecked | Cmp -> false
   | Div _ | Rem _ | Add _ | Sub _ | Mul _ | Shl _ | Shr _ | Offset -> true
+
+let mk_unit_const : constant_expr = { kind = CAdt (None, []); ty = mk_unit_ty }

--- a/charon-ml/src/GAst.ml
+++ b/charon-ml/src/GAst.ml
@@ -40,6 +40,5 @@ type crate = {
   global_decls : global_decl GlobalDeclId.Map.t;
   trait_decls : trait_decl TraitDeclId.Map.t;
   trait_impls : trait_impl TraitImplId.Map.t;
-  unit_metadata : global_decl_ref;
 }
 [@@deriving show]

--- a/charon-ml/src/LlbcAstUtils.ml
+++ b/charon-ml/src/LlbcAstUtils.ml
@@ -176,7 +176,6 @@ class ['self] map_crate =
         global_decls;
         trait_decls;
         trait_impls;
-        unit_metadata;
       } =
         crate
       in
@@ -203,7 +202,6 @@ class ['self] map_crate =
       let trait_impls =
         TraitImplId.Map.map (self#visit_trait_impl env) trait_impls
       in
-      let unit_metadata = self#visit_global_decl_ref env unit_metadata in
       {
         name;
         options;
@@ -214,7 +212,6 @@ class ['self] map_crate =
         global_decls;
         trait_decls;
         trait_impls;
-        unit_metadata;
       }
   end
 
@@ -315,7 +312,6 @@ class ['self] iter_crate =
         global_decls;
         trait_decls;
         trait_impls;
-        unit_metadata;
       } =
         crate
       in
@@ -326,8 +322,7 @@ class ['self] iter_crate =
       FunDeclId.Map.iter (fun _ -> self#visit_fun_decl env) fun_decls;
       GlobalDeclId.Map.iter (fun _ -> self#visit_global_decl env) global_decls;
       TraitDeclId.Map.iter (fun _ -> self#visit_trait_decl env) trait_decls;
-      TraitImplId.Map.iter (fun _ -> self#visit_trait_impl env) trait_impls;
-      self#visit_global_decl_ref env unit_metadata
+      TraitImplId.Map.iter (fun _ -> self#visit_trait_impl env) trait_impls
   end
 
 (** This visitor keeps track of the last (most precise) span it found, together

--- a/charon-ml/src/OfJson.ml
+++ b/charon-ml/src/OfJson.ml
@@ -54,6 +54,5 @@ let crate_of_json (js : json) : (crate, string) result =
             global_decls;
             trait_decls;
             trait_impls;
-            unit_metadata = Option.get crate.unit_metadata;
           }
   | _ -> combine_error_msgs js __FUNCTION__ (Error "")

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -309,10 +309,6 @@ and translated_crate = {
       (** The translated trait declarations *)
   trait_impls : trait_impl option list;
       (** The translated trait declarations *)
-  unit_metadata : global_decl_ref option;
-      (** A [const UNIT: () = ();] used whenever we make a thin
-          pointer/reference to avoid creating a local [let unit = ();] variable.
-          It is always [Some]. *)
   ordered_decls : declaration_group list option;
       (** The re-ordered groups of declarations, initialized as empty. *)
 }

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2806,7 +2806,6 @@ and translated_crate_of_json (ctx : of_json_ctx) (js : json) :
           ("global_decls", global_decls);
           ("trait_decls", trait_decls);
           ("trait_impls", trait_impls);
-          ("unit_metadata", unit_metadata);
           ("ordered_decls", ordered_decls);
         ] ->
         let* crate_name = string_of_json ctx crate_name in
@@ -2844,9 +2843,6 @@ and translated_crate_of_json (ctx : of_json_ctx) (js : json) :
           opt_indexed_map_of_json trait_impl_id_of_json trait_impl_of_json ctx
             trait_impls
         in
-        let* unit_metadata =
-          option_of_json global_decl_ref_of_json ctx unit_metadata
-        in
         let* ordered_decls =
           option_of_json
             (list_of_json declaration_group_of_json)
@@ -2865,7 +2861,6 @@ and translated_crate_of_json (ctx : of_json_ctx) (js : json) :
              global_decls;
              trait_decls;
              trait_impls;
-             unit_metadata;
              ordered_decls;
            }
             : translated_crate)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.185"
+version = "0.1.186"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.185"
+version = "0.1.186"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -90,6 +90,13 @@ impl Place {
 }
 
 impl ConstantExpr {
+    pub fn mk_unit() -> Self {
+        ConstantExpr {
+            kind: ConstantExprKind::Adt(None, Vec::new()),
+            ty: Ty::mk_unit(),
+        }
+    }
+
     pub fn mk_usize(scalar: ScalarValue) -> Self {
         ConstantExpr {
             kind: ConstantExprKind::Literal(Literal::Scalar(scalar)),
@@ -100,10 +107,7 @@ impl ConstantExpr {
 
 impl Operand {
     pub fn mk_const_unit() -> Self {
-        Operand::Const(Box::new(ConstantExpr {
-            kind: ConstantExprKind::Adt(None, Vec::new()),
-            ty: Ty::mk_unit(),
-        }))
+        Operand::Const(Box::new(ConstantExpr::mk_unit()))
     }
 
     pub fn ty(&self) -> &Ty {

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -218,9 +218,6 @@ pub struct TranslatedCrate {
     pub trait_decls: IndexMap<TraitDeclId, TraitDecl>,
     /// The translated trait declarations
     pub trait_impls: IndexMap<TraitImplId, TraitImpl>,
-    /// A `const UNIT: () = ();` used whenever we make a thin pointer/reference to avoid creating a
-    /// local `let unit = ();` variable. It is always `Some`.
-    pub unit_metadata: Option<GlobalDeclRef>,
     /// The re-ordered groups of declarations, initialized as empty.
     #[drive(skip)]
     #[serde_state(stateless)]

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -811,8 +811,6 @@ pub fn translate<'tcx>(
         &ctx.items_to_translate
     );
 
-    ctx.translate_unit_metadata_const();
-
     // Translate.
     //
     // For as long as the queue of items to translate is not empty, we pop the top item and

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -2,7 +2,6 @@ use super::translate_crate::*;
 use super::translate_ctx::*;
 use crate::hax;
 use crate::hax::SInto;
-use charon_lib::ast::ullbc_ast_utils::BodyBuilder;
 use charon_lib::ast::*;
 use charon_lib::formatter::IntoFormatter;
 use charon_lib::pretty::FmtWithCtx;
@@ -276,64 +275,6 @@ impl<'tcx> TranslateCtx<'tcx> {
         }
         let item = self.translated.get_item(id);
         Ok(item.unwrap())
-    }
-
-    /// Add a `const UNIT: () = ();` const, used as metadata for thin pointers/references.
-    pub fn translate_unit_metadata_const(&mut self) {
-        use charon_lib::ullbc_ast::*;
-        let name = Name::from_path(&["UNIT_METADATA"]);
-        let item_meta = ItemMeta {
-            name: name.clone(),
-            span: Span::dummy(),
-            source_text: None,
-            attr_info: AttrInfo::default(),
-            is_local: false,
-            opacity: ItemOpacity::Foreign,
-            lang_item: None,
-        };
-
-        let body = {
-            let mut builder = BodyBuilder::new(Span::dummy(), 0);
-            let _ = builder.new_var(None, Ty::mk_unit());
-            builder.build()
-        };
-
-        let global_id = self.translated.global_decls.reserve_slot();
-        let initializer = self.translated.fun_decls.push_with(|def_id| FunDecl {
-            def_id,
-            item_meta: item_meta.clone(),
-            src: ItemSource::TopLevel,
-            is_global_initializer: Some(global_id),
-            generics: Default::default(),
-            signature: FunSig {
-                is_unsafe: false,
-                inputs: vec![],
-                output: Ty::mk_unit(),
-            },
-            body: Body::Unstructured(body),
-        });
-        self.translated
-            .item_names
-            .insert(ItemId::Fun(initializer), name.clone());
-        self.translated.global_decls.set_slot(
-            global_id,
-            GlobalDecl {
-                def_id: global_id,
-                item_meta,
-                generics: Default::default(),
-                ty: Ty::mk_unit(),
-                src: ItemSource::TopLevel,
-                global_kind: GlobalKind::NamedConst,
-                init: initializer,
-            },
-        );
-        self.translated
-            .item_names
-            .insert(ItemId::Global(global_id), name);
-        self.translated.unit_metadata = Some(GlobalDeclRef {
-            id: global_id,
-            generics: Box::new(GenericArgs::empty()),
-        });
     }
 
     /// Keep only the methods we marked as "used".

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -149,7 +149,6 @@ impl CrateMerger {
             global_decls,
             trait_decls,
             trait_impls,
-            unit_metadata,
             ordered_decls: _, // Recomputed on the merged crate
         } = krate;
         if self.merged.translated.crate_name.is_empty() {
@@ -180,9 +179,6 @@ impl CrateMerger {
             .translated
             .trait_impls
             .extend_from_other(trait_impls);
-        if self.merged.translated.unit_metadata.is_none() {
-            self.merged.translated.unit_metadata = unit_metadata;
-        }
     }
 }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -359,13 +359,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for ClauseDbVar {
     }
 }
 
-impl_display_via_ctx!(ConstantExpr);
-impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
-    fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.kind.with_ctx(ctx))
-    }
-}
-
 impl<C: AstFormatter> FmtWithCtx<C> for ConstGenericDbVar {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ctx.format_bound_var(f, *self, "@ConstGeneric", |v| Some(v.name.clone()))
@@ -1287,20 +1280,52 @@ impl<C: AstFormatter> FmtWithCtx<C> for Byte {
     }
 }
 
-impl<C: AstFormatter> FmtWithCtx<C> for ConstantExprKind {
+impl_display_via_ctx!(ConstantExpr);
+impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match &self.kind {
             ConstantExprKind::Literal(c) => write!(f, "{}", c),
             ConstantExprKind::Adt(variant_id, values) => {
-                // It is a bit annoying: in order to properly format the value,
-                // we need the type (which contains the type def id).
-                // Anyway, the printing utilities are mostly for debugging.
-                let variant_id = match variant_id {
-                    Some(id) => format!("Some({id})"),
-                    None => "None".to_string(),
-                };
-                let values = values.iter().map(|v| v.with_ctx(ctx)).format(", ");
-                write!(f, "ConstAdt {} [{}]", variant_id, values)
+                let values = values.iter().map(|v| v.with_ctx(ctx));
+                match self.ty.as_adt() {
+                    Some(ty_ref) => match ty_ref.id {
+                        TypeId::Tuple => {
+                            let trailing_comma = if values.len() == 1 { "," } else { "" };
+                            let values = values.format(", ");
+                            write!(f, "({values}{trailing_comma})")
+                        }
+                        TypeId::Builtin(BuiltinTy::Box) => {
+                            let values = values.format(", ");
+                            write!(f, "Box({values})")
+                        }
+                        TypeId::Builtin(BuiltinTy::Str) => {
+                            let values = values.format(", ");
+                            write!(f, "[{values}]")
+                        }
+                        TypeId::Adt(ty_id) => {
+                            match variant_id {
+                                None => ty_id.fmt_with_ctx(ctx, f)?,
+                                Some(variant_id) => {
+                                    ctx.format_enum_variant(f, ty_id, *variant_id)?
+                                }
+                            }
+                            write!(f, " {{ ")?;
+                            for (comma, (i, val)) in
+                                repeat_except_first(", ").zip(values.enumerate())
+                            {
+                                write!(f, "{}", comma.unwrap_or_default())?;
+                                let field_id = FieldId::new(i);
+                                ctx.format_field_name(f, ty_id, *variant_id, field_id)?;
+                                write!(f, ": {}", val)?;
+                            }
+                            write!(f, " }}")
+                        }
+                    },
+                    None => {
+                        let values = values.format(", ");
+                        write!(f, "ConstAdt [{values}]")
+                    }
+                }
             }
             ConstantExprKind::Array(values) => {
                 let values = values.iter().map(|v| v.with_ctx(ctx)).format(", ");

--- a/charon/src/transform/ctx.rs
+++ b/charon/src/transform/ctx.rs
@@ -365,13 +365,6 @@ pub trait BodyTransformCtx: Sized {
     /// and return `Operand::Move(len)`.
     ///
     fn compute_place_metadata(&mut self, place: &Place) -> Operand {
-        /// No metadata. We use the `unit_metadata` global to avoid having to define unit locals
-        /// everywhere.
-        fn no_metadata<T: BodyTransformCtx>(ctx: &T) -> Operand {
-            let unit_meta = ctx.get_crate().unit_metadata.clone().unwrap();
-            Operand::Copy(Place::new_global(unit_meta, Ty::mk_unit()))
-        }
-
         /// Compute the metadata for a place. Return `None` if the place has no metadata.
         fn compute_place_metadata_inner<T: BodyTransformCtx>(
             ctx: &mut T,
@@ -416,13 +409,14 @@ pub trait BodyTransformCtx: Sized {
             || matches!(metadata_ty.kind(), TyKind::PtrMetadata(ty) if self.is_sized_type_var(ty))
         {
             // If the type var is known to be `Sized`, then no metadata is needed
-            return no_metadata(self);
+            return Operand::mk_const_unit();
         }
         trace!(
             "computed metadata type: {}",
             metadata_ty.with_ctx(&self.to_fmt())
         );
-        compute_place_metadata_inner(self, place, &metadata_ty).unwrap_or_else(|| no_metadata(self))
+        compute_place_metadata_inner(self, place, &metadata_ty)
+            .unwrap_or_else(Operand::mk_const_unit)
     }
 
     /// Create a `&` borrow of the place.

--- a/charon/src/transform/simplify_output/simplify_constants.rs
+++ b/charon/src/transform/simplify_output/simplify_constants.rs
@@ -94,6 +94,10 @@ fn transform_constant_expr(
                 }
             }
         }
+        ConstantExprKind::Adt(..) if val.ty.is_unit() => {
+            // Keep unit constants to avoid adding countless unit locals.
+            return Operand::Const(val);
+        }
         ConstantExprKind::Adt(variant, fields) => {
             let fields = fields
                 .into_iter()
@@ -175,6 +179,9 @@ impl FusedUllbcPass for Transform {
                                 && let Ok(op) = fields.iter().dedup().exactly_one() =>
                         {
                             Rvalue::Repeat(op.clone(), ty.clone(), len)
+                        }
+                        Rvalue::Use(Operand::Const(e)) if e.kind.is_adt() && e.ty.is_unit() => {
+                            Rvalue::unit_value()
                         }
                         _ => rvalue,
                     });

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -68,18 +68,6 @@ where
     @TraitClause2::Output = T,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_cargo_dependencies::main::silly_incr::closure
 struct closure {}
 

--- a/charon/tests/cargo/issue-412-dup-deps.out
+++ b/charon/tests/cargo/issue-412-dup-deps.out
@@ -33,18 +33,6 @@ pub enum AssertKind {
   Match,
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: mydup::hello
 pub fn hello() -> u32
 {

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -37,18 +37,6 @@ where
     return
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_cargo_toml::included::run
 pub fn run()
 {

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -100,7 +100,7 @@ fn spans() -> anyhow::Result<()> {
         ",
         &["--reconstruct-fallible-operations"],
     )?;
-    let function = &crate_data.fun_decls[1];
+    let function = &crate_data.fun_decls[0];
     // Span of the whole function.
     assert_eq!(repr_span(function.item_meta.span), "2:8-10:9");
 
@@ -308,20 +308,20 @@ fn attributes() -> anyhow::Result<()> {
         vec!["clippy::foo"]
     );
     assert_eq!(
+        unknown_attrs(&crate_data.global_decls[0].item_meta),
+        vec!["clippy::foo"]
+    );
+    assert_eq!(
         unknown_attrs(&crate_data.global_decls[1].item_meta),
         vec!["clippy::foo"]
     );
+    assert!(unknown_attrs(&crate_data.fun_decls[0].item_meta).is_empty());
     assert_eq!(
-        unknown_attrs(&crate_data.global_decls[2].item_meta),
-        vec!["clippy::foo"]
-    );
-    assert!(unknown_attrs(&crate_data.fun_decls[1].item_meta).is_empty());
-    assert_eq!(
-        crate_data.fun_decls[1].item_meta.attr_info.inline,
+        crate_data.fun_decls[0].item_meta.attr_info.inline,
         Some(InlineAttr::Never)
     );
     assert_eq!(
-        crate_data.fun_decls[1]
+        crate_data.fun_decls[0]
             .item_meta
             .attr_info
             .attributes
@@ -514,7 +514,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[1]
+        crate_data.fun_decls[0]
             .item_meta
             .attr_info
             .rename
@@ -523,7 +523,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[2]
+        crate_data.fun_decls[1]
             .item_meta
             .attr_info
             .rename
@@ -532,7 +532,16 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.fun_decls[3]
+        crate_data.fun_decls[2]
+            .item_meta
+            .attr_info
+            .rename
+            .as_deref(),
+        Some("retTest")
+    );
+
+    assert_eq!(
+        crate_data.fun_decls[4]
             .item_meta
             .attr_info
             .rename
@@ -542,15 +551,6 @@ fn rename_attribute() -> anyhow::Result<()> {
 
     assert_eq!(
         crate_data.fun_decls[5]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
-        Some("retTest")
-    );
-
-    assert_eq!(
-        crate_data.fun_decls[6]
             .item_meta
             .attr_info
             .rename
@@ -604,7 +604,7 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.global_decls[1]
+        crate_data.global_decls[0]
             .item_meta
             .attr_info
             .rename
@@ -645,9 +645,8 @@ fn declaration_groups() -> anyhow::Result<()> {
         "#,
     )?;
 
-    // There are 3 function items: one for `foo`, one for the initializer of `Trait::FOO`, and
-    // one for the initializer of UNIT_METADATA (always included).
-    assert_eq!(crate_data.fun_decls.iter().count(), 3);
+    // There are 2 function items: one for `foo`, and one for the initializer of `Trait::FOO`.
+    assert_eq!(crate_data.fun_decls.iter().count(), 2);
     let decl_groups = crate_data.ordered_decls.unwrap();
     assert_eq!(decl_groups.len(), 6);
 
@@ -704,7 +703,7 @@ fn known_trait_method_call() -> anyhow::Result<()> {
         }
         "#,
     )?;
-    let function = &crate_data.fun_decls[1];
+    let function = &crate_data.fun_decls[0];
     assert_eq!(
         repr_name(&crate_data, &function.item_meta.name),
         "test_crate::use_default"
@@ -724,7 +723,7 @@ fn known_trait_method_call() -> anyhow::Result<()> {
         panic!()
     };
     // This is the function that gets called.
-    let function = &crate_data.fun_decls[id.index()];
+    let function = &crate_data.fun_decls[*id];
     assert_eq!(
         repr_name(&crate_data, &function.item_meta.name),
         "test_crate::<impl Default for ??>::default"
@@ -755,10 +754,10 @@ fn multiple_deserialize() -> anyhow::Result<()> {
         fn bar(_: u32) {}
         ",
     )?;
-    let ty1_1 = krate1.fun_decls[1].signature.inputs[0].clone();
-    let ty1_2 = krate1.fun_decls[2].signature.inputs[0].clone();
-    let ty2_1 = krate2.fun_decls[1].signature.inputs[0].clone();
-    let ty2_2 = krate2.fun_decls[2].signature.inputs[0].clone();
+    let ty1_1 = krate1.fun_decls[0].signature.inputs[0].clone();
+    let ty1_2 = krate1.fun_decls[1].signature.inputs[0].clone();
+    let ty2_1 = krate2.fun_decls[0].signature.inputs[0].clone();
+    let ty2_2 = krate2.fun_decls[1].signature.inputs[0].clone();
     assert_eq!(ty1_1.kind().as_literal(), Some(&LiteralTy::Bool));
     assert_eq!(ty1_2, ty1_1);
     assert_eq!(

--- a/charon/tests/ui/advanced-const-generics.out
+++ b/charon/tests/ui/advanced-const-generics.out
@@ -88,18 +88,6 @@ pub trait ConstParamTy_<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 enum Foo {
   A,

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -256,18 +256,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
 unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(_1: *mut [T; N])
 where

--- a/charon/tests/ui/arrays_const_generics.out
+++ b/charon/tests/ui/arrays_const_generics.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::index_array_generic
 pub fn index_array_generic<const N : usize>(s_1: [u32; N], i_2: usize) -> u32
 {

--- a/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
@@ -73,18 +73,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Trait
 pub trait Trait<Self, Self_Foo>
 {

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -142,18 +142,6 @@ where
     [@TraitClause0]: ToOwned<Self, Clause0_Owned>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 trait test_crate::Foo<'a, Self, Self_Item>
 where
     Self_Item : 'a,

--- a/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -82,18 +82,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::PrimeField
 pub trait PrimeField<Self, Self_Repr>
 {

--- a/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
@@ -49,18 +49,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Iterator
 trait Iterator<Self, Self_Item>
 {

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -42,18 +42,6 @@ pub trait StructuralPartialEq<Self>
     vtable: core::marker::StructuralPartialEq::{vtable}
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Enum
 enum Enum {
   Some(u8),

--- a/charon/tests/ui/associated_types/pointee_metadata.out
+++ b/charon/tests/ui/associated_types/pointee_metadata.out
@@ -213,18 +213,6 @@ pub trait Pointee<Self>
 pub fn to_raw_parts<T>(_1: *const T) -> (*const (), {built_in impl Pointee for T}::Metadata)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::empty_metadata
 fn empty_metadata()
 {

--- a/charon/tests/ui/closure-as-fn.out
+++ b/charon/tests/ui/closure-as-fn.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main::closure
 struct closure {}
 

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -136,18 +136,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_in_place
 unsafe fn {impl Destruct for (A,)}::drop_in_place<A>(_1: *mut (A,))
 {

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -77,18 +77,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Ops
 trait Ops<Self, const K : usize>
 {

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -71,18 +71,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::function_call
 fn function_call(_1: u32)
 {

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -19,18 +19,6 @@ pub fn MAX() -> u32
 // Full name: core::num::{u32}::MAX
 pub const MAX: u32 = MAX()
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::X0
 pub fn X0() -> u32
 {

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -77,18 +77,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::f1
 fn f1<'_0>(a_1: &'_0 [u8]) -> usize
 {

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -463,18 +463,6 @@ where
     [@TraitClause3]: SliceIndex<I, [T]>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::test_loop1
 pub fn test_loop1(max_1: u32) -> u32
 {

--- a/charon/tests/ui/control-flow/simple-fallthrough.out
+++ b/charon/tests/ui/control-flow/simple-fallthrough.out
@@ -22,18 +22,6 @@ where
   Some(T),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::do_something
 fn do_something()
 {

--- a/charon/tests/ui/control-flow/ullbc-control-flow.out
+++ b/charon/tests/ui/control-flow/ullbc-control-flow.out
@@ -266,20 +266,6 @@ where
     [@TraitClause0]: Iterator<Self>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    bb0: {
-        _0 = ();
-        return;
-    }
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::nested_loops_enum
 pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
 {

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -675,18 +675,6 @@ where
     return
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::write
 fn write<'_0, '_1, T>(x_1: &'_0 mut T, y_2: &'_1 T)
 where

--- a/charon/tests/ui/cross_compile_32_bit.out
+++ b/charon/tests/ui/cross_compile_32_bit.out
@@ -15,18 +15,6 @@ pub opaque type NonNull<T>
 pub unsafe fn new_unchecked<T>(_1: *mut T) -> NonNull<T>
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::HasPointerNiche
 enum HasPointerNiche {
   First,

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -16,18 +16,6 @@ pub trait Sized<Self>
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::choose
 pub fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where

--- a/charon/tests/ui/desugar_drops_to_calls.out
+++ b/charon/tests/ui/desugar_drops_to_calls.out
@@ -99,18 +99,6 @@ where
     [@TraitClause3]: Destruct<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::use_string
 fn use_string(_1: String)
 {

--- a/charon/tests/ui/desugar_drops_to_calls_mono.out
+++ b/charon/tests/ui/desugar_drops_to_calls_mono.out
@@ -87,18 +87,6 @@ impl Destruct for String {    non-dyn-compatible
 impl Destruct for Vec::<i32, Global> {    non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::use_string
 fn use_string(_1: String)
 {

--- a/charon/tests/ui/drop_after_overflow.out
+++ b/charon/tests/ui/drop_after_overflow.out
@@ -41,20 +41,6 @@ where
 pub fn _print<'_0>(_1: Arguments<'_0>)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    bb0: {
-        _0 = ();
-        return;
-    }
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 struct Foo {}
 

--- a/charon/tests/ui/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.out
@@ -18,18 +18,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Super::{vtable}<T> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -219,18 +219,6 @@ where
     [@TraitClause2]: Destruct<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 pub fn test_crate::swap<'a, T>(x_1: &'a mut T, y_2: &'a mut T)
 where
     [@TraitClause0]: Sized<T>,

--- a/charon/tests/ui/filtering/opacity.out
+++ b/charon/tests/ui/filtering/opacity.out
@@ -85,18 +85,6 @@ where
     return
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/filtering/opaque_attribute.out
+++ b/charon/tests/ui/filtering/opaque_attribute.out
@@ -22,18 +22,6 @@ where
   Some(T),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -117,18 +117,6 @@ where
 pub fn _eprint<'_0>(_1: Arguments<'_0>)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::debug_slice
 fn debug_slice<'_0, T>(slice_1: &'_0 [T])
 where

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -87,18 +87,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -28,18 +28,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <missing>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::discriminant_value
 fn discriminant_value<'_0, T>(opt_1: &'_0 Option<T>[@TraitClause0]) -> isize
 where

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::slice_pat1
 fn slice_pat1()
 {

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -66,18 +66,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Rng
 struct Rng {}
 

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -52,18 +52,6 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
 pub fn new() -> String
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::F
 fn F() -> fn(u8) -> Option<u8>[{built_in impl Sized for u8}]
 {

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -90,18 +90,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::sparse_transitions::closure
 struct closure<'a> {}
 

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -294,18 +294,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::map::closure
 struct closure {}
 

--- a/charon/tests/ui/issue-70-override-provided-method.2.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2.out
@@ -4,18 +4,6 @@
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -93,18 +93,6 @@ where
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::GenericTrait
 trait GenericTrait<Self, T>
 {

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -88,18 +88,6 @@ where
     [@TraitClause1]: PartialEq<T, T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Hasher
 pub trait Hasher<Self>
 {

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Ord
 pub trait Ord<Self>
 {

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -5088,18 +5088,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -49,18 +49,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/ml-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-mono-name-matcher-tests.out
@@ -21,18 +21,6 @@ pub fn is_some::<i32><'_0>(_1: &'_0 Option::<i32>) -> bool
 pub fn index::<bool, RangeFrom::<usize>><'_0>(_1: &'_0 [bool], _2: RangeFrom::<usize>) -> &'_0 [bool]
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::bar
 fn bar()
 {

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -177,18 +177,6 @@ where
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::bar
 fn bar()
 {

--- a/charon/tests/ui/monomorphization/bound_lifetime.out
+++ b/charon/tests/ui/monomorphization/bound_lifetime.out
@@ -7,18 +7,6 @@ pub enum Option::<&'_ u32> {
   Some(&'_ u32),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo
 fn foo<'_0>(x_1: &'_0 u32) -> Option::<&'_ u32>
 {

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -85,18 +85,6 @@ pub fn call_mut<'_0>(_1: &'_0 mut closure<'_, '_>, _2: (u8, u8)) -> u8
 pub fn call_once(_1: closure<'_, '_>, _2: (u8, u8)) -> u8
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnOnce<(u8, u8)> for closure<'_0, '_1> {
     parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -53,18 +53,6 @@ pub trait FnOnce<Self, Args>
 pub fn call_once(_1: closure, _2: (u8,)) -> u8
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main::closure::{impl Destruct for closure}
 impl Destruct for closure {    non-dyn-compatible
 }

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -100,18 +100,6 @@ pub fn call_mut<'_0>(_1: &'_0 mut test_crate::main::closure#1<'_>, _2: (u8,)) ->
 pub fn call_once(_1: test_crate::main::closure#2, _2: (u8,)) -> u8
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main::closure::{impl Destruct for test_crate::main::closure<'_0>}
 impl<'_0> Destruct for test_crate::main::closure<'_0> {    non-dyn-compatible
 }

--- a/charon/tests/ui/monomorphization/fn_ptr_generics.out
+++ b/charon/tests/ui/monomorphization/fn_ptr_generics.out
@@ -7,18 +7,6 @@ pub enum Option::<u8> {
   Some(u8),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::init_option
 fn init_option()
 {

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -75,18 +75,6 @@ fn foo::<u32><'a>(x_1: &'a u32)
 pub fn call<'_0>(_1: &'_0 for<'a> foo::<u32><'a>, _2: (&'_ u32,))
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::<u8>
 fn foo::<u8><'a>(x_1: &'a u8)
 {

--- a/charon/tests/ui/monomorphization/global_with_generics.out
+++ b/charon/tests/ui/monomorphization/global_with_generics.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo::<bool>
 struct Foo::<bool> {
   value: bool,

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -74,18 +74,6 @@ pub trait Fn<Self, Args>
 pub fn call_mut<'_0>(_1: &'_0 mut closure::<()>, _2: ((),))
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::{const}::closure::{impl Destruct for closure::<()>}
 impl Destruct for closure::<()> {    non-dyn-compatible
 }

--- a/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
+++ b/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-2.out
@@ -14,18 +14,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
@@ -14,18 +14,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
@@ -14,18 +14,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics.out
@@ -14,18 +14,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-two-methods.out
+++ b/charon/tests/ui/monomorphization/simple-trait-two-methods.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple_trait.out
+++ b/charon/tests/ui/monomorphization/simple_trait.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/trait_impls.out
+++ b/charon/tests/ui/monomorphization/trait_impls.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::{impl Trait for bool}::method
 pub fn method<'_0>(self_1: &'_0 bool)
 {

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -4,20 +4,6 @@
 pub fn eq<'_0, '_1>(_1: &'_0 bool, _2: &'_1 bool) -> bool
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    bb0: {
-        _0 = ();
-        return;
-    }
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::do_test::<bool>
 fn do_test::<bool>(init_1: bool, expected_2: bool)
 {

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -6,18 +6,6 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::MyIterator::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -91,18 +91,6 @@ unsafe fn core::marker::Destruct::drop_in_place::<Option<&_ mut _>><'_0, T0>(_1:
 unsafe fn core::marker::Destruct::drop_in_place::<Option<Option<&_ mut _>>><'_0, T0>(_1: *mut Option<Option<&'_0 mut T0>>)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::identity
 fn identity<T>(x_1: T) -> T
 where

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -315,18 +315,6 @@ where
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::option_mut
 fn option_mut<X, A>(x_1: A)
 where

--- a/charon/tests/ui/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target-from-symcrypt.out
@@ -268,16 +268,6 @@ where
     [@TraitClause0]: core::marker::Sized<T>,
 = <opaque>
 
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-const UNIT_METADATA: () = UNIT_METADATA()
-
 trait test_crate::NttIntrinsicsInterface<Self>
 {
     parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -48,18 +48,6 @@ where
     [@TraitClause1]: Sized<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
 where

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -251,18 +251,6 @@ impl BuildHasher for RandomState {
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::get_or_insert
 pub fn get_or_insert<'_0>(map_1: &'_0 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]) -> &'_0 u32
 {

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -84,18 +84,6 @@ where
     [@TraitClause1]: Sized<E>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::wrap
 fn wrap<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {

--- a/charon/tests/ui/projection-index-from-end.out
+++ b/charon/tests/ui/projection-index-from-end.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::slice_pattern_end
 fn slice_pattern_end<'_0>(x_1: &'_0 [()])
 {

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -303,18 +303,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/regressions/invalid-reconstruct-assert.out
+++ b/charon/tests/ui/regressions/invalid-reconstruct-assert.out
@@ -96,20 +96,6 @@ where
   Err(E),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    bb0: {
-        _0 = ();
-        return;
-    }
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 fn core::hint::assert_unchecked::precondition_check(_1: bool)
 = <opaque>
 

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::make_early
 fn make_early<'a, T>(_1: fn(&'a T))
 where

--- a/charon/tests/ui/regressions/issue-1067-filename-ice.out
+++ b/charon/tests/ui/regressions/issue-1067-filename-ice.out
@@ -89,18 +89,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -174,18 +174,6 @@ fn precondition_check(_1: *mut (), _2: usize, _3: usize, _4: usize)
 
 pub opaque type std::io::IoSlice<'a>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: libc::unix::iovec
 pub struct iovec {
   iov_base: *mut c_void,

--- a/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
+++ b/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
@@ -23,18 +23,6 @@ pub trait Destruct<Self>
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::MyTrait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -140,18 +140,6 @@ impl Debug for u32 {
     vtable: {impl Debug for u32}::{vtable}
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: core::result::unwrap_failed
 fn unwrap_failed<'_0, '_1>(_1: &'_0 Str, _2: &'_1 (dyn Debug + '_1)) -> !
 = <missing>

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -38,18 +38,6 @@ where
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::bar
 fn bar()
 {

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -122,18 +122,6 @@ where
     [@TraitClause1]: Sized<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::addr_of
 fn addr_of()
 {

--- a/charon/tests/ui/simple-cmp.out
+++ b/charon/tests/ui/simple-cmp.out
@@ -12,18 +12,6 @@ pub enum Ordering {
 pub fn {impl Ord for i32}::cmp<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i32) -> Ordering
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/array_index.out
+++ b/charon/tests/ui/simple/array_index.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::first
 pub fn first(s_1: [u32; 0 : usize]) -> u32
 {

--- a/charon/tests/ui/simple/box-into-inner.out
+++ b/charon/tests/ui/simple/box-into-inner.out
@@ -149,18 +149,6 @@ pub opaque type String
 unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::into_inner
 fn into_inner(b_1: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
 {

--- a/charon/tests/ui/simple/builtin-drop-mono.out
+++ b/charon/tests/ui/simple/builtin-drop-mono.out
@@ -55,18 +55,6 @@ impl Destruct for alloc::boxed::Box<[String]>[{built_in impl MetaSized for [Stri
 impl Destruct for String {    non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::<array>::{impl Destruct for [String; 4 : usize]}
 impl Destruct for [String; 4 : usize] {    non-dyn-compatible
 }

--- a/charon/tests/ui/simple/builtin-drop.out
+++ b/charon/tests/ui/simple/builtin-drop.out
@@ -60,18 +60,6 @@ impl Destruct for String {
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
 unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(_1: *mut [T; N])
 where

--- a/charon/tests/ui/simple/call-foreign-defaulted-method.out
+++ b/charon/tests/ui/simple/call-foreign-defaulted-method.out
@@ -4,18 +4,6 @@
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::{impl Trait for ()}::defaulted
 pub fn {impl Trait for ()}::defaulted<'_0>(self_1: &'_0 ())
 {

--- a/charon/tests/ui/simple/call-method-via-supertrait-bound.out
+++ b/charon/tests/ui/simple/call-method-via-supertrait-bound.out
@@ -24,18 +24,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::OtherTrait
 trait OtherTrait<Self>
 {

--- a/charon/tests/ui/simple/closure-capture-ref-by-move.out
+++ b/charon/tests/ui/simple/closure-capture-ref-by-move.out
@@ -66,18 +66,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::closure
 struct closure<'_0> {
   &'_0 mut i32,

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::apply_to
 fn apply_to<'_0, T0>(f_1: &'_0 T0) -> u8
 where

--- a/charon/tests/ui/simple/closure-fnmut.out
+++ b/charon/tests/ui/simple/closure-fnmut.out
@@ -66,18 +66,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::apply_to_zero_mut
 fn apply_to_zero_mut<T0>(f_1: T0) -> u8
 where

--- a/charon/tests/ui/simple/closure-fnonce.out
+++ b/charon/tests/ui/simple/closure-fnonce.out
@@ -57,18 +57,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::apply_to_zero_once
 fn apply_to_zero_once<T0>(f_1: T0) -> u8
 where

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 pub struct Foo<F>
 where

--- a/charon/tests/ui/simple/closure-inside-inline-const.out
+++ b/charon/tests/ui/simple/closure-inside-inline-const.out
@@ -90,18 +90,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::{const}::closure
 struct closure<T>
 where

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Thing
 trait Thing<Self>
 {

--- a/charon/tests/ui/simple/closure-with-drops.out
+++ b/charon/tests/ui/simple/closure-with-drops.out
@@ -99,18 +99,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::foo::closure<T>
 where
     [@TraitClause0]: Sized<T>,

--- a/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
+++ b/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::call_fn::closure
 struct closure<'_0, '_1> {
   &'_0 &'_1 [u8],

--- a/charon/tests/ui/simple/const-subslice.out
+++ b/charon/tests/ui/simple/const-subslice.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/double-promotion.out
+++ b/charon/tests/ui/simple/double-promotion.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Ref
 pub struct Ref<'a, B>
 where

--- a/charon/tests/ui/simple/drop-cow.out
+++ b/charon/tests/ui/simple/drop-cow.out
@@ -62,18 +62,6 @@ where
     [@TraitClause0]: ToOwned<Self>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Cow
 enum Cow<'a, B>
 where

--- a/charon/tests/ui/simple/drop-string-desugar.out
+++ b/charon/tests/ui/simple/drop-string-desugar.out
@@ -52,18 +52,6 @@ pub struct String {
   vec: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}],
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
 unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
 where

--- a/charon/tests/ui/simple/drop-string.out
+++ b/charon/tests/ui/simple/drop-string.out
@@ -52,18 +52,6 @@ pub struct String {
   vec: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}],
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
 unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
 where

--- a/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
@@ -26,18 +26,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {

--- a/charon/tests/ui/simple/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/simple/dyn-cast-to-supertrait.out
@@ -17,18 +17,6 @@ pub trait Destruct<Self>
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Feline::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/simple/dyn-fn.out
+++ b/charon/tests/ui/simple/dyn-fn.out
@@ -85,18 +85,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::takes_fn
 fn takes_fn<'_0>(f_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '_0))
 {

--- a/charon/tests/ui/simple/gat-complex-lifetimes.out
+++ b/charon/tests/ui/simple/gat-complex-lifetimes.out
@@ -24,18 +24,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 pub trait Foo<Self, T>
 {

--- a/charon/tests/ui/simple/gat-implied-clause.out
+++ b/charon/tests/ui/simple/gat-implied-clause.out
@@ -40,18 +40,6 @@ pub trait Destruct<Self>
 unsafe fn drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/simple/generic-cast-to-dyn.out
+++ b/charon/tests/ui/simple/generic-cast-to-dyn.out
@@ -35,18 +35,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo
 fn foo<'_0, T>(x_1: &'_0 T) -> &'_0 (dyn Any + 'static)
 where

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -93,18 +93,6 @@ pub enum AssertKind {
   Match,
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::LendingIterator
 pub trait LendingIterator<Self>
 {

--- a/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
+++ b/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
@@ -31,18 +31,6 @@ where
     [@TraitClause0]: Sized<U>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Convert
 trait Convert<Self, T>
 {

--- a/charon/tests/ui/simple/metadata-without-marker-trait.out
+++ b/charon/tests/ui/simple/metadata-without-marker-trait.out
@@ -7,18 +7,6 @@ pub enum Option<T> {
   Some(T),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::wrap_shared_in_option
 pub fn wrap_shared_in_option<'a, T>(x_1: &'a T) -> Option<&'a T>
 {

--- a/charon/tests/ui/simple/monomorphized-intrinsic.out
+++ b/charon/tests/ui/simple/monomorphized-intrinsic.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::E1
 enum E1 {
   A,

--- a/charon/tests/ui/simple/multiple-promoteds.out
+++ b/charon/tests/ui/simple/multiple-promoteds.out
@@ -4,18 +4,6 @@
 pub fn {impl Add<&'_0 u32> for &'_1 u32}::add<'_0, '_1>(_1: &'_1 u32, _2: &'_0 u32) -> u32
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::six
 fn six() -> u32
 {

--- a/charon/tests/ui/simple/nested-closure-lifetime.out
+++ b/charon/tests/ui/simple/nested-closure-lifetime.out
@@ -99,18 +99,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::foo::closure::closure<'_0, T>
 where
     [@TraitClause0]: Sized<T>,

--- a/charon/tests/ui/simple/nested-closure-trait-ref.out
+++ b/charon/tests/ui/simple/nested-closure-trait-ref.out
@@ -99,18 +99,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::foo::closure::closure<T>
 where
     [@TraitClause0]: Sized<T>,

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -99,18 +99,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 struct Foo<'a, T>
 where

--- a/charon/tests/ui/simple/opaque-vtable.out
+++ b/charon/tests/ui/simple/opaque-vtable.out
@@ -4,18 +4,6 @@
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 opaque type test_crate::x::Trait::{vtable}
 
 // Full name: test_crate::x::Trait

--- a/charon/tests/ui/simple/place_mention.out
+++ b/charon/tests/ui/simple/place_mention.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/promoted-closure-no-warns.out
+++ b/charon/tests/ui/simple/promoted-closure-no-warns.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::closure
 struct closure {}
 

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo::closure
 struct closure {}
 

--- a/charon/tests/ui/simple/promoted-in-generic-fn.out
+++ b/charon/tests/ui/simple/promoted-in-generic-fn.out
@@ -19,18 +19,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::f
 fn f<T>()
 where

--- a/charon/tests/ui/simple/promoted-inside-impl.out
+++ b/charon/tests/ui/simple/promoted-inside-impl.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Foo
 pub struct Foo<F>
 where

--- a/charon/tests/ui/simple/promoted-literal-addition-overflow.out
+++ b/charon/tests/ui/simple/promoted-literal-addition-overflow.out
@@ -7,18 +7,6 @@ pub fn MAX() -> u32
 // Full name: core::num::{u32}::MAX
 pub const MAX: u32 = MAX()
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::overflow
 fn overflow() -> &'static u32
 {

--- a/charon/tests/ui/simple/promoted-literal-addition.out
+++ b/charon/tests/ui/simple/promoted-literal-addition.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::two
 fn two() -> &'static u32
 {

--- a/charon/tests/ui/simple/promoted-u32-slice.out
+++ b/charon/tests/ui/simple/promoted-u32-slice.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo
 pub fn foo() -> &'static [u32]
 {

--- a/charon/tests/ui/simple/promoted_in_closure.out
+++ b/charon/tests/ui/simple/promoted_in_closure.out
@@ -83,18 +83,6 @@ where
     [@TraitClause0]: FnOnce<Self, Args>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main::closure
 struct closure {}
 

--- a/charon/tests/ui/simple/promoted_in_default_method.out
+++ b/charon/tests/ui/simple/promoted_in_default_method.out
@@ -4,18 +4,6 @@
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Thing
 trait Thing<Self>
 {

--- a/charon/tests/ui/simple/ptr-from-raw-parts.out
+++ b/charon/tests/ui/simple/ptr-from-raw-parts.out
@@ -263,18 +263,6 @@ where
     return
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/ptr_to_promoted.out
+++ b/charon/tests/ui/simple/ptr_to_promoted.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/range-iter.out
+++ b/charon/tests/ui/simple/range-iter.out
@@ -180,18 +180,6 @@ where
     [@TraitClause0]: Iterator<Self, Clause0_Item>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::iter
 fn iter(n_1: usize)
 {

--- a/charon/tests/ui/simple/ref-in-const.out
+++ b/charon/tests/ui/simple/ref-in-const.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::SOME_INT
 fn SOME_INT() -> &'static &'static i32
 {

--- a/charon/tests/ui/simple/single-variant-enum-drop-glue.out
+++ b/charon/tests/ui/simple/single-variant-enum-drop-glue.out
@@ -34,18 +34,6 @@ where
     [@TraitClause1]: Sized<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Thing
 pub enum Thing {
   A(alloc::boxed::Box<()>[{built_in impl MetaSized for ()}, {built_in impl Sized for Global}]),

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -59,18 +59,6 @@ pub struct Arguments<'a> {
 pub fn {impl Display for usize}::fmt<'_0, '_1, '_2>(_1: &'_0 usize, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 = <missing>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 fn core::slice::index::slice_index_fail::do_panic::runtime(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return

--- a/charon/tests/ui/simple/struct-with-drops.out
+++ b/charon/tests/ui/simple/struct-with-drops.out
@@ -61,18 +61,6 @@ where
     [@TraitClause3]: Destruct<A>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::B
 struct B {
   x: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}],

--- a/charon/tests/ui/simple/trait-alias.out
+++ b/charon/tests/ui/simple/trait-alias.out
@@ -49,18 +49,6 @@ where
   Some(T),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Trait
 trait Trait<Self, T, Self_Item>
 {

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -188,18 +188,6 @@ where
   len: usize,
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push_mut
 pub fn push_mut<'_0, T, A>(self_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], value_2: T) -> &'_0 mut T
 where

--- a/charon/tests/ui/simple/well-formedness-bound.out
+++ b/charon/tests/ui/simple/well-formedness-bound.out
@@ -22,18 +22,6 @@ where
   Some(T),
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::get
 pub fn get<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {

--- a/charon/tests/ui/skip-borrowck.out
+++ b/charon/tests/ui/skip-borrowck.out
@@ -12,18 +12,6 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::choose
 fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -72,18 +72,6 @@ enum ArgumentType<'a> {
 #[lang_item("format_argument")]
 pub opaque type Argument<'a>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 fn core::slice::index::slice_index_fail::do_panic::runtime(start_1: usize, len_2: usize) -> !
 {
     let _0: !; // return

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -1,17 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::constant::CONST
 fn CONST() -> usize
 {

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -64,18 +64,6 @@ where
     [@TraitClause1]: Display<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::FOO
 fn FOO() -> &'static Str
 {

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -114,18 +114,6 @@ where
 #[lang_item("String")]
 pub opaque type String
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -110,18 +110,6 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 pub fn _print<'_0>(_1: Arguments<'_0>)
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::Left
 trait Left<Self, T>
 {

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -282,18 +282,6 @@ where
     [@TraitClause0]: Thin<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::call_unsafe_fn
 fn call_unsafe_fn()
 {

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -104,18 +104,6 @@ impl Display for String {
     vtable: {impl Display for String}::{vtable}
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/unsized-string-consts.out
+++ b/charon/tests/ui/unsized-string-consts.out
@@ -64,18 +64,6 @@ where
     [@TraitClause1]: Display<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::FOO
 fn FOO() -> &'static Str
 {

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -43,18 +43,6 @@ where
     [@TraitClause0]: Sized<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/vtable-simple.out
+++ b/charon/tests/ui/vtable-simple.out
@@ -40,18 +40,6 @@ impl Clone for i32 {
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Modifiable::{vtable}<T> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/vtable_drop.out
+++ b/charon/tests/ui/vtable_drop.out
@@ -99,18 +99,6 @@ where
     non-dyn-compatible
 }
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Modifiable::{vtable}<T> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -128,18 +128,6 @@ where
     [@TraitClause1]: Display<T>,
 = <opaque>
 
-// Full name: UNIT_METADATA
-fn UNIT_METADATA()
-{
-    let _0: (); // return
-
-    _0 = ()
-    return
-}
-
-// Full name: UNIT_METADATA
-const UNIT_METADATA: () = UNIT_METADATA()
-
 struct test_crate::Super::{vtable}<T> {
   size: usize,
   align: usize,


### PR DESCRIPTION
This hack was added because back then aeneas didn't support some `ConstantExprKind` variants and it felt cleaner not to expand that. Time has taught me that this was a mistake.

ci: use https://github.com/AeneasVerif/eurydice/pull/402
ci: use https://github.com/AeneasVerif/aeneas/pull/985