### PR TITLE
Fix some issues with multi-target extraction

### DIFF
--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -383,6 +383,7 @@ impl<'a> ItemDeduplicator<'a> {
             let prev_len = groups_map.len();
             let remap: HashMap<ItemId, ItemId> = groups_map
                 .values()
+                .filter(|ids| ids.len() == num_targets)
                 .cloned()
                 .map(|ids| TargetGroup { ids })
                 .flat_map(|g| g.into_remap_entries())
@@ -402,16 +403,18 @@ impl<'a> ItemDeduplicator<'a> {
                     }
                 }
             }
+            // Only retain complete groups after checking for convergence: incomplete
+            // groups might merge into complete ones after ID remapping.
+            let new_len = groups_map.len();
             groups_map.retain(|_, v| v.len() == num_targets);
-            if prev_len == groups_map.len() {
+            if new_len == prev_len {
                 break;
             }
         }
         let groups: IndexVec<TargetGroupId, TargetGroup> = groups_map
-            .values()
-            .filter(|&per_target| per_target.len() == num_targets)
-            .cloned()
-            .map(|ids| TargetGroup { ids })
+            .into_iter()
+            .filter(|(_, per_target)| per_target.len() == num_targets)
+            .map(|(_name, ids)| TargetGroup { ids })
             .collect();
         groups
     }
@@ -552,11 +555,53 @@ fn normalize_item(
         .name
         .name
         .retain(|elem| !matches!(elem, PathElem::Target(_)));
+    // Normalize spans, file IDs, and attributes for cross-target comparison.
+    item.as_mut().drive_mut(&mut NormalizeFileIdsVisitor);
+    strip_unknown_attributes(&mut item);
+    // Clear source text: it can have OS-specific line endings.
+    item.as_mut().item_meta().source_text = None;
     if let ItemByVal::Type(ty_decl) = &mut item {
         // Layouts are allowed to differ per-target.
         ty_decl.layout.clear();
     }
     item
+}
+
+/// Visitor that normalizes items for cross-target comparison:
+/// - File IDs are reset (they differ across targets for the same source file).
+/// Visitor that normalizes file IDs for cross-target comparison.
+#[derive(Visitor)]
+struct NormalizeFileIdsVisitor;
+
+impl VisitAstMut for NormalizeFileIdsVisitor {
+    fn enter_file_id(&mut self, id: &mut FileId) {
+        *id = FileId::from_raw(0);
+    }
+}
+
+/// Strip `Unknown` attributes from an item and all its nested declarations.
+/// These are rustc-internal attributes (like `rustc_diagnostic_item`) whose
+/// arguments can vary across targets.
+fn strip_unknown_attributes(item: &mut ItemByVal) {
+    fn strip_in_vec(attrs: &mut Vec<Attribute>) {
+        attrs.retain(|attr| !matches!(attr, Attribute::Unknown(..)));
+    }
+
+    // Strip from the top-level item_meta
+    strip_in_vec(&mut item.as_mut().item_meta().attr_info.attributes);
+
+    // Strip from nested items in trait declarations
+    if let ItemByVal::TraitDecl(d) = item {
+        for method in &mut d.methods {
+            strip_in_vec(&mut method.skip_binder.attr_info.attributes);
+        }
+        for cst in &mut d.consts {
+            strip_in_vec(&mut cst.attr_info.attributes);
+        }
+        for ty in &mut d.types {
+            strip_in_vec(&mut ty.skip_binder.attr_info.attributes);
+        }
+    }
 }
 
 /// Visitor that remaps references to the given items.

--- a/charon/tests/ui/multi-targets-3-dedup.out
+++ b/charon/tests/ui/multi-targets-3-dedup.out
@@ -1,0 +1,72 @@
+pub fn core::clone::impls::{impl core::clone::Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
+= <opaque>
+
+fn test_crate::clone_it<'_0>(x_1: &'_0 u32) -> u32
+{
+    let _0: u32; // return
+    let x_1: &'1 u32; // arg #1
+    let _2: &'2 u32; // anonymous local
+
+    storage_live(_2)
+    _2 = &(*x_1)
+    _0 = core::clone::impls::{impl core::clone::Clone for u32}::clone<'4>(move _2)
+    storage_dead(_2)
+    return
+}
+
+fn test_crate::platform_specific::x86_64-pc-windows-msvc() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 42 : u32
+    return
+}
+
+fn test_crate::platform_specific::i686-pc-windows-msvc() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 44 : u32
+    return
+}
+
+fn test_crate::platform_specific::aarch64-apple-darwin() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 43 : u32
+    return
+}
+
+fn test_crate::platform_specific() -> u32
+= target_dispatch {
+    x86_64-pc-windows-msvc => test_crate::platform_specific::x86_64-pc-windows-msvc,
+    aarch64-apple-darwin => test_crate::platform_specific::aarch64-apple-darwin,
+    i686-pc-windows-msvc => test_crate::platform_specific::i686-pc-windows-msvc,
+}
+
+pub fn test_crate::call_both<'_0>(x_1: &'_0 u32) -> u32
+{
+    let _0: u32; // return
+    let x_1: &'1 u32; // arg #1
+    let _2: u32; // anonymous local
+    let _3: &'2 u32; // anonymous local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
+
+    storage_live(_5)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*x_1)
+    _2 = test_crate::clone_it<'4>(move _3)
+    storage_dead(_3)
+    storage_live(_4)
+    _4 = test_crate::platform_specific()
+    _5 = copy _2 panic.+ copy _4
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_2)
+    return
+}
+
+

--- a/charon/tests/ui/multi-targets-3-dedup.rs
+++ b/charon/tests/ui/multi-targets-3-dedup.rs
@@ -1,0 +1,19 @@
+//@ charon-args=--targets=x86_64-pc-windows-msvc,aarch64-apple-darwin,i686-pc-windows-msvc
+#![allow(unused)]
+
+fn clone_it(x: &u32) -> u32 {
+    x.clone()
+}
+
+#[cfg(target_arch = "x86_64")]
+fn platform_specific() -> u32 { 42 }
+
+#[cfg(target_arch = "aarch64")]
+fn platform_specific() -> u32 { 43 }
+
+#[cfg(target_arch = "x86")]
+fn platform_specific() -> u32 { 44 }
+
+pub fn call_both(x: &u32) -> u32 {
+    clone_it(x) + platform_specific()
+}


### PR DESCRIPTION
This PR was AI generated and I'm not asking to merge it: I'm opening it because it is informative.
It solves https://github.com/AeneasVerif/charon/issues/1130

Importantly, you will note that attributes, spans and source text led to item duplication, and the agent had to filter them to solve the issue. This is of course not what we want to do, but it seems the fix below is enough to make the deduplication work. About attributes specifically: Aeneas relies on some Unknown attributes (such as `verify::test`) so we can't just clear them (we need a merge operation, and maybe we need to introduce the notion of target-specific attribute?).