### PR TITLE
Cache item predicates

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -1991,6 +1991,7 @@ name = "rustc_trait_elaboration"
 version = "0.1.0"
 dependencies = [
  "itertools",
+ "rustc-hash",
  "tracing",
 ]
 

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -19,6 +19,7 @@ assert_tokens_eq = "0.1.0"
 itertools = "0.13"
 proc-macro2 = "1.0"
 quote = "1.0"
+rustc-hash = "2"
 syn = { version = "1.0.107", features = ["extra-traits", "full"] }
 tracing = { version = "0.1", features = ["max_level_trace"] }
 
@@ -96,7 +97,7 @@ paste = "1.0.11"
 petgraph = "0.8.0"
 postcard = { version = "1.1.3", features = ["use-std"] }
 reqwest = { version = "0.12.8", optional = true }
-rustc-hash = "2"
+rustc-hash.workspace = true
 rustc_version = "0.4"
 serde_json = { version = "1.0.91", features = ["unbounded_depth"] }
 serde_stacker = "0.1.11"

--- a/charon/rustc_trait_elaboration/Cargo.toml
+++ b/charon/rustc_trait_elaboration/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 itertools.workspace = true
+rustc-hash.workspace = true
 tracing.workspace = true
 
 [package.metadata.rust-analyzer]

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -1,9 +1,11 @@
 use rustc_arena::TypedArena;
 use rustc_data_structures::sharded::ShardedHashMap;
+use rustc_hash::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
+use std::cell::{RefCell, RefMut};
 
-use crate::{BoundsOptions, ImplExpr, ImplExprContents, ItemPredicates};
+use crate::{BoundsOptions, ImplExpr, ImplExprContents, ItemPredicates, PredicateSearcher};
 
 mod intern {
     use rustc_data_structures::intern::Interned;
@@ -80,6 +82,7 @@ struct ElaborationData<'tcx> {
     bounds_options: BoundsOptions,
     impl_exprs: intern::ImplExprInterner<'tcx>,
     impl_exprs_arena: TypedArena<ImplExprContents<'tcx>>,
+    predicate_searchers: RefCell<FxHashMap<DefId, PredicateSearcher<'tcx>>>,
     required_predicates: PredicateCache<'tcx>,
     required_recursively_predicates: PredicateCache<'tcx>,
     implied_predicates: PredicateCache<'tcx>,
@@ -133,6 +136,16 @@ impl<'tcx> ElaborationCtx<'tcx> {
 
     pub fn intern_impl_expr(&self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {
         self.data.intern_impl_expr(contents)
+    }
+
+    pub fn predicate_searcher_for(&self, def_id: DefId) -> RefMut<'_, PredicateSearcher<'tcx>> {
+        let mut predicate_searchers = self.data.predicate_searchers.borrow_mut();
+        predicate_searchers
+            .entry(def_id)
+            .or_insert_with(|| PredicateSearcher::new_for_owner(*self, def_id));
+        RefMut::map(predicate_searchers, |predicate_searchers| {
+            predicate_searchers.get_mut(&def_id).unwrap()
+        })
     }
 
     pub(crate) fn cached_required_predicates(

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -1,7 +1,9 @@
 use rustc_arena::TypedArena;
+use rustc_data_structures::sharded::ShardedHashMap;
+use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
 
-use crate::{ImplExpr, ImplExprContents};
+use crate::{BoundsOptions, ImplExpr, ImplExprContents, ItemPredicates};
 
 mod intern {
     use rustc_data_structures::intern::Interned;
@@ -70,17 +72,51 @@ mod intern {
 #[derive(Clone, Copy)]
 pub struct ElaborationCtx<'tcx> {
     pub tcx: ty::TyCtxt<'tcx>,
-    pub interner: &'tcx ImplExprInterner<'tcx>,
+    data: &'tcx ElaborationData<'tcx>,
 }
 
 #[derive(Default)]
-pub struct ImplExprInterner<'tcx> {
+struct ElaborationData<'tcx> {
     impl_exprs: intern::ImplExprInterner<'tcx>,
     impl_exprs_arena: TypedArena<ImplExprContents<'tcx>>,
+    required_predicates: PredicateCache<'tcx>,
+    required_recursively_predicates: PredicateCache<'tcx>,
+    implied_predicates: PredicateCache<'tcx>,
 }
 
-impl<'tcx> ImplExprInterner<'tcx> {
-    pub fn intern_impl_expr(&'tcx self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct PredicateCacheKey {
+    def_id: DefId,
+    options: BoundsOptions,
+}
+
+#[derive(Default)]
+struct PredicateCache<'tcx> {
+    values: ShardedHashMap<PredicateCacheKey, ItemPredicates<'tcx>>,
+}
+
+impl<'tcx> PredicateCache<'tcx> {
+    fn get_or_insert_with(
+        &'tcx self,
+        def_id: DefId,
+        options: &BoundsOptions,
+        compute: impl FnOnce() -> ItemPredicates<'tcx>,
+    ) -> ItemPredicates<'tcx> {
+        let key = PredicateCacheKey {
+            def_id,
+            options: options.clone(),
+        };
+        if let Some(predicates) = self.values.get(&key) {
+            return predicates;
+        }
+        let predicates = compute();
+        let _ = self.values.insert(key, predicates.clone());
+        predicates
+    }
+}
+
+impl<'tcx> ElaborationData<'tcx> {
+    fn intern_impl_expr(&'tcx self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {
         let interned = self
             .impl_exprs
             .intern(contents, |contents| self.impl_exprs_arena.alloc(contents));
@@ -94,11 +130,44 @@ impl<'tcx> ElaborationCtx<'tcx> {
         // `ImplExpr` is a copyable `Interned<'tcx, _>` and may outlive the `PredicateSearcher`
         // that produced it. We therefore give each elaboration context session-long storage, like
         // rustc's own arenas. The interned values still contain rustc data bounded by `'tcx`.
-        let interner = Box::leak(Box::new(ImplExprInterner::default()));
-        ElaborationCtx { tcx, interner }
+        let data = Box::leak(Box::new(ElaborationData::default()));
+        ElaborationCtx { tcx, data }
     }
 
     pub fn intern_impl_expr(&self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {
-        self.interner.intern_impl_expr(contents)
+        self.data.intern_impl_expr(contents)
+    }
+
+    pub(crate) fn cached_required_predicates(
+        &self,
+        def_id: DefId,
+        options: &BoundsOptions,
+        compute: impl FnOnce() -> ItemPredicates<'tcx>,
+    ) -> ItemPredicates<'tcx> {
+        self.data
+            .required_predicates
+            .get_or_insert_with(def_id, options, compute)
+    }
+
+    pub(crate) fn cached_required_recursively_predicates(
+        &self,
+        def_id: DefId,
+        options: &BoundsOptions,
+        compute: impl FnOnce() -> ItemPredicates<'tcx>,
+    ) -> ItemPredicates<'tcx> {
+        self.data
+            .required_recursively_predicates
+            .get_or_insert_with(def_id, options, compute)
+    }
+
+    pub(crate) fn cached_implied_predicates(
+        &self,
+        def_id: DefId,
+        options: &BoundsOptions,
+        compute: impl FnOnce() -> ItemPredicates<'tcx>,
+    ) -> ItemPredicates<'tcx> {
+        self.data
+            .implied_predicates
+            .get_or_insert_with(def_id, options, compute)
     }
 }

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -77,6 +77,7 @@ pub struct ElaborationCtx<'tcx> {
 
 #[derive(Default)]
 struct ElaborationData<'tcx> {
+    bounds_options: BoundsOptions,
     impl_exprs: intern::ImplExprInterner<'tcx>,
     impl_exprs_arena: TypedArena<ImplExprContents<'tcx>>,
     required_predicates: PredicateCache<'tcx>,
@@ -84,33 +85,22 @@ struct ElaborationData<'tcx> {
     implied_predicates: PredicateCache<'tcx>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-struct PredicateCacheKey {
-    def_id: DefId,
-    options: BoundsOptions,
-}
-
 #[derive(Default)]
 struct PredicateCache<'tcx> {
-    values: ShardedHashMap<PredicateCacheKey, ItemPredicates<'tcx>>,
+    values: ShardedHashMap<DefId, ItemPredicates<'tcx>>,
 }
 
 impl<'tcx> PredicateCache<'tcx> {
     fn get_or_insert_with(
         &'tcx self,
         def_id: DefId,
-        options: &BoundsOptions,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
-        let key = PredicateCacheKey {
-            def_id,
-            options: options.clone(),
-        };
-        if let Some(predicates) = self.values.get(&key) {
+        if let Some(predicates) = self.values.get(&def_id) {
             return predicates;
         }
         let predicates = compute();
-        let _ = self.values.insert(key, predicates.clone());
+        let _ = self.values.insert(def_id, predicates.clone());
         predicates
     }
 }
@@ -126,12 +116,19 @@ impl<'tcx> ElaborationData<'tcx> {
 
 impl<'tcx> ElaborationCtx<'tcx> {
     /// Warning: only create a single one.
-    pub fn new(tcx: ty::TyCtxt<'tcx>) -> Self {
+    pub fn new(tcx: ty::TyCtxt<'tcx>, bounds_options: BoundsOptions) -> Self {
         // `ImplExpr` is a copyable `Interned<'tcx, _>` and may outlive the `PredicateSearcher`
         // that produced it. We therefore give each elaboration context session-long storage, like
         // rustc's own arenas. The interned values still contain rustc data bounded by `'tcx`.
-        let data = Box::leak(Box::new(ElaborationData::default()));
+        let data = Box::leak(Box::new(ElaborationData {
+            bounds_options,
+            ..ElaborationData::default()
+        }));
         ElaborationCtx { tcx, data }
+    }
+
+    pub fn bounds_options(&self) -> &BoundsOptions {
+        &self.data.bounds_options
     }
 
     pub fn intern_impl_expr(&self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {
@@ -141,33 +138,30 @@ impl<'tcx> ElaborationCtx<'tcx> {
     pub(crate) fn cached_required_predicates(
         &self,
         def_id: DefId,
-        options: &BoundsOptions,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
         self.data
             .required_predicates
-            .get_or_insert_with(def_id, options, compute)
+            .get_or_insert_with(def_id, compute)
     }
 
     pub(crate) fn cached_required_recursively_predicates(
         &self,
         def_id: DefId,
-        options: &BoundsOptions,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
         self.data
             .required_recursively_predicates
-            .get_or_insert_with(def_id, options, compute)
+            .get_or_insert_with(def_id, compute)
     }
 
     pub(crate) fn cached_implied_predicates(
         &self,
         def_id: DefId,
-        options: &BoundsOptions,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
         self.data
             .implied_predicates
-            .get_or_insert_with(def_id, options, compute)
+            .get_or_insert_with(def_id, compute)
     }
 }

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -1,4 +1,5 @@
 use rustc_arena::TypedArena;
+use rustc_middle::ty;
 
 use crate::{ImplExpr, ImplExprContents};
 
@@ -66,8 +67,9 @@ mod intern {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct ElaborationCtx<'tcx> {
+    pub tcx: ty::TyCtxt<'tcx>,
     pub interner: &'tcx ImplExprInterner<'tcx>,
 }
 
@@ -88,12 +90,12 @@ impl<'tcx> ImplExprInterner<'tcx> {
 
 impl<'tcx> ElaborationCtx<'tcx> {
     /// Warning: only create a single one.
-    pub fn new() -> Self {
+    pub fn new(tcx: ty::TyCtxt<'tcx>) -> Self {
         // `ImplExpr` is a copyable `Interned<'tcx, _>` and may outlive the `PredicateSearcher`
         // that produced it. We therefore give each elaboration context session-long storage, like
         // rustc's own arenas. The interned values still contain rustc data bounded by `'tcx`.
         let interner = Box::leak(Box::new(ImplExprInterner::default()));
-        ElaborationCtx { interner }
+        ElaborationCtx { tcx, interner }
     }
 
     pub fn intern_impl_expr(&self, contents: ImplExprContents<'tcx>) -> ImplExpr<'tcx> {

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -35,13 +35,14 @@ fn initial_self_pred<'tcx>(
     Some(self_pred)
 }
 
-#[tracing::instrument(level = "trace", skip(tcx))]
+#[tracing::instrument(level = "trace", skip(elab_ctx))]
 fn parents_trait_predicates<'tcx>(
-    tcx: TyCtxt<'tcx>,
+    elab_ctx: ElaborationCtx<'tcx>,
     self_trait_ref: PolyTraitRef<'tcx>,
     options: &BoundsOptions,
 ) -> Vec<PolyTraitRef<'tcx>> {
-    ItemPredicates::implied(tcx, self_trait_ref.def_id(), options)
+    let tcx = elab_ctx.tcx;
+    ItemPredicates::implied(elab_ctx, self_trait_ref.def_id(), options)
         .iter()
         // Substitute with the `self` args so that the clause makes sense in the
         // outside context.
@@ -122,7 +123,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             clause,
         }));
         out.insert_bound_predicates(
-            ItemPredicates::required_recursively(tcx, owner_id, options).predicates,
+            ItemPredicates::required_recursively(elab_ctx, owner_id, options).predicates,
         );
         out
     }
@@ -182,12 +183,12 @@ impl<'tcx> PredicateSearcher<'tcx> {
     /// polymorphic recursion due to the closures capturing the type parameters of this
     /// function.
     fn insert_candidate_parents(&mut self, new_candidates: Vec<Candidate<'tcx>>) {
-        let tcx = self.elab_ctx.tcx;
+        let elab_ctx = self.elab_ctx;
         // Then recursively add their parents. This way ensures a breadth-first order,
         // which means we select the shortest path when looking up predicates.
         let options = self.options.clone();
         self.insert_candidates(new_candidates.into_iter().flat_map(|candidate| {
-            parents_trait_predicates(tcx, candidate.pred, &options)
+            parents_trait_predicates(elab_ctx, candidate.pred, &options)
                 .into_iter()
                 .enumerate()
                 .map(move |(index, parent_pred)| {
@@ -223,7 +224,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         let item_ref = self.resolve_item_reference(alias_ty.def_id, alias_ty.args, true);
 
         // The bounds that hold on the associated type.
-        let item_bounds = ItemPredicates::implied(tcx, alias_ty.def_id, &self.options);
+        let item_bounds = ItemPredicates::implied(self.elab_ctx, alias_ty.def_id, &self.options);
         let item_bounds = item_bounds
             .iter_trait_clauses()
             // Substitute the item generics
@@ -445,9 +446,8 @@ impl<'tcx> PredicateSearcher<'tcx> {
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        let tcx = self.elab_ctx.tcx;
         self.resolve_predicates(
-            ItemPredicates::required_recursively(tcx, def_id, &self.options),
+            ItemPredicates::required_recursively(self.elab_ctx, def_id, &self.options),
             generics,
         )
     }
@@ -458,9 +458,8 @@ impl<'tcx> PredicateSearcher<'tcx> {
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        let tcx = self.elab_ctx.tcx;
         self.resolve_predicates(
-            ItemPredicates::implied(tcx, def_id, &self.options),
+            ItemPredicates::implied(self.elab_ctx, def_id, &self.options),
             generics,
         )
     }

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -81,7 +81,6 @@ impl<'tcx> Candidate<'tcx> {
 /// Stores a set of predicates along with where they came from.
 #[derive(Clone)]
 pub struct PredicateSearcher<'tcx> {
-    pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) elab_ctx: ElaborationCtx<'tcx>,
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
@@ -100,14 +99,13 @@ pub struct PredicateSearcher<'tcx> {
 impl<'tcx> PredicateSearcher<'tcx> {
     /// Initialize the elaborator with the predicates accessible within this item.
     pub fn new_for_owner(
-        tcx: TyCtxt<'tcx>,
         elab_ctx: ElaborationCtx<'tcx>,
         owner_id: DefId,
         options: &BoundsOptions,
     ) -> Self {
+        let tcx = elab_ctx.tcx;
         let initial_self_pred = initial_self_pred(tcx, owner_id);
         let mut out = Self {
-            tcx,
             elab_ctx,
             typing_env: TypingEnv {
                 param_env: tcx.param_env(owner_id),
@@ -163,7 +161,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
     /// Insert new candidates and all their parent predicates. This deduplicates predicates
     /// to avoid divergence.
     fn insert_candidates(&mut self, candidates: impl IntoIterator<Item = Candidate<'tcx>>) {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         // Filter out duplicated candidates.
         let mut new_candidates = Vec::new();
         for mut candidate in candidates {
@@ -184,7 +182,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
     /// polymorphic recursion due to the closures capturing the type parameters of this
     /// function.
     fn insert_candidate_parents(&mut self, new_candidates: Vec<Candidate<'tcx>>) {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         // Then recursively add their parents. This way ensures a breadth-first order,
         // which means we select the shortest path when looking up predicates.
         let options = self.options.clone();
@@ -209,7 +207,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
 
     /// If the type is a trait associated type, we add any relevant bounds to our context.
     fn add_associated_type_refs(&mut self, ty: Binder<'tcx, Ty<'tcx>>) {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         // Note: We skip a binder but rebind it just after.
         let TyKind::Alias(AliasTyKind::Projection, alias_ty) = ty.skip_binder().kind() else {
             return;
@@ -284,13 +282,13 @@ impl<'tcx> PredicateSearcher<'tcx> {
         use rustc_trait_selection::traits::{
             BuiltinImplSource, ImplSource, ImplSourceUserDefinedData,
         };
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
 
-        let erased_tref = normalize_bound_val(self.tcx, self.typing_env, *tref);
+        let erased_tref = normalize_bound_val(tcx, self.typing_env, *tref);
         let trait_def_id = erased_tref.skip_binder().def_id;
 
-        let elab_ctx = self.elab_ctx.clone();
+        let elab_ctx = self.elab_ctx;
         let error = |msg: String| {
             elab_ctx.intern_impl_expr(ImplExprContents {
                 r#trait: *tref,
@@ -314,7 +312,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                 args: generics,
                 ..
             }) => ImplExprAtom::Concrete(self.resolve_item_reference(impl_def_id, generics, true)),
-            ImplSource::Param(_) => match self.resolve_local(erased_tref.upcast(self.tcx)) {
+            ImplSource::Param(_) => match self.resolve_local(erased_tref.upcast(tcx)) {
                 Some(candidate) => candidate.into_impl_expr(tcx, self.implicit_self_clause),
                 None => {
                     let msg =
@@ -394,7 +392,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                             if self.options.add_destruct_bounds {
                                 // We've added `Destruct` impls on everything, we should be able to resolve
                                 // it.
-                                match self.resolve_local(erased_tref.upcast(self.tcx)) {
+                                match self.resolve_local(erased_tref.upcast(tcx)) {
                                     Some(candidate) => Either::Right(
                                         candidate.into_impl_expr(tcx, self.implicit_self_clause),
                                     ),
@@ -447,7 +445,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         self.resolve_predicates(
             ItemPredicates::required_recursively(tcx, def_id, &self.options),
             generics,
@@ -460,7 +458,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         self.resolve_predicates(
             ItemPredicates::implied(tcx, def_id, &self.options),
             generics,
@@ -474,7 +472,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         predicates: ItemPredicates<'tcx>,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         predicates
             .iter_trait_clauses()
             // Substitute the item generics

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -39,10 +39,9 @@ fn initial_self_pred<'tcx>(
 fn parents_trait_predicates<'tcx>(
     elab_ctx: ElaborationCtx<'tcx>,
     self_trait_ref: PolyTraitRef<'tcx>,
-    options: &BoundsOptions,
 ) -> Vec<PolyTraitRef<'tcx>> {
     let tcx = elab_ctx.tcx;
-    ItemPredicates::implied(elab_ctx, self_trait_ref.def_id(), options)
+    ItemPredicates::implied(elab_ctx, self_trait_ref.def_id())
         .iter()
         // Substitute with the `self` args so that the clause makes sense in the
         // outside context.
@@ -86,8 +85,6 @@ pub struct PredicateSearcher<'tcx> {
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
     candidates: HashMap<PolyTraitRef<'tcx>, Candidate<'tcx>>,
-    /// Resolution options.
-    pub(crate) options: BoundsOptions,
     /// Whether we're in a trait declaration context where an implicit `Self: Trait` clause is
     /// accessible.
     implicit_self_clause: bool,
@@ -99,11 +96,7 @@ pub struct PredicateSearcher<'tcx> {
 
 impl<'tcx> PredicateSearcher<'tcx> {
     /// Initialize the elaborator with the predicates accessible within this item.
-    pub fn new_for_owner(
-        elab_ctx: ElaborationCtx<'tcx>,
-        owner_id: DefId,
-        options: &BoundsOptions,
-    ) -> Self {
+    pub fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: DefId) -> Self {
         let tcx = elab_ctx.tcx;
         let initial_self_pred = initial_self_pred(tcx, owner_id);
         let mut out = Self {
@@ -113,7 +106,6 @@ impl<'tcx> PredicateSearcher<'tcx> {
                 typing_mode: TypingMode::PostAnalysis,
             },
             candidates: Default::default(),
-            options: options.clone(),
             implicit_self_clause: initial_self_pred.is_some(),
             item_refs_cache: Default::default(),
             impl_exprs_cache: Default::default(),
@@ -123,7 +115,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             clause,
         }));
         out.insert_bound_predicates(
-            ItemPredicates::required_recursively(elab_ctx, owner_id, options).predicates,
+            ItemPredicates::required_recursively(elab_ctx, owner_id).predicates,
         );
         out
     }
@@ -186,9 +178,8 @@ impl<'tcx> PredicateSearcher<'tcx> {
         let elab_ctx = self.elab_ctx;
         // Then recursively add their parents. This way ensures a breadth-first order,
         // which means we select the shortest path when looking up predicates.
-        let options = self.options.clone();
         self.insert_candidates(new_candidates.into_iter().flat_map(|candidate| {
-            parents_trait_predicates(elab_ctx, candidate.pred, &options)
+            parents_trait_predicates(elab_ctx, candidate.pred)
                 .into_iter()
                 .enumerate()
                 .map(move |(index, parent_pred)| {
@@ -224,7 +215,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         let item_ref = self.resolve_item_reference(alias_ty.def_id, alias_ty.args, true);
 
         // The bounds that hold on the associated type.
-        let item_bounds = ItemPredicates::implied(self.elab_ctx, alias_ty.def_id, &self.options);
+        let item_bounds = ItemPredicates::implied(self.elab_ctx, alias_ty.def_id);
         let item_bounds = item_bounds
             .iter_trait_clauses()
             // Substitute the item generics
@@ -390,7 +381,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                         // `dyn` has `Destruct` in its list of traits.
                         ty::Dynamic(..) => Either::Right(ImplExprAtom::Dyn),
                         ty::Param(..) | ty::Alias(..) | ty::Bound(..) => {
-                            if self.options.add_destruct_bounds {
+                            if self.elab_ctx.bounds_options().add_destruct_bounds {
                                 // We've added `Destruct` impls on everything, we should be able to resolve
                                 // it.
                                 match self.resolve_local(erased_tref.upcast(tcx)) {
@@ -447,7 +438,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
         self.resolve_predicates(
-            ItemPredicates::required_recursively(self.elab_ctx, def_id, &self.options),
+            ItemPredicates::required_recursively(self.elab_ctx, def_id),
             generics,
         )
     }
@@ -458,10 +449,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<ImplExpr<'tcx>> {
-        self.resolve_predicates(
-            ItemPredicates::implied(self.elab_ctx, def_id, &self.options),
-            generics,
-        )
+        self.resolve_predicates(ItemPredicates::implied(self.elab_ctx, def_id), generics)
     }
 
     /// Apply the given generics to the provided clauses and resolve the trait references in the

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -96,7 +96,7 @@ pub struct PredicateSearcher<'tcx> {
 
 impl<'tcx> PredicateSearcher<'tcx> {
     /// Initialize the elaborator with the predicates accessible within this item.
-    pub fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: DefId) -> Self {
+    pub(crate) fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: DefId) -> Self {
         let tcx = elab_ctx.tcx;
         let initial_self_pred = initial_self_pred(tcx, owner_id);
         let mut out = Self {

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -62,7 +62,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             return item_ref;
         }
         use rustc_infer::infer::canonical::ir::TypeVisitableExt;
-        let tcx = self.tcx;
+        let tcx = self.elab_ctx.tcx;
         let typing_env = self.typing_env;
         // Normalize the generics.
         let mut generics = normalize(tcx, typing_env, generics);

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -82,7 +82,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                 let generics = generics.truncate_to(tcx, tcx.generics_of(tr_def_id));
                 let self_pred = ty::EarlyBinder::bind(self_pred).instantiate(tcx, generics);
                 let num_trait_req_clauses =
-                    ItemPredicates::required_recursively(elab_ctx, tr_def_id, &self.options).len();
+                    ItemPredicates::required_recursively(elab_ctx, tr_def_id).len();
                 Some((self.resolve(&self_pred), num_trait_req_clauses))
             } else {
                 None

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -62,6 +62,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             return item_ref;
         }
         use rustc_infer::infer::canonical::ir::TypeVisitableExt;
+        let elab_ctx = self.elab_ctx;
         let tcx = self.elab_ctx.tcx;
         let typing_env = self.typing_env;
         // Normalize the generics.
@@ -81,7 +82,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                 let generics = generics.truncate_to(tcx, tcx.generics_of(tr_def_id));
                 let self_pred = ty::EarlyBinder::bind(self_pred).instantiate(tcx, generics);
                 let num_trait_req_clauses =
-                    ItemPredicates::required_recursively(tcx, tr_def_id, &self.options).len();
+                    ItemPredicates::required_recursively(elab_ctx, tr_def_id, &self.options).len();
                 Some((self.resolve(&self_pred), num_trait_req_clauses))
             } else {
                 None

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -28,7 +28,6 @@
 //! required vs implied are subtle. We may change our choice if this proves to be a problem.
 use itertools::Itertools;
 use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
 
 use rustc_hir::LangItem;
 use rustc_hir::def::DefKind;
@@ -38,26 +37,13 @@ use rustc_span::{DUMMY_SP, Span};
 
 use crate::{ElaborationCtx, ToPolyTraitRef};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone)]
 pub struct BoundsOptions {
     /// Add `T: Destruct` bounds to every type generic, so that we can build `ImplExpr`s to know
     /// what code is run on drop.
     pub add_destruct_bounds: bool,
     /// Traits to filter out from the predicate lists.
     pub remove_traits: HashSet<DefId>,
-}
-
-impl Hash for BoundsOptions {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.add_destruct_bounds.hash(state);
-        for def_id in self
-            .remove_traits
-            .iter()
-            .sorted_by_key(|def_id| (def_id.krate.as_u32(), def_id.index.as_u32()))
-        {
-            def_id.hash(state);
-        }
-    }
 }
 
 /// Uniquely identifies a predicate.
@@ -219,14 +205,11 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// ```
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic.
-    pub fn required(
-        elab_ctx: ElaborationCtx<'tcx>,
-        def_id: DefId,
-        options: &BoundsOptions,
-    ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_required_predicates(def_id, options, || {
+    pub fn required(elab_ctx: ElaborationCtx<'tcx>, def_id: DefId) -> ItemPredicates<'tcx> {
+        elab_ctx.cached_required_predicates(def_id, || {
             use DefKind::*;
             let tcx = elab_ctx.tcx;
+            let options = elab_ctx.bounds_options();
             let def_kind = tcx.def_kind(def_id);
             let mut predicates = match def_kind {
                 AssocConst
@@ -283,22 +266,20 @@ impl<'tcx> ItemPredicates<'tcx> {
     pub fn required_recursively(
         elab_ctx: ElaborationCtx<'tcx>,
         def_id: rustc_span::def_id::DefId,
-        options: &BoundsOptions,
     ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_required_recursively_predicates(def_id, options, || {
+        elab_ctx.cached_required_recursively_predicates(def_id, || {
             fn acc_predicates<'tcx>(
                 elab_ctx: ElaborationCtx<'tcx>,
                 def_id: rustc_span::def_id::DefId,
-                options: &BoundsOptions,
                 predicates: &mut ItemPredicates<'tcx>,
                 is_parent: bool,
             ) {
                 let tcx = elab_ctx.tcx;
                 if inherits_parent_clauses(tcx, def_id) {
                     let parent = tcx.parent(def_id);
-                    acc_predicates(elab_ctx, parent, options, predicates, true);
+                    acc_predicates(elab_ctx, parent, predicates, true);
                 }
-                let required = ItemPredicates::required(elab_ctx, def_id, options);
+                let required = ItemPredicates::required(elab_ctx, def_id);
                 predicates.predicates.extend(required.iter());
                 if !is_parent {
                     // Use the next_id that corresponds to the current item.
@@ -311,7 +292,7 @@ impl<'tcx> ItemPredicates<'tcx> {
                 next_id: 0,
                 predicates: vec![],
             };
-            acc_predicates(elab_ctx, def_id, options, &mut predicates, false);
+            acc_predicates(elab_ctx, def_id, &mut predicates, false);
             predicates
         })
     }
@@ -328,14 +309,11 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// ```
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic and associated type.
-    pub fn implied(
-        elab_ctx: ElaborationCtx<'tcx>,
-        def_id: DefId,
-        options: &BoundsOptions,
-    ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_implied_predicates(def_id, options, || {
+    pub fn implied(elab_ctx: ElaborationCtx<'tcx>, def_id: DefId) -> ItemPredicates<'tcx> {
+        elab_ctx.cached_implied_predicates(def_id, || {
             use DefKind::*;
             let tcx = elab_ctx.tcx;
+            let options = elab_ctx.bounds_options();
             let parent = tcx.opt_parent(def_id);
             let mut predicates = match tcx.def_kind(def_id) {
                 // We consider all predicates on traits to be outputs

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -28,6 +28,7 @@
 //! required vs implied are subtle. We may change our choice if this proves to be a problem.
 use itertools::Itertools;
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 
 use rustc_hir::LangItem;
 use rustc_hir::def::DefKind;
@@ -35,15 +36,28 @@ use rustc_middle::ty::*;
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span};
 
-use crate::ToPolyTraitRef;
+use crate::{ElaborationCtx, ToPolyTraitRef};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct BoundsOptions {
     /// Add `T: Destruct` bounds to every type generic, so that we can build `ImplExpr`s to know
     /// what code is run on drop.
     pub add_destruct_bounds: bool,
     /// Traits to filter out from the predicate lists.
     pub remove_traits: HashSet<DefId>,
+}
+
+impl Hash for BoundsOptions {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.add_destruct_bounds.hash(state);
+        for def_id in self
+            .remove_traits
+            .iter()
+            .sorted_by_key(|def_id| (def_id.krate.as_u32(), def_id.index.as_u32()))
+        {
+            def_id.hash(state);
+        }
+    }
 }
 
 /// Uniquely identifies a predicate.
@@ -180,7 +194,7 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// Returns a list of type predicates for the definition with id `def_id`, including inferred
     /// lifetime constraints. This is the basic list of predicates we use for essentially all
     /// items.
-    pub fn defined_on(tcx: TyCtxt<'_>, def_id: DefId, required: bool) -> ItemPredicates<'_> {
+    fn defined_on(tcx: TyCtxt<'_>, def_id: DefId, required: bool) -> ItemPredicates<'_> {
         let predicates = tcx
             .explicit_predicates_of(def_id)
             .predicates
@@ -206,53 +220,56 @@ impl<'tcx> ItemPredicates<'tcx> {
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic.
     pub fn required(
-        tcx: TyCtxt<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx>,
         def_id: DefId,
         options: &BoundsOptions,
     ) -> ItemPredicates<'tcx> {
-        use DefKind::*;
-        let def_kind = tcx.def_kind(def_id);
-        let mut predicates = match def_kind {
-            AssocConst
-            | AssocFn
-            | AssocTy
-            | Const
-            | Enum
-            | Fn
-            | ForeignTy
-            | Impl { .. }
-            | OpaqueTy
-            | Static { .. }
-            | Struct
-            | TyAlias
-            | Union => Self::defined_on(tcx, def_id, true),
-            // We consider all predicates on traits to be outputs
-            Trait | TraitAlias => Default::default(),
-            // `predicates_defined_on` ICEs on other def kinds.
-            _ => Default::default(),
-        };
-        // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
-        // Associated types get to use the implicit `Self: Trait` clause instead.
-        if !matches!(def_kind, AssocTy)
-            && let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
-        {
-            let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
-            predicates.predicates.insert(
-                0,
-                ItemPredicate {
-                    id: ItemPredicateId::TraitSelf,
-                    clause: self_clause,
-                    span: DUMMY_SP,
-                },
-            );
-        }
-        if options.add_destruct_bounds && !matches!(def_kind, Trait | TraitAlias) {
-            // Add a `T: Destruct` bound for every generic. For traits we consider these predicates
-            // implied instead of required.
-            predicates.add_destruct_bounds(tcx, def_id);
-        }
-        predicates.filter_traits(options);
-        predicates
+        elab_ctx.cached_required_predicates(def_id, options, || {
+            use DefKind::*;
+            let tcx = elab_ctx.tcx;
+            let def_kind = tcx.def_kind(def_id);
+            let mut predicates = match def_kind {
+                AssocConst
+                | AssocFn
+                | AssocTy
+                | Const
+                | Enum
+                | Fn
+                | ForeignTy
+                | Impl { .. }
+                | OpaqueTy
+                | Static { .. }
+                | Struct
+                | TyAlias
+                | Union => Self::defined_on(tcx, def_id, true),
+                // We consider all predicates on traits to be outputs
+                Trait | TraitAlias => Default::default(),
+                // `predicates_defined_on` ICEs on other def kinds.
+                _ => Default::default(),
+            };
+            // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
+            // Associated types get to use the implicit `Self: Trait` clause instead.
+            if !matches!(def_kind, AssocTy)
+                && let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
+            {
+                let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
+                predicates.predicates.insert(
+                    0,
+                    ItemPredicate {
+                        id: ItemPredicateId::TraitSelf,
+                        clause: self_clause,
+                        span: DUMMY_SP,
+                    },
+                );
+            }
+            if options.add_destruct_bounds && !matches!(def_kind, Trait | TraitAlias) {
+                // Add a `T: Destruct` bound for every generic. For traits we consider these predicates
+                // implied instead of required.
+                predicates.add_destruct_bounds(tcx, def_id);
+            }
+            predicates.filter_traits(options);
+            predicates
+        })
     }
     /// The predicates that must hold to mention this item, including its parents. E.g.
     ///
@@ -264,36 +281,39 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// }
     /// ```
     pub fn required_recursively(
-        tcx: TyCtxt<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx>,
         def_id: rustc_span::def_id::DefId,
         options: &BoundsOptions,
     ) -> ItemPredicates<'tcx> {
-        fn acc_predicates<'tcx>(
-            tcx: TyCtxt<'tcx>,
-            def_id: rustc_span::def_id::DefId,
-            options: &BoundsOptions,
-            predicates: &mut ItemPredicates<'tcx>,
-            is_parent: bool,
-        ) {
-            if inherits_parent_clauses(tcx, def_id) {
-                let parent = tcx.parent(def_id);
-                acc_predicates(tcx, parent, options, predicates, true);
+        elab_ctx.cached_required_recursively_predicates(def_id, options, || {
+            fn acc_predicates<'tcx>(
+                elab_ctx: ElaborationCtx<'tcx>,
+                def_id: rustc_span::def_id::DefId,
+                options: &BoundsOptions,
+                predicates: &mut ItemPredicates<'tcx>,
+                is_parent: bool,
+            ) {
+                let tcx = elab_ctx.tcx;
+                if inherits_parent_clauses(tcx, def_id) {
+                    let parent = tcx.parent(def_id);
+                    acc_predicates(elab_ctx, parent, options, predicates, true);
+                }
+                let required = ItemPredicates::required(elab_ctx, def_id, options);
+                predicates.predicates.extend(required.iter());
+                if !is_parent {
+                    // Use the next_id that corresponds to the current item.
+                    predicates.next_id = required.next_id;
+                }
             }
-            let required = ItemPredicates::required(tcx, def_id, options);
-            predicates.predicates.extend(required.iter());
-            if !is_parent {
-                // Use the next_id that corresponds to the current item.
-                predicates.next_id = required.next_id;
-            }
-        }
 
-        let mut predicates = Self {
-            required: true,
-            next_id: 0,
-            predicates: vec![],
-        };
-        acc_predicates(tcx, def_id, options, &mut predicates, false);
-        predicates
+            let mut predicates = Self {
+                required: true,
+                next_id: 0,
+                predicates: vec![],
+            };
+            acc_predicates(elab_ctx, def_id, options, &mut predicates, false);
+            predicates
+        })
     }
     /// The predicates that can be deduced from the presence of this item in a signature. We only
     /// consider predicates implied by traits here, not implied bounds such as `&'a T` implying `T:
@@ -309,63 +329,66 @@ impl<'tcx> ItemPredicates<'tcx> {
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic and associated type.
     pub fn implied(
-        tcx: TyCtxt<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx>,
         def_id: DefId,
         options: &BoundsOptions,
     ) -> ItemPredicates<'tcx> {
-        use DefKind::*;
-        let parent = tcx.opt_parent(def_id);
-        let mut predicates = match tcx.def_kind(def_id) {
-            // We consider all predicates on traits to be outputs
-            Trait | TraitAlias => {
-                let mut predicates = Self::defined_on(tcx, def_id, false);
-                if options.add_destruct_bounds {
-                    // Add a `T: Drop` bound for every generic, unless the current trait is `Drop` itself, or a
-                    // built-in marker trait that we know doesn't need the bound.
-                    if !matches!(
-                        tcx.as_lang_item(def_id),
-                        Some(
-                            LangItem::Destruct
-                                | LangItem::Sized
-                                | LangItem::MetaSized
-                                | LangItem::PointeeSized
-                                | LangItem::DiscriminantKind
-                                | LangItem::PointeeTrait
-                                | LangItem::Tuple
-                        )
-                    ) {
-                        predicates.add_destruct_bounds(tcx, def_id);
+        elab_ctx.cached_implied_predicates(def_id, options, || {
+            use DefKind::*;
+            let tcx = elab_ctx.tcx;
+            let parent = tcx.opt_parent(def_id);
+            let mut predicates = match tcx.def_kind(def_id) {
+                // We consider all predicates on traits to be outputs
+                Trait | TraitAlias => {
+                    let mut predicates = Self::defined_on(tcx, def_id, false);
+                    if options.add_destruct_bounds {
+                        // Add a `T: Drop` bound for every generic, unless the current trait is `Drop` itself, or a
+                        // built-in marker trait that we know doesn't need the bound.
+                        if !matches!(
+                            tcx.as_lang_item(def_id),
+                            Some(
+                                LangItem::Destruct
+                                    | LangItem::Sized
+                                    | LangItem::MetaSized
+                                    | LangItem::PointeeSized
+                                    | LangItem::DiscriminantKind
+                                    | LangItem::PointeeTrait
+                                    | LangItem::Tuple
+                            )
+                        ) {
+                            predicates.add_destruct_bounds(tcx, def_id);
+                        }
                     }
+                    predicates
                 }
-                predicates
-            }
-            AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
-                // `skip_binder` is for the GAT `EarlyBinder`
-                let mut predicates = ItemPredicates::new(
-                    def_id,
-                    false,
-                    tcx.explicit_item_bounds(def_id)
-                        .skip_binder()
-                        .iter()
-                        .copied(),
-                );
-                if options.add_destruct_bounds {
-                    // Add a `Drop` bound to the assoc item.
-                    let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
-                    let ty = Ty::new_projection(
-                        tcx,
+                AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
+                    // `skip_binder` is for the GAT `EarlyBinder`
+                    let mut predicates = ItemPredicates::new(
                         def_id,
-                        GenericArgs::identity_for_item(tcx, def_id),
+                        false,
+                        tcx.explicit_item_bounds(def_id)
+                            .skip_binder()
+                            .iter()
+                            .copied(),
                     );
-                    let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
-                    predicates.add_synthetic_predicates(def_id, [tref.upcast(tcx)]);
+                    if options.add_destruct_bounds {
+                        // Add a `Drop` bound to the assoc item.
+                        let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
+                        let ty = Ty::new_projection(
+                            tcx,
+                            def_id,
+                            GenericArgs::identity_for_item(tcx, def_id),
+                        );
+                        let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
+                        predicates.add_synthetic_predicates(def_id, [tref.upcast(tcx)]);
+                    }
+                    predicates
                 }
-                predicates
-            }
-            _ => ItemPredicates::default(),
-        };
-        predicates.filter_traits(options);
-        predicates
+                _ => ItemPredicates::default(),
+            };
+            predicates.filter_traits(options);
+            predicates
+        })
     }
 
     pub fn len(&self) -> usize {

--- a/charon/src/bin/charon-driver/hax/mod.rs
+++ b/charon/src/bin/charon-driver/hax/mod.rs
@@ -28,7 +28,5 @@ pub mod options {
         /// blocks or advanced constant expressions as in `[T; N+1]`), or refer to them as
         /// `GlobalName`s.
         pub inline_anon_consts: bool,
-        /// Options related to bounds.
-        pub bounds_options: BoundsOptions,
     }
 }

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -129,6 +129,7 @@ mod types {
         pub fn new(
             tcx: rustc_middle::ty::TyCtxt<'tcx>,
             options: crate::hax::options::Options,
+            bounds_options: crate::hax::options::BoundsOptions,
         ) -> Self {
             Self {
                 tcx,
@@ -138,7 +139,7 @@ mod types {
                 // `opt_def_id` is used in `utils` for error reporting
                 opt_def_id: None,
                 local_ctx: Rc::new(RefCell::new(LocalContextS::new())),
-                elab_ctx: ElaborationCtx::new(tcx),
+                elab_ctx: ElaborationCtx::new(tcx, bounds_options),
             }
         }
     }
@@ -161,9 +162,13 @@ pub type StateWithOwner<'tcx> = State<Base<'tcx>, DefId, ()>;
 pub type StateWithBinder<'tcx> = State<Base<'tcx>, DefId, types::UnitBinder<'tcx>>;
 
 impl<'tcx> StateWithBase<'tcx> {
-    pub fn new(tcx: rustc_middle::ty::TyCtxt<'tcx>, options: crate::hax::options::Options) -> Self {
+    pub fn new(
+        tcx: rustc_middle::ty::TyCtxt<'tcx>,
+        options: crate::hax::options::Options,
+        bounds_options: crate::hax::options::BoundsOptions,
+    ) -> Self {
         Self {
-            base: Base::new(tcx, options),
+            base: Base::new(tcx, options, bounds_options),
             owner: (),
             binder: (),
         }
@@ -243,11 +248,7 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
     fn with_predicate_searcher<T>(&self, f: impl FnOnce(&mut PredicateSearcher<'tcx>) -> T) -> T {
         self.with_cache(|cache| {
             f(cache.predicate_searcher.get_or_insert_with(|| {
-                PredicateSearcher::new_for_owner(
-                    self.base().elab_ctx,
-                    self.owner_id(),
-                    &self.base().options.bounds_options,
-                )
+                PredicateSearcher::new_for_owner(self.base().elab_ctx, self.owner_id())
             }))
         })
     }

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -121,7 +121,7 @@ mod types {
         pub local_ctx: Rc<RefCell<LocalContextS>>,
         pub opt_def_id: Option<rustc_hir::def_id::DefId>,
         pub cache: Rc<RefCell<GlobalCache<'tcx>>>,
-        pub elaboration_ctx: crate::hax::traits::ElaborationCtx<'tcx>,
+        pub elab_ctx: crate::hax::traits::ElaborationCtx<'tcx>,
         pub tcx: ty::TyCtxt<'tcx>,
     }
 
@@ -138,7 +138,7 @@ mod types {
                 // `opt_def_id` is used in `utils` for error reporting
                 opt_def_id: None,
                 local_ctx: Rc::new(RefCell::new(LocalContextS::new())),
-                elaboration_ctx: ElaborationCtx::new(),
+                elab_ctx: ElaborationCtx::new(tcx),
             }
         }
     }
@@ -244,8 +244,7 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
         self.with_cache(|cache| {
             f(cache.predicate_searcher.get_or_insert_with(|| {
                 PredicateSearcher::new_for_owner(
-                    self.base().tcx,
-                    self.base().elaboration_ctx.clone(),
+                    self.base().elab_ctx,
                     self.owner_id(),
                     &self.base().options.bounds_options,
                 )

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -109,8 +109,6 @@ mod types {
         pub tys: HashMap<ty::Ty<'tcx>, Ty>,
         /// Cache the `ItemRef` translations. This is fast because `GenericArgsRef` is interned.
         pub item_refs: HashMap<(DefId, ty::GenericArgsRef<'tcx>, bool), ItemRef>,
-        /// Cache the trait resolution engine for each item.
-        pub predicate_searcher: Option<crate::hax::traits::PredicateSearcher<'tcx>>,
         /// Cache of trait refs to resolved impl expressions.
         pub impl_exprs: HashMap<ty::PolyTraitRef<'tcx>, crate::hax::traits::ImplExpr>,
     }
@@ -246,11 +244,9 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
         self.with_item_cache(self.owner_id(), f)
     }
     fn with_predicate_searcher<T>(&self, f: impl FnOnce(&mut PredicateSearcher<'tcx>) -> T) -> T {
-        self.with_cache(|cache| {
-            f(cache.predicate_searcher.get_or_insert_with(|| {
-                PredicateSearcher::new_for_owner(self.base().elab_ctx, self.owner_id())
-            }))
-        })
+        let base = self.base();
+        let mut predicate_searcher = base.elab_ctx.predicate_searcher_for(self.owner_id());
+        f(&mut predicate_searcher)
     }
 }
 impl<'tcx, S: UnderOwnerState<'tcx>> WithItemCacheExt<'tcx> for S {}

--- a/charon/src/bin/charon-driver/hax/traits.rs
+++ b/charon/src/bin/charon-driver/hax/traits.rs
@@ -217,7 +217,7 @@ pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<ImplExpr> {
     let predicates = ItemPredicates::required_recursively(
-        s.base().tcx,
+        s.base().elab_ctx,
         def_id,
         &s.base().options.bounds_options,
     );
@@ -233,7 +233,7 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<ImplExpr> {
     let predicates =
-        ItemPredicates::implied(s.base().tcx, def_id, &s.base().options.bounds_options);
+        ItemPredicates::implied(s.base().elab_ctx, def_id, &s.base().options.bounds_options);
     solve_item_traits_inner(s, generics, predicates)
 }
 

--- a/charon/src/bin/charon-driver/hax/traits.rs
+++ b/charon/src/bin/charon-driver/hax/traits.rs
@@ -216,11 +216,7 @@ pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<ImplExpr> {
-    let predicates = ItemPredicates::required_recursively(
-        s.base().elab_ctx,
-        def_id,
-        &s.base().options.bounds_options,
-    );
+    let predicates = ItemPredicates::required_recursively(s.base().elab_ctx, def_id);
     solve_item_traits_inner(s, generics, predicates)
 }
 
@@ -232,8 +228,7 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<ImplExpr> {
-    let predicates =
-        ItemPredicates::implied(s.base().elab_ctx, def_id, &s.base().options.bounds_options);
+    let predicates = ItemPredicates::implied(s.base().elab_ctx, def_id);
     solve_item_traits_inner(s, generics, predicates)
 }
 

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -1324,7 +1324,12 @@ fn get_param_env<'tcx, S: UnderOwnerState<'tcx>>(
             predicates: if is_typeck_child {
                 GenericPredicates::default()
             } else {
-                ItemPredicates::required(tcx, def_id, &s.base().options.bounds_options).sinto(s)
+                ItemPredicates::required(
+                    s.base().elab_ctx,
+                    def_id,
+                    &s.base().options.bounds_options,
+                )
+                .sinto(s)
             },
             parent,
         },
@@ -1349,7 +1354,7 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     let def_id = s.owner_id();
     let typing_env = s.typing_env();
     let mut implied_predicates =
-        ItemPredicates::implied(tcx, def_id, &s.base().options.bounds_options);
+        ItemPredicates::implied(s.base().elab_ctx, def_id, &s.base().options.bounds_options);
     if args.is_some() {
         for pred in implied_predicates.iter_mut() {
             pred.clause = substitute(tcx, typing_env, args, pred.clause);

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -1324,12 +1324,7 @@ fn get_param_env<'tcx, S: UnderOwnerState<'tcx>>(
             predicates: if is_typeck_child {
                 GenericPredicates::default()
             } else {
-                ItemPredicates::required(
-                    s.base().elab_ctx,
-                    def_id,
-                    &s.base().options.bounds_options,
-                )
-                .sinto(s)
+                ItemPredicates::required(s.base().elab_ctx, def_id).sinto(s)
             },
             parent,
         },
@@ -1353,8 +1348,7 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     let tcx = s.base().tcx;
     let def_id = s.owner_id();
     let typing_env = s.typing_env();
-    let mut implied_predicates =
-        ItemPredicates::implied(s.base().elab_ctx, def_id, &s.base().options.bounds_options);
+    let mut implied_predicates = ItemPredicates::implied(s.base().elab_ctx, def_id);
     if args.is_some() {
         for pred in implied_predicates.iter_mut() {
             pred.clause = substitute(tcx, typing_env, args, pred.clause);

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -834,7 +834,11 @@ pub fn translate<'tcx>(
     let translate_options = TranslateOptions::new(&mut error_ctx, cli_options);
 
     let traits_to_remove: HashSet<rustc_hir::def_id::DefId> = {
-        let hax_state = hax::state::State::new(tcx, hax::options::Options::default());
+        let hax_state = hax::state::State::new(
+            tcx,
+            hax::options::Options::default(),
+            hax::options::BoundsOptions::default(),
+        );
         translate_options
             .hide_traits
             .iter()
@@ -845,10 +849,10 @@ pub fn translate<'tcx>(
         tcx,
         hax::options::Options {
             inline_anon_consts: !translate_options.raw_consts,
-            bounds_options: hax::options::BoundsOptions {
-                add_destruct_bounds: translate_options.add_destruct_bounds,
-                remove_traits: traits_to_remove,
-            },
+        },
+        hax::options::BoundsOptions {
+            add_destruct_bounds: translate_options.add_destruct_bounds,
+            remove_traits: traits_to_remove,
         },
     );
 


### PR DESCRIPTION
This reorganizes `rustc_trait_elaboration` around an `ElaborationCtx` which is used as basis for the workings of the whole crate.