### PR TITLE
Identify trait methods by an id instead of by name

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.190"
+let supported_charon_version = "0.1.191"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -59,15 +59,13 @@ let bound_fun_sig_of_decl (def : fun_decl) : bound_fun_sig =
 (** Lookup a method in this trait decl. The two levels of binders in the output
     reflect that there are two binding levels: the trait generics and the method
     generics. *)
-let lookup_trait_decl_method (tdecl : trait_decl) (name : trait_item_name) :
+let lookup_trait_decl_method (tdecl : trait_decl) (id : trait_method_id) :
     trait_method binder item_binder option =
   Option.map
     (fun m -> { item_binder_params = tdecl.generics; item_binder_value = m })
-    (List.find_opt
-       (fun (m : trait_method binder) -> m.binder_value.name = name)
-       tdecl.methods)
+    (TraitMethodId.Map.find_opt id tdecl.methods)
 
-let lookup_trait_decl_method_ref (tdecl : trait_decl) (name : trait_item_name) :
+let lookup_trait_decl_method_ref (tdecl : trait_decl) (id : trait_method_id) :
     fun_decl_ref binder item_binder option =
   Option.map
     (fun m ->
@@ -79,17 +77,34 @@ let lookup_trait_decl_method_ref (tdecl : trait_decl) (name : trait_item_name) :
             binder_value = m.item_binder_value.binder_value.item;
           };
       })
-    (lookup_trait_decl_method tdecl name)
+    (lookup_trait_decl_method tdecl id)
 
 (** Lookup a method in this trait impl. The two levels of binders in the output
     reflect that there are two binding levels: the impl generics and the method
     generics. *)
-let lookup_trait_impl_method (timpl : trait_impl) (name : trait_item_name) :
+let lookup_trait_impl_method (timpl : trait_impl) (id : trait_method_id) :
     fun_decl_ref binder item_binder option =
   Option.map
-    (fun (_, bound_fn) ->
+    (fun bound_fn ->
       { item_binder_params = timpl.generics; item_binder_value = bound_fn })
-    (List.find_opt (fun (s, _) -> s = name) timpl.methods)
+    (TraitMethodId.Map.find_opt id timpl.methods)
+
+(** Resolve a [trait_method_id] to a method name, following the same logic as
+    the Rust [format_method_name]: first try the method map, then fall back to
+    [method_names] (for mono mode), then to the raw id. *)
+let format_method_name (crate : crate) (trait_id : trait_decl_id)
+    (method_id : trait_method_id) : trait_item_name =
+  match TraitDeclId.Map.find_opt trait_id crate.trait_decls with
+  | Some tdecl -> begin
+      match TraitMethodId.Map.find_opt method_id tdecl.methods with
+      | Some m -> m.binder_value.name
+      | None -> begin
+          match TraitMethodId.nth_opt tdecl.method_names method_id with
+          | Some name -> name
+          | None -> TraitMethodId.to_string method_id
+        end
+    end
+  | None -> TraitMethodId.to_string method_id
 
 let g_declaration_group_to_list (g : 'a g_declaration_group) : 'a list =
   match g with

--- a/charon-ml/src/Identifiers.ml
+++ b/charon-ml/src/Identifiers.ml
@@ -48,6 +48,29 @@ module type Id = sig
     include C.Map
 
     val add_in_place : id -> 'a -> 'a t ref -> unit
+    val to_list : 'a t -> (id * 'a) list
+    val values : 'a t -> 'a list
+
+    (** Visitor helpers for the [visitors] ppx. *)
+
+    val visit_iter : ('env -> 'a -> unit) -> 'env -> 'a t -> unit
+    val visit_map : ('env -> 'a -> 'b) -> 'env -> 'a t -> 'b t
+
+    val visit_reduce :
+      zero:'z ->
+      plus:('z -> 'z -> 'z) ->
+      ('env -> 'a -> 'z) ->
+      'env ->
+      'a t ->
+      'z
+
+    val visit_mapreduce :
+      zero:'z ->
+      plus:('z -> 'z -> 'z) ->
+      ('env -> 'a -> 'b * 'z) ->
+      'env ->
+      'a t ->
+      'b t * 'z
   end
   with type key = id
 
@@ -174,6 +197,20 @@ module IdGen () : Id = struct
     include C.MakeMap (Ord)
 
     let add_in_place id x m = m := add id x !m
+    let to_list m = bindings m
+    let values m = List.map (fun (_k, v) -> v) (bindings m)
+    let visit_iter visit_a env m = iter (fun _ v -> visit_a env v) m
+    let visit_map visit_a env m = map (fun v -> visit_a env v) m
+
+    let visit_reduce ~zero ~plus visit_a env m =
+      fold (fun _ v acc -> plus acc (visit_a env v)) m zero
+
+    let visit_mapreduce ~zero ~plus visit_a env m =
+      fold
+        (fun k v (m', acc) ->
+          let v', z = visit_a env v in
+          (add k v' m', plus acc z))
+        m (empty, zero)
   end
 
   module InjSubst = C.MakeInjMap (Ord) (Ord)

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -796,7 +796,11 @@ let match_fn_ptr (ctx : ctx) (c : match_config) (p : pattern) (func : T.fn_ptr)
         | _ -> false
       in
       match_function_name || match_trait_ref
-  | TraitMethod (tr, method_name, _) ->
+  | TraitMethod (tr, method_id, _) ->
+      let method_name =
+        GAstUtils.format_method_name ctx.crate tr.trait_decl_ref.binder_value.id
+          method_id
+      in
       match_trait_decl_ref_item ctx c (mk_empty_maps ()) p tr.trait_decl_ref
         method_name func.generics
 
@@ -1203,7 +1207,11 @@ let fn_ptr_to_pattern (ctx : ctx) (c : to_pat_config)
     | FunId (FRegular fid) ->
         let d = Types.FunDeclId.Map.find fid ctx.crate.fun_decls in
         name_with_generic_args_to_pattern_aux ctx c d.item_meta.name (Some args)
-    | TraitMethod (tr, method_name, _) ->
+    | TraitMethod (tr, method_id, _) ->
+        let method_name =
+          GAstUtils.format_method_name ctx.crate
+            tr.trait_decl_ref.binder_value.id method_id
+        in
         trait_ref_item_with_generics_to_pattern ctx c m tr method_name
           func.generics
   in

--- a/charon-ml/src/OfJson.ml
+++ b/charon-ml/src/OfJson.ml
@@ -35,24 +35,17 @@ let crate_of_json (js : json) : (crate, string) result =
       else
         let ctx = empty_of_json_ctx in
         let* crate = translated_crate_of_json ctx translated in
-        let type_decls = TypeDeclId.map_of_indexed_list crate.type_decls in
-        let fun_decls = FunDeclId.map_of_indexed_list crate.fun_decls in
-        let global_decls =
-          GlobalDeclId.map_of_indexed_list crate.global_decls
-        in
-        let trait_decls = TraitDeclId.map_of_indexed_list crate.trait_decls in
-        let trait_impls = TraitImplId.map_of_indexed_list crate.trait_impls in
         Ok
           {
             name = crate.crate_name;
             options = crate.options;
             target_information = crate.target_information;
             declarations = Option.value ~default:[] crate.ordered_decls;
-            type_decls;
-            fun_decls;
-            global_decls;
-            trait_decls;
-            trait_impls;
+            type_decls = crate.type_decls;
+            fun_decls = crate.fun_decls;
+            global_decls = crate.global_decls;
+            trait_decls = crate.trait_decls;
+            trait_impls = crate.trait_impls;
           }
   | _ -> combine_error_msgs js __FUNCTION__ (Error "")
 

--- a/charon-ml/src/OfPostcard.ml
+++ b/charon-ml/src/OfPostcard.ml
@@ -27,21 +27,16 @@ let crate_of_postcard_file (file : string) : (GAst.crate, string) result =
     let* crate = translated_crate_of_postcard ctx st in
     let* _has_errors = bool_of_postcard ctx st in
     let* () = ensure_eof st in
-    let type_decls = TypeDeclId.map_of_indexed_list crate.type_decls in
-    let fun_decls = FunDeclId.map_of_indexed_list crate.fun_decls in
-    let global_decls = GlobalDeclId.map_of_indexed_list crate.global_decls in
-    let trait_decls = TraitDeclId.map_of_indexed_list crate.trait_decls in
-    let trait_impls = TraitImplId.map_of_indexed_list crate.trait_impls in
     Ok
       ({
          name = crate.crate_name;
          options = crate.options;
          target_information = crate.target_information;
          declarations = Option.value ~default:[] crate.ordered_decls;
-         type_decls;
-         fun_decls;
-         global_decls;
-         trait_decls;
-         trait_impls;
+         type_decls = crate.type_decls;
+         fun_decls = crate.fun_decls;
+         global_decls = crate.global_decls;
+         trait_decls = crate.trait_decls;
+         trait_impls = crate.trait_impls;
        }
         : GAst.crate)

--- a/charon-ml/src/Print.ml
+++ b/charon-ml/src/Print.ml
@@ -376,7 +376,11 @@ and fun_id_to_string (env : fmt_env) (fid : fun_id) : string =
 
 and fn_ptr_kind_to_string (env : fmt_env) (r : fn_ptr_kind) : string =
   match r with
-  | TraitMethod (trait_ref, method_name, _) ->
+  | TraitMethod (trait_ref, method_id, _) ->
+      let method_name =
+        GAstUtils.format_method_name env.crate
+          trait_ref.trait_decl_ref.binder_value.id method_id
+      in
       trait_ref_to_string env trait_ref ^ "::" ^ method_name
   | FunId fid -> fun_id_to_string env fid
 
@@ -1078,7 +1082,7 @@ let trait_decl_to_string (env : fmt_env) (indent : string)
           indent1 ^ "fn " ^ m.binder_value.name ^ " : "
           ^ fun_decl_id_to_string env m.binder_value.item.id
           ^ "\n")
-        def.methods
+        (TraitMethodId.Map.values def.methods)
     in
     let items = List.concat [ parent_clauses; consts; types; methods ] in
     if items = [] then "" else "\n{\n" ^ String.concat "" items ^ "}"
@@ -1138,12 +1142,18 @@ let trait_impl_to_string (env : fmt_env) (indent : string)
           ^ "\n")
         def.types
     in
-    let env_method ((name, f) : _ * fun_decl_ref binder) =
-      indent1 ^ "fn " ^ name ^ " : "
-      ^ fun_decl_id_to_string env f.binder_value.id
-      ^ "\n"
+    let methods =
+      let trait_id = def.impl_trait.id in
+      List.map
+        (fun (method_id, (f : fun_decl_ref binder)) ->
+          let name =
+            GAstUtils.format_method_name env.crate trait_id method_id
+          in
+          indent1 ^ "fn " ^ name ^ " : "
+          ^ fun_decl_id_to_string env f.binder_value.id
+          ^ "\n")
+        (TraitMethodId.Map.to_list def.methods)
     in
-    let methods = List.map env_method def.methods in
     let items = List.concat [ parent_clauses; consts; types; methods ] in
     if items = [] then "" else "\n{\n" ^ String.concat "" items ^ "}"
   in

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -581,20 +581,20 @@ let instantiate_trait_method (trait_ref : trait_ref) =
 (** Like lookup_trait_decl_method, but also correctly substitutes the generics.
 *)
 let lookup_and_subst_trait_decl_method (tdecl : trait_decl)
-    (name : trait_item_name) (trait_ref : trait_ref)
+    (id : trait_method_id) (trait_ref : trait_ref)
     (method_generics : generic_args) : fun_decl_ref option =
   Option.map
     (instantiate_trait_method trait_ref method_generics)
-    (lookup_trait_decl_method_ref tdecl name)
+    (lookup_trait_decl_method_ref tdecl id)
 
 (** Like lookup_trait_impl_method, but also correctly substitutes the generics.
 *)
 let lookup_and_subst_trait_impl_method (timpl : trait_impl)
-    (name : trait_item_name) (impl_generics : generic_args)
+    (id : trait_method_id) (impl_generics : generic_args)
     (method_generics : generic_args) : fun_decl_ref option =
   Option.map
     (instantiate_method Self impl_generics method_generics)
-    (lookup_trait_impl_method timpl name)
+    (lookup_trait_impl_method timpl id)
 
 (* Lookup the signature of a method. This returns a signature bound in two
    levels of binders: one for the trait generics and one for the method
@@ -602,14 +602,14 @@ let lookup_and_subst_trait_impl_method (timpl : trait_impl)
    found.
 *)
 let lookup_method_sig (crate : crate) (trait_id : trait_decl_id)
-    (name : trait_item_name) : fun_sig binder item_binder option =
+    (id : trait_method_id) : fun_sig binder item_binder option =
   let* tdecl = TraitDeclId.Map.find_opt trait_id crate.trait_decls in
   let* {
          item_binder_params : generic_params = trait_params;
          item_binder_value : trait_method binder =
            { binder_params = method_params; binder_value = trait_method };
        } =
-    lookup_trait_decl_method tdecl name
+    lookup_trait_decl_method tdecl id
   in
   Some
     {
@@ -621,8 +621,8 @@ let lookup_method_sig (crate : crate) (trait_id : trait_decl_id)
 (* Like [lookup_method_sig], but with no binder shenanigans: the returned
    binder binds the concatenation of trait generics and method generics. *)
 let lookup_flat_method_sig (crate : crate) (trait_id : trait_decl_id)
-    (name : trait_item_name) : bound_fun_sig option =
-  let* bound_sig = lookup_method_sig crate trait_id name in
+    (id : trait_method_id) : bound_fun_sig option =
+  let* bound_sig = lookup_method_sig crate trait_id id in
   let bound_sig = fuse_binders st_substitute_visitor#visit_fun_sig bound_sig in
   Some bound_sig
 

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -308,13 +308,15 @@ and translated_crate = {
           corresponding item wasn't translated. *)
   short_names : (item_id * name) list;
       (** Short names, for items whose last PathElem is unique. *)
-  type_decls : type_decl option list;  (** The translated type definitions *)
-  fun_decls : fun_decl option list;  (** The translated function definitions *)
-  global_decls : global_decl option list;
+  type_decls : type_decl TypeDeclId.Map.t;
+      (** The translated type definitions *)
+  fun_decls : fun_decl FunDeclId.Map.t;
+      (** The translated function definitions *)
+  global_decls : global_decl GlobalDeclId.Map.t;
       (** The translated global definitions *)
-  trait_decls : trait_decl option list;
+  trait_decls : trait_decl TraitDeclId.Map.t;
       (** The translated trait declarations *)
-  trait_impls : trait_impl option list;
+  trait_impls : trait_impl TraitImplId.Map.t;
       (** The translated trait declarations *)
   ordered_decls : declaration_group list option;
       (** The re-ordered groups of declarations, initialized as empty. *)

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -308,15 +308,15 @@ and translated_crate = {
           corresponding item wasn't translated. *)
   short_names : (item_id * name) list;
       (** Short names, for items whose last PathElem is unique. *)
-  type_decls : type_decl TypeDeclId.Map.t;
+  type_decls : type_decl type_decl_id_map;
       (** The translated type definitions *)
-  fun_decls : fun_decl FunDeclId.Map.t;
+  fun_decls : fun_decl fun_decl_id_map;
       (** The translated function definitions *)
-  global_decls : global_decl GlobalDeclId.Map.t;
+  global_decls : global_decl global_decl_id_map;
       (** The translated global definitions *)
-  trait_decls : trait_decl TraitDeclId.Map.t;
+  trait_decls : trait_decl trait_decl_id_map;
       (** The translated trait declarations *)
-  trait_impls : trait_impl TraitImplId.Map.t;
+  trait_impls : trait_impl trait_impl_id_map;
       (** The translated trait declarations *)
   ordered_decls : declaration_group list option;
       (** The re-ordered groups of declarations, initialized as empty. *)

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -209,6 +209,28 @@ and global_kind =
       nude = true (* Don't inherit VisitorsRuntime *);
     }]
 
+class ['self] iter_trait_decl_base =
+  object (self : 'self)
+    inherit [_] iter_global_decl
+
+    method visit_trait_method_id_map :
+        'a. ('env -> 'a -> unit) -> 'env -> 'a trait_method_id_map -> unit =
+      TraitMethodId.Map.visit_iter
+  end
+
+class ['self] map_trait_decl_base =
+  object (self : 'self)
+    inherit [_] map_global_decl
+
+    method visit_trait_method_id_map :
+        'a 'b.
+        ('env -> 'a -> 'b) ->
+        'env ->
+        'a trait_method_id_map ->
+        'b trait_method_id_map =
+      TraitMethodId.Map.visit_map
+  end
+
 (** An associated constant in a trait. *)
 type trait_assoc_const = {
   name : trait_item_name;
@@ -281,7 +303,7 @@ and trait_decl = {
       (** The associated types declared in the trait. The binder binds the
           generic parameters of the type if it is a GAT (Generic Associated
           Type). For a plain associated type the binder binds nothing. *)
-  methods : trait_method binder list;
+  methods : trait_method binder trait_method_id_map;
       (** The methods declared by the trait. The binder binds the generic
           parameters of the method.
 
@@ -292,6 +314,10 @@ and trait_decl = {
               fn method<'a, U>(x: &'a U);
             }
           ]} *)
+  method_names : trait_item_name list;
+      (** In mono mode we can't translate [TraitMethod]s because they'd include
+          the polymorphic signature. In order to keep access to the method
+          names, we store them here too; this is empty in poly mode. *)
   vtable : type_decl_ref option;
       (** The virtual table struct for this trait, if it has one. It is
           guaranteed that the trait has a vtable iff it is dyn-compatible. *)
@@ -317,7 +343,7 @@ and trait_method = {
       name = "iter_trait_decl";
       monomorphic = [ "env" ];
       variety = "iter";
-      ancestors = [ "iter_global_decl" ];
+      ancestors = [ "iter_trait_decl_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     },
   visitors
@@ -325,7 +351,7 @@ and trait_method = {
       name = "map_trait_decl";
       monomorphic = [ "env" ];
       variety = "map";
-      ancestors = [ "map_global_decl" ];
+      ancestors = [ "map_trait_decl_base" ];
       nude = true (* Don't inherit VisitorsRuntime *);
     }]
 
@@ -364,7 +390,7 @@ and trait_impl = {
       (** The implemented associated constants. *)
   types : (trait_item_name * trait_assoc_ty_impl binder) list;
       (** The implemented associated types. *)
-  methods : (trait_item_name * fun_decl_ref binder) list;
+  methods : fun_decl_ref binder trait_method_id_map;
       (** The implemented methods *)
   vtable : global_decl_ref option;
       (** The virtual table instance for this trait implementation. This is

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -197,7 +197,7 @@ and binder_kind_of_json (ctx : of_json_ctx) (js : json) :
         Ok (BKTraitType (x_0, x_1))
     | `Assoc [ ("TraitMethod", `List [ x_0; x_1 ]) ] ->
         let* x_0 = trait_decl_id_of_json ctx x_0 in
-        let* x_1 = trait_item_name_of_json ctx x_1 in
+        let* x_1 = trait_method_id_of_json ctx x_1 in
         Ok (BKTraitMethod (x_0, x_1))
     | `String "InherentImplBlock" -> Ok BKInherentImplBlock
     | `String "Dyn" -> Ok BKDyn
@@ -587,7 +587,7 @@ and fn_ptr_kind_of_json (ctx : of_json_ctx) (js : json) :
         Ok (FunId fun_)
     | `Assoc [ ("Trait", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = trait_ref_of_json ctx x_0 in
-        let* x_1 = trait_item_name_of_json ctx x_1 in
+        let* x_1 = trait_method_id_of_json ctx x_1 in
         let* x_2 = fun_decl_id_of_json ctx x_2 in
         Ok (TraitMethod (x_0, x_1, x_2))
     | _ -> Error "")
@@ -1220,6 +1220,13 @@ and trait_item_name_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | x -> string_of_json ctx x
+    | _ -> Error "")
+
+and trait_method_id_of_json (ctx : of_json_ctx) (js : json) :
+    (trait_method_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> TraitMethodId.id_of_json ctx x
     | _ -> Error "")
 
 and trait_param_of_json (ctx : of_json_ctx) (js : json) :
@@ -2685,6 +2692,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("consts", consts);
           ("types", types);
           ("methods", methods);
+          ("method_names", method_names);
           ("vtable", vtable);
         ] ->
         let* def_id = trait_decl_id_of_json ctx def_id in
@@ -2699,7 +2707,16 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
           list_of_json (binder_of_json trait_assoc_ty_of_json) ctx types
         in
         let* methods =
-          list_of_json (binder_of_json trait_method_of_json) ctx methods
+          (fun ctx json ->
+            Result.map TraitMethodId.map_of_indexed_list
+              (opt_indexed_map_of_json trait_method_id_of_json
+                 (binder_of_json trait_method_of_json)
+                 ctx json))
+            ctx methods
+        in
+        let* method_names =
+          index_vec_of_json trait_method_id_of_json trait_item_name_of_json ctx
+            method_names
         in
         let* vtable = option_of_json type_decl_ref_of_json ctx vtable in
         Ok
@@ -2711,6 +2728,7 @@ and trait_decl_of_json (ctx : of_json_ctx) (js : json) :
              consts;
              types;
              methods;
+             method_names;
              vtable;
            }
             : trait_decl)
@@ -2752,9 +2770,11 @@ and trait_impl_of_json (ctx : of_json_ctx) (js : json) :
             ctx types
         in
         let* methods =
-          list_of_json
-            (pair_of_json trait_item_name_of_json
-               (binder_of_json fun_decl_ref_of_json))
+          (fun ctx json ->
+            Result.map TraitMethodId.map_of_indexed_list
+              (opt_indexed_map_of_json trait_method_id_of_json
+                 (binder_of_json fun_decl_ref_of_json)
+                 ctx json))
             ctx methods
         in
         let* vtable = option_of_json global_decl_ref_of_json ctx vtable in
@@ -2958,7 +2978,7 @@ and v_table_field_of_json (ctx : of_json_ctx) (js : json) :
     | `String "Align" -> Ok VTableAlign
     | `String "Drop" -> Ok VTableDrop
     | `Assoc [ ("Method", method_) ] ->
-        let* method_ = trait_item_name_of_json ctx method_ in
+        let* method_ = trait_method_id_of_json ctx method_ in
         Ok (VTableMethod method_)
     | `Assoc [ ("SuperTrait", super_trait) ] ->
         let* super_trait = trait_clause_id_of_json ctx super_trait in

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2326,21 +2326,6 @@ and index_map_of_json :
         list_of_json (key_value_pair_of_json arg0_of_json arg1_of_json) ctx json
     | _ -> Error "")
 
-and indexed_map_of_json :
-    'a0 'a1.
-    (of_json_ctx -> json -> ('a0, string) result) ->
-    (of_json_ctx -> json -> ('a1, string) result) ->
-    of_json_ctx ->
-    json ->
-    ('a1 list, string) result =
- fun arg0_of_json arg1_of_json ctx js ->
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | json ->
-        let* list = list_of_json (option_of_json arg1_of_json) ctx json in
-        Ok (List.filter_map (fun x -> x) list)
-    | _ -> Error "")
-
 and inline_attr_of_json (ctx : of_json_ctx) (js : json) :
     (inline_attr, string) result =
   combine_error_msgs js __FUNCTION__
@@ -2841,24 +2826,39 @@ and translated_crate_of_json (ctx : of_json_ctx) (js : json) :
             short_names
         in
         let* type_decls =
-          opt_indexed_map_of_json type_decl_id_of_json type_decl_of_json ctx
-            type_decls
+          (fun ctx json ->
+            Result.map TypeDeclId.map_of_indexed_list
+              (opt_indexed_map_of_json type_decl_id_of_json type_decl_of_json
+                 ctx json))
+            ctx type_decls
         in
         let* fun_decls =
-          opt_indexed_map_of_json fun_decl_id_of_json fun_decl_of_json ctx
-            fun_decls
+          (fun ctx json ->
+            Result.map FunDeclId.map_of_indexed_list
+              (opt_indexed_map_of_json fun_decl_id_of_json fun_decl_of_json ctx
+                 json))
+            ctx fun_decls
         in
         let* global_decls =
-          opt_indexed_map_of_json global_decl_id_of_json global_decl_of_json ctx
-            global_decls
+          (fun ctx json ->
+            Result.map GlobalDeclId.map_of_indexed_list
+              (opt_indexed_map_of_json global_decl_id_of_json
+                 global_decl_of_json ctx json))
+            ctx global_decls
         in
         let* trait_decls =
-          opt_indexed_map_of_json trait_decl_id_of_json trait_decl_of_json ctx
-            trait_decls
+          (fun ctx json ->
+            Result.map TraitDeclId.map_of_indexed_list
+              (opt_indexed_map_of_json trait_decl_id_of_json trait_decl_of_json
+                 ctx json))
+            ctx trait_decls
         in
         let* trait_impls =
-          opt_indexed_map_of_json trait_impl_id_of_json trait_impl_of_json ctx
-            trait_impls
+          (fun ctx json ->
+            Result.map TraitImplId.map_of_indexed_list
+              (opt_indexed_map_of_json trait_impl_id_of_json trait_impl_of_json
+                 ctx json))
+            ctx trait_impls
         in
         let* ordered_decls =
           option_of_json

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1989,20 +1989,6 @@ and index_map_of_postcard :
        (key_value_pair_of_postcard arg0_of_postcard arg1_of_postcard)
        ctx st)
 
-and indexed_map_of_postcard :
-    'a0 'a1.
-    (of_postcard_ctx -> postcard_state -> ('a0, string) result) ->
-    (of_postcard_ctx -> postcard_state -> ('a1, string) result) ->
-    of_postcard_ctx ->
-    postcard_state ->
-    ('a1 list, string) result =
- fun arg0_of_postcard arg1_of_postcard ctx st ->
-  combine_error_msgs st __FUNCTION__
-    (let* list =
-       list_of_postcard (option_of_postcard arg1_of_postcard) ctx st
-     in
-     Ok (List.filter_map (fun x -> x) list))
-
 and inline_attr_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (inline_attr, string) result =
   combine_error_msgs st __FUNCTION__
@@ -2379,24 +2365,39 @@ and translated_crate_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
          int_of_postcard ctx st
      in
      let* type_decls =
-       opt_indexed_map_of_postcard type_decl_id_of_postcard
-         type_decl_of_postcard ctx st
+       (fun ctx st ->
+         Result.map TypeDeclId.map_of_indexed_list
+           (opt_indexed_map_of_postcard type_decl_id_of_postcard
+              type_decl_of_postcard ctx st))
+         ctx st
      in
      let* fun_decls =
-       opt_indexed_map_of_postcard fun_decl_id_of_postcard fun_decl_of_postcard
+       (fun ctx st ->
+         Result.map FunDeclId.map_of_indexed_list
+           (opt_indexed_map_of_postcard fun_decl_id_of_postcard
+              fun_decl_of_postcard ctx st))
          ctx st
      in
      let* global_decls =
-       opt_indexed_map_of_postcard global_decl_id_of_postcard
-         global_decl_of_postcard ctx st
+       (fun ctx st ->
+         Result.map GlobalDeclId.map_of_indexed_list
+           (opt_indexed_map_of_postcard global_decl_id_of_postcard
+              global_decl_of_postcard ctx st))
+         ctx st
      in
      let* trait_decls =
-       opt_indexed_map_of_postcard trait_decl_id_of_postcard
-         trait_decl_of_postcard ctx st
+       (fun ctx st ->
+         Result.map TraitDeclId.map_of_indexed_list
+           (opt_indexed_map_of_postcard trait_decl_id_of_postcard
+              trait_decl_of_postcard ctx st))
+         ctx st
      in
      let* trait_impls =
-       opt_indexed_map_of_postcard trait_impl_id_of_postcard
-         trait_impl_of_postcard ctx st
+       (fun ctx st ->
+         Result.map TraitImplId.map_of_indexed_list
+           (opt_indexed_map_of_postcard trait_impl_id_of_postcard
+              trait_impl_of_postcard ctx st))
+         ctx st
      in
      let* ordered_decls =
        option_of_postcard

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -185,7 +185,7 @@ and binder_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
          Ok (BKTraitType (x_0, x_1))
      | 1 ->
          let* x_0 = trait_decl_id_of_postcard ctx st in
-         let* x_1 = trait_item_name_of_postcard ctx st in
+         let* x_1 = trait_method_id_of_postcard ctx st in
          Ok (BKTraitMethod (x_0, x_1))
      | 2 -> Ok BKInherentImplBlock
      | 3 -> Ok BKDyn
@@ -553,7 +553,7 @@ and fn_ptr_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
          Ok (FunId x_0)
      | 1 ->
          let* x_0 = trait_ref_of_postcard ctx st in
-         let* x_1 = trait_item_name_of_postcard ctx st in
+         let* x_1 = trait_method_id_of_postcard ctx st in
          let* x_2 = fun_decl_id_of_postcard ctx st in
          Ok (TraitMethod (x_0, x_1, x_2))
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
@@ -1117,6 +1117,10 @@ and trait_impl_ref_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and trait_item_name_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (trait_item_name, string) result =
   combine_error_msgs st __FUNCTION__ (string_of_postcard ctx st)
+
+and trait_method_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
+    (trait_method_id, string) result =
+  combine_error_msgs st __FUNCTION__ (TraitMethodId.id_of_postcard ctx st)
 
 and trait_param_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (trait_param, string) result =
@@ -2275,7 +2279,16 @@ and trait_decl_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
        list_of_postcard (binder_of_postcard trait_assoc_ty_of_postcard) ctx st
      in
      let* methods =
-       list_of_postcard (binder_of_postcard trait_method_of_postcard) ctx st
+       (fun ctx st ->
+         Result.map TraitMethodId.map_of_indexed_list
+           (opt_indexed_map_of_postcard trait_method_id_of_postcard
+              (binder_of_postcard trait_method_of_postcard)
+              ctx st))
+         ctx st
+     in
+     let* method_names =
+       index_vec_of_postcard trait_method_id_of_postcard
+         trait_item_name_of_postcard ctx st
      in
      let* vtable = option_of_postcard type_decl_ref_of_postcard ctx st in
      Ok
@@ -2287,6 +2300,7 @@ and trait_decl_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           consts;
           types;
           methods;
+          method_names;
           vtable;
         }
          : trait_decl))
@@ -2315,9 +2329,11 @@ and trait_impl_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
          ctx st
      in
      let* methods =
-       list_of_postcard
-         (pair_of_postcard trait_item_name_of_postcard
-            (binder_of_postcard fun_decl_ref_of_postcard))
+       (fun ctx st ->
+         Result.map TraitMethodId.map_of_indexed_list
+           (opt_indexed_map_of_postcard trait_method_id_of_postcard
+              (binder_of_postcard fun_decl_ref_of_postcard)
+              ctx st))
          ctx st
      in
      let* vtable = option_of_postcard global_decl_ref_of_postcard ctx st in
@@ -2478,7 +2494,7 @@ and v_table_field_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      | 1 -> Ok VTableAlign
      | 2 -> Ok VTableDrop
      | 3 ->
-         let* x_0 = trait_item_name_of_postcard ctx st in
+         let* x_0 = trait_method_id_of_postcard ctx st in
          Ok (VTableMethod x_0)
      | 4 ->
          let* x_0 = trait_clause_id_of_postcard ctx st in

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -18,13 +18,13 @@ module GlobalDeclId = IdGen ()
 module ConstGenericVarId = IdGen ()
 module TraitDeclId = IdGen ()
 module TraitImplId = IdGen ()
+module TraitMethodId = IdGen ()
 module TraitClauseId = IdGen ()
 module TraitTypeConstraintId = IdGen ()
 module UnsolvedTraitId = IdGen ()
 module RegionId = IdGen ()
 module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
-module BodyId = IdGen ()
 
 type integer_type = Values.integer_type [@@deriving show, ord, eq]
 type float_type = Values.float_type [@@deriving show, ord, eq]
@@ -35,6 +35,13 @@ type literal_type = Values.literal_type [@@deriving show, ord, eq]
    declare it within a visitor group. *)
 type trait_type_constraint_id = TraitTypeConstraintId.id
 [@@deriving show, ord, eq]
+
+type 'a fun_decl_id_map = 'a FunDeclId.Map.t
+and 'a global_decl_id_map = 'a GlobalDeclId.Map.t
+and 'a type_decl_id_map = 'a TypeDeclId.Map.t
+and 'a trait_decl_id_map = 'a TraitDeclId.Map.t
+and 'a trait_impl_id_map = 'a TraitImplId.Map.t
+and 'a trait_method_id_map = 'a TraitMethodId.Map.t [@@deriving show, eq, ord]
 
 (** The index of a binder, counting from the innermost. See [[DeBruijnVar]] for
     details. *)
@@ -160,7 +167,7 @@ type 'a0 binder = {
 and binder_kind =
   | BKTraitType of trait_decl_id * trait_item_name
       (** The parameters of a generic associated type. *)
-  | BKTraitMethod of trait_decl_id * trait_item_name
+  | BKTraitMethod of trait_decl_id * trait_method_id
       (** The parameters of a trait method. Used in the [methods] lists in trait
           decls and trait impls. *)
   | BKInherentImplBlock
@@ -395,7 +402,7 @@ and fn_ptr = { kind : fn_ptr_kind; generics : generic_args }
 
 and fn_ptr_kind =
   | FunId of fun_id
-  | TraitMethod of trait_ref * trait_item_name * fun_decl_id
+  | TraitMethod of trait_ref * trait_method_id * fun_decl_id
       (** If a trait: the reference to the trait and the id of the trait method.
           The fun decl id is not really necessary - we put it here for
           convenience purposes. *)
@@ -531,6 +538,7 @@ and trait_decl_ref = { id : trait_decl_id; generics : generic_args }
 and trait_impl_ref = { id : trait_impl_id; generics : generic_args }
 
 and trait_item_name = string
+and trait_method_id = (TraitMethodId.id[@visitors.opaque])
 
 (** A trait predicate in a signature, of the form [Type: Trait<Args>]. This
     functions like a variable binder, to which variables of the form
@@ -1154,7 +1162,7 @@ and v_table_field =
   | VTableSize
   | VTableAlign
   | VTableDrop
-  | VTableMethod of trait_item_name
+  | VTableMethod of trait_method_id
   | VTableSuperTrait of trait_clause_id
 
 and variant = {

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.190"
+version = "0.1.191"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.190"
+version = "0.1.191"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -510,7 +510,7 @@ pub enum FnPtrKind {
     /// The fun decl id is not really necessary - we put it here for convenience
     /// purposes.
     #[charon::rename("TraitMethod")]
-    Trait(TraitRef, TraitItemName, FunDeclId),
+    Trait(TraitRef, TraitMethodId, FunDeclId),
 }
 
 impl From<FunId> for FnPtrKind {

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -209,7 +209,7 @@ pub enum VTableField {
     Size,
     Align,
     Drop,
-    Method(TraitItemName),
+    Method(TraitMethodId),
     SuperTrait(TraitClauseId),
 }
 
@@ -296,6 +296,8 @@ pub struct GlobalDeclRef {
 #[serde_state(stateless)]
 pub struct TraitItemName(pub ustr::Ustr);
 
+generate_index_type!(TraitMethodId, "TraitMethod");
+
 /// A trait **declaration**.
 ///
 /// For instance:
@@ -362,7 +364,11 @@ pub struct TraitDecl {
     ///   fn method<'a, U>(x: &'a U);
     /// }
     /// ```
-    pub methods: Vec<Binder<TraitMethod>>,
+    pub methods: IndexMap<TraitMethodId, Binder<TraitMethod>>,
+    /// In mono mode we can't translate `TraitMethod`s because they'd include the polymorphic
+    /// signature. In order to keep access to the method names, we store them here too; this is
+    /// empty in poly mode.
+    pub method_names: IndexVec<TraitMethodId, TraitItemName>,
     /// The virtual table struct for this trait, if it has one.
     /// It is guaranteed that the trait has a vtable iff it is dyn-compatible.
     pub vtable: Option<TypeDeclRef>,
@@ -431,7 +437,7 @@ pub struct TraitImpl {
     /// The implemented associated types.
     pub types: Vec<(TraitItemName, Binder<TraitAssocTyImpl>)>,
     /// The implemented methods
-    pub methods: Vec<(TraitItemName, Binder<FunDeclRef>)>,
+    pub methods: IndexMap<TraitMethodId, Binder<FunDeclRef>>,
     /// The virtual table instance for this trait implementation. This is `Some` iff the trait is
     /// dyn-compatible.
     pub vtable: Option<GlobalDeclRef>,

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -119,7 +119,7 @@ impl TraitDecl {
     }
 }
 impl TraitImpl {
-    pub fn methods(&self) -> impl Iterator<Item = &(TraitItemName, Binder<FunDeclRef>)> {
+    pub fn methods(&self) -> impl Iterator<Item = &Binder<FunDeclRef>> {
         self.methods.iter()
     }
 }

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -256,7 +256,7 @@ pub enum BinderKind {
     TraitType(TraitDeclId, TraitItemName),
     /// The parameters of a trait method. Used in the `methods` lists in trait decls and trait
     /// impls.
-    TraitMethod(TraitDeclId, TraitItemName),
+    TraitMethod(TraitDeclId, TraitMethodId),
     /// The parameters bound in a non-trait `impl` block. Used in the `Name`s of inherent methods.
     InherentImplBlock,
     /// Binder used for `dyn Trait` existential predicates.

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1471,6 +1471,15 @@ impl TypeDecl {
             .is_some_and(|repr| repr.repr_algo == ReprAlgorithm::C)
     }
 
+    pub fn get_field(&self, variant: Option<VariantId>, field: FieldId) -> Option<&Field> {
+        let fields = match &self.kind {
+            TypeDeclKind::Struct(fields) | TypeDeclKind::Union(fields) => fields,
+            TypeDeclKind::Enum(variants) => &variants[variant.unwrap()].fields,
+            _ => return None,
+        };
+        fields.get(field)
+    }
+
     pub fn get_field_by_name(
         &self,
         variant: Option<VariantId>,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -49,7 +49,7 @@ use derive_generic_visitor::*;
         FnOperand, FunId, FnPtrKind, FunSig, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ConstantExprKind,
-        RefKind, RegionId, RegionParam, ScalarValue, TraitItemName,
+        RefKind, RegionId, RegionParam, ScalarValue, TraitItemName, TraitMethodId,
         TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypeVarId, llbc_ast::StatementId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
         ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -107,7 +107,7 @@ mod types {
         /// Cache the `Ty` translations.
         pub tys: HashMap<ty::Ty<'tcx>, Ty>,
         /// Cache the `ItemRef` translations. This is fast because `GenericArgsRef` is interned.
-        pub item_refs: HashMap<(DefId, ty::GenericArgsRef<'tcx>), ItemRef>,
+        pub item_refs: HashMap<(DefId, ty::GenericArgsRef<'tcx>, bool), ItemRef>,
         /// Cache the trait resolution engine for each item.
         pub predicate_searcher: Option<crate::hax::traits::PredicateSearcher<'tcx>>,
         /// Cache of trait refs to resolved impl expressions.

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -1051,7 +1051,6 @@ pub enum ImplAssocItemValue {
 
 /// Partial data for a trait impl, used for fake trait impls that we generate ourselves such as
 /// `FnOnce` and `Drop` impls.
-
 #[derive(Clone, Debug)]
 pub struct VirtualTraitImpl {
     /// The trait that is implemented by this impl block.
@@ -1060,6 +1059,8 @@ pub struct VirtualTraitImpl {
     pub implied_impl_exprs: Vec<ImplExpr>,
     /// The associated types and their predicates, in definition order.
     pub types: Vec<(Ty, Vec<ImplExpr>)>,
+    /// The methods, in definition order.
+    pub methods: Vec<DefId>,
 }
 
 impl<'tcx> FullDef<'tcx> {
@@ -1269,10 +1270,17 @@ where
             (ty, required_impl_exprs)
         })
         .collect();
+    let methods = tcx
+        .associated_items(trait_ref.def_id)
+        .in_definition_order()
+        .filter(|assoc| matches!(assoc.kind, ty::AssocKind::Fn { .. }))
+        .map(|assoc| assoc.def_id.sinto(s))
+        .collect();
     Box::new(VirtualTraitImpl {
         trait_pred,
         implied_impl_exprs: required_impl_exprs,
         types,
+        methods,
     })
 }
 

--- a/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
@@ -115,16 +115,25 @@ impl ItemRef {
         hax_def_id: DefId,
         generics: ty::GenericArgsRef<'tcx>,
     ) -> ItemRef {
-        let key = (hax_def_id.clone(), generics);
+        Self::translate_from_hax_def_id_maybe_resolve(s, hax_def_id, generics, true)
+    }
+    pub fn translate_from_hax_def_id_maybe_resolve<'tcx, S: UnderOwnerState<'tcx>>(
+        s: &S,
+        hax_def_id: DefId,
+        generics: ty::GenericArgsRef<'tcx>,
+        resolve_assoc_item_trait_ref: bool,
+    ) -> ItemRef {
+        let key = (hax_def_id.clone(), generics, resolve_assoc_item_trait_ref);
         if let Some(item) = s.with_cache(|cache| cache.item_refs.get(&key).cloned()) {
             return item;
         }
 
         // Don't resolve if the DefId isn't real.
         let is_real_def_id = hax_def_id.as_rust_def_id().is_some();
+        let resolve_assoc_item_trait_ref = is_real_def_id && resolve_assoc_item_trait_ref;
         let def_id = hax_def_id.as_def_id_even_synthetic();
         let item_ref = s.with_predicate_searcher(|pred_searcher| {
-            pred_searcher.resolve_item_reference(def_id, generics, is_real_def_id)
+            pred_searcher.resolve_item_reference(def_id, generics, resolve_assoc_item_trait_ref)
         });
 
         // If the original `DefId` was not real, make sure we keep that around.

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -1594,11 +1594,18 @@ impl AssocItem {
                 let implemented_trait_ref = tcx
                     .impl_trait_ref(container_id)
                     .instantiate(tcx, container_args);
-                let implemented_trait_item = translate_item_ref(
-                    s,
-                    implemented_item_id,
-                    item_args.rebase_onto(tcx, container_id, implemented_trait_ref.args),
-                );
+                let implemented_trait_item = {
+                    let implemented_item_id = implemented_item_id.sinto(s);
+                    let generics =
+                        item_args.rebase_onto(tcx, container_id, implemented_trait_ref.args);
+                    // Don't resolve, otherwise we'll always get the impl item id back.
+                    ItemRef::translate_from_hax_def_id_maybe_resolve(
+                        s,
+                        implemented_item_id,
+                        generics,
+                        false,
+                    )
+                };
                 AssocItemContainer::TraitImplContainer {
                     impl_: item,
                     implemented_trait_ref: implemented_trait_ref.sinto(s),

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -1637,6 +1637,17 @@ impl AssocItem {
             has_value: item.defaultness(tcx).has_value(),
         }
     }
+
+    /// The `DefId` of the item being implemented.
+    pub fn implemented_trait_item_id(&self) -> &DefId {
+        match &self.container {
+            AssocItemContainer::TraitImplContainer {
+                implemented_trait_item,
+                ..
+            } => &implemented_trait_item.def_id,
+            _ => &self.def_id,
+        }
+    }
 }
 
 /// Reflects [`ty::AssocKind`]

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -562,7 +562,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         }
 
         // Construct the `call_*` method reference.
-        let call_fn_name = TraitItemName(target_kind.method_name().into());
+        let trait_decl_id = timpl.impl_trait.id;
+        let trait_method_id = self.register_trait_method_id(trait_decl_id, &vimpl.methods[0])?;
         let call_fn_binder = {
             let kind = TransItemSourceKind::ClosureMethod(target_kind);
             let bound_method_ref: RegionBinder<DeclRef<ItemId>> =
@@ -573,12 +574,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             };
             let fn_decl_ref: FunDeclRef = bound_method_ref.skip_binder.try_into().unwrap();
             Binder::new(
-                BinderKind::TraitMethod(timpl.impl_trait.id, call_fn_name),
+                BinderKind::TraitMethod(trait_decl_id, trait_method_id),
                 params,
                 fn_decl_ref,
             )
         };
-        timpl.methods.push((call_fn_name, call_fn_binder));
+        timpl
+            .methods
+            .set_slot_extend(trait_method_id, call_fn_binder);
 
         Ok(timpl)
     }

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -333,6 +333,64 @@ impl<'tcx> TranslateCtx<'tcx> {
         }
     }
 
+    /// Register a trait method and return its `TraitMethodId`. This id is unique per trait.
+    /// This does not make the method be considered "used"; use `mark_method_as_used` for that.
+    pub fn register_trait_method_id_no_enqueue(
+        &mut self,
+        trait_id: TraitDeclId,
+        method_def_id: &hax::DefId,
+    ) -> Result<TraitMethodId, Error> {
+        if let Some(&method_id) = self.method_id_map.get(method_def_id) {
+            return Ok(method_id);
+        }
+
+        let method_def = self.poly_hax_def(method_def_id)?;
+        let hax::FullDefKind::AssocFn {
+            associated_item, ..
+        } = method_def.kind()
+        else {
+            unreachable!()
+        };
+        let decl_def_id = associated_item.implemented_trait_item_id();
+
+        if let Some(&method_id) = self.method_id_map.get(decl_def_id) {
+            self.method_id_map.insert(method_def_id.clone(), method_id);
+            return Ok(method_id);
+        }
+
+        // Allocate method ids in item definition order.
+        let map: IndexMap<TraitMethodId, MethodStatus> = {
+            let trait_def_id = decl_def_id.parent(&self.hax_state).unwrap();
+            let trait_def = self.poly_hax_def(&trait_def_id)?;
+            let hax::FullDefKind::Trait { items, .. } = trait_def.kind() else {
+                unreachable!()
+            };
+            let mut map = IndexMap::new();
+            for item in items {
+                if matches!(item.kind, hax::AssocKind::Fn { .. }) {
+                    let id = map.push(MethodStatus::default());
+                    self.method_id_map.insert(item.def_id.clone(), id);
+                }
+            }
+            map
+        };
+        self.method_status
+            .get_or_extend_and_insert(trait_id, || map);
+        let method_id = *self.method_id_map.get(decl_def_id).unwrap();
+        Ok(method_id)
+    }
+    /// Register a trait method and return its `TraitMethodId`. This id is unique per trait.
+    /// This makes the method be considered "used".
+    pub fn register_trait_method_id(
+        &mut self,
+        trait_id: TraitDeclId,
+        def_id: &hax::DefId,
+    ) -> Result<TraitMethodId, Error> {
+        let method_id = self.register_trait_method_id_no_enqueue(trait_id, def_id)?;
+        self.mark_method_as_used(trait_id, method_id);
+        Ok(method_id)
+    }
+
     pub(crate) fn register_target_info(&mut self) {
         let target_data = &self.tcx.data_layout;
         let triple = self.get_target_triple();
@@ -610,13 +668,13 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             None => FnPtrKind::Fun(fun_item.id),
             // Trait method
             Some(trait_ref) => {
-                let name = self.t_ctx.translate_trait_item_name(&item.def_id)?;
                 let method_decl_id = *fun_item
                     .id
                     .as_regular()
                     .expect("methods are not builtin functions");
-                self.mark_method_as_used(trait_ref.trait_decl_ref.skip_binder.id, name);
-                FnPtrKind::Trait(trait_ref.move_under_binder(), name, method_decl_id)
+                let trait_decl_id = trait_ref.trait_id();
+                let method_id = self.register_trait_method_id(trait_decl_id, &item.def_id)?;
+                FnPtrKind::Trait(trait_ref.move_under_binder(), method_id, method_decl_id)
             }
         };
         let late_bound = match self.hax_def(item)?.kind() {
@@ -729,6 +787,7 @@ pub fn translate<'tcx>(
             ..TranslatedCrate::default()
         },
         method_status: Default::default(),
+        method_id_map: Default::default(),
         id_map: Default::default(),
         reverse_id_map: Default::default(),
         file_to_id: Default::default(),

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -44,12 +44,14 @@ pub struct TranslateCtx<'tcx> {
     /// When we find a use of a method, we mark it "used" using `mark_method_as_used`. This
     /// enqueues all known and future impls of this method. We also mark a method as used if we
     /// find an implementation of it in a non-opaque impl, and if the method is a required method.
-    pub method_status: IndexMap<TraitDeclId, HashMap<TraitItemName, MethodStatus>>,
+    pub method_status: IndexMap<TraitDeclId, IndexMap<TraitMethodId, MethodStatus>>,
 
     /// The map from rustc id to translated id.
     pub id_map: HashMap<TransItemSource, ItemId>,
     /// The reverse map of ids.
     pub reverse_id_map: HashMap<ItemId, TransItemSource>,
+    /// Map from rustc id to method id
+    pub method_id_map: HashMap<hax::DefId, TraitMethodId>,
     /// The reverse filename map.
     pub file_to_id: HashMap<FileName, FileId>,
 

--- a/charon/src/bin/charon-driver/translate/translate_drops.rs
+++ b/charon/src/bin/charon-driver/translate/translate_drops.rs
@@ -7,6 +7,29 @@ use crate::translate::translate_crate::TransItemSourceKind;
 use charon_lib::{ast::*, formatter::IntoFormatter, pretty::FmtWithCtx};
 
 impl<'tcx> ItemTransCtx<'tcx, '_> {
+    pub fn translate_drop_in_place_method_ref(
+        &mut self,
+        span: Span,
+        item_ref: &hax::ItemRef,
+        destruct_trait_id: TraitDeclId,
+        impl_kind: Option<TraitImplSource>,
+    ) -> (FunDeclId, TraitMethodId, TraitItemName) {
+        let fun_id = self.register_item(
+            span,
+            item_ref,
+            TransItemSourceKind::DropInPlaceMethod(impl_kind),
+        );
+        let method_id = TraitMethodId::ZERO; // It's the only method
+        // Make sure `method_id` is a valid id into `self.method_status[destruct_trait_id]`.
+        let _ = self
+            .method_status
+            .get_or_extend_and_insert(destruct_trait_id, || {
+                [MethodStatus::default()].into_iter().collect()
+            });
+        let method_name = TraitItemName("drop_in_place".into());
+        (fun_id, method_id, method_name)
+    }
+
     /// Translate a call to `drop_in_place` for that type.
     pub fn translate_drop_in_place_method_call(
         &mut self,
@@ -15,17 +38,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<FnPtr, Error> {
         let impl_expr = hax::solve_destruct(self.hax_state_with_id(), ty);
         let tref = self.translate_trait_impl_expr(span, &impl_expr)?;
-        let method_id = self.register_item(
+        let (fun_id, method_id, _) = self.translate_drop_in_place_method_ref(
             span,
             impl_expr.r#trait.hax_skip_binder_ref(),
-            TransItemSourceKind::DropInPlaceMethod(None),
+            tref.trait_id(),
+            None,
         );
         let fn_ptr = FnPtr {
-            kind: Box::new(FnPtrKind::Trait(
-                tref,
-                TraitItemName("drop_in_place".into()),
-                method_id,
-            )),
+            kind: Box::new(FnPtrKind::Trait(tref, method_id, fun_id)),
             generics: Box::new(GenericArgs::empty()),
         };
         Ok(fn_ptr)
@@ -176,28 +196,24 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         span: Span,
         destruct_trait_id: TraitDeclId,
         impl_kind: Option<TraitImplSource>,
-    ) -> (TraitItemName, Binder<FunDeclRef>) {
-        let method_id = self.register_item(
-            span,
-            def.this(),
-            TransItemSourceKind::DropInPlaceMethod(impl_kind),
-        );
-        let method_name = TraitItemName("drop_in_place".into());
+    ) -> (TraitMethodId, TraitItemName, Binder<FunDeclRef>) {
+        let (fun_id, method_id, method_name) =
+            self.translate_drop_in_place_method_ref(span, def.this(), destruct_trait_id, impl_kind);
         let method_binder = {
             let generics = self
                 .outermost_binder()
                 .params
                 .identity_args_at_depth(DeBruijnId::one());
             Binder::new(
-                BinderKind::TraitMethod(destruct_trait_id, method_name),
+                BinderKind::TraitMethod(destruct_trait_id, method_id),
                 GenericParams::empty(),
                 FunDeclRef {
-                    id: method_id,
+                    id: fun_id,
                     generics: Box::new(generics),
                 },
             )
         };
-        (method_name, method_binder)
+        (method_id, method_name, method_binder)
     }
 
     #[tracing::instrument(skip(self, item_meta, def))]
@@ -217,12 +233,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let mut timpl = self.translate_virtual_trait_impl(impl_id, item_meta, destruct_impl)?;
 
         // Add the `drop_in_place(*mut self)` method.
-        timpl.methods.push(self.prepare_drop_in_place_method(
+        let destruct_trait_id = timpl.impl_trait.id;
+        let (method_id, _, method_binder) = self.prepare_drop_in_place_method(
             def,
             span,
-            timpl.impl_trait.id,
+            destruct_trait_id,
             Some(TraitImplSource::ImplicitDestruct),
-        ));
+        );
+        timpl.methods.set_slot_extend(method_id, method_binder);
 
         Ok(timpl)
     }

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -262,24 +262,55 @@ impl<'tcx> TranslateCtx<'tcx> {
         Ok(item.unwrap())
     }
 
+    /// Record that `method_id` is an implementation of the given method of the trait. If the
+    /// method is not used anywhere yet we simply record the implementation. If the method is used
+    /// then we enqueue it for translation.
+    pub fn register_method_impl(
+        &mut self,
+        trait_id: TraitDeclId,
+        method_id: TraitMethodId,
+        fun_id: FunDeclId,
+    ) {
+        match &mut self.method_status[trait_id][method_id] {
+            MethodStatus::Unused { implementors } => {
+                implementors.insert(fun_id);
+            }
+            MethodStatus::Used => {
+                self.enqueue_id(fun_id);
+            }
+        }
+    }
+
+    /// Mark the method as "used", which will enqueue for translation all the implementations of
+    /// that method.
+    pub fn mark_method_as_used(&mut self, trait_id: TraitDeclId, method_id: TraitMethodId) {
+        let old_status = mem::replace(
+            &mut self.method_status[trait_id][method_id],
+            MethodStatus::Used,
+        );
+        match old_status {
+            MethodStatus::Unused { implementors } => {
+                for fun_id in implementors {
+                    self.enqueue_id(fun_id);
+                }
+            }
+            MethodStatus::Used => {}
+        }
+    }
+
     /// Keep only the methods we marked as "used".
     pub fn remove_unused_methods(&mut self) {
-        let method_is_used = |trait_id, name| {
-            self.method_status.get(trait_id).is_some_and(|map| {
-                map.get(&name)
-                    .is_some_and(|status| matches!(status, MethodStatus::Used))
-            })
+        let method_is_used = |trait_id: TraitDeclId, method_id: TraitMethodId| {
+            matches!(self.method_status[trait_id][method_id], MethodStatus::Used)
         };
         for tdecl in self.translated.trait_decls.iter_mut() {
             tdecl
                 .methods
-                .retain(|m| method_is_used(tdecl.def_id, m.name()));
+                .retain(|i, _m| method_is_used(tdecl.def_id, i));
         }
         for timpl in self.translated.trait_impls.iter_mut() {
             let trait_id = timpl.impl_trait.id;
-            timpl
-                .methods
-                .retain(|(name, _)| method_is_used(trait_id, *name));
+            timpl.methods.retain(|i, _m| method_is_used(trait_id, i));
         }
     }
 }
@@ -351,8 +382,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             hax::AssocItemContainer::TraitImplContainer {
                 impl_,
                 implemented_trait_ref,
+                implemented_trait_item,
                 overrides_default,
-                ..
             } => {
                 let impl_ref =
                     self.translate_trait_impl_ref(span, impl_, TraitImplSource::Normal)?;
@@ -361,7 +392,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 if matches!(def.kind(), hax::FullDefKind::AssocFn { .. }) {
                     // If the implementation is getting translated, that means the method is
                     // getting used.
-                    self.mark_method_as_used(trait_ref.id, item_name);
+                    let _ = self
+                        .register_trait_method_id(trait_ref.id, &implemented_trait_item.def_id)?;
                 }
                 ItemSource::TraitImpl {
                     impl_ref,
@@ -604,7 +636,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     #[tracing::instrument(skip(self, item_meta, def))]
     pub fn translate_trait_decl(
         mut self,
-        def_id: TraitDeclId,
+        trait_decl_id: TraitDeclId,
         item_meta: ItemMeta,
         def: &hax::FullDef<'tcx>,
     ) -> Result<TraitDecl, Error> {
@@ -634,13 +666,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         if let hax::FullDefKind::TraitAlias { .. } = def.kind() {
             // Trait aliases don't have any items. Everything interesting is in the parent clauses.
             return Ok(TraitDecl {
-                def_id,
+                def_id: trait_decl_id,
                 item_meta,
                 implied_clauses,
                 generics: self.into_generics(),
                 consts: Default::default(),
                 types: Default::default(),
                 methods: Default::default(),
+                method_names: Default::default(),
                 vtable,
             });
         }
@@ -661,20 +694,39 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // Translate the associated items
         let mut consts = Vec::new();
         let mut types = Vec::new();
-        let mut methods = Vec::new();
+        let mut methods: IndexMap<TraitMethodId, _> = IndexMap::new();
 
         // skip all associated items of trait decl in mono mode
         // question: what if the associated methods (or consts) has default implmentation?
         // TODO: support default methods and default consts
         if self.monomorphize() {
+            let method_names = {
+                let mut method_names: IndexMap<TraitMethodId, _> = IndexMap::new();
+                for hax_item in items {
+                    if let hax::AssocKind::Fn { .. } = hax_item.kind {
+                        let item_def_id = &hax_item.def_id;
+                        let item_name = self.translate_trait_item_name(item_def_id)?;
+                        let trait_method_id =
+                            self.register_trait_method_id_no_enqueue(trait_decl_id, item_def_id)?;
+                        method_names.set_slot_extend(trait_method_id, item_name);
+                    }
+                }
+                if def.lang_item == Some(sym::destruct) {
+                    let (method_id, method_name, _) =
+                        self.prepare_drop_in_place_method(def, span, trait_decl_id, None);
+                    method_names.set_slot_extend(method_id, method_name);
+                }
+                method_names.make_contiguous()
+            };
             return Ok(TraitDecl {
-                def_id,
+                def_id: trait_decl_id,
                 item_meta,
                 implied_clauses,
                 generics: self.into_generics(),
                 consts,
                 types,
                 methods,
+                method_names,
                 vtable,
             });
         }
@@ -698,19 +750,21 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
             match item_def.kind() {
                 hax::FullDefKind::AssocFn { sig, .. } => {
-                    let method_id = self.register_no_enqueue(item_span, &item_src);
+                    let fun_id = self.register_no_enqueue(item_span, &item_src);
+                    let trait_method_id =
+                        self.register_trait_method_id_no_enqueue(trait_decl_id, item_def_id)?;
                     // Register this method.
-                    self.register_method_impl(def_id, item_name, method_id);
+                    self.register_method_impl(trait_decl_id, trait_method_id, fun_id);
                     // By default we only enqueue required methods (those that don't have a default
                     // impl). If the trait is transparent, we enqueue all its methods.
                     if self.options.translate_all_methods
                         || item_meta.opacity.is_transparent()
                         || !hax_item.has_value
                     {
-                        self.mark_method_as_used(def_id, item_name);
+                        self.mark_method_as_used(trait_decl_id, trait_method_id);
                     }
 
-                    let binder_kind = BinderKind::TraitMethod(def_id, item_name);
+                    let binder_kind = BinderKind::TraitMethod(trait_decl_id, trait_method_id);
                     let mut method = self.translate_binder_for_def(
                         item_span,
                         binder_kind,
@@ -728,7 +782,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                                         .identity_args_at_depth(DeBruijnId::zero()),
                                 );
                             let fn_ref = FunDeclRef {
-                                id: method_id,
+                                id: fun_id,
                                 generics: Box::new(fun_generics),
                             };
                             // `skip_binder` is allowed because `translate_binder_for_def` puts the
@@ -777,7 +831,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
                     // We insert the `Binder<TraitMethod>` unconditionally here; we'll remove the
                     // ones that correspond to unused methods at the end of translation.
-                    methods.push(method);
+                    methods.set_slot_extend(trait_method_id, method);
                 }
                 hax::FullDefKind::AssocConst { ty, .. } => {
                     // The const is defined in a context that has an extra `Self: Trait` clause, so
@@ -828,7 +882,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     value: default,
                     ..
                 } => {
-                    let binder_kind = BinderKind::TraitType(def_id, item_name);
+                    let binder_kind = BinderKind::TraitType(trait_decl_id, item_name);
                     let assoc_ty =
                         self.translate_binder_for_def(item_span, binder_kind, &item_def, |ctx| {
                             // Also add the implied predicates.
@@ -865,10 +919,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         if def.lang_item == Some(sym::destruct) {
             // Add a `drop_in_place(*mut self)` method that contains the drop glue for this type.
-            let (method_name, method_binder) =
-                self.prepare_drop_in_place_method(def, span, def_id, None);
-            self.mark_method_as_used(def_id, method_name);
-            methods.push(method_binder.map(|fn_ref| {
+            let (method_id, method_name, method_binder) =
+                self.prepare_drop_in_place_method(def, span, trait_decl_id, None);
+            self.mark_method_as_used(trait_decl_id, method_id);
+            let method = method_binder.map(|fn_ref| {
                 let self_ty = if self.monomorphize() {
                     // FIXME: put something real here
                     Ty::mk_unit()
@@ -883,20 +937,22 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     attr_info: AttrInfo::dummy_public(),
                     signature,
                 }
-            }));
+            });
+            methods.set_slot_extend(method_id, method);
         }
 
         // In case of a trait implementation, some values may not have been
         // provided, in case the declaration provided default values. We
         // check those, and lookup the relevant values.
         Ok(TraitDecl {
-            def_id,
+            def_id: trait_decl_id,
             item_meta,
             implied_clauses,
             generics: self.into_generics(),
             consts,
             types,
             methods,
+            method_names: Default::default(),
             vtable,
         })
     }
@@ -964,7 +1020,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // Explore the associated items
         let mut consts = Vec::new();
         let mut types = Vec::new();
-        let mut methods = Vec::new();
+        let mut methods: IndexMap<TraitMethodId, _> = IndexMap::new();
 
         // In mono mode, we do not translate any associated items in trait impl.
         if self.monomorphize() {
@@ -1001,7 +1057,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
             match item_def.kind() {
                 hax::FullDefKind::AssocFn { .. } => {
-                    let method_id: FunDeclId = {
+                    let trait_method_id =
+                        self.register_trait_method_id_no_enqueue(trait_id, &impl_item.decl_def_id)?;
+
+                    let fun_id: FunDeclId = {
                         let method_src = match &impl_item.value {
                             Provided { .. } => item_src,
                             // This will generate a copy of the default method. Note that the base
@@ -1017,16 +1076,16 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     };
 
                     // Register this method.
-                    self.register_method_impl(trait_id, name, method_id);
+                    self.register_method_impl(trait_id, trait_method_id, fun_id);
                     // By default we only enqueue required methods (those that don't have a default
                     // impl). If the impl is transparent, we enqueue all the implemented methods.
                     if matches!(impl_item.value, Provided { .. })
                         && item_meta.opacity.is_transparent()
                     {
-                        self.mark_method_as_used(trait_id, name);
+                        self.mark_method_as_used(trait_id, trait_method_id);
                     }
 
-                    let binder_kind = BinderKind::TraitMethod(trait_id, name);
+                    let binder_kind = BinderKind::TraitMethod(trait_id, trait_method_id);
                     let bound_fn_ref = match &impl_item.value {
                         Provided { .. } => self.translate_binder_for_def(
                             item_span,
@@ -1041,33 +1100,32 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                                             .identity_args_at_depth(DeBruijnId::zero()),
                                     );
                                 Ok(FunDeclRef {
-                                    id: method_id,
+                                    id: fun_id,
                                     generics: Box::new(generics),
                                 })
                             },
                         )?,
                         DefaultedFn { .. } => {
                             // Retrieve the method generics from the trait decl.
-                            let decl_methods =
+                            let bound_method =
                                 match self.get_or_translate(implemented_trait.id.into()) {
-                                    Ok(ItemRef::TraitDecl(tdecl)) => tdecl.methods.as_slice(),
-                                    _ => &[],
+                                    Ok(ItemRef::TraitDecl(tdecl)) => {
+                                        tdecl.methods.get(trait_method_id).cloned()
+                                    }
+                                    _ => None,
                                 };
-                            let Some(bound_method) = decl_methods.iter().find(|m| m.name() == name)
-                            else {
+                            let Some(bound_method) = bound_method else {
                                 continue;
                             };
-                            let method_params = bound_method
-                                .clone()
-                                .substitute_with_tref(&self_predicate)
-                                .params;
+                            let method_params =
+                                bound_method.substitute_with_tref(&self_predicate).params;
 
                             let generics = self
                                 .outermost_generics()
                                 .identity_args_at_depth(DeBruijnId::one())
                                 .concat(&method_params.identity_args_at_depth(DeBruijnId::zero()));
                             let fn_ref = FunDeclRef {
-                                id: method_id,
+                                id: fun_id,
                                 generics: Box::new(generics),
                             };
                             Binder::new(binder_kind, method_params, fn_ref)
@@ -1077,7 +1135,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
                     // We insert the `Binder<FunDeclRef>` unconditionally here; we'll remove the
                     // ones that correspond to unused methods at the end of translation.
-                    methods.push((name, bound_fn_ref));
+                    methods.set_slot_extend(trait_method_id, bound_fn_ref);
                 }
                 hax::FullDefKind::AssocConst { .. } => {
                     let id = self.register_and_enqueue(item_span, item_src);
@@ -1317,54 +1375,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             implied_trait_refs,
             consts: vec![],
             types,
-            methods: vec![],
+            methods: IndexMap::new(),
             // TODO(dyn): generate vtable instances for builtin traits
             vtable: None,
         })
-    }
-
-    /// Record that `method_id` is an implementation of the given method of the trait. If the
-    /// method is not used anywhere yet we simply record the implementation. If the method is used
-    /// then we enqueue it for translation.
-    pub fn register_method_impl(
-        &mut self,
-        trait_id: TraitDeclId,
-        method_name: TraitItemName,
-        method_id: FunDeclId,
-    ) {
-        match self
-            .method_status
-            .get_or_extend_and_insert_default(trait_id)
-            .entry(method_name)
-            .or_default()
-        {
-            MethodStatus::Unused { implementors } => {
-                implementors.insert(method_id);
-            }
-            MethodStatus::Used => {
-                self.enqueue_id(method_id);
-            }
-        }
-    }
-
-    /// Mark the method as "used", which will enqueue for translation all the implementations of
-    /// that method.
-    pub fn mark_method_as_used(&mut self, trait_id: TraitDeclId, method_name: TraitItemName) {
-        let method_status = self
-            .method_status
-            .get_or_extend_and_insert_default(trait_id)
-            .entry(method_name)
-            .or_default();
-        match method_status {
-            MethodStatus::Unused { implementors } => {
-                let implementors = mem::take(implementors);
-                *method_status = MethodStatus::Used;
-                for fun_id in implementors {
-                    self.enqueue_id(fun_id);
-                }
-            }
-            MethodStatus::Used => {}
-        }
     }
 
     /// In case an impl does not override a trait method, this duplicates the original trait method

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -179,7 +179,7 @@ pub enum TrVTableField {
     Size,
     Align,
     Drop,
-    Method(TraitItemName, hax::Binder<hax::TyFnSig>),
+    Method(TraitMethodId, TraitItemName, hax::Binder<hax::TyFnSig>),
     SuperTrait(TraitClauseId, hax::Clause),
 }
 
@@ -291,6 +291,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     fn prepare_vtable_fields(
         &mut self,
         trait_def: &hax::FullDef<'tcx>,
+        trait_id: TraitDeclId,
         implied_predicates: &hax::GenericPredicates,
     ) -> Result<VTableData, Error> {
         let mut supertrait_map: IndexVec<TraitClauseId, _> =
@@ -317,8 +318,9 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     ..
                 } = item_def.kind()
                 {
+                    let id = self.register_trait_method_id_no_enqueue(trait_id, item_def_id)?;
                     let name = self.translate_trait_item_name(item_def_id)?;
-                    fields.push(TrVTableField::Method(name, sig.clone()));
+                    fields.push(TrVTableField::Method(id, name, sig.clone()));
                 }
             }
         }
@@ -389,7 +391,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                         ("drop".into(), drop_ty)
                     }
                 }
-                TrVTableField::Method(item_name, sig) => {
+                TrVTableField::Method(_, item_name, sig) => {
                     let field_name = format!("method_{}", item_name.0);
                     // In Mono mode, method shims are opaque function pointers.
                     if self.monomorphize() {
@@ -496,6 +498,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             TraitRefKind::SelfId,
             RegionBinder::empty(self.translate_trait_predicate(span, self_predicate)?),
         );
+        let trait_id = self_trait_ref.trait_id();
 
         let mut field_map = IndexVec::new();
         let mut supertrait_map: IndexVec<TraitClauseId, _> =
@@ -507,7 +510,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         } else {
             // First construct fields that use the real method signatures (which may use the `Self`
             // type). We fixup the types and generics below.
-            let vtable_data = self.prepare_vtable_fields(trait_def, implied_predicates)?;
+            let vtable_data =
+                self.prepare_vtable_fields(trait_def, trait_id, implied_predicates)?;
             let fields = self.gen_vtable_struct_fields(span, &self_trait_ref, &vtable_data)?;
 
             let kind = TypeDeclKind::Struct(fields);
@@ -517,7 +521,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 TrVTableField::Size => VTableField::Size,
                 TrVTableField::Align => VTableField::Align,
                 TrVTableField::Drop => VTableField::Drop,
-                TrVTableField::Method(name, ..) => VTableField::Method(name),
+                TrVTableField::Method(id, ..) => VTableField::Method(id),
                 TrVTableField::SuperTrait(clause_id, ..) => VTableField::SuperTrait(clause_id),
             });
             let layout = [(self.get_target_triple(), l)].into();
@@ -884,6 +888,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
 
         let implemented_trait = self.translate_trait_decl_ref(span, &trait_pred.trait_ref)?;
+        let trait_id = implemented_trait.id;
         // The type this impl is for.
         let self_ty = &implemented_trait.generics.types[0];
 
@@ -891,7 +896,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let ret_ty = Ty::new(TyKind::Adt(vtable_struct_ref.clone()));
         let ret_place = builder.new_var(Some("ret".into()), ret_ty.clone());
 
-        let vtable_data = self.prepare_vtable_fields(&trait_def, implied_preds)?;
+        let vtable_data = self.prepare_vtable_fields(&trait_def, trait_id, implied_preds)?;
         // Retrieve the expected field types from the struct definition. This avoids complicated
         // substitutions.
         let field_tys = {

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -359,7 +359,7 @@ fn generate_ml(
                     "GlobalDecl",
                 ]),
                 (GenerationKind::TypeDecl(Some(DeriveVisitors {
-                    ancestors: &["global_decl"],
+                    ancestors: &["trait_decl_base"],
                     name: "trait_decl",
                     reduce: false,
                     extra_types: &[],

--- a/charon/src/bin/generate-ml/main.rs
+++ b/charon/src/bin/generate-ml/main.rs
@@ -38,9 +38,6 @@ struct GenerateCtx<'a> {
     current_module: Option<String>,
     /// The list of types currently being generated.
     current_ids: Vec<TypeDeclId>,
-    /// The OCaml ident for the item currently being generated; this matters for
-    /// TranslatedCrate, where we treat IndexMap differently.
-    current_item: Option<String>,
 }
 
 impl<'a> GenerateCtx<'a> {
@@ -69,7 +66,6 @@ impl<'a> GenerateCtx<'a> {
             ambiguous_types: Default::default(),
             current_module: None,
             current_ids: vec![],
-            current_item: None,
         };
 
         ctx.ambiguous_types = ambiguous_types
@@ -206,6 +202,7 @@ fn generate_ml(
     {
         let mut all_types: HashSet<_> = ctx.children_of("TranslatedCrate");
         all_types.insert(ctx.id_from_name("indexmap::map::IndexMap")); // Add this one foreign type
+        all_types.remove(&ctx.id_from_name("charon_lib::ids::index_map::IndexMap"));
         let all_llbc_types: HashSet<_> =
             ctx.children_of_many(&["charon_lib::ast::llbc_ast::Block"]);
         let all_ullbc_types: HashSet<_> = ctx.children_of_many(&[

--- a/charon/src/bin/generate-ml/of_json.rs
+++ b/charon/src/bin/generate-ml/of_json.rs
@@ -138,6 +138,7 @@ impl<'a> GenerateCtx<'a> {
                 for ty in &tref.generics.types {
                     expr.push(self.type_to_ocaml_call(ty))
                 }
+                let mut wrap_in_map = false;
                 match tref.id {
                     TypeId::Adt(id) => {
                         let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(id) {
@@ -163,8 +164,9 @@ impl<'a> GenerateCtx<'a> {
                             expr[2] = "int_of_json".to_string();
                         }
 
-                        if first == "indexed_map" && self.use_opt_index_map() {
-                            first = format!("opt_{first}");
+                        if first == "indexed_map" {
+                            wrap_in_map = true;
+                            first = format!("opt_indexed_map");
                         }
 
                         expr.insert(0, first + "_of_json");
@@ -180,7 +182,14 @@ impl<'a> GenerateCtx<'a> {
                     }
                     _ => unimplemented!("{ty:?}"),
                 }
-                expr.into_iter().map(|f| format!("({f})")).join(" ")
+                let mut expr = expr.into_iter().map(|f| format!("({f})")).join(" ");
+                if wrap_in_map {
+                    let index_name = self.type_to_rust_name(&tref.generics.types[0]).unwrap();
+                    expr = format!(
+                        "(fun ctx json -> Result.map {index_name}.map_of_indexed_list ({expr} ctx json))"
+                    );
+                }
+                expr
             }
             TyKind::TypeVar(DeBruijnVar::Free(id)) => format!("arg{id}_of_json"),
             _ => unimplemented!("{ty:?}"),
@@ -375,11 +384,7 @@ impl<'a> GenerateCtx<'a> {
         let manual_impls = self.names_to_type_id_map(MANUAL_IMPLS);
         let fns = tys
             .iter()
-            .map(|ty| {
-                self.with_item(ty, |ctx| {
-                    ctx.type_decl_to_json_deserializer(&manual_impls, ty)
-                })
-            })
+            .map(|ty| self.type_decl_to_json_deserializer(&manual_impls, ty))
             .format("\n");
         format!("let rec ___ = ()\n{fns}")
     }

--- a/charon/src/bin/generate-ml/of_json.rs
+++ b/charon/src/bin/generate-ml/of_json.rs
@@ -166,7 +166,7 @@ impl<'a> GenerateCtx<'a> {
 
                         if first == "indexed_map" {
                             wrap_in_map = true;
-                            first = format!("opt_indexed_map");
+                            first = "opt_indexed_map".to_string();
                         }
 
                         expr.insert(0, first + "_of_json");

--- a/charon/src/bin/generate-ml/of_postcard.rs
+++ b/charon/src/bin/generate-ml/of_postcard.rs
@@ -140,6 +140,7 @@ impl<'a> GenerateCtx<'a> {
                 for ty in &tref.generics.types {
                     expr.push(self.type_to_ocaml_postcard_call(ty))
                 }
+                let mut wrap_in_map = false;
                 match tref.id {
                     TypeId::Adt(id) => {
                         let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(id) {
@@ -163,8 +164,9 @@ impl<'a> GenerateCtx<'a> {
                             expr[2] = "int_of_postcard".to_string();
                         }
 
-                        if first == "indexed_map" && self.use_opt_index_map() {
-                            first = format!("opt_{first}");
+                        if first == "indexed_map" {
+                            wrap_in_map = true;
+                            first = format!("opt_indexed_map");
                         }
 
                         expr.insert(0, first + "_of_postcard");
@@ -180,7 +182,14 @@ impl<'a> GenerateCtx<'a> {
                     }
                     _ => unimplemented!("{ty:?}"),
                 }
-                expr.into_iter().map(|f| format!("({f})")).join(" ")
+                let mut expr = expr.into_iter().map(|f| format!("({f})")).join(" ");
+                if wrap_in_map {
+                    let index_name = self.type_to_rust_name(&tref.generics.types[0]).unwrap();
+                    expr = format!(
+                        "(fun ctx st -> Result.map {index_name}.map_of_indexed_list ({expr} ctx st))"
+                    );
+                }
+                expr
             }
             TyKind::TypeVar(DeBruijnVar::Free(id)) => format!("arg{id}_of_postcard"),
             _ => unimplemented!("{ty:?}"),
@@ -321,11 +330,7 @@ impl<'a> GenerateCtx<'a> {
         let manual_impls = self.names_to_type_id_map(MANUAL_IMPLS);
         let fns = tys
             .iter()
-            .map(|ty| {
-                self.with_item(ty, |ctx| {
-                    ctx.type_decl_to_postcard_deserializer(&manual_impls, ty)
-                })
-            })
+            .map(|ty| self.type_decl_to_postcard_deserializer(&manual_impls, ty))
             .format("\n");
         format!("let rec ___ = ()\n{fns}")
     }

--- a/charon/src/bin/generate-ml/of_postcard.rs
+++ b/charon/src/bin/generate-ml/of_postcard.rs
@@ -166,7 +166,7 @@ impl<'a> GenerateCtx<'a> {
 
                         if first == "indexed_map" {
                             wrap_in_map = true;
-                            first = format!("opt_indexed_map");
+                            first = "opt_indexed_map".to_string();
                         }
 
                         expr.insert(0, first + "_of_postcard");

--- a/charon/src/bin/generate-ml/templates/GAst.ml
+++ b/charon/src/bin/generate-ml/templates/GAst.ml
@@ -28,6 +28,22 @@ type fun_decl_id = Types.fun_decl_id [@@deriving show, ord]
 
 (* __REPLACE1__ *)
 
+class ['self] iter_trait_decl_base =
+  object (self : 'self)
+    inherit [_] iter_global_decl
+    method visit_trait_method_id_map
+        : 'a. ('env -> 'a -> unit) -> 'env -> 'a trait_method_id_map -> unit =
+      TraitMethodId.Map.visit_iter
+  end
+
+class ['self] map_trait_decl_base =
+  object (self : 'self)
+    inherit [_] map_global_decl
+    method visit_trait_method_id_map
+        : 'a 'b. ('env -> 'a -> 'b) -> 'env -> 'a trait_method_id_map -> 'b trait_method_id_map =
+      TraitMethodId.Map.visit_map
+  end
+
 (* __REPLACE2__ *)
 
 (* __REPLACE3__ *)

--- a/charon/src/bin/generate-ml/templates/Types.ml
+++ b/charon/src/bin/generate-ml/templates/Types.ml
@@ -21,13 +21,13 @@ module GlobalDeclId = IdGen ()
 module ConstGenericVarId = IdGen ()
 module TraitDeclId = IdGen ()
 module TraitImplId = IdGen ()
+module TraitMethodId = IdGen ()
 module TraitClauseId = IdGen ()
 module TraitTypeConstraintId = IdGen ()
 module UnsolvedTraitId = IdGen ()
 module RegionId = IdGen ()
 module Disambiguator = IdGen ()
 module FunDeclId = IdGen ()
-module BodyId = IdGen ()
 
 type integer_type = Values.integer_type [@@deriving show, ord, eq]
 type float_type = Values.float_type [@@deriving show, ord, eq]
@@ -37,6 +37,13 @@ type literal_type = Values.literal_type [@@deriving show, ord, eq]
    vectors in generic_params), which causes visitor inference problems if we
    declare it within a visitor group. *)
 type trait_type_constraint_id = TraitTypeConstraintId.id [@@deriving show, ord, eq]
+
+type 'a fun_decl_id_map = 'a FunDeclId.Map.t
+and 'a global_decl_id_map = 'a GlobalDeclId.Map.t
+and 'a type_decl_id_map = 'a TypeDeclId.Map.t
+and 'a trait_decl_id_map = 'a TraitDeclId.Map.t
+and 'a trait_impl_id_map = 'a TraitImplId.Map.t
+and 'a trait_method_id_map = 'a TraitMethodId.Map.t [@@deriving show, eq, ord]
 
 
 (* __REPLACE0__ *)

--- a/charon/src/bin/generate-ml/to_ocaml_ty.rs
+++ b/charon/src/bin/generate-ml/to_ocaml_ty.rs
@@ -432,14 +432,7 @@ impl<'a> GenerateCtx<'a> {
             .enumerate()
             .map(|(i, ty)| {
                 let co_recursive = i != 0;
-                self.with_item(ty, |ctx| {
-                    ctx.type_decl_to_ocaml_decl(
-                        &opaque_for_visitors,
-                        &manual_impls,
-                        ty,
-                        co_recursive,
-                    )
-                })
+                self.type_decl_to_ocaml_decl(&opaque_for_visitors, &manual_impls, ty, co_recursive)
             })
             .join("\n");
         match visitors {

--- a/charon/src/bin/generate-ml/util.rs
+++ b/charon/src/bin/generate-ml/util.rs
@@ -145,7 +145,7 @@ impl<'a> GenerateCtx<'a> {
                     .iter()
                     .map(|ty| self.type_to_ocaml_name(ty))
                     .map(|name| {
-                        if !name.chars().all(|c| c.is_alphanumeric()) {
+                        if !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
                             format!("({name})")
                         } else {
                             name
@@ -169,10 +169,8 @@ impl<'a> GenerateCtx<'a> {
                             base_ty = "string".to_string();
                         }
                         if base_ty == "indexed_map" {
-                            let index_name =
-                                self.type_to_rust_name(&tref.generics.types[0]).unwrap();
-                            base_ty = format!("{index_name}.Map.t");
-                            args.remove(0); // Remove the index generic param
+                            let index_name = args.remove(0); // Remove the index generic param
+                            base_ty = format!("{index_name}_map");
                         }
                         if base_ty == "index_vec" {
                             base_ty = "list".to_string();
@@ -185,10 +183,10 @@ impl<'a> GenerateCtx<'a> {
                         }
                         let args = match args.as_slice() {
                             [] => String::new(),
-                            [arg] => arg.clone(),
+                            [arg] => format!("{arg} "),
                             args => format!("({})", args.iter().join(",")),
                         };
-                        format!("{args} {base_ty}")
+                        format!("{args}{base_ty}")
                     }
                     TypeId::Builtin(BuiltinTy::Box) => args[0].clone(),
                     TypeId::Tuple => args.iter().join("*"),

--- a/charon/src/bin/generate-ml/util.rs
+++ b/charon/src/bin/generate-ml/util.rs
@@ -115,6 +115,12 @@ impl<'a> GenerateCtx<'a> {
         }
     }
 
+    /// For a type that refers to an ADT, return the name of that ADT.
+    pub fn type_to_rust_name(&self, ty: &Ty) -> Option<&String> {
+        let index_ty: TypeDeclId = *ty.as_adt()?.id.as_adt()?;
+        Some(self.crate_data.item_name(index_ty)?.short_str())
+    }
+
     /// Converts a type to the appropriate ocaml name. In case of generics, this provides appropriate
     /// parameters.
     pub fn type_to_ocaml_name(&self, ty: &Ty) -> String {
@@ -163,11 +169,9 @@ impl<'a> GenerateCtx<'a> {
                             base_ty = "string".to_string();
                         }
                         if base_ty == "indexed_map" {
-                            base_ty = if self.use_opt_index_map() {
-                                "option list".to_string()
-                            } else {
-                                "list".to_string()
-                            };
+                            let index_name =
+                                self.type_to_rust_name(&tref.generics.types[0]).unwrap();
+                            base_ty = format!("{index_name}.Map.t");
                             args.remove(0); // Remove the index generic param
                         }
                         if base_ty == "index_vec" {
@@ -204,20 +208,5 @@ impl<'a> GenerateCtx<'a> {
 
     pub fn names_to_type_id_set(&self, data: &[&str]) -> HashSet<TypeDeclId> {
         data.iter().map(|name| self.id_from_name(name)).collect()
-    }
-
-    pub fn with_item<F, T>(&mut self, new_item: &TypeDecl, f: F) -> T
-    where
-        F: FnOnce(&mut Self) -> T,
-    {
-        let (name, _) = self.type_to_ocaml_ident_raw(new_item);
-        let old_name = self.current_item.replace(name);
-        let res = f(self);
-        self.current_item = old_name;
-        res
-    }
-
-    pub fn use_opt_index_map(&self) -> bool {
-        self.current_item == Some("translated_crate".to_string())
     }
 }

--- a/charon/src/ids/index_map.rs
+++ b/charon/src/ids/index_map.rs
@@ -73,12 +73,23 @@ where
         // Push a `None` to ensure we don't reuse the id.
         self.vector.push(None)
     }
+    /// Ensure there's a slot for this id.
+    fn ensure_slot_for(&mut self, id: I) {
+        if id.index() >= self.vector.len() {
+            self.vector.resize_with(id.index() + 1, || None);
+        }
+    }
 
     /// Fill the reserved slot.
     pub fn set_slot(&mut self, id: I, x: T) {
         assert!(self.vector[id].is_none());
         self.vector[id] = Some(x);
         self.elem_count += 1;
+    }
+    /// Fill the given slot even if it hadn't been reserved before.
+    pub fn set_slot_extend(&mut self, id: I, x: T) {
+        self.ensure_slot_for(id);
+        self.set_slot(id, x);
     }
 
     /// Remove the value from this slot, leaving other ids unchanged.
@@ -142,9 +153,7 @@ where
     /// it has enough elements. If the element doesn't exist, use the provided function to
     /// initialize it.
     pub fn get_or_extend_and_insert(&mut self, id: I, f: impl FnOnce() -> T) -> &mut T {
-        if id.index() >= self.vector.len() {
-            self.vector.resize_with(id.index() + 1, || None);
-        }
+        self.ensure_slot_for(id);
         self.vector[id].get_or_insert_with(f)
     }
 
@@ -304,7 +313,7 @@ where
 
     /// Remove matching items and return and iterator over the removed items. This is lazy: items
     /// are only removed as the iterator is consumed.
-    pub fn extract<'a, F: FnMut(&mut T) -> bool>(
+    pub fn extract<'a, F: FnMut(I, &mut T) -> bool>(
         &'a mut self,
         mut f: F,
     ) -> impl Iterator<Item = (I, T)> + use<'a, I, T, F> {
@@ -312,7 +321,7 @@ where
         self.vector
             .iter_mut_enumerated()
             .filter_map(move |(i, opt)| {
-                if f(opt.as_mut()?) {
+                if f(i, opt.as_mut()?) {
                     *elem_count -= 1;
                     let elem = opt.take()?;
                     Some((i, elem))
@@ -323,8 +332,8 @@ where
     }
 
     /// Remove the elements that don't match the predicate.
-    pub fn retain(&mut self, mut f: impl FnMut(&mut T) -> bool) {
-        self.extract(|x| !f(x)).for_each(drop);
+    pub fn retain(&mut self, mut f: impl FnMut(I, &mut T) -> bool) {
+        self.extract(|i, x| !f(i, x)).for_each(drop);
     }
 
     /// Like `Vec::clear`.

--- a/charon/src/ids/index_map.rs
+++ b/charon/src/ids/index_map.rs
@@ -28,15 +28,6 @@ where
     elem_count: usize,
 }
 
-impl<I: std::fmt::Debug, T: std::fmt::Debug> std::fmt::Debug for IndexMap<I, T>
-where
-    I: Idx,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <IndexVec<_, _> as std::fmt::Debug>::fmt(&self.vector, f)
-    }
-}
-
 impl<I, T> IndexMap<I, T>
 where
     I: Idx,
@@ -257,28 +248,35 @@ where
         self.vector.iter_mut().filter_map(|opt| opt.as_mut())
     }
 
-    pub fn iter_indexed(&self) -> impl Iterator<Item = (I, &T)> {
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (I, &T)> {
         self.vector
             .iter_enumerated()
             .flat_map(|(i, opt)| Some((i, opt.as_ref()?)))
     }
-
-    pub fn iter_mut_indexed(&mut self) -> impl Iterator<Item = (I, &mut T)> {
-        self.vector
-            .iter_mut_enumerated()
-            .flat_map(|(i, opt)| Some((i, opt.as_mut()?)))
+    pub fn iter_indexed(&self) -> impl Iterator<Item = (I, &T)> {
+        self.iter_enumerated()
     }
-
-    pub fn into_iter_indexed(self) -> impl Iterator<Item = (I, T)> {
-        self.vector
-            .into_iter_enumerated()
-            .flat_map(|(i, opt)| Some((i, opt?)))
-    }
-
     pub fn iter_indexed_values(&self) -> impl Iterator<Item = (I, &T)> {
         self.iter_indexed()
     }
 
+    pub fn iter_mut_enumerated(&mut self) -> impl Iterator<Item = (I, &mut T)> {
+        self.vector
+            .iter_mut_enumerated()
+            .flat_map(|(i, opt)| Some((i, opt.as_mut()?)))
+    }
+    pub fn iter_mut_indexed(&mut self) -> impl Iterator<Item = (I, &mut T)> {
+        self.iter_mut_enumerated()
+    }
+
+    pub fn into_iter_enumerated(self) -> impl Iterator<Item = (I, T)> {
+        self.vector
+            .into_iter_enumerated()
+            .flat_map(|(i, opt)| Some((i, opt?)))
+    }
+    pub fn into_iter_indexed(self) -> impl Iterator<Item = (I, T)> {
+        self.into_iter_enumerated()
+    }
     pub fn into_iter_indexed_values(self) -> impl Iterator<Item = (I, T)> {
         self.into_iter_indexed()
     }
@@ -288,8 +286,11 @@ where
         self.vector.iter()
     }
 
-    pub fn iter_indexed_all_slots(&self) -> impl Iterator<Item = (I, &Option<T>)> {
+    pub fn iter_enumerated_all_slots(&self) -> impl Iterator<Item = (I, &Option<T>)> {
         self.vector.iter_enumerated()
+    }
+    pub fn iter_indexed_all_slots(&self) -> impl Iterator<Item = (I, &Option<T>)> {
+        self.iter_enumerated_all_slots()
     }
 
     pub fn iter_indices(&self) -> impl Iterator<Item = I> + '_ {
@@ -361,6 +362,15 @@ where
 impl<I: Idx, T> Default for IndexMap<I, T> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<I: std::fmt::Debug, T: std::fmt::Debug> std::fmt::Debug for IndexMap<I, T>
+where
+    I: Idx,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <IndexVec<_, _> as std::fmt::Debug>::fmt(&self.vector, f)
     }
 }
 

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -543,7 +543,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for FnPtr {
             FnPtrKind::Fun(FunId::Regular(def_id)) => write!(f, "{}", def_id.with_ctx(ctx))?,
             FnPtrKind::Fun(FunId::Builtin(builtin)) => write!(f, "@{}", builtin)?,
             FnPtrKind::Trait(trait_ref, method_id, _) => {
-                write!(f, "{}::{}", trait_ref.with_ctx(ctx), &method_id.0)?
+                write!(f, "{}::", trait_ref.with_ctx(ctx))?;
+                ctx.format_method_name(f, trait_ref.trait_id(), *method_id)?;
             }
         };
         write!(f, "{}", self.generics.with_ctx(ctx))
@@ -1993,6 +1994,7 @@ impl TraitDeclRef {
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let trait_id = self.impl_trait.id;
         let full_name = self.item_meta.name.with_ctx(ctx);
         writeln!(f, "// Full name: {full_name}")?;
 
@@ -2030,9 +2032,11 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
                     .fmt_split_with(ctx, |ctx, assoc_ty| assoc_ty.value.to_string_with_ctx(ctx));
                 writeln!(f, "{TAB_INCR}type {name}{params} = {ty}",)?;
             }
-            for (name, bound_fn) in self.methods() {
+            for (method_id, bound_fn) in self.methods.iter_enumerated() {
                 let (params, fn_ref) = bound_fn.fmt_split(ctx);
-                writeln!(f, "{TAB_INCR}fn {name}{params} = {fn_ref}")?;
+                write!(f, "{TAB_INCR}fn ")?;
+                ctx.format_method_name(f, trait_id, method_id)?;
+                writeln!(f, "{params} = {fn_ref}")?;
             }
         }
         if let Some(vtb_ref) = &self.vtable {

--- a/charon/src/pretty/formatter.rs
+++ b/charon/src/pretty/formatter.rs
@@ -53,6 +53,25 @@ pub trait AstFormatter: Sized {
     where
         GenericParams: HasIdxVecOf<Id, Output = T>;
 
+    fn format_method_name(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        trait_id: TraitDeclId,
+        method_id: TraitMethodId,
+    ) -> fmt::Result {
+        if let Some(translated) = self.get_crate()
+            && let Some(def) = translated.trait_decls.get(trait_id)
+            && let Some(name) = def
+                .methods
+                .get(method_id)
+                .map(|m| m.name())
+                .or(def.method_names.get(method_id).copied())
+        {
+            write!(f, "{name}")
+        } else {
+            write!(f, "{}", &method_id.to_pretty_string())
+        }
+    }
     fn format_enum_variant_name(
         &self,
         f: &mut fmt::Formatter<'_>,

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -357,6 +357,7 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
                     consts,
                     types,
                     methods,
+                    method_names: _,
                     vtable,
                 } = d;
                 let _ = def_id.drive(&mut visitor); // For `seen_current_id`

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1284,11 +1284,11 @@ impl TransformPass for Transform {
                 let modifications = computer.compute_item_modifications(item);
                 item_modifications.insert(GenericsSource::Item(id), modifications);
                 if let ItemRef::TraitDecl(tdecl) = item {
-                    for method in &tdecl.methods {
+                    for (method_id, method) in tdecl.methods.iter_enumerated() {
                         let modifications =
                             computer.compute_non_trait_modifications(&method.params);
                         item_modifications.insert(
-                            GenericsSource::Method(tdecl.def_id, method.skip_binder.name),
+                            GenericsSource::Method(tdecl.def_id, method_id),
                             modifications,
                         );
                     }

--- a/charon/src/transform/normalize/skip_trait_refs_when_known.rs
+++ b/charon/src/transform/normalize/skip_trait_refs_when_known.rs
@@ -28,7 +28,7 @@ impl VisitAstMut for NormalizeFnPtr<'_> {
 
 fn transform_fn_ptr(ctx: &TransformCtx, span: Span, fn_ptr: &mut FnPtr) {
     // We find references to a trait method where the impl is known; otherwise we return.
-    let FnPtrKind::Trait(trait_ref, name, _) = fn_ptr.kind.as_ref() else {
+    let FnPtrKind::Trait(trait_ref, method_id, _) = fn_ptr.kind.as_ref() else {
         return;
     };
     let TraitRefKind::TraitImpl(impl_ref) = &trait_ref.kind else {
@@ -38,7 +38,7 @@ fn transform_fn_ptr(ctx: &TransformCtx, span: Span, fn_ptr: &mut FnPtr) {
         return;
     };
     // Find the function declaration corresponding to this impl.
-    let Some((_, bound_fn)) = trait_impl.methods().find(|(n, _)| n == name) else {
+    let Some(bound_fn) = trait_impl.methods.get(*method_id) else {
         return;
     };
     let method_generics = &fn_ptr.generics;

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -68,14 +68,17 @@ fn transform_dyn_trait_call(
     let Some(vtable_decl) = ctx.ctx.translated.type_decls.get(vtable_decl_id) else {
         return Ok(()); // Missing data
     };
-    if matches!(vtable_decl.kind, TypeDeclKind::Opaque) {
-        return Ok(()); // Missing data
-    }
 
-    // Retreive the method field from the vtable struct definition.
-    let method_field_name = format!("method_{}", method_name);
-    let Some((method_field_id, method_field)) =
-        vtable_decl.get_field_by_name(None, &method_field_name)
+    let TypeDeclKind::Struct(fields) = &vtable_decl.kind else {
+        return Ok(()); // Missing data
+    };
+    let ItemSource::VTableTy { field_map, .. } = &vtable_decl.src else {
+        return Ok(()); // Weird
+    };
+    // Retrieve the method field from the vtable struct definition.
+    let Some((method_field_id, _)) = field_map
+        .iter_enumerated()
+        .find(|(_, field)| **field == VTableField::Method(*method_name))
     else {
         let vtable_name = vtable_decl_ref.id.with_ctx(fmt_ctx).to_string();
         raise_error!(
@@ -86,6 +89,8 @@ fn transform_dyn_trait_call(
             vtable_name
         );
     };
+
+    let method_field = &fields[method_field_id];
     let method_ty = method_field
         .ty
         .clone()

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -40,7 +40,7 @@ fn transform_dyn_trait_call(
     let FnOperand::Regular(fn_ptr) = &call.func else {
         return Ok(()); // Not a regular function call
     };
-    let FnPtrKind::Trait(trait_ref, method_name, _) = fn_ptr.kind.as_ref() else {
+    let FnPtrKind::Trait(trait_ref, method_id, _) = fn_ptr.kind.as_ref() else {
         return Ok(()); // Not a trait method call
     };
     let TraitRefKind::Dyn = &trait_ref.kind else {
@@ -78,14 +78,14 @@ fn transform_dyn_trait_call(
     // Retrieve the method field from the vtable struct definition.
     let Some((method_field_id, _)) = field_map
         .iter_enumerated()
-        .find(|(_, field)| **field == VTableField::Method(*method_name))
+        .find(|(_, field)| **field == VTableField::Method(*method_id))
     else {
         let vtable_name = vtable_decl_ref.id.with_ctx(fmt_ctx).to_string();
         raise_error!(
             ctx.ctx,
             ctx.span,
-            "Could not determine method index for {} in vtable {}",
-            method_name,
+            "Could not determine method index for method {} in vtable {}",
+            method_id,
             vtable_name
         );
     };

--- a/charon/src/transform/simplify_output/inline_anon_consts.rs
+++ b/charon/src/transform/simplify_output/inline_anon_consts.rs
@@ -14,7 +14,7 @@ impl UllbcPass for Transform {
         let anon_consts: HashMap<GlobalDeclId, ExprBody> = ctx
             .translated
             .global_decls
-            .extract(|gdecl| matches!(gdecl.global_kind, GlobalKind::AnonConst))
+            .extract(|_, gdecl| matches!(gdecl.global_kind, GlobalKind::AnonConst))
             .filter_map(|(id, gdecl)| {
                 let fdecl = ctx.translated.fun_decls.remove(gdecl.init)?;
                 let body = fdecl.body.to_unstructured()?;

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -352,15 +352,15 @@ impl TypeCheckVisitor<'_> {
     fn assert_matches_method(
         &mut self,
         trait_ref: &TraitRef,
-        method_name: TraitItemName,
+        method_id: TraitMethodId,
         args: &mut GenericArgs,
     ) {
         let trait_id = trait_ref.trait_decl_ref.skip_binder.id;
-        let target = &GenericsSource::Method(trait_id, method_name);
+        let target = &GenericsSource::Method(trait_id, method_id);
         let Some(trait_decl) = self.ctx.translated.trait_decls.get(trait_id) else {
             return;
         };
-        let Some(bound_fn) = trait_decl.methods().find(|m| m.name() == method_name) else {
+        let Some(bound_fn) = trait_decl.methods.get(method_id) else {
             return;
         };
         if let Ok(bound_fn) = Substituted::new_for_trait_ref(bound_fn, trait_ref).try_substitute() {
@@ -482,8 +482,8 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
             FnPtrKind::Fun(FunId::Regular(id)) => self.assert_matches_item(*id, &mut x.generics),
             // TODO: check builtin generics.
             FnPtrKind::Fun(FunId::Builtin(_)) => {}
-            FnPtrKind::Trait(trait_ref, method_name, _) => {
-                self.assert_matches_method(trait_ref, *method_name, &mut x.generics);
+            FnPtrKind::Trait(trait_ref, method_id, _) => {
+                self.assert_matches_method(trait_ref, *method_id, &mut x.generics);
             }
         }
     }
@@ -530,7 +530,7 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
             return;
         };
 
-        let fmt1 = self.ctx.into_fmt();
+        let fmt1 = &self.ctx.into_fmt();
         let tdecl_fmt = fmt1.push_binder(Cow::Borrowed(&tdecl.generics));
         let impl_tref_kind = TraitRefKind::TraitImpl(TraitImplRef {
             id: timpl.def_id,
@@ -571,15 +571,21 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
                 "The associated consts supplied by the trait impl don't match the trait decl.",
             )
         }
-        let methods_match = timpl.methods.len() == tdecl.methods.len();
+        let methods_match = timpl.methods.elem_count() == tdecl.methods.elem_count();
         if !methods_match && self.phase != Check::PostTranslation {
             let decl_methods = tdecl
                 .methods()
                 .map(|m| format!("- {}", m.name()))
                 .join("\n");
             let impl_methods = timpl
-                .methods()
-                .map(|(name, _)| format!("- {name}"))
+                .methods
+                .iter_enumerated()
+                .map(|(id, _)| {
+                    std::fmt::from_fn(move |f| {
+                        write!(f, "- ")?;
+                        fmt1.format_method_name(f, tdecl.def_id, id)
+                    })
+                })
                 .join("\n");
             self.error(format!(
                 "The methods supplied by the trait impl don't match the trait decl.\n\

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -11,7 +11,7 @@ pub enum GenericsSource {
     /// A top-level item.
     Item(ItemId),
     /// A trait method.
-    Method(TraitDeclId, TraitItemName),
+    Method(TraitDeclId, TraitMethodId),
     /// A builtin item like `Box`.
     Builtin,
     /// Some other use of generics outside the main Charon ast.

--- a/charon/tests/ui/hide-marker-traits.out
+++ b/charon/tests/ui/hide-marker-traits.out
@@ -27,7 +27,7 @@ fn foo<T>(_x_1: T)
 
     _0 = ()
     _0 = ()
-    conditional_drop[{built_in impl Destruct for T}::drop_in_place] _x_1
+    conditional_drop[{built_in impl Destruct for T}::@TraitMethod0] _x_1
     return
 }
 


### PR DESCRIPTION
Until now we used the method name as the way to identify a given method. Beyond string comparison being slow, this isn't very principled: macros or monomorphization would want to introduce several methods with the same name, and for assoc types it's already the case that names aren't the right thing to use.

Hence this PR instead gives an id to each method, counting them in definition order for a given trait.

ci: use https://github.com/AeneasVerif/aeneas/pull/1015
ci: use https://github.com/AeneasVerif/eurydice/pull/404