### PR TITLE
defer const-eval until needed

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -106,7 +106,6 @@ where
                 param_env,
                 ty,
                 kind: ConstKind::PromotedConst,
-                value: None,
             };
 
             lang_item = Default::default();
@@ -439,14 +438,12 @@ pub enum FullDefKind<'tcx> {
         param_env: ParamEnv,
         ty: Ty,
         kind: ConstKind,
-        value: Option<ConstantExpr>,
     },
     /// Associated constant: `trait MyTrait { const ASSOC: usize; }`
     AssocConst {
         param_env: ParamEnv,
         associated_item: AssocItem,
         ty: Ty,
-        value: Option<ConstantExpr>,
     },
     Static {
         param_env: ParamEnv,
@@ -928,14 +925,12 @@ where
                 param_env: get_param_env(s, args),
                 ty: self_ty.sinto(s),
                 kind,
-                value: const_value(s, def_id, args_or_default()),
             }
         }
         RDefKind::AssocConst { .. } => FullDefKind::AssocConst {
             param_env: get_param_env(s, args),
             associated_item: AssocItem::sfrom_instantiated(s, &tcx.associated_item(def_id), args),
             ty: type_of_self().sinto(s),
-            value: const_value(s, def_id, args_or_default()),
         },
         RDefKind::Static {
             safety,
@@ -1075,6 +1070,26 @@ impl<'tcx> FullDef<'tcx> {
 
     pub fn kind(&self) -> &FullDefKind<'tcx> {
         &self.kind
+    }
+
+    /// Evaluate the value of a `Const` or `AssocConst` item.
+    pub fn const_value<S>(&self, s: &S) -> Option<ConstantExpr>
+    where
+        S: BaseState<'tcx>,
+    {
+        match self.kind() {
+            FullDefKind::Const { .. } | FullDefKind::AssocConst { .. } => {}
+            _ => panic!("expected a Const or AssocConst definition"),
+        }
+        let s = &s.with_hax_owner(self.def_id());
+        let def_id = self.def_id().as_rust_def_id()?;
+        let args = self.this().rustc_args(s);
+        let uneval = ty::UnevaluatedConst::new(def_id, args);
+        let c = eval_ty_constant(s, uneval)?;
+        match c.kind() {
+            ty::ConstKind::Error(..) => None,
+            _ => Some(c.sinto(s)),
+        }
     }
 
     /// Returns the generics and predicates for definitions that have those.
@@ -1341,17 +1356,4 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
         }
     }
     implied_predicates.sinto(s)
-}
-
-fn const_value<'tcx, S: UnderOwnerState<'tcx>>(
-    s: &S,
-    def_id: RDefId,
-    args: ty::GenericArgsRef<'tcx>,
-) -> Option<ConstantExpr> {
-    let uneval = ty::UnevaluatedConst::new(def_id, args);
-    let c = eval_ty_constant(s, uneval)?;
-    match c.kind() {
-        ty::ConstKind::Error(..) => None,
-        _ => Some(c.sinto(s)),
-    }
 }

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -156,15 +156,16 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         if let Some(body) = self.get_mir(def.this(), span)? {
             Ok(self.translate_body(span, body, &def.source_text))
         } else {
-            if let hax::FullDefKind::Const { value, .. }
-            | hax::FullDefKind::AssocConst { value, .. } = def.kind()
-                && let Some(value) = value
+            if matches!(
+                def.kind(),
+                hax::FullDefKind::Const { .. } | hax::FullDefKind::AssocConst { .. }
+            ) && let Some(value) = def.const_value(self.hax_state_with_id())
             {
                 // For globals we can generate a body by evaluating the global.
                 // TODO: we lost the MIR of some consts on a rustc update. A trait assoc const
                 // default value no longer has a cross-crate MIR so it's unclear how to retreive
                 // the value. See the `trait-default-const-cross-crate` test.
-                let c = self.translate_constant_expr(span, value)?;
+                let c = self.translate_constant_expr(span, &value)?;
                 let mut bb = BodyBuilder::new(span, 0);
                 let ret = bb.new_var(None, c.ty.clone());
                 bb.push_statement(StatementKind::Assign(

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -12,6 +12,18 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_in_place = drop_in_place<Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct::drop_in_place
+unsafe fn drop_in_place<Self>(_1: *mut Self)
+= <opaque>
+
 // Full name: core::num::{u32}::MAX
 pub fn MAX() -> u32
 = <opaque>
@@ -204,7 +216,9 @@ where
     storage_live(_2)
     _2 = move value_1
     _0 = Wrap { value: move _2 }
+    conditional_drop[{built_in impl Destruct for T}::drop_in_place] _2
     storage_dead(_2)
+    conditional_drop[{built_in impl Destruct for T}::drop_in_place] value_1
     return
 }
 


### PR DESCRIPTION
Picked from https://github.com/AeneasVerif/charon/pull/1173, split off so we can see individual effects.