### PR TITLE
Improve error message when trying to lift a type across a GAT

### DIFF
--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -44,7 +44,9 @@ pub enum Region {
 /// definition. Note that every path designated by `TraitInstanceId` refers
 /// to a *trait instance*, which is why the [`TraitRefKind::Clause`] variant may seem redundant
 /// with some of the other variants.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, EnumIsA, Drive, DriveMut,
+)]
 pub enum TraitRefKind {
     /// A specific top-level implementation item.
     TraitImpl(TraitImplRef),

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -321,6 +321,15 @@ mod trait_ref_path {
             })
         }
 
+        /// Apply `self` onto a real `TraitRef`, going up through the `tref`'s parent
+        /// clauses. Returns `None` if the crate did not contain all the `TraitDecl`s we need to do
+        /// that.
+        pub fn on_real_tref(&self, krate: &TranslatedCrate, tref: TraitRef) -> Option<Ty> {
+            let tref = self.tref.on_real_tref(krate, tref)?;
+            let ty = TyKind::TraitType(tref, self.type_id).into_ty();
+            Some(ty)
+        }
+
         /// Construct a name that can be used to name a new type parameter/associated type
         /// corresponding to this path.
         pub fn to_name(&self, krate: &TranslatedCrate) -> String {
@@ -859,11 +868,8 @@ impl<'a> ComputeItemModifications<'a> {
                     && let Some(trait_mods) = self.trait_modifications[pred.id].as_processed()
                 {
                     for path in trait_mods.required_extra_params() {
-                        if let Some(tref) =
-                            path.tref.on_real_tref(&self.ctx.translated, tref.clone())
-                        {
+                        if let Some(ty) = path.on_real_tref(&self.ctx.translated, tref.clone()) {
                             // This will get normalized further by `lookup_type_replacement`.
-                            let ty = TyKind::TraitType(tref, path.type_id).into_ty();
                             let path = path.on_tref(&clause_path);
                             set.insert_path(&path, ty);
                         }
@@ -1020,32 +1026,49 @@ impl UpdateItemBody<'_> {
             let ty = if let Some(ty) = self.lookup_path_on_trait_ref(&path, base_tref) {
                 ty.clone()
             } else {
-                let path = path.fmt_with_krate(&self.ctx.translated);
+                let fmt_ctx = &self.ctx.into_fmt();
+                let path_fmt = path.fmt_with_krate(&self.ctx.translated);
                 if self.is_type_alias {
                     register_error!(
                         self.ctx,
                         self.span,
-                        "Could not compute the value of {path}: type aliases are allowed to \
+                        "Could not compute the value of {path_fmt}: type aliases are allowed to \
                         make use of unproved trait facts. To fix this, add the necessary \
                         trait bound to the type alias, ignoring the `type_alias_bounds` warning."
                     );
                 } else {
-                    let fmt_ctx = &self.ctx.into_fmt();
-                    let item_name = target.item_name(&self.ctx.translated, fmt_ctx);
-                    let base_tref = base_tref.with_ctx(fmt_ctx);
-                    let args = args.with_ctx(fmt_ctx);
-                    register_error!(
-                        self.ctx,
-                        self.span,
-                        "Could not compute the value of {path} (on {base_tref}) needed to update \
+                    let path_fmt = path
+                        .on_real_tref(&self.ctx.translated, base_tref.clone())
+                        .map(|ty| ty.to_string_with_ctx(fmt_ctx))
+                        .unwrap_or_else(|| path_fmt.to_string());
+                    if self_path
+                        .as_ref()
+                        .is_some_and(|tref| tref.kind.is_item_clause())
+                    {
+                        register_error!(
+                            self.ctx,
+                            self.span,
+                            "Could not compute the value of {path_fmt} on a GAT: \
+                        lifting associated types can fail in the presence of GATs. \
+                        To fix this, `--exclude` this trait."
+                        );
+                    } else {
+                        let item_name = target.item_name(&self.ctx.translated, fmt_ctx);
+                        let base_tref = base_tref.with_ctx(fmt_ctx);
+                        let args = args.with_ctx(fmt_ctx);
+                        register_error!(
+                            self.ctx,
+                            self.span,
+                            "Could not compute the value of {path_fmt} (on {base_tref}) needed to update \
                         item reference {item_name}{args}.\
                         \nConstraints in scope:\n{}",
-                        self.type_replacements
-                            .iter()
-                            .flat_map(|x| x.iter())
-                            .map(|(path, ty)| format!("  - {path} = {}", ty.with_ctx(fmt_ctx)))
-                            .join("\n"),
-                    );
+                            self.type_replacements
+                                .iter()
+                                .flat_map(|x| x.iter())
+                                .map(|(path, ty)| format!("  - {path} = {}", ty.with_ctx(fmt_ctx)))
+                                .join("\n"),
+                        );
+                    }
                 }
                 TyKind::Error(format!("Can't compute {path}")).into_ty()
             };

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1020,8 +1020,8 @@ impl UpdateItemBody<'_> {
             let ty = if let Some(ty) = self.lookup_path_on_trait_ref(&path, base_tref) {
                 ty.clone()
             } else {
+                let path = path.fmt_with_krate(&self.ctx.translated);
                 if self.is_type_alias {
-                    let path = path.fmt_with_krate(&self.ctx.translated);
                     register_error!(
                         self.ctx,
                         self.span,
@@ -1201,6 +1201,20 @@ impl VisitAstMut for UpdateItemBody<'_> {
         for (clause_id, clause) in tdecl.implied_clauses.iter_mut_enumerated() {
             let self_path = TraitRefKind::ParentClause(Box::new(self_tref.clone()), clause_id);
             self.process_poly_trait_decl_ref(&mut clause.trait_, self_path);
+        }
+        for (type_id, assoc_ty) in tdecl.types.iter_mut_enumerated() {
+            if !assoc_ty.binds_anything() {
+                continue;
+            }
+            self.under_binder(Default::default(), |this| {
+                for (clause_id, clause) in
+                    assoc_ty.skip_binder.implied_clauses.iter_mut_enumerated()
+                {
+                    let self_path =
+                        TraitRefKind::ItemClause(Box::new(self_tref.clone()), type_id, clause_id);
+                    this.process_poly_trait_decl_ref(&mut clause.trait_, self_path);
+                }
+            });
         }
     }
     fn enter_generic_params(&mut self, params: &mut GenericParams) {

--- a/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
@@ -1,24 +1,11 @@
-error: Type error after transformations:
-       Mismatched type generics:
-       target: Foo
-       expected: [Self, Self_Size]
-            got: [Self::Item]
-       Visitor stack:
-         charon_lib::ast::types::TraitDeclRef
-         charon_lib::ast::types::RegionBinder<charon_lib::ast::types::TraitDeclRef>
-         charon_lib::ast::types::vars::TraitParam
-         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::vars::TraitParam>
-         charon_lib::ast::gast::TraitAssocTy
-         charon_lib::ast::types::Binder<charon_lib::ast::gast::TraitAssocTy>
-         charon_lib::ids::index_map::IndexMap<charon_lib::ast::gast::AssocTypeId, charon_lib::ast::types::Binder<charon_lib::ast::gast::TraitAssocTy>>
-         charon_lib::ast::gast::TraitDecl
-       Binding stack (depth 3):
-         0: 
-         1: <T, [@TraitClause0]: @TraitDecl3<missing(@TypeBound(1, 0))>>
-         2: <Self>
- --> tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs:8:19
+error: Could not compute the value of Self::Size (on (Self::Item::[@TraitClause1])) needed to update item reference test_crate::Foo<Self::Item>.
+       Constraints in scope:
+       
+ --> tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs:7:1
   |
-8 |     type Item<T>: Foo;
-  |                   ^^^
+7 | / pub trait Bar {
+8 | |     type Item<T>: Foo;
+9 | | }
+  | |_^
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
@@ -1,6 +1,4 @@
-error: Could not compute the value of Self::Size (on (Self::Item::[@TraitClause1])) needed to update item reference test_crate::Foo<Self::Item>.
-       Constraints in scope:
-       
+error: Could not compute the value of (Self::Item::[@TraitClause1])::Size on a GAT: lifting associated types can fail in the presence of GATs. To fix this, `--exclude` this trait.
  --> tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs:7:1
   |
 7 | / pub trait Bar {

--- a/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
@@ -1,0 +1,24 @@
+error: Type error after transformations:
+       Mismatched type generics:
+       target: Foo
+       expected: [Self, Self_Size]
+            got: [Self::Item]
+       Visitor stack:
+         charon_lib::ast::types::TraitDeclRef
+         charon_lib::ast::types::RegionBinder<charon_lib::ast::types::TraitDeclRef>
+         charon_lib::ast::types::vars::TraitParam
+         charon_lib::ids::index_vec::IndexVec<charon_lib::ast::types::vars::TraitClauseId, charon_lib::ast::types::vars::TraitParam>
+         charon_lib::ast::gast::TraitAssocTy
+         charon_lib::ast::types::Binder<charon_lib::ast::gast::TraitAssocTy>
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::gast::AssocTypeId, charon_lib::ast::types::Binder<charon_lib::ast::gast::TraitAssocTy>>
+         charon_lib::ast::gast::TraitDecl
+       Binding stack (depth 3):
+         0: 
+         1: <T, [@TraitClause0]: @TraitDecl3<missing(@TypeBound(1, 0))>>
+         2: <Self>
+ --> tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs:8:19
+  |
+8 |     type Item<T>: Foo;
+  |                   ^^^
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs
+++ b/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs
@@ -1,0 +1,9 @@
+//@ known-failure
+//@ charon-args=--lift-associated-types=_
+pub trait Foo {
+    type Size: Copy;
+}
+
+pub trait Bar {
+    type Item<T>: Foo;
+}


### PR DESCRIPTION
For the bug found in https://github.com/AeneasVerif/charon/issues/1068#issuecomment-4431194287, cc @maximebuyse. Fixing this properly is possible, and would "just" require adding a GAT to the `Bar` trait. Since Aeneas can't handle the trait either way, I improved the error message instead.