### PR TITLE
Fix union layout variants and field offsets

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -471,7 +471,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 r_abi::FieldsShape::Arbitrary { offsets, .. } => {
                     offsets.iter().map(|o| o.bytes()).collect()
                 }
-                r_abi::FieldsShape::Primitive | r_abi::FieldsShape::Union(_) => IndexVec::default(),
+                r_abi::FieldsShape::Union(n) => vec![0; n.get()].into(),
+                r_abi::FieldsShape::Primitive => IndexVec::default(),
                 r_abi::FieldsShape::Array { .. } => panic!("Unexpected layout shape"),
             };
             VariantLayout {
@@ -619,25 +620,31 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             }
             r_abi::Variants::Single { index } => {
                 let variant_id = self.translate_variant_id(*index);
-                let variant_layouts = if let r_abi::FieldsShape::Arbitrary { .. } = layout.fields()
-                {
-                    let n_variants = if let Some(range) = ty.variant_range(tcx) {
-                        range.end.index()
-                    } else {
-                        1
-                    };
-                    // All the variants not initialized below are uninhabited.
-                    let mut variant_layouts: IndexVec<VariantId, VariantLayout> = (0..n_variants)
-                        .map(|_| VariantLayout {
-                            field_offsets: IndexVec::default(),
-                            uninhabited: true,
-                            tagger: vec![],
-                        })
-                        .collect();
-                    variant_layouts[variant_id] = translate_variant_layout(&layout, vec![]);
-                    variant_layouts
-                } else {
-                    IndexVec::new()
+                let variant_layouts = match layout.fields() {
+                    r_abi::FieldsShape::Arbitrary { .. } => {
+                        let n_variants = if let Some(range) = ty.variant_range(self.t_ctx.tcx) {
+                            range.end.index()
+                        } else {
+                            1
+                        };
+                        // All the variants not initialized below are uninhabited.
+                        let mut variant_layouts: IndexVec<VariantId, VariantLayout> = (0
+                            ..n_variants)
+                            .map(|_| VariantLayout {
+                                field_offsets: IndexVec::default(),
+                                uninhabited: true,
+                                tagger: vec![],
+                            })
+                            .collect();
+                        variant_layouts[variant_id] = translate_variant_layout(&layout, vec![]);
+                        variant_layouts
+                    }
+                    r_abi::FieldsShape::Union(_) => {
+                        vec![translate_variant_layout(&layout, vec![])].into()
+                    }
+                    r_abi::FieldsShape::Primitive | r_abi::FieldsShape::Array { .. } => {
+                        vec![].into()
+                    }
                 };
                 (Some(Discriminator::trivial(variant_id)), variant_layouts)
             }

--- a/charon/tests/layout.json
+++ b/charon/tests/layout.json
@@ -562,6 +562,24 @@
       }
     ]
   },
+  "test_crate::MaybeUninitInt": {
+    "size": 4,
+    "align": 4,
+    "discriminator": {
+      "Known": 0
+    },
+    "uninhabited": false,
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0,
+          0
+        ],
+        "uninhabited": false,
+        "tagger": []
+      }
+    ]
+  },
   "test_crate::PackIntsUnion": {
     "size": 8,
     "align": 8,
@@ -569,7 +587,16 @@
       "Known": 0
     },
     "uninhabited": false,
-    "variant_layouts": []
+    "variant_layouts": [
+      {
+        "field_offsets": [
+          0,
+          0
+        ],
+        "uninhabited": false,
+        "tagger": []
+      }
+    ]
   },
   "test_crate::NonZeroNiche": {
     "size": 4,

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -98,6 +98,11 @@ fn type_layout() -> anyhow::Result<()> {
             Some((usize, &'a T))
         }
 
+        union MaybeUninitInt {
+            x: u32,
+            y: (),
+        }
+
         union PackIntsUnion {
             x: (u32, u32),
             y: u64,


### PR DESCRIPTION
Union layouts are currently translated as having no variants, which is wrong (given they always have the trivial variant 0). Changed it so they have one variant, and all fields are encoded at offset 0; this is hardcoded for now because it's what Rust does but note [this isn't a guarantee](https://doc.rust-lang.org/reference/items/unions.html#r-items.union.fields.offset) (though it seems like [it probably will be](https://github.com/rust-lang/unsafe-code-guidelines/issues/595))

Another doubt I have is that right now for enums with only one uninhabited variant we set all other variant layouts to an empty value with no fields; I'm not _sure_ this is correct. Can one not write values (and thus enums) field-by-field, regardless of uninhabitedness? i.e.
```rust
enum Foo {
	Bar,
	Baz { x: u32, y: !, z: u32 }
}

let foo: Foo;
set_discriminant!(foo, Baz);
foo.x = 0;
foo.z = 0;
```

Or is it instant UB to just set the discriminant to an uninhabited variant?