### PR TITLE
Add support for `PeTarget` to the name matcher

### DIFF
--- a/charon-ml/name_matcher_parser/Lexer.mll
+++ b/charon-ml/name_matcher_parser/Lexer.mll
@@ -5,7 +5,7 @@
 
 let digit = ['0'-'9']
 let alpha = ['a'-'z' 'A'-'Z']
-let ident = (alpha | '_') (alpha | digit | '_')*
+let ident = (alpha | '_') (alpha | digit | '_')* ('-' (alpha | digit | '_')+)*
 let whitespace = [' ']+
 
 (* Rules *)

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -492,6 +492,10 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
       pid = id
       && T.Disambiguator.of_int pd = d
       && match_generic_args ctx c m pg g
+  | [ PIdent (pid, pd, pg) ], [ PeTarget target ] ->
+      pid = target
+      && pd = 0
+      && match_generic_args ctx c m pg g
   | [ PImpl pty ], [ PeImpl impl ] -> (
       (* We can get there when matching a prefix of the name with a pattern *)
       (* We have to distinguish two cases:
@@ -510,6 +514,11 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
       (* This is not the end: check that the generics are empty *)
       pid = id
       && T.Disambiguator.of_int pd = d
+      && pg = []
+      && match_name_with_generics ctx c p n g
+  | PIdent (pid, pd, pg) :: p, PeTarget target :: n ->
+      pid = target
+      && pd = 0
       && pg = []
       && match_name_with_generics ctx c p n g
   | PImpl pty :: p, PeImpl impl :: n -> (
@@ -974,7 +983,12 @@ and path_elem_with_generic_args_to_pattern (ctx : ctx) (c : to_pat_config)
       | Some args -> [ PIdent (s, d, args) ]
     end
   | PeImpl impl -> [ impl_elem_to_pattern ctx c impl ]
-  | PeInstantiated _ | PeTarget _ ->
+  | PeTarget tgt -> begin
+      match generics with
+      | None -> [ PIdent (tgt, 0, []) ]
+      | Some args -> [ PIdent (tgt, 0, args) ]
+    end
+  | PeInstantiated _ ->
       (* In pattern generation, we skip monomorphized elements since patterns
          are meant to match the logical structure, not the instantiation details *)
       []

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -493,9 +493,7 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
       && T.Disambiguator.of_int pd = d
       && match_generic_args ctx c m pg g
   | [ PIdent (pid, pd, pg) ], [ PeTarget target ] ->
-      pid = target
-      && pd = 0
-      && match_generic_args ctx c m pg g
+      pid = target && pd = 0 && match_generic_args ctx c m pg g
   | [ PImpl pty ], [ PeImpl impl ] -> (
       (* We can get there when matching a prefix of the name with a pattern *)
       (* We have to distinguish two cases:
@@ -517,10 +515,7 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
       && pg = []
       && match_name_with_generics ctx c p n g
   | PIdent (pid, pd, pg) :: p, PeTarget target :: n ->
-      pid = target
-      && pd = 0
-      && pg = []
-      && match_name_with_generics ctx c p n g
+      pid = target && pd = 0 && pg = [] && match_name_with_generics ctx c p n g
   | PImpl pty :: p, PeImpl impl :: n -> (
       (* We have to distinguish two cases:
          - the impl is an inherent impl (linked to a type)

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -34,6 +34,8 @@ let parse_tests () =
       "{fn (@T, @U) -> u32}";
       "{*const @T}";
       "{*mut @T}";
+      "x::y::x86_64-apple-darwin";
+      "test_crate::foo::aarch64-unknown-linux-gnu";
     ]
   in
   let _ = List.map parse_pattern patterns in

--- a/charon-ml/tests/Tests.ml
+++ b/charon-ml/tests/Tests.ml
@@ -22,3 +22,7 @@ let () = Test_NameMatcher.run_tests (llbc_dir ^ "/ml-name-matcher-tests.llbc")
 
 let () =
   Test_NameMatcher.run_tests (llbc_dir ^ "/ml-mono-name-matcher-tests.llbc")
+
+let () =
+  Test_NameMatcher.run_tests
+    (llbc_dir ^ "/ml-multi-target-name-matcher-tests.llbc")

--- a/charon/tests/ui/ml-multi-target-name-matcher-tests.out
+++ b/charon/tests/ui/ml-multi-target-name-matcher-tests.out
@@ -1,0 +1,25 @@
+fn test_crate::x86_only::x86_64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 42 : u64
+    return
+}
+
+fn test_crate::arm_only::aarch64-apple-darwin() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 99 : u64
+    return
+}
+
+fn test_crate::shared_fn() -> u64
+{
+    let _0: u64; // return
+
+    _0 = const 0 : u64
+    return
+}
+
+

--- a/charon/tests/ui/ml-multi-target-name-matcher-tests.rs
+++ b/charon/tests/ui/ml-multi-target-name-matcher-tests.rs
@@ -1,0 +1,31 @@
+//@ charon-args=--targets=x86_64-apple-darwin,aarch64-apple-darwin
+#![register_tool(pattern)]
+//! Tests for the ml name matcher with multi-target items. After multi-target merging,
+//! target-specific items get a `PeTarget` path element appended to their name. The name
+//! matcher should handle these correctly.
+
+// Target-specific functions get a PeTarget path element after multi-target merging.
+#[cfg(target_arch = "x86_64")]
+#[pattern::pass("test_crate::x86_only::x86_64-apple-darwin")]
+#[pattern::pass("test_crate::x86_only::_")]
+#[pattern::fail("test_crate::x86_only")]
+#[pattern::fail("test_crate::x86_only::aarch64-apple-darwin")]
+fn x86_only() -> u64 {
+    42
+}
+
+#[cfg(target_arch = "aarch64")]
+#[pattern::pass("test_crate::arm_only::aarch64-apple-darwin")]
+#[pattern::pass("test_crate::arm_only::_")]
+#[pattern::fail("test_crate::arm_only")]
+#[pattern::fail("test_crate::arm_only::x86_64-apple-darwin")]
+fn arm_only() -> u64 {
+    99
+}
+
+// Shared function: exists identically on all targets. After merging, it should be
+// deduplicated and have no PeTarget suffix, so the pattern matches without a target.
+#[pattern::pass("test_crate::shared_fn")]
+fn shared_fn() -> u64 {
+    0
+}


### PR DESCRIPTION
This required extending the lexer to support names like `test_crate::x86_only::aarch64-apple-darwin`.