### PR TITLE
Include method signatures in the trait declaration

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.186"
+let supported_charon_version = "0.1.187"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -57,20 +57,26 @@ let bound_fun_sig_of_decl (def : fun_decl) : bound_fun_sig =
     reflect that there are two binding levels: the trait generics and the method
     generics. *)
 let lookup_trait_decl_method (tdecl : trait_decl) (name : trait_item_name) :
+    trait_method binder item_binder option =
+  Option.map
+    (fun m -> { item_binder_params = tdecl.generics; item_binder_value = m })
+    (List.find_opt
+       (fun (m : trait_method binder) -> m.binder_value.name = name)
+       tdecl.methods)
+
+let lookup_trait_decl_method_ref (tdecl : trait_decl) (name : trait_item_name) :
     fun_decl_ref binder item_binder option =
   Option.map
     (fun m ->
       {
-        item_binder_params = tdecl.generics;
+        item_binder_params = m.item_binder_params;
         item_binder_value =
           {
-            binder_params = m.binder_params;
-            binder_value = m.binder_value.item;
+            binder_params = m.item_binder_value.binder_params;
+            binder_value = m.item_binder_value.binder_value.item;
           };
       })
-    (List.find_opt
-       (fun (m : trait_method binder) -> m.binder_value.name = name)
-       tdecl.methods)
+    (lookup_trait_decl_method tdecl name)
 
 (** Lookup a method in this trait impl. The two levels of binders in the output
     reflect that there are two binding levels: the impl generics and the method

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -562,12 +562,12 @@ let fuse_binders (substitutor : subst -> 'a -> 'a)
 (** Helper *)
 let instantiate_method (trait_self : trait_ref_kind)
     (item_generics : generic_args) (method_generics : generic_args)
-    (bound_fn : fun_decl_ref binder item_binder) : fun_decl_ref =
+    (bound_method : fun_decl_ref binder item_binder) : fun_decl_ref =
   let bound_fn =
     apply_args_to_item_binder trait_self item_generics
       (st_substitute_visitor#visit_binder
          st_substitute_visitor#visit_fun_decl_ref)
-      bound_fn
+      bound_method
   in
   apply_args_to_binder method_generics st_substitute_visitor#visit_fun_decl_ref
     bound_fn
@@ -585,7 +585,7 @@ let lookup_and_subst_trait_decl_method (tdecl : trait_decl)
     (method_generics : generic_args) : fun_decl_ref option =
   Option.map
     (instantiate_trait_method trait_ref method_generics)
-    (lookup_trait_decl_method tdecl name)
+    (lookup_trait_decl_method_ref tdecl name)
 
 (** Like lookup_trait_impl_method, but also correctly substitutes the generics.
 *)
@@ -606,26 +606,17 @@ let lookup_method_sig (crate : crate) (trait_id : trait_decl_id)
   let* tdecl = TraitDeclId.Map.find_opt trait_id crate.trait_decls in
   let* {
          item_binder_params : generic_params = trait_params;
-         item_binder_value : fun_decl_ref binder = bound_method;
+         item_binder_value : trait_method binder =
+           { binder_params = method_params; binder_value = trait_method };
        } =
     lookup_trait_decl_method tdecl name
   in
-  let method_decl_id = bound_method.binder_value.id in
-  let* method_decl =
-    LlbcAst.FunDeclId.Map.find_opt method_decl_id crate.fun_decls
-  in
-  (* Substitute the signature to be valid under the binder. *)
-  let signature =
-    st_substitute_visitor#visit_fun_sig
-      (make_subst_from_generics method_decl.generics
-         bound_method.binder_value.generics Self)
-      method_decl.signature
-  in
-  (* Rebind everything *)
-  let bound_sig =
-    { binder_params = bound_method.binder_params; binder_value = signature }
-  in
-  Some { item_binder_params = trait_params; item_binder_value = bound_sig }
+  Some
+    {
+      item_binder_params = trait_params;
+      item_binder_value =
+        { binder_params = method_params; binder_value = trait_method.signature };
+    }
 
 (* Like [lookup_method_sig], but with no binder shenanigans: the returned
    binder binds the concatenation of trait generics and method generics. *)

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -301,6 +301,7 @@ and trait_decl = {
 and trait_method = {
   name : trait_item_name;
   attr_info : attr_info;
+  signature : fun_sig;
   item : fun_decl_ref;
       (** Each method declaration is represented by a function item. That
           function contains the signature of the method as well as information

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2782,11 +2782,18 @@ and trait_method_of_json (ctx : of_json_ctx) (js : json) :
     (trait_method, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("name", name); ("attr_info", attr_info); ("item", item) ] ->
+    | `Assoc
+        [
+          ("name", name);
+          ("attr_info", attr_info);
+          ("signature", signature);
+          ("item", item);
+        ] ->
         let* name = trait_item_name_of_json ctx name in
         let* attr_info = attr_info_of_json ctx attr_info in
+        let* signature = fun_sig_of_json ctx signature in
         let* item = fun_decl_ref_of_json ctx item in
-        Ok ({ name; attr_info; item } : trait_method)
+        Ok ({ name; attr_info; signature; item } : trait_method)
     | _ -> Error "")
 
 and translated_crate_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.186"
+version = "0.1.187"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.186"
+version = "0.1.187"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -399,6 +399,7 @@ pub struct TraitMethod {
     #[drive(skip)]
     #[serde_state(stateless)]
     pub attr_info: AttrInfo,
+    pub signature: FunSig,
     /// Each method declaration is represented by a function item. That function contains the
     /// signature of the method as well as information like attributes. It has a body iff the
     /// method declaration has a default implementation; otherwise it has an `Opaque` body.

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -194,7 +194,6 @@ pub struct TranslatedCrate {
 
     /// The translated files. This field must come before any field containing spans,
     /// as the OCaml deserialization of spans requires the files to be deserialized already.
-    #[drive(skip)]
     #[serde_state(stateless)]
     pub files: IndexVec<FileId, File>,
 

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -263,6 +263,7 @@ pub struct File {
     #[charon::opaque]
     pub id: FileId,
     /// The path to the file.
+    #[drive(skip)]
     pub name: FileName,
     /// Name of the crate this file comes from.
     pub crate_name: String,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -45,7 +45,7 @@ use derive_generic_visitor::*;
     drive(
         AbortKind, Assert, BinOp, BorrowKind, BuiltinAssertKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy,
         Call, CastKind, ClosureInfo, ClosureKind, ConstGenericParam, ConstGenericVarId,
-        Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, FloatTy, FloatValue,
+        Disambiguator, DynPredicate, Field, FieldId, FieldProjKind, File, FloatTy, FloatValue,
         FnOperand, FunId, FnPtrKind, FunSig, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ConstantExprKind,

--- a/charon/src/bin/charon-driver/translate/translate_drops.rs
+++ b/charon/src/bin/charon-driver/translate/translate_drops.rs
@@ -119,6 +119,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             .unwrap()
             .clone();
 
+        let signature = self.drop_in_place_method_sig(self_ty.clone());
         let src = match impl_kind {
             Some(impl_kind) => {
                 let destruct_impl_id =
@@ -147,13 +148,6 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             self.translate_drop_in_place_method_body(span, def, &self_ty)?
         };
 
-        let input = TyKind::RawPtr(self_ty, RefKind::Mut).into_ty();
-        let signature = FunSig {
-            is_unsafe: true,
-            inputs: vec![input],
-            output: Ty::mk_unit(),
-        };
-
         Ok(FunDecl {
             def_id,
             item_meta,
@@ -163,6 +157,16 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             is_global_initializer: None,
             body,
         })
+    }
+
+    // Small helper to deduplicate. Generates the signature `*mut self_ty -> ()`.
+    pub fn drop_in_place_method_sig(&self, self_ty: Ty) -> FunSig {
+        let self_ptr = TyKind::RawPtr(self_ty, RefKind::Mut).into_ty();
+        FunSig {
+            is_unsafe: true,
+            inputs: [self_ptr].into(),
+            output: Ty::mk_unit(),
+        }
     }
 
     // Small helper to deduplicate.

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -672,13 +672,6 @@ impl ItemTransCtx<'_, '_> {
             TraitRefKind::SelfId,
             RegionBinder::empty(self.translate_trait_predicate(span, self_predicate)?),
         );
-        let items: Vec<(TraitItemName, &hax::AssocItem)> = items
-            .iter()
-            .map(|item| -> Result<_, Error> {
-                let name = self.t_ctx.translate_trait_item_name(&item.def_id)?;
-                Ok((name, item))
-            })
-            .try_collect()?;
 
         // Translate the associated items
         let mut consts = Vec::new();
@@ -701,8 +694,9 @@ impl ItemTransCtx<'_, '_> {
             });
         }
 
-        for &(item_name, hax_item) in &items {
+        for hax_item in items {
             let item_def_id = &hax_item.def_id;
+            let item_name = self.translate_trait_item_name(item_def_id)?;
             let item_span = self.def_span(item_def_id);
 
             // In --mono mode, we keep only non-polymorphic items; in not-mono mode, we use the
@@ -718,7 +712,7 @@ impl ItemTransCtx<'_, '_> {
             let attr_info = self.translate_attr_info(&item_def);
 
             match item_def.kind() {
-                hax::FullDefKind::AssocFn { .. } => {
+                hax::FullDefKind::AssocFn { sig, .. } => {
                     let method_id = self.register_no_enqueue(item_span, &item_src);
                     // Register this method.
                     self.register_method_impl(def_id, item_name, method_id);
@@ -752,9 +746,14 @@ impl ItemTransCtx<'_, '_> {
                                 id: method_id,
                                 generics: Box::new(fun_generics),
                             };
+                            // `skip_binder` is allowed because `translate_binder_for_def` puts the
+                            // late bound params in scope.
+                            let signature =
+                                bt_ctx.translate_fun_sig(span, sig.hax_skip_binder_ref())?;
                             Ok(TraitMethod {
                                 name: item_name,
                                 attr_info,
+                                signature,
                                 item: fn_ref,
                             })
                         },
@@ -884,10 +883,21 @@ impl ItemTransCtx<'_, '_> {
             let (method_name, method_binder) =
                 self.prepare_drop_in_place_method(def, span, def_id, None);
             self.mark_method_as_used(def_id, method_name);
-            methods.push(method_binder.map(|fn_ref| TraitMethod {
-                name: method_name,
-                attr_info: AttrInfo::dummy_public(),
-                item: fn_ref,
+            methods.push(method_binder.map(|fn_ref| {
+                let self_ty = if self.monomorphize() {
+                    // FIXME: put something real here
+                    Ty::mk_unit()
+                } else {
+                    TyKind::TypeVar(DeBruijnVar::bound(DeBruijnId::one(), TypeVarId::ZERO))
+                        .into_ty()
+                };
+                let signature = self.drop_in_place_method_sig(self_ty);
+                TraitMethod {
+                    name: method_name,
+                    item: fn_ref,
+                    attr_info: AttrInfo::dummy_public(),
+                    signature,
+                }
             }));
         }
 

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -331,8 +331,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 ..
             } => {
                 let tref = &impl_source.r#trait;
-                let trait_def =
-                    self.hax_def(&tref.hax_skip_binder_ref().erase(self.hax_state_with_id()))?;
+                let trait_def = self.poly_hax_def(&tref.hax_skip_binder_ref().def_id)?;
                 let kind = if let hax::FullDefKind::TraitAlias { .. } = trait_def.kind() {
                     // We reuse the same `def_id` to generate a blanket impl for the trait.
                     let mut impl_ref: TraitImplRef = self.translate_item(

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -383,12 +383,9 @@ impl ItemTransCtx<'_, '_> {
                     } else {
                         let self_ty =
                             TyKind::TypeVar(DeBruijnVar::new_at_zero(TypeVarId::ZERO)).into_ty();
-                        let self_ptr = TyKind::RawPtr(self_ty, RefKind::Mut).into_ty();
-                        let drop_ty = Ty::new(TyKind::FnPtr(RegionBinder::empty(FunSig {
-                            is_unsafe: true,
-                            inputs: [self_ptr].into(),
-                            output: Ty::mk_unit(),
-                        })));
+                        let drop_ty = Ty::new(TyKind::FnPtr(RegionBinder::empty(
+                            self.drop_in_place_method_sig(self_ty),
+                        )));
                         ("drop".into(), drop_ty)
                     }
                 }
@@ -1322,30 +1319,24 @@ impl ItemTransCtx<'_, '_> {
             raise_error!(
                 self,
                 span,
-                "Trying to generate a vtable drop shim for a non-trait impl"
+                "Trying to generate a vtable drop shim for a non-dyn-compatible trait impl"
             );
         };
 
-        // `*mut dyn Trait`
-        let ref_dyn_self =
-            TyKind::RawPtr(self.translate_ty(span, dyn_self)?, RefKind::Mut).into_ty();
+        let dyn_self = self.translate_ty(span, dyn_self)?;
+        // `*mut dyn Trait -> ()`
+        let signature = self.drop_in_place_method_sig(dyn_self.clone());
+
         // `*mut T` for `impl Trait for T`
-        let ref_target_self = {
+        let target_self_ptr = {
             let impl_trait = self.translate_trait_ref(span, &trait_pred.trait_ref)?;
             TyKind::RawPtr(impl_trait.generics.types[0].clone(), RefKind::Mut).into_ty()
         };
 
-        // `*mut dyn Trait -> ()`
-        let signature = FunSig {
-            is_unsafe: true,
-            inputs: vec![ref_dyn_self.clone()],
-            output: Ty::mk_unit(),
-        };
-
         let body: Body = self.translate_vtable_drop_shim_body(
             span,
-            &ref_dyn_self,
-            &ref_target_self,
+            &signature.inputs[0],
+            &target_self_ptr,
             trait_pred,
         )?;
 

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -85,7 +85,11 @@ impl CrateMerger {
                 if let Some(&existing_id) = self.file_name_to_id.get(&file.name) {
                     existing_id
                 } else {
-                    let new_id = self.merged.translated.files.push(file.clone());
+                    let new_id = self.merged.translated.files.push_with(|new_id| {
+                        let mut file = file.clone();
+                        file.id = new_id;
+                        file
+                    });
                     self.file_name_to_id.insert(file.name.clone(), new_id);
                     new_id
                 }

--- a/charon/tests/ptr-metadata.json
+++ b/charon/tests/ptr-metadata.json
@@ -46,5 +46,6 @@
   "core::fmt::Formatter": "None",
   "core::fmt::Error": "None",
   "core::cmp::Ordering": "None",
-  "core::option::Option": "None"
+  "core::option::Option": "None",
+  "core::ops::control_flow::ControlFlow": "None"
 }

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -321,17 +321,16 @@ where
     [@TraitClause0]: Iterator<Self>,
 = <opaque>
 
-// Full name: core::slice::index::private_slice_index::Sealed
-pub trait Sealed<Self>
+pub trait core::slice::index::private_slice_index::Sealed<Self>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
-// Full name: core::slice::index::private_slice_index::{impl Sealed for usize}
-impl Sealed for usize {
+// Full name: core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize}
+impl core::slice::index::private_slice_index::Sealed for usize {
     parent_clause0 = {built_in impl MetaSized for usize}
-    vtable: {impl Sealed for usize}::{vtable}
+    vtable: {impl core::slice::index::private_slice_index::Sealed for usize}::{vtable}
 }
 
 // Full name: core::slice::index::SliceIndex
@@ -339,7 +338,7 @@ impl Sealed for usize {
 pub trait SliceIndex<Self, T>
 {
     parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sealed<Self>
+    parent_clause1 : [@TraitClause1]: core::slice::index::private_slice_index::Sealed<Self>
     parent_clause2 : [@TraitClause2]: MetaSized<T>
     parent_clause3 : [@TraitClause3]: MetaSized<Self::Output>
     type Output
@@ -424,7 +423,7 @@ where
     [@TraitClause0]: Sized<T>,
 {
     parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl Sealed for usize}
+    parent_clause1 = {impl core::slice::index::private_slice_index::Sealed for usize}
     parent_clause2 = {built_in impl MetaSized for [T]}
     parent_clause3 = @TraitClause0::parent_clause0
     type Output = T

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1696:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1687:13:
 Could not determine method index for drop in vtable
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `core::fmt::Display`.
@@ -11,7 +11,7 @@ note: the error occurred when translating `core::fmt::Display::{vtable_drop_pres
 12 |     let _ = dyn_to_string(&str);
    |                           ----
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1574:13:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:1565:13:
 Could not determine method index for method_fmt in vtable
 error: Thread panicked when extracting item `core::fmt::Display`.
  --> /rustc/library/core/src/fmt/mod.rs:1186:1

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -17,13 +17,12 @@ pub trait Sized<Self>
 pub trait Clone<Self>
 {
     parent_clause0 : [@TraitClause0]: Sized<Self>
-    fn clone<'_0_1> = clone<'_0_1, Self>[Self]
+    fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
 
-// Full name: core::clone::Clone::clone
 #[lang_item("clone_fn")]
-pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
+pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
     [@TraitClause0]: Clone<Self>,
 = <opaque>


### PR DESCRIPTION
This is a step towards eventually removing the empty "method declaration" function items.