### PR TITLE
Pretty-print predicates more like real items

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.205"
+let supported_charon_version = "0.1.206"

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -165,10 +165,13 @@ let const_generic_param_to_string (ty_to_string : ty -> string)
   "const " ^ v.name ^ " : " ^ ty_to_string v.ty
 
 let trait_clause_id_to_pretty_string (id : trait_clause_id) : string =
-  "@TraitClause" ^ TraitClauseId.to_string id
+  "TraitClause" ^ TraitClauseId.to_string id
+
+let trait_clause_id_format_as_implied (id : trait_clause_id) : string =
+  "ImpliedClause" ^ TraitClauseId.to_string id
 
 let trait_db_var_to_pretty_string (var : trait_db_var) : string =
-  "@TraitClause" ^ de_bruijn_var_to_pretty_string TraitClauseId.to_string var
+  "TraitClause" ^ de_bruijn_var_to_pretty_string TraitClauseId.to_string var
 
 let type_decl_id_to_pretty_string (id : type_decl_id) : string =
   "TypeDecl@" ^ TypeDeclId.to_string id
@@ -643,7 +646,7 @@ and dyn_trait_type_constraint_to_string (env : fmt_env)
     match tref.kind with
     | ParentClause (parent, clause_id) ->
         target_clause_and_path
-          (("parent_clause" ^ TraitClauseId.to_string clause_id) :: path)
+          (trait_clause_id_format_as_implied clause_id :: path)
           parent
     | Clause (Bound (_, clause_id)) | Clause (Free clause_id) ->
         Some (clause_id, List.rev path)
@@ -775,15 +778,15 @@ and pp_trait_ref_kind (env : fmt_env)
       pp_string fmt "}"
   | Clause id -> pp_string fmt (trait_db_var_to_string env id)
   | ParentClause (tref, clause_id) ->
-      Format.fprintf fmt "%a::parent_clause%s" (pp_trait_ref env) tref
-        (TraitClauseId.to_string clause_id)
+      Format.fprintf fmt "%a::%s" (pp_trait_ref env) tref
+        (trait_clause_id_format_as_implied clause_id)
   | ItemClause (tref, type_id, clause_id) ->
       let type_name =
         GAstUtils.get_assoc_type_name env.crate
           tref.trait_decl_ref.binder_value.id type_id
       in
-      Format.fprintf fmt "(%a::%s::[%s])" (pp_trait_ref env) tref type_name
-        (trait_clause_id_to_pretty_string clause_id)
+      Format.fprintf fmt "%a::%s::%s" (pp_trait_ref env) tref type_name
+        (trait_clause_id_format_as_implied clause_id)
   | Dyn -> pp_region_binder pp_trait_decl_ref env fmt (Option.get implements)
   | UnknownTrait msg -> Format.fprintf fmt "UNKNOWN(%s)" msg
 
@@ -807,6 +810,33 @@ and pp_trait_decl_ref_as_impl (env : fmt_env) (fmt : Format.formatter)
       Format.fprintf fmt "%a for %a" (pp_trait_decl_ref env)
         { tr with generics } (pp_ty env) self_ty
   | [] -> pp_trait_decl_ref env fmt tr
+
+and pp_trait_decl_ref_as_pred (env : fmt_env) (fmt : Format.formatter)
+    (tr : trait_decl_ref) : unit =
+  match tr.generics.types with
+  | self_ty :: types ->
+      let generics = { tr.generics with types } in
+      Format.fprintf fmt "%a: %a" (pp_ty env) self_ty (pp_trait_decl_ref env)
+        { tr with generics }
+  | [] -> pp_trait_decl_ref env fmt tr
+
+and pp_poly_trait_decl_ref_as_pred (env : fmt_env) (fmt : Format.formatter)
+    (tr : trait_decl_ref region_binder) : unit =
+  pp_region_binder
+    (fun env fmt tr ->
+      Format.fprintf fmt "(%a)" (pp_trait_decl_ref_as_pred env) tr)
+    env fmt tr
+
+and pp_trait_proof (env : fmt_env) (fmt : Format.formatter)
+    (clause_id : trait_clause_id) (trait_ : trait_decl_ref region_binder)
+    (value : trait_ref option) : unit =
+  Format.fprintf fmt "proof %s: %a"
+    (trait_clause_id_format_as_implied clause_id)
+    (pp_poly_trait_decl_ref_as_pred env)
+    trait_;
+  match value with
+  | None -> ()
+  | Some value -> Format.fprintf fmt " = %a" (pp_trait_ref env) value
 
 and pp_impl_elem (env : fmt_env) (fmt : Format.formatter) (elem : impl_elem) :
     unit =
@@ -873,8 +903,8 @@ and pp_raw_attribute (fmt : Format.formatter) (attr : raw_attribute) : unit =
 and pp_trait_param (env : fmt_env) (fmt : Format.formatter)
     (clause : trait_param) : unit =
   let clause_id = trait_clause_id_to_string_for_env env clause.clause_id in
-  Format.fprintf fmt "[%s]: %a" clause_id
-    (pp_region_binder pp_trait_decl_ref env)
+  Format.fprintf fmt "%s: %a" clause_id
+    (pp_poly_trait_decl_ref_as_pred env)
     clause.trait
 
 and trait_param_to_string env clause =
@@ -954,6 +984,39 @@ let pp_trait_type_constraint (env : fmt_env) (fmt : Format.formatter)
 let trait_type_constraint_to_string env ttc =
   pp_to_string (fun fmt -> pp_trait_type_constraint env fmt ttc)
 
+let generic_clauses_to_strings (env : fmt_env) (generics : generic_params) :
+    string list =
+  let _, trait_clauses = generic_params_to_strings env generics in
+  let regions_outlive =
+    let outlive_to_string env (x, y) =
+      region_to_string env x ^ ": " ^ region_to_string env y
+    in
+    List.mapi
+      (fun i rb ->
+        "RegionOutlives" ^ string_of_int i ^ ": "
+        ^ region_binder_to_string outlive_to_string env rb)
+      generics.regions_outlive
+  in
+  let types_outlive =
+    let outlive_to_string env (x, y) =
+      ty_to_string env x ^ ": " ^ region_to_string env y
+    in
+    List.mapi
+      (fun i rb ->
+        "TypeOutlives" ^ string_of_int i ^ ": "
+        ^ region_binder_to_string outlive_to_string env rb)
+      generics.types_outlive
+  in
+  let trait_type_constraints =
+    List.mapi
+      (fun i rb ->
+        "TypeConstraint" ^ string_of_int i ^ ": "
+        ^ region_binder_to_string trait_type_constraint_to_string env rb)
+      generics.trait_type_constraints
+  in
+  List.concat
+    [ trait_clauses; types_outlive; regions_outlive; trait_type_constraints ]
+
 (** Helper to format "where" clauses *)
 let pp_clauses (indent : string) (indent_incr : string) (fmt : Format.formatter)
     (clauses : string list) : unit =
@@ -969,74 +1032,34 @@ let pp_clauses (indent : string) (indent_incr : string) (fmt : Format.formatter)
 let clauses_to_string indent indent_incr clauses =
   pp_to_string (fun fmt -> pp_clauses indent indent_incr fmt clauses)
 
+let pp_assoc_ty_clauses (indent : string) (indent_incr : string)
+    (fmt : Format.formatter) (clauses : string list) : unit =
+  match clauses with
+  | [] -> ()
+  | clauses ->
+      Format.fprintf fmt "\n%swhere" indent;
+      List.iteri
+        (fun i clause ->
+          let sep = if i + 1 = List.length clauses then ";" else "," in
+          Format.fprintf fmt "\n%s%s%s" (indent ^ indent_incr) clause sep)
+        clauses
+
+let assoc_ty_clauses_to_string indent indent_incr clauses =
+  pp_to_string (fun fmt -> pp_assoc_ty_clauses indent indent_incr fmt clauses)
+
 (** Helper to format "where" clauses *)
 let predicates_and_trait_clauses_to_string (env : fmt_env) (indent : string)
     (indent_incr : string) (generics : generic_params) : string list * string =
-  let params, trait_clauses = generic_params_to_strings env generics in
-  let regions_outlive =
-    let outlive_to_string env (x, y) =
-      region_to_string env x ^ " : " ^ region_to_string env y
-    in
-    List.map
-      (region_binder_to_string outlive_to_string env)
-      generics.regions_outlive
-  in
-  let types_outlive =
-    let outlive_to_string env (x, y) =
-      ty_to_string env x ^ " : " ^ region_to_string env y
-    in
-    List.map
-      (region_binder_to_string outlive_to_string env)
-      generics.types_outlive
-  in
-  let trait_type_constraints =
-    List.map
-      (region_binder_to_string trait_type_constraint_to_string env)
-      generics.trait_type_constraints
-  in
+  let params, _ = generic_params_to_strings env generics in
+  let clauses = generic_clauses_to_strings env generics in
   (* Split between the inherited clauses and the local clauses *)
-  let clauses =
-    clauses_to_string indent indent_incr
-      (List.concat
-         [
-           trait_clauses; types_outlive; regions_outlive; trait_type_constraints;
-         ])
-  in
+  let clauses = clauses_to_string indent indent_incr clauses in
   (params, clauses)
 
 let pp_generic_params_single_line (env : fmt_env) (fmt : Format.formatter)
     (generics : generic_params) : unit =
-  let params, trait_clauses = generic_params_to_strings env generics in
-  let regions_outlive =
-    List.map
-      (region_binder_to_string
-         (fun env (x, y) ->
-           region_to_string env x ^ " : " ^ region_to_string env y)
-         env)
-      generics.regions_outlive
-  in
-  let types_outlive =
-    List.map
-      (region_binder_to_string
-         (fun env (x, y) -> ty_to_string env x ^ " : " ^ region_to_string env y)
-         env)
-      generics.types_outlive
-  in
-  let trait_type_constraints =
-    List.map
-      (region_binder_to_string trait_type_constraint_to_string env)
-      generics.trait_type_constraints
-  in
-  let all =
-    List.concat
-      [
-        params;
-        trait_clauses;
-        types_outlive;
-        regions_outlive;
-        trait_type_constraints;
-      ]
-  in
+  let params, _ = generic_params_to_strings env generics in
+  let all = params @ generic_clauses_to_strings env generics in
   if all <> [] then Format.fprintf fmt "<%a>" (pp_sep_list ", " pp_string) all
 
 let generic_params_to_string_single_line env generics =
@@ -1536,9 +1559,10 @@ let pp_trait_decl (env : fmt_env) (indent : string) (indent_incr : string)
     pp_string fmt "\n{\n";
     List.iter
       (fun clause ->
-        Format.fprintf fmt "%sparent_clause%s : %s\n" indent1
-          (TraitClauseId.to_string clause.clause_id)
-          (trait_param_to_string env clause))
+        Format.fprintf fmt "%s%a\n" indent1
+          (fun fmt clause ->
+            pp_trait_proof env fmt clause.clause_id clause.trait None)
+          clause)
       def.implied_clauses;
     List.iter
       (fun (c : trait_assoc_const) ->
@@ -1549,20 +1573,27 @@ let pp_trait_decl (env : fmt_env) (indent : string) (indent_incr : string)
       (fun (bound_ty : trait_assoc_ty binder) ->
         let env = fmt_env_push_generics_and_preds env bound_ty.binder_params in
         let params =
-          generic_params_to_string_single_line env bound_ty.binder_params
+          let params, _ =
+            generic_params_to_strings env bound_ty.binder_params
+          in
+          if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
         in
         Format.fprintf fmt "%stype %s%s" indent1 bound_ty.binder_value.name
           params;
-        if bound_ty.binder_value.implied_clauses <> [] then (
-          Format.fprintf fmt "\n%swhere\n" indent1;
-          List.iter
-            (fun c ->
-              Format.fprintf fmt "%simplied_clause_%s : %s\n"
-                (indent1 ^ indent_incr)
-                (TraitClauseId.to_string c.clause_id)
-                (trait_param_to_string env c))
-            bound_ty.binder_value.implied_clauses);
-        pp_string fmt "\n")
+        Option.iter
+          (fun default ->
+            Format.fprintf fmt " = %s" (ty_to_string env default.value))
+          bound_ty.binder_value.default;
+        let clauses =
+          generic_clauses_to_strings env bound_ty.binder_params
+          @ List.map
+              (fun c ->
+                pp_to_string (fun fmt ->
+                    pp_trait_proof env fmt c.clause_id c.trait None))
+              bound_ty.binder_value.implied_clauses
+        in
+        Format.fprintf fmt "%s\n"
+          (assoc_ty_clauses_to_string indent1 indent_incr clauses))
       types;
     List.iter
       (fun (m : trait_method binder) ->
@@ -1598,8 +1629,11 @@ let pp_trait_impl (env : fmt_env) (indent : string) (indent_incr : string)
   pp_string fmt "\n";
   List.iteri
     (fun i trait_ref ->
-      Format.fprintf fmt "%sparent_clause%s = %s\n" indent1 (string_of_int i)
-        (trait_ref_to_string env trait_ref))
+      Format.fprintf fmt "%s%a\n" indent1
+        (fun fmt (clause_id, trait_ref) ->
+          pp_trait_proof env fmt clause_id trait_ref.trait_decl_ref
+            (Some trait_ref))
+        (TraitClauseId.of_int i, trait_ref))
     def.implied_trait_refs;
   AssocConstId.Map.to_list def.consts
   |> List.iter (fun (const_id, gref) ->
@@ -1609,14 +1643,27 @@ let pp_trait_impl (env : fmt_env) (indent : string) (indent_incr : string)
          Format.fprintf fmt "%sconst %s = %a\n" indent1 name
            (pp_global_decl_ref env) gref);
   AssocTypeId.Map.to_list def.types
-  |> List.iter (fun (type_id, bound_ty) ->
+  |> List.iter (fun (type_id, (bound_ty : trait_assoc_ty_impl binder)) ->
          let name = GAstUtils.get_assoc_type_name env.crate trait_id type_id in
          let env = fmt_env_push_generics_and_preds env bound_ty.binder_params in
          let params =
-           generic_params_to_string_single_line env bound_ty.binder_params
+           let params, _ =
+             generic_params_to_strings env bound_ty.binder_params
+           in
+           if params = [] then "" else "<" ^ String.concat ", " params ^ ">"
          in
-         Format.fprintf fmt "%stype %s%s = %s\n" indent1 name params
-           (ty_to_string env bound_ty.binder_value.value));
+         let clauses =
+           generic_clauses_to_strings env bound_ty.binder_params
+           @ List.mapi
+               (fun i trait_ref ->
+                 pp_to_string (fun fmt ->
+                     pp_trait_proof env fmt (TraitClauseId.of_int i)
+                       trait_ref.trait_decl_ref (Some trait_ref)))
+               bound_ty.binder_value.implied_trait_refs
+         in
+         Format.fprintf fmt "%stype %s%s = %s%s\n" indent1 name params
+           (ty_to_string env bound_ty.binder_value.value)
+           (assoc_ty_clauses_to_string indent1 indent_incr clauses));
   TraitMethodId.Map.to_list def.methods
   |> List.iter (fun (method_id, (f : fun_decl_ref binder)) ->
          let name = GAstUtils.get_method_name env.crate trait_id method_id in

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -648,7 +648,7 @@ let lookup_fndef_sig (crate : crate) (fn_ptr : fn_ptr region_binder) :
 (* Construct a set of generic arguments in the scope of `params` that matches
    `params` and feeds each required parameter with itself. E.g. given
    parameters for `<T, U> where U: PartialEq<T>`, the arguments would be `<T,
-   U>[@TraitClause0]`. This uses `Bound` variables; we could define the same
+   U>[TraitClause0]`. This uses `Bound` variables; we could define the same
    for `Free` variables if needed.
 *)
 let bound_identity_args (params : generic_params) : generic_args =

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -1207,9 +1207,13 @@ and trait_assoc_ty_impl_of_json (ctx : of_json_ctx) (js : json) :
     (trait_assoc_ty_impl, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("value", value); ("implied_trait_refs", _) ] ->
+    | `Assoc [ ("value", value); ("implied_trait_refs", implied_trait_refs) ] ->
         let* value = ty_of_json ctx value in
-        Ok ({ value } : trait_assoc_ty_impl)
+        let* implied_trait_refs =
+          index_vec_of_json trait_clause_id_of_json trait_ref_of_json ctx
+            implied_trait_refs
+        in
+        Ok ({ value; implied_trait_refs } : trait_assoc_ty_impl)
     | _ -> Error "")
 
 and trait_clause_id_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1111,11 +1111,11 @@ and trait_assoc_ty_impl_of_postcard (ctx : of_postcard_ctx)
     (st : postcard_state) : (trait_assoc_ty_impl, string) result =
   combine_error_msgs st __FUNCTION__
     (let* value = ty_of_postcard ctx st in
-     let* _ =
+     let* implied_trait_refs =
        index_vec_of_postcard trait_clause_id_of_postcard trait_ref_of_postcard
          ctx st
      in
-     Ok ({ value } : trait_assoc_ty_impl))
+     Ok ({ value; implied_trait_refs } : trait_assoc_ty_impl))
 
 and trait_clause_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (trait_clause_id, string) result =

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -583,7 +583,12 @@ and region_param = {
 }
 
 (** The value of a trait associated type. *)
-and trait_assoc_ty_impl = { value : ty }
+and trait_assoc_ty_impl = {
+  value : ty;
+  implied_trait_refs : trait_ref list;
+      (** This matches the corresponding vector in [TraitAssocTy]. In the same
+          way, this is empty after the [lift_associated_item_clauses] pass. *)
+}
 
 (** A predicate of the form [Type: Trait<Args>].
 

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.205"
+version = "0.1.206"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.205"
+version = "0.1.206"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -453,7 +453,6 @@ pub struct TraitAssocTyImpl {
     pub value: Ty,
     /// This matches the corresponding vector in `TraitAssocTy`. In the same way, this is empty
     /// after the `lift_associated_item_clauses` pass.
-    #[cfg_attr(feature = "charon_on_charon", charon::opaque)]
     pub implied_trait_refs: IndexVec<TraitClauseId, TraitRef>,
 }
 

--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -95,7 +95,7 @@ impl GenericParams {
 
     /// Construct a set of generic arguments in the scope of `self` that matches `self` and feeds
     /// each required parameter with itself. E.g. given parameters for `<T, U> where U:
-    /// PartialEq<T>`, the arguments would be `<T, U>[@TraitClause0]`.
+    /// PartialEq<T>`, the arguments would be `<T, U>[TraitClause0]`.
     pub fn identity_args(&self) -> GenericArgs {
         self.identity_args_at_depth(DeBruijnId::zero())
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -12,7 +12,7 @@ use either::Either;
 use itertools::Itertools;
 use std::{
     borrow::Cow,
-    fmt::{self, Debug, Display, Write},
+    fmt::{self, Debug, Display},
 };
 
 pub struct WithCtx<'a, C, T: ?Sized> {
@@ -63,6 +63,27 @@ macro_rules! impl_debug_via_display {
             }
         }
     };
+}
+
+fn fmt_where_clauses<'a, I>(clauses: I, indent: &'a str) -> impl Display + 'a
+where
+    I: IntoIterator,
+    I::Item: Display,
+{
+    let clauses = clauses
+        .into_iter()
+        .map(|clause| clause.to_string())
+        .collect_vec();
+    std::fmt::from_fn(move |f| {
+        if !clauses.is_empty() {
+            write!(f, "\n{indent}where")?;
+            for (i, clause) in clauses.iter().enumerate() {
+                let sep = if i + 1 == clauses.len() { ";" } else { "," };
+                write!(f, "\n{indent}{TAB_INCR}{clause}{sep}")?;
+            }
+        }
+        Ok(())
+    })
 }
 
 //------- Impls, sorted by name --------
@@ -361,7 +382,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for CastKind {
 
 impl<C: AstFormatter> FmtWithCtx<C> for ClauseDbVar {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        ctx.format_bound_var(f, *self, "@TraitClause", |_| None)
+        ctx.format_bound_var(f, *self, "TraitClause", |_| None)
     }
 }
 
@@ -435,7 +456,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for DynPredicate {
                 loop {
                     match &tref.kind {
                         TraitRefKind::ParentClause(parent_trait_ref, clause_id) => {
-                            path.push(format!("parent_clause{clause_id}"));
+                            path.push(*clause_id);
                             tref = parent_trait_ref;
                         }
                         &TraitRefKind::Clause(DeBruijnVar::Bound(_, clause_id)) => {
@@ -446,7 +467,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for DynPredicate {
                     }
                 }
                 let ty = cstr.ty.with_ctx(ctx);
-                let path_fmt = path.iter().format("::");
+                let path_fmt = path.iter().map(|id| id.format_as_implied()).format("::");
                 std::fmt::from_fn(|f| {
                     write!(f, "{path_fmt}")?;
                     if !path.is_empty() {
@@ -760,12 +781,20 @@ impl GenericParams {
         C: AstFormatter,
     {
         let trait_clauses = self.trait_clauses.iter().map(|x| x.to_string_with_ctx(ctx));
-        let types_outlive = self.types_outlive.iter().map(|x| x.fmt_as_for(ctx));
-        let regions_outlive = self.regions_outlive.iter().map(|x| x.fmt_as_for(ctx));
+        let types_outlive = self
+            .types_outlive
+            .iter()
+            .enumerate()
+            .map(|(i, x)| format!("TypeOutlives{i}: {}", x.fmt_as_for(ctx)));
+        let regions_outlive = self
+            .regions_outlive
+            .iter()
+            .enumerate()
+            .map(|(i, x)| format!("RegionOutlives{i}: {}", x.fmt_as_for(ctx)));
         let type_constraints = self
             .trait_type_constraints
-            .iter()
-            .map(|x| x.fmt_as_for(ctx));
+            .iter_enumerated()
+            .map(|(i, x)| format!("TypeConstraint{i}: {}", x.fmt_as_for(ctx)));
         trait_clauses.map(Either::Left).chain(
             types_outlive
                 .chain(regions_outlive)
@@ -1168,7 +1197,7 @@ where
     U: FmtWithCtx<C>,
 {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} : {}", self.0.with_ctx(ctx), self.1.with_ctx(ctx))
+        write!(f, "{}: {}", self.0.with_ctx(ctx), self.1.with_ctx(ctx))
     }
 }
 
@@ -1278,6 +1307,39 @@ impl<C: AstFormatter> FmtWithCtx<C> for Place {
 impl<C: AstFormatter> FmtWithCtx<C> for PolyTraitDeclRef {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.fmt_as_for(ctx))
+    }
+}
+
+impl PolyTraitDeclRef {
+    fn fmt_trait_proof<'a, C: AstFormatter + 'a>(
+        &'a self,
+        id: TraitClauseId,
+        value: Option<&'a TraitRef>,
+        ctx: &'a C,
+    ) -> impl Display + 'a {
+        std::fmt::from_fn(move |f| {
+            write!(
+                f,
+                "proof {}: {}",
+                id.format_as_implied(),
+                self.format_as_pred(ctx)
+            )?;
+            if let Some(value) = value {
+                write!(f, " = {}", value.with_ctx(ctx))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn format_as_pred<'a, C: AstFormatter + 'a>(&'a self, ctx: &'a C) -> impl Display + 'a {
+        std::fmt::from_fn(move |f| {
+            let ctx = &ctx.push_bound_regions(&self.regions);
+            if !self.regions.is_empty() {
+                let regions = self.regions.iter().map(|r| r.with_ctx(ctx));
+                write!(f, "for<{}> ", regions.format(", "))?;
+            }
+            write!(f, "({})", self.skip_binder.format_as_pred(ctx))
+        })
     }
 }
 
@@ -1927,14 +1989,21 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
 
 impl<C: AstFormatter> FmtWithCtx<C> for TraitParam {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let clause_id = self.clause_id.to_pretty_string();
-        let trait_ = self.trait_.with_ctx(ctx);
-        write!(f, "[{clause_id}")?;
+        write!(f, "{}", self.clause_id.format_as_required())?;
         if let Some(d @ 1..) = ctx.binder_depth().checked_sub(1) {
             write!(f, "_{d}")?;
         }
-        write!(f, "]: {trait_}")?;
-        Ok(())
+        write!(f, ": {}", self.trait_.format_as_pred(ctx))
+    }
+}
+
+impl TraitClauseId {
+    pub(crate) fn format_as_implied(self) -> impl Display {
+        std::fmt::from_fn(move |f| write!(f, "ImpliedClause{self}"))
+    }
+
+    pub(crate) fn format_as_required(self) -> impl Display {
+        std::fmt::from_fn(move |f| write!(f, "TraitClause{self}"))
     }
 }
 
@@ -1958,9 +2027,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
             for c in &self.implied_clauses {
                 writeln!(
                     f,
-                    "{TAB_INCR}parent_clause{} : {}",
-                    c.clause_id,
-                    c.with_ctx(ctx)
+                    "{TAB_INCR}{}",
+                    c.trait_.fmt_trait_proof(c.clause_id, None, ctx)
                 )?;
             }
             for assoc_const in &self.consts {
@@ -1970,23 +2038,28 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitDecl {
             }
             for assoc_ty in &self.types {
                 let name = assoc_ty.name();
-                let (params, implied_clauses) = assoc_ty.fmt_split_with(ctx, |ctx, assoc_ty| {
-                    let mut out = String::new();
-                    let f = &mut out;
-                    if !assoc_ty.implied_clauses.is_empty() {
-                        let _ = writeln!(f, "\n{TAB_INCR}where",);
-                        for c in &assoc_ty.implied_clauses {
-                            let _ = writeln!(
-                                f,
-                                "{TAB_INCR}{TAB_INCR}implied_clause_{} : {}",
-                                c.clause_id,
-                                c.with_ctx(ctx)
-                            );
-                        }
-                    }
-                    out
-                });
-                writeln!(f, "{TAB_INCR}type {name}{params}{implied_clauses}")?;
+                let ctx = &ctx.push_binder(Cow::Borrowed(&assoc_ty.params));
+                let clauses = assoc_ty
+                    .params
+                    .formatted_clauses(ctx)
+                    .map(|x| x.to_string())
+                    .chain(assoc_ty.skip_binder.implied_clauses.iter().map(|clause| {
+                        clause
+                            .trait_
+                            .fmt_trait_proof(clause.clause_id, None, ctx)
+                            .to_string()
+                    }));
+                let params = if assoc_ty.params.has_explicits() {
+                    format!("<{}>", assoc_ty.params.formatted_params(ctx).format(", "))
+                } else {
+                    String::new()
+                };
+                write!(f, "{TAB_INCR}type {name}{params}")?;
+                if let Some(default) = &assoc_ty.skip_binder.default {
+                    write!(f, " = {}", default.value.with_ctx(ctx))?;
+                }
+                write!(f, "{}", fmt_where_clauses(clauses, TAB_INCR))?;
+                writeln!(f)?;
             }
             for method in self.methods() {
                 let name = method.name();
@@ -2028,18 +2101,26 @@ impl TraitDeclRef {
         (self_ty, pred)
     }
 
-    fn format_as_impl<C: AstFormatter>(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (self_ty, pred) = self.split_self();
-        let pred = pred.with_ctx(ctx);
-        match self_ty {
-            Some(self_ty) => {
-                let self_ty = self_ty.with_ctx(ctx);
-                write!(f, "{pred} for {self_ty}")?;
+    fn format_as_pred<'a, C: AstFormatter + 'a>(&'a self, ctx: &'a C) -> impl Display + 'a {
+        std::fmt::from_fn(move |f| {
+            let (self_ty, pred) = self.split_self();
+            match self_ty {
+                Some(self_ty) => write!(f, "{}: {}", self_ty.with_ctx(ctx), pred.with_ctx(ctx)),
+                // Monomorphized traits don't have self types.
+                None => write!(f, "{}", pred.with_ctx(ctx)),
             }
-            // Monomorphized traits don't have self types.
-            None => write!(f, "{pred}")?,
-        }
-        Ok(())
+        })
+    }
+
+    fn format_as_impl<'a, C: AstFormatter>(&'a self, ctx: &'a C) -> impl Display + 'a {
+        std::fmt::from_fn(move |f| {
+            let (self_ty, pred) = self.split_self();
+            match self_ty {
+                Some(self_ty) => write!(f, "{} for {}", pred.with_ctx(ctx), self_ty.with_ctx(ctx)),
+                // Monomorphized traits don't have self types.
+                None => write!(f, "{}", pred.with_ctx(ctx)),
+            }
+        })
     }
 }
 
@@ -2053,9 +2134,8 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
         let ctx = &ctx.set_generics(&self.generics);
 
         let (generics, clauses) = self.generics.fmt_with_ctx_with_trait_clauses(ctx);
-        write!(f, "impl{generics} ")?;
-        self.impl_trait.format_as_impl(ctx, f)?;
-        write!(f, "{clauses}")?;
+        let impl_trait = self.impl_trait.format_as_impl(ctx);
+        write!(f, "impl{generics} {impl_trait}{clauses}",)?;
 
         let newline = if clauses.is_empty() {
             " ".to_string()
@@ -2069,9 +2149,14 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
             || !self.types.is_empty()
             || !self.methods.is_empty();
         if any_item {
-            for (i, c) in self.implied_trait_refs.iter().enumerate() {
-                let i = TraitClauseId::new(i);
-                writeln!(f, "{TAB_INCR}parent_clause{i} = {}", c.with_ctx(ctx))?;
+            for (id, trait_ref) in self.implied_trait_refs.iter_enumerated() {
+                writeln!(
+                    f,
+                    "{TAB_INCR}{}",
+                    trait_ref
+                        .trait_decl_ref
+                        .fmt_trait_proof(id, Some(trait_ref), ctx)
+                )?;
             }
             for (const_id, global) in self.consts.iter_enumerated() {
                 write!(f, "{TAB_INCR}const ")?;
@@ -2079,12 +2164,34 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitImpl {
                 writeln!(f, " = {}", global.with_ctx(ctx))?;
             }
             for (type_id, assoc_ty) in self.types.iter_enumerated() {
-                // TODO: implied trait refs
-                let (params, ty) = assoc_ty
-                    .fmt_split_with(ctx, |ctx, assoc_ty| assoc_ty.value.to_string_with_ctx(ctx));
+                let ctx = &ctx.push_binder(Cow::Borrowed(&assoc_ty.params));
+                let params = if assoc_ty.params.has_explicits() {
+                    format!("<{}>", assoc_ty.params.formatted_params(ctx).format(", "))
+                } else {
+                    String::new()
+                };
+                let ty = assoc_ty.skip_binder.value.with_ctx(ctx);
+                let clauses = assoc_ty
+                    .params
+                    .formatted_clauses(ctx)
+                    .map(|x| x.to_string())
+                    .chain(
+                        assoc_ty
+                            .skip_binder
+                            .implied_trait_refs
+                            .iter_enumerated()
+                            .map(|(id, trait_ref)| {
+                                trait_ref
+                                    .trait_decl_ref
+                                    .fmt_trait_proof(id, Some(trait_ref), ctx)
+                                    .to_string()
+                            }),
+                    );
                 write!(f, "{TAB_INCR}type ")?;
                 ctx.format_assoc_type_name(f, trait_id, type_id)?;
-                writeln!(f, "{params} = {ty}",)?;
+                write!(f, "{params} = {ty}")?;
+                write!(f, "{}", fmt_where_clauses(clauses, TAB_INCR))?;
+                writeln!(f)?;
             }
             for (method_id, bound_fn) in self.methods.iter_enumerated() {
                 let (params, fn_ref) = bound_fn.fmt_split(ctx);
@@ -2129,25 +2236,21 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitRef {
             TraitRefKind::SelfId => write!(f, "Self"),
             TraitRefKind::ParentClause(sub, clause_id) => {
                 let sub = sub.with_ctx(ctx);
-                write!(f, "{sub}::parent_clause{clause_id}")
+                write!(f, "{sub}::{}", clause_id.format_as_implied())
             }
             TraitRefKind::ItemClause(sub, type_id, clause_id) => {
-                write!(f, "({}::", sub.with_ctx(ctx))?;
+                write!(f, "{}::", sub.with_ctx(ctx))?;
                 ctx.format_assoc_type_name(f, sub.trait_id(), *type_id)?;
-                // Using on purpose `to_pretty_string` instead of `with_ctx`: the clause is local
-                // to the associated type, so it should not be referenced in the current context.
-                write!(f, "::[{}])", clause_id.to_pretty_string())
+                write!(f, "::{}", clause_id.format_as_implied())
             }
             TraitRefKind::TraitImpl(impl_ref) => {
                 write!(f, "{}", impl_ref.with_ctx(ctx))
             }
             TraitRefKind::Clause(id) => write!(f, "{}", id.with_ctx(ctx)),
             TraitRefKind::BuiltinOrAuto { types, .. } => {
-                write!(f, "{{built_in impl ")?;
                 let bound_ctx = &ctx.push_bound_regions(&self.trait_decl_ref.regions);
-                self.trait_decl_ref
-                    .skip_binder
-                    .format_as_impl(bound_ctx, f)?;
+                let impl_trait = self.trait_decl_ref.skip_binder.format_as_impl(bound_ctx);
+                write!(f, "{{built_in impl {impl_trait}")?;
                 if !types.is_empty() {
                     let trait_id = self.trait_decl_ref.skip_binder.id;
                     let types = types

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -20,7 +20,7 @@ pub trait Sized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,25 +28,25 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -62,10 +62,10 @@ pub enum AssertKind {
 // Full name: take_mut::take
 pub fn take<'_0, T, F>(_1: &'_0 mut T, _2: F)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: FnOnce<F, (T,)>,
-    @TraitClause2::Output = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (F: FnOnce<(T,)>),
+    TypeConstraint0: TraitClause2::Output = T,
 = <opaque>
 
 // Full name: test_cargo_dependencies::main::silly_incr::closure
@@ -95,10 +95,10 @@ fn {impl FnOnce<(u32,)> for closure}::call_once(_1: closure, tupled_args_2: (u32
 
 // Full name: test_cargo_dependencies::main::silly_incr::{impl FnOnce<(u32,)> for closure}
 impl FnOnce<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
     fn call_once = {impl FnOnce<(u32,)> for closure}::call_once
     non-dyn-compatible

--- a/charon/tests/cargo/issue-412-dup-deps.out
+++ b/charon/tests/cargo/issue-412-dup-deps.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -20,7 +20,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,19 +16,19 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::is_some
-pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: core::option::{Option<T>[TraitClause0]}::is_some
+pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
     let _2: isize; // anonymous local
 
     storage_live(_2)

--- a/charon/tests/ui/advanced-const-generics.out
+++ b/charon/tests/ui/advanced-const-generics.out
@@ -11,21 +11,21 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     fn assert_receiver_is_total_eq<'_0_1> = core::cmp::Eq::assert_receiver_is_total_eq<'_0_1, Self>[Self]
     non-dyn-compatible
 }
 
 pub fn core::cmp::Eq::assert_receiver_is_total_eq<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Eq<Self>,
+    TraitClause0: (Self: Eq),
 = <opaque>
 
 // Full name: core::fmt::Error
@@ -39,7 +39,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -47,8 +47,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -64,7 +64,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 pub fn core::fmt::{Formatter<'a>}::write_str<'a, '_1, '_2>(_1: &'_1 mut Formatter<'a>, _2: &'_2 str) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
@@ -74,7 +74,7 @@ pub fn core::fmt::{Formatter<'a>}::write_str<'a, '_1, '_2>(_1: &'_1 mut Formatte
 #[lang_item("structural_peq")]
 pub trait StructuralPartialEq<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::marker::StructuralPartialEq::{vtable}
 }
 
@@ -82,9 +82,9 @@ pub trait StructuralPartialEq<Self>
 #[lang_item("const_param_ty")]
 pub trait ConstParamTy_<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: StructuralPartialEq<Self>
-    parent_clause2 : [@TraitClause2]: Eq<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: StructuralPartialEq)
+    proof ImpliedClause2: (Self: Eq)
     non-dyn-compatible
 }
 
@@ -148,22 +148,22 @@ impl PartialEq<Foo> for Foo {
 
 // Full name: test_crate::{impl Eq for Foo}
 impl Eq for Foo {
-    parent_clause0 = {impl PartialEq<Foo> for Foo}
+    proof ImpliedClause0: (Foo: PartialEq<Foo>) = {impl PartialEq<Foo> for Foo}
     fn assert_receiver_is_total_eq<'_0_1> = {impl Eq for Foo}::assert_receiver_is_total_eq<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl StructuralPartialEq for Foo}
 impl StructuralPartialEq for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
     vtable: {impl StructuralPartialEq for Foo}::{vtable}
 }
 
 // Full name: test_crate::{impl ConstParamTy_ for Foo}
 impl ConstParamTy_ for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {impl StructuralPartialEq for Foo}
-    parent_clause2 = {impl Eq for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Foo: StructuralPartialEq) = {impl StructuralPartialEq for Foo}
+    proof ImpliedClause2: (Foo: Eq) = {impl Eq for Foo}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -8,9 +8,9 @@ pub trait MetaSized<Self>
 #[lang_item("index")]
 pub trait Index<Self, Idx, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Idx>
-    parent_clause2 : [@TraitClause2]: MetaSized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Idx: MetaSized)
+    proof ImpliedClause2: (Self_Output: MetaSized)
     fn index<'_0_1> = core::ops::index::Index::index<'_0_1, Self, Idx, Self_Output>[Self]
     vtable: core::ops::index::Index::{vtable}<Idx, Self_Output>
 }
@@ -19,25 +19,25 @@ pub trait Index<Self, Idx, Self_Output>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: core::array::{impl Index<I, Clause2_Output> for [T; N]}::index
 pub fn {impl Index<I, Clause2_Output> for [T; N]}::index<'_0, T, I, Clause2_Output, const N : usize>(_1: &'_0 [T; N], _2: I) -> &'_0 Clause2_Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<[T], I, Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: ([T]: Index<I, Clause2_Output>),
 = <opaque>
 
 // Full name: core::ops::index::IndexMut
 #[lang_item("index_mut")]
 pub trait IndexMut<Self, Idx, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Index<Self, Idx, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: MetaSized<Idx>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Index<Idx, Self_Clause1_Output>)
+    proof ImpliedClause2: (Idx: MetaSized)
     fn index_mut<'_0_1> = core::ops::index::IndexMut::index_mut<'_0_1, Self, Idx, Self_Clause1_Output>[Self]
     vtable: core::ops::index::IndexMut::{vtable}<Idx, Self_Clause1_Output>
 }
@@ -45,9 +45,9 @@ pub trait IndexMut<Self, Idx, Self_Clause1_Output>
 // Full name: core::array::{impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut
 pub fn {impl IndexMut<I, Clause2_Clause1_Output> for [T; N]}::index_mut<'_0, T, I, Clause2_Clause1_Output, const N : usize>(_1: &'_0 mut [T; N], _2: I) -> &'_0 mut Clause2_Clause1_Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IndexMut<[T], I, Clause2_Clause1_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: ([T]: IndexMut<I, Clause2_Clause1_Output>),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -63,19 +63,19 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 
 pub fn core::ops::index::Index::index<'_0, Self, Idx, Clause0_Output>(_1: &'_0 Self, _2: Idx) -> &'_0 Clause0_Output
 where
-    [@TraitClause0]: Index<Self, Idx, Clause0_Output>,
+    TraitClause0: (Self: Index<Idx, Clause0_Output>),
 = <opaque>
 
 pub fn core::ops::index::IndexMut::index_mut<'_0, Self, Idx, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Idx) -> &'_0 mut Clause0_Clause1_Output
 where
-    [@TraitClause0]: IndexMut<Self, Idx, Clause0_Clause1_Output>,
+    TraitClause0: (Self: IndexMut<Idx, Clause0_Clause1_Output>),
 = <opaque>
 
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
@@ -85,7 +85,7 @@ where
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -94,7 +94,7 @@ where
 // Full name: core::slice::index::private_slice_index::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
@@ -102,10 +102,10 @@ pub trait Sealed<Self>
 #[lang_item("SliceIndex")]
 pub trait SliceIndex<Self, T, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sealed<Self>
-    parent_clause2 : [@TraitClause2]: MetaSized<T>
-    parent_clause3 : [@TraitClause3]: MetaSized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Sealed)
+    proof ImpliedClause2: (T: MetaSized)
+    proof ImpliedClause3: (Self_Output: MetaSized)
     fn get<'_0_1> = core::slice::index::SliceIndex::get<'_0_1, Self, T, Self_Output>[Self]
     fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut<'_0_1, Self, T, Self_Output>[Self]
     fn get_unchecked = core::slice::index::SliceIndex::get_unchecked<Self, T, Self_Output>[Self]
@@ -118,148 +118,148 @@ pub trait SliceIndex<Self, T, Self_Output>
 // Full name: core::slice::index::{impl Index<I, Clause2_Output> for [T]}::index
 pub fn {impl Index<I, Clause2_Output> for [T]}::index<'_0, T, I, Clause2_Output>(_1: &'_0 [T], _2: I) -> &'_0 Clause2_Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T], Clause2_Output>),
 = <opaque>
 
 // Full name: core::slice::index::{impl Index<I, Clause2_Output> for [T]}
 impl<T, I, Clause2_Output> Index<I, Clause2_Output> for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T], Clause2_Output>),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = @TraitClause1::parent_clause0
-    parent_clause2 = @TraitClause2::parent_clause3
-    fn index<'_0_1> = {impl Index<I, Clause2_Output> for [T]}::index<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I, Clause2_Output> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: (I: MetaSized) = TraitClause1::ImpliedClause0
+    proof ImpliedClause2: (Clause2_Output: MetaSized) = TraitClause2::ImpliedClause3
+    fn index<'_0_1> = {impl Index<I, Clause2_Output> for [T]}::index<'_0_1, T, I, Clause2_Output>[TraitClause0, TraitClause1, TraitClause2]
+    vtable: {impl Index<I, Clause2_Output> for [T]}::{vtable}<T, I>[TraitClause0, TraitClause1, TraitClause2]
 }
 
 // Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for [T]}::index_mut
 pub fn {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_0, T, I, Clause2_Output>(_1: &'_0 mut [T], _2: I) -> &'_0 mut Clause2_Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T], Clause2_Output>),
 = <opaque>
 
 // Full name: core::slice::index::{impl IndexMut<I, Clause2_Output> for [T]}
 impl<T, I, Clause2_Output> IndexMut<I, Clause2_Output> for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T], Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T], Clause2_Output>),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = {impl Index<I, Clause2_Output> for [T]}<T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    parent_clause2 = @TraitClause1::parent_clause0
-    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_0_1, T, I, Clause2_Output>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl IndexMut<I, Clause2_Output> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: ([T]: Index<I, Clause2_Output>) = {impl Index<I, Clause2_Output> for [T]}<T, I, Clause2_Output>[TraitClause0, TraitClause1, TraitClause2]
+    proof ImpliedClause2: (I: MetaSized) = TraitClause1::ImpliedClause0
+    fn index_mut<'_0_1> = {impl IndexMut<I, Clause2_Output> for [T]}::index_mut<'_0_1, T, I, Clause2_Output>[TraitClause0, TraitClause1, TraitClause2]
+    vtable: {impl IndexMut<I, Clause2_Output> for [T]}::{vtable}<T, I>[TraitClause0, TraitClause1, TraitClause2]
 }
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
 impl Sealed for Range<usize>[{built_in impl Sized for usize}] {
-    parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause0: (Range<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
     vtable: {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}::{vtable}
 }
 
 pub fn core::slice::index::SliceIndex::get<'_0, Self, T, Clause0_Output>(_1: Self, _2: &'_0 T) -> Option<&'_0 Clause0_Output>[{built_in impl Sized for &'_0 Clause0_Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T, Clause0_Output>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut Clause0_Output>[{built_in impl Sized for &'_0 mut Clause0_Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T, Clause0_Output>(_1: Self, _2: *const T) -> *const Clause0_Output
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T, Clause0_Output>(_1: Self, _2: *mut T) -> *mut Clause0_Output
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 pub fn core::slice::index::SliceIndex::index<'_0, Self, T, Clause0_Output>(_1: Self, _2: &'_0 T) -> &'_0 Clause0_Output
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T, Clause0_Output>(_1: Self, _2: &'_0 mut T) -> &'_0 mut Clause0_Output
 where
-    [@TraitClause0]: SliceIndex<Self, T, Clause0_Output>,
+    TraitClause0: (Self: SliceIndex<T, Clause0_Output>),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
 pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> &'_0 mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index
 pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
 pub unsafe fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: *mut [T]) -> *mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
 pub unsafe fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: *const [T]) -> *const [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
 pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 pub fn {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(_1: Range<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}
 impl<T> SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause1 = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for [T]}
-    parent_clause3 = {built_in impl MetaSized for [T]}
-    fn get<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Range<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause1: (Range<usize>[{built_in impl Sized for usize}]: Sealed) = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause2: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause3: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    fn get<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl SliceIndex<[T], [T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: core::slice::{[T]}::len
 #[lang_item("slice_len_fn")]
 pub fn len<'_0, T>(_1: &'_0 [T]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
 unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(_1: *mut [T; N])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: *mut [T; N]; // arg #1
@@ -307,9 +307,9 @@ where
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}
 impl<T, const N : usize> Destruct for [T; N]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[TraitClause0]
     non-dyn-compatible
 }
 
@@ -337,7 +337,7 @@ pub fn incr<'_0>(x_1: &'_0 mut u32)
 // Full name: test_crate::array_to_shared_slice_
 pub fn array_to_shared_slice_<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 [T]; // return
     let s_1: &'3 [T; 32 : usize]; // arg #1
@@ -353,7 +353,7 @@ where
 // Full name: test_crate::array_to_mut_slice_
 pub fn array_to_mut_slice_<'_0, T>(s_1: &'_0 mut [T; 32 : usize]) -> &'_0 mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut [T]; // return
     let s_1: &'3 mut [T; 32 : usize]; // arg #1
@@ -373,7 +373,7 @@ where
 // Full name: test_crate::array_len
 pub fn array_len<T>(s_1: [T; 32 : usize]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let s_1: [T; 32 : usize]; // arg #1
@@ -385,16 +385,16 @@ where
     _3 = &s_1
     _2 = @ArrayToSliceShared<'_, T, 32 : usize>(move _3)
     storage_dead(_3)
-    _0 = len<'6, T>[@TraitClause0](move _2)
+    _0 = len<'6, T>[TraitClause0](move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for [T; N]}::drop_in_place<T, 32 : usize>[@TraitClause0]] s_1
+    conditional_drop[{impl Destruct for [T; N]}::drop_in_place<T, 32 : usize>[TraitClause0]] s_1
     return
 }
 
 // Full name: test_crate::shared_array_len
 pub fn shared_array_len<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let s_1: &'1 [T; 32 : usize]; // arg #1
@@ -406,7 +406,7 @@ where
     _3 = &(*s_1)
     _2 = @ArrayToSliceShared<'_, T, 32 : usize>(move _3)
     storage_dead(_3)
-    _0 = len<'7, T>[@TraitClause0](move _2)
+    _0 = len<'7, T>[TraitClause0](move _2)
     storage_dead(_2)
     return
 }
@@ -414,7 +414,7 @@ where
 // Full name: test_crate::shared_slice_len
 pub fn shared_slice_len<'_0, T>(s_1: &'_0 [T]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let s_1: &'1 [T]; // arg #1
@@ -422,7 +422,7 @@ where
 
     storage_live(_2)
     _2 = &(*s_1) with_metadata(copy s_1.metadata)
-    _0 = len<'4, T>[@TraitClause0](move _2)
+    _0 = len<'4, T>[TraitClause0](move _2)
     storage_dead(_2)
     return
 }
@@ -430,7 +430,7 @@ where
 // Full name: test_crate::index_array_shared
 pub fn index_array_shared<'_0, T>(s_1: &'_0 [T; 32 : usize], i_2: usize) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
     let s_1: &'3 [T; 32 : usize]; // arg #1
@@ -498,7 +498,7 @@ pub fn index_array_copy<'_0>(x_1: &'_0 [u32; 32 : usize]) -> u32
 // Full name: test_crate::index_mut_array
 pub fn index_mut_array<'_0, T>(s_1: &'_0 mut [T; 32 : usize], i_2: usize) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
     let s_1: &'3 mut [T; 32 : usize]; // arg #1
@@ -529,7 +529,7 @@ where
 // Full name: test_crate::index_slice
 pub fn index_slice<'_0, T>(s_1: &'_0 [T], i_2: usize) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
     let s_1: &'3 [T]; // arg #1
@@ -556,7 +556,7 @@ where
 // Full name: test_crate::index_mut_slice
 pub fn index_mut_slice<'_0, T>(s_1: &'_0 mut [T], i_2: usize) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
     let s_1: &'3 mut [T]; // arg #1
@@ -771,7 +771,7 @@ pub fn array_subslice_mut_<'_0>(x_1: &'_0 mut [u32; 32 : usize], y_2: usize, z_3
 // Full name: test_crate::index_slice_0
 pub fn index_slice_0<'_0, T>(s_1: &'_0 [T]) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
     let s_1: &'3 [T]; // arg #1
@@ -797,7 +797,7 @@ where
 // Full name: test_crate::index_array_0
 pub fn index_array_0<'_0, T>(s_1: &'_0 [T; 32 : usize]) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
     let s_1: &'3 [T; 32 : usize]; // arg #1
@@ -2218,7 +2218,7 @@ fn slice_pattern_1(x_1: [(); 1 : usize])
 // Full name: test_crate::slice_pattern_2
 fn slice_pattern_2<'_0, T>(x_1: [&'_0 mut T; 3 : usize])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let x_1: [&'2 mut T; 3 : usize]; // arg #1

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -8,21 +8,21 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::V
 struct V<T, const N : usize>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   x: [T; N],
 }
 
-fn test_crate::{V<T, N>[@TraitClause0]}::LEN<T, const N : usize>() -> usize
+fn test_crate::{V<T, N>[TraitClause0]}::LEN<T, const N : usize>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
@@ -30,15 +30,15 @@ where
     return
 }
 
-const test_crate::{V<T, N>[@TraitClause0]}::LEN<T, const N : usize>: usize
+const test_crate::{V<T, N>[TraitClause0]}::LEN<T, const N : usize>: usize
 where
-    [@TraitClause0]: Sized<T>,
- = test_crate::{V<T, N>[@TraitClause0]}::LEN()
+    TraitClause0: (T: Sized),
+ = test_crate::{V<T, N>[TraitClause0]}::LEN()
 
 // Full name: test_crate::HasLen
 trait HasLen<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const LEN : usize
     non-dyn-compatible
 }
@@ -57,7 +57,7 @@ const {impl HasLen for [(); N]}::LEN<const N : usize>: usize = {impl HasLen for 
 
 // Full name: test_crate::{impl HasLen for [(); N]}
 impl<const N : usize> HasLen for [(); N] {
-    parent_clause0 = {built_in impl MetaSized for [(); N]}
+    proof ImpliedClause0: ([(); N]: MetaSized) = {built_in impl MetaSized for [(); N]}
     const LEN = {impl HasLen for [(); N]}::LEN<N>
     non-dyn-compatible
 }
@@ -79,7 +79,7 @@ const {impl HasLen for [bool; N]}::LEN<const N : usize>: usize = {impl HasLen fo
 
 // Full name: test_crate::{impl HasLen for [bool; N]}
 impl<const N : usize> HasLen for [bool; N] {
-    parent_clause0 = {built_in impl MetaSized for [bool; N]}
+    proof ImpliedClause0: ([bool; N]: MetaSized) = {built_in impl MetaSized for [bool; N]}
     const LEN = {impl HasLen for [bool; N]}::LEN<N>
     non-dyn-compatible
 }
@@ -87,52 +87,52 @@ impl<const N : usize> HasLen for [bool; N] {
 // Full name: test_crate::Wrapper
 struct Wrapper<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::{impl HasLen for Wrapper<T>[@TraitClause0]}::LEN
-fn {impl HasLen for Wrapper<T>[@TraitClause0]}::LEN<T>() -> usize
+// Full name: test_crate::{impl HasLen for Wrapper<T>[TraitClause0]}::LEN
+fn {impl HasLen for Wrapper<T>[TraitClause0]}::LEN<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasLen<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasLen),
 {
     let _0: usize; // return
 
-    _0 = const @TraitClause1::LEN
+    _0 = const TraitClause1::LEN
     return
 }
 
-// Full name: test_crate::{impl HasLen for Wrapper<T>[@TraitClause0]}::LEN
-const {impl HasLen for Wrapper<T>[@TraitClause0]}::LEN<T>: usize
+// Full name: test_crate::{impl HasLen for Wrapper<T>[TraitClause0]}::LEN
+const {impl HasLen for Wrapper<T>[TraitClause0]}::LEN<T>: usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasLen<T>,
- = {impl HasLen for Wrapper<T>[@TraitClause0]}::LEN()
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasLen),
+ = {impl HasLen for Wrapper<T>[TraitClause0]}::LEN()
 
-// Full name: test_crate::{impl HasLen for Wrapper<T>[@TraitClause0]}
-impl<T> HasLen for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::{impl HasLen for Wrapper<T>[TraitClause0]}
+impl<T> HasLen for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasLen<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasLen),
 {
-    parent_clause0 = {built_in impl MetaSized for Wrapper<T>[@TraitClause0]}
-    const LEN = {impl HasLen for Wrapper<T>[@TraitClause0]}::LEN<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Wrapper<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Wrapper<T>[TraitClause0]}
+    const LEN = {impl HasLen for Wrapper<T>[TraitClause0]}::LEN<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasDefaultLen
 pub trait HasDefaultLen<Self, const M : usize>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const LEN : usize
     non-dyn-compatible
 }
 
 pub fn test_crate::HasDefaultLen::LEN<Self, const M : usize>() -> usize
 where
-    [@TraitClause0]: HasDefaultLen<Self, M>,
+    TraitClause0: (Self: HasDefaultLen<M>),
 {
     let _0: usize; // return
 
@@ -142,12 +142,12 @@ where
 
 pub const test_crate::HasDefaultLen::LEN<Self, const M : usize>: usize
 where
-    [@TraitClause0]: HasDefaultLen<Self, M>,
+    TraitClause0: (Self: HasDefaultLen<M>),
  = test_crate::HasDefaultLen::LEN()
 
 // Full name: test_crate::{impl HasDefaultLen<N> for [(); N]}
 impl<const N : usize> HasDefaultLen<N> for [(); N] {
-    parent_clause0 = {built_in impl MetaSized for [(); N]}
+    proof ImpliedClause0: ([(); N]: MetaSized) = {built_in impl MetaSized for [(); N]}
     const LEN = test_crate::HasDefaultLen::LEN<[(); N], N>[{impl HasDefaultLen<N> for [(); N]}<N>]
     non-dyn-compatible
 }
@@ -174,7 +174,7 @@ pub const {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>: usize = {
 
 // Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}
 impl<const N : usize> HasDefaultLen<N> for [bool; N] {
-    parent_clause0 = {built_in impl MetaSized for [bool; N]}
+    proof ImpliedClause0: ([bool; N]: MetaSized) = {built_in impl MetaSized for [bool; N]}
     const LEN = {impl HasDefaultLen<N> for [bool; N]}::LEN<N>
     non-dyn-compatible
 }
@@ -182,8 +182,8 @@ impl<const N : usize> HasDefaultLen<N> for [bool; N] {
 // Full name: test_crate::AlsoHasLen
 trait AlsoHasLen<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: HasLen<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: HasLen)
     const ALSO_LEN : usize
     non-dyn-compatible
 }
@@ -191,13 +191,13 @@ trait AlsoHasLen<Self>
 // Full name: test_crate::AlsoHasLen::ALSO_LEN
 fn ALSO_LEN<Self>() -> usize
 where
-    [@TraitClause0]: AlsoHasLen<Self>,
+    TraitClause0: (Self: AlsoHasLen),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local
 
     storage_live(_1)
-    _1 = const @TraitClause0::parent_clause1::LEN panic.+ const 1 : usize
+    _1 = const TraitClause0::ImpliedClause1::LEN panic.+ const 1 : usize
     _0 = move _1
     return
 }
@@ -205,13 +205,13 @@ where
 // Full name: test_crate::AlsoHasLen::ALSO_LEN
 const ALSO_LEN<Self>: usize
 where
-    [@TraitClause0]: AlsoHasLen<Self>,
+    TraitClause0: (Self: AlsoHasLen),
  = ALSO_LEN()
 
 // Full name: test_crate::{impl AlsoHasLen for [(); N]}
 impl<const N : usize> AlsoHasLen for [(); N] {
-    parent_clause0 = {built_in impl MetaSized for [(); N]}
-    parent_clause1 = {impl HasLen for [(); N]}<N>
+    proof ImpliedClause0: ([(); N]: MetaSized) = {built_in impl MetaSized for [(); N]}
+    proof ImpliedClause1: ([(); N]: HasLen) = {impl HasLen for [(); N]}<N>
     const ALSO_LEN = ALSO_LEN<[(); N]>[{impl AlsoHasLen for [(); N]}<N>]
     non-dyn-compatible
 }

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty-nested.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty-nested.out
@@ -8,42 +8,42 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
     vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::IntoIterator
 trait IntoIterator<Self, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
-    parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_IntoIter: Sized)
+    proof ImpliedClause2: (Self_IntoIter: Trait<()>)
     vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::IntoIntoIterator
 trait IntoIntoIterator<Self, Self_IntoIntoIter, Self_Clause2_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_IntoIntoIter>
-    parent_clause2 : [@TraitClause2]: IntoIterator<Self_IntoIntoIter, Self_Clause2_IntoIter>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_IntoIntoIter: Sized)
+    proof ImpliedClause2: (Self_IntoIntoIter: IntoIterator<Self_Clause2_IntoIter>)
     vtable: test_crate::IntoIntoIterator::{vtable}<Self_IntoIntoIter>
 }
 
 // Full name: test_crate::foo
 fn foo<I, Clause1_IntoIntoIter, Clause1_Clause2_IntoIter, Clause2_Assoc>()
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IntoIntoIterator<I, Clause1_IntoIntoIter, Clause1_Clause2_IntoIter>,
-    [@TraitClause2]: Trait<Clause1_Clause2_IntoIter, Clause2_Assoc>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IntoIntoIterator<Clause1_IntoIntoIter, Clause1_Clause2_IntoIter>),
+    TraitClause2: (Clause1_Clause2_IntoIter: Trait<Clause2_Assoc>),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.2.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.2.out
@@ -8,33 +8,33 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
     vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::IntoIterator
 trait IntoIterator<Self, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
-    parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_IntoIter: Sized)
+    proof ImpliedClause2: (Self_IntoIter: Trait<()>)
     vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::foo
 fn foo<I, Clause1_IntoIter, Clause2_Assoc>()
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IntoIterator<I, Clause1_IntoIter>,
-    [@TraitClause2]: Trait<Clause1_IntoIter, Clause2_Assoc>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IntoIterator<Clause1_IntoIter>),
+    TraitClause2: (Clause1_IntoIter: Trait<Clause2_Assoc>),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,16 +27,16 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
     vtable: test_crate::Trait::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::takes_trait
 fn takes_trait<I, Clause1_Assoc>(it_1: I)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Trait<I, Clause1_Assoc>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Trait<Clause1_Assoc>),
 {
     let _0: (); // return
     let it_1: I; // arg #1
@@ -50,17 +50,17 @@ where
 // Full name: test_crate::IntoIterator
 trait IntoIterator<Self, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_IntoIter>
-    parent_clause2 : [@TraitClause2]: Trait<Self_IntoIter, ()>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_IntoIter: Sized)
+    proof ImpliedClause2: (Self_IntoIter: Trait<()>)
     vtable: test_crate::IntoIterator::{vtable}<Self_IntoIter>
 }
 
 // Full name: test_crate::collect
 fn collect<I, Clause1_IntoIter>(it_1: Clause1_IntoIter)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IntoIterator<I, Clause1_IntoIter>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IntoIterator<Clause1_IntoIter>),
 {
     let _0: (); // return
     let it_1: Clause1_IntoIter; // arg #1
@@ -69,7 +69,7 @@ where
     _0 = ()
     storage_live(_2)
     _2 = move it_1
-    _0 = takes_trait<Clause1_IntoIter, ()>[@TraitClause1::parent_clause1, @TraitClause1::parent_clause2](move _2)
+    _0 = takes_trait<Clause1_IntoIter, ()>[TraitClause1::ImpliedClause1, TraitClause1::ImpliedClause2](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for Clause1_IntoIter}::drop_in_place] it_1
     return

--- a/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,33 +27,33 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Iterator
 pub trait Iterator<Self, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Item: Sized)
     vtable: test_crate::Iterator::{vtable}<Self_Item>
 }
 
 // Full name: test_crate::IsIterator
 pub trait IsIterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::IsIterator::{vtable}
 }
 
 // Full name: test_crate::{impl IsIterator for I}
 impl<I, Clause1_Item> IsIterator for I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I, Clause1_Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator<Clause1_Item>),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    vtable: {impl IsIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (I: MetaSized) = TraitClause0::ImpliedClause0
+    vtable: {impl IsIterator for I}::{vtable}<I>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::assert_is_iterator
 fn assert_is_iterator<I>(it_1: I)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IsIterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IsIterator),
 {
     let _0: (); // return
     let it_1: I; // arg #1
@@ -67,18 +67,18 @@ where
 // Full name: test_crate::IntoIterator
 pub trait IntoIterator<Self, Self_Item, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Item>
-    parent_clause2 : [@TraitClause2]: Sized<Self_IntoIter>
-    parent_clause3 : [@TraitClause3]: Iterator<Self_IntoIter, Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Item: Sized)
+    proof ImpliedClause2: (Self_IntoIter: Sized)
+    proof ImpliedClause3: (Self_IntoIter: Iterator<Self_Item>)
     vtable: test_crate::IntoIterator::{vtable}<Self_Item, Self_IntoIter>
 }
 
 // Full name: test_crate::check
 fn check<I, Clause1_Item, Clause1_IntoIter>(it_1: Clause1_IntoIter)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IntoIterator<I, Clause1_Item, Clause1_IntoIter>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IntoIterator<Clause1_Item, Clause1_IntoIter>),
 {
     let _0: (); // return
     let it_1: Clause1_IntoIter; // arg #1
@@ -89,7 +89,7 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = move it_1
-    _2 = assert_is_iterator<Clause1_IntoIter>[@TraitClause1::parent_clause2, {impl IsIterator for I}<Clause1_IntoIter, Clause1_Item>[@TraitClause1::parent_clause2, @TraitClause1::parent_clause3]](move _3)
+    _2 = assert_is_iterator<Clause1_IntoIter>[TraitClause1::ImpliedClause2, {impl IsIterator for I}<Clause1_IntoIter, Clause1_Item>[TraitClause1::ImpliedClause2, TraitClause1::ImpliedClause3]](move _3)
     storage_dead(_3)
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
+++ b/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
@@ -8,16 +8,18 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Ret>
-    type Ret<[@TraitClause0_1]: Sized<Self>>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Ret: Sized)
+    type Ret = ()
+    where
+        TraitClause0_1: (Self: Sized);
     vtable: test_crate::MyTrait::{vtable}<Self::Ret>
 }
 
@@ -26,9 +28,11 @@ pub struct S {}
 
 // Full name: test_crate::{impl MyTrait for S}
 impl MyTrait for S {
-    parent_clause0 = {built_in impl MetaSized for S}
-    parent_clause1 = {impl MyTrait for S}::parent_clause1
-    type Ret<[@TraitClause0_1]: Sized<S>> = ()
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    proof ImpliedClause1: ({impl MyTrait for S}::Ret: Sized) = {impl MyTrait for S}::ImpliedClause1
+    type Ret = ()
+    where
+        TraitClause0_1: (S: Sized);
     vtable: {impl MyTrait for S}::{vtable}
 }
 

--- a/charon/tests/ui/associated_types/assoc-ty-via-supertrait-and-bounds.out
+++ b/charon/tests/ui/associated_types/assoc-ty-via-supertrait-and-bounds.out
@@ -8,75 +8,75 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasOutput
 pub trait HasOutput<Self, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Output: Sized)
     vtable: test_crate::HasOutput::{vtable}<Self_Output>
 }
 
 // Full name: test_crate::{impl HasOutput<()> for ()}
 impl HasOutput<()> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
     vtable: {impl HasOutput<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::HasOutput2
 pub trait HasOutput2<Self, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: HasOutput<Self, Self_Clause1_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: HasOutput<Self_Clause1_Output>)
     vtable: test_crate::HasOutput2::{vtable}<Self_Clause1_Output>
 }
 
 // Full name: test_crate::{impl HasOutput2<()> for ()}
 impl HasOutput2<()> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {impl HasOutput<()> for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): HasOutput<()>) = {impl HasOutput<()> for ()}
     vtable: {impl HasOutput2<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::Wrapper
 struct Wrapper<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::{impl HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]}
-impl<T, Clause1_Output> HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::{impl HasOutput<Clause1_Output> for Wrapper<T>[TraitClause0]}
+impl<T, Clause1_Output> HasOutput<Clause1_Output> for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasOutput<T, Clause1_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasOutput<Clause1_Output>),
 {
-    parent_clause0 = {built_in impl MetaSized for Wrapper<T>[@TraitClause0]}
-    parent_clause1 = @TraitClause1::parent_clause1
-    vtable: {impl HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Wrapper<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Wrapper<T>[TraitClause0]}
+    proof ImpliedClause1: (Clause1_Output: Sized) = TraitClause1::ImpliedClause1
+    vtable: {impl HasOutput<Clause1_Output> for Wrapper<T>[TraitClause0]}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::{impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]}
-impl<T, Clause1_Clause1_Output> HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::{impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[TraitClause0]}
+impl<T, Clause1_Clause1_Output> HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasOutput2<T, Clause1_Clause1_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasOutput2<Clause1_Clause1_Output>),
 {
-    parent_clause0 = {built_in impl MetaSized for Wrapper<T>[@TraitClause0]}
-    parent_clause1 = {impl HasOutput<Clause1_Output> for Wrapper<T>[@TraitClause0]}<T, Clause1_Clause1_Output>[@TraitClause0, @TraitClause1::parent_clause1]
-    vtable: {impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Wrapper<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Wrapper<T>[TraitClause0]}
+    proof ImpliedClause1: (Wrapper<T>[TraitClause0]: HasOutput<Clause1_Clause1_Output>) = {impl HasOutput<Clause1_Output> for Wrapper<T>[TraitClause0]}<T, Clause1_Clause1_Output>[TraitClause0, TraitClause1::ImpliedClause1]
+    vtable: {impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[TraitClause0]}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::take
 fn take<T, Clause1_Clause1_Output>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasOutput2<T, Clause1_Clause1_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasOutput2<Clause1_Clause1_Output>),
 {
     let _0: (); // return
 
@@ -91,7 +91,7 @@ fn main()
     let _0: (); // return
 
     _0 = ()
-    _0 = take<Wrapper<()>[{built_in impl Sized for ()}], ()>[{built_in impl Sized for Wrapper<()>[{built_in impl Sized for ()}]}, {impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[@TraitClause0]}<(), ()>[{built_in impl Sized for ()}, {impl HasOutput2<()> for ()}]]()
+    _0 = take<Wrapper<()>[{built_in impl Sized for ()}], ()>[{built_in impl Sized for Wrapper<()>[{built_in impl Sized for ()}]}, {impl HasOutput2<Clause1_Clause1_Output> for Wrapper<T>[TraitClause0]}<(), ()>[{built_in impl Sized for ()}, {impl HasOutput2<()> for ()}]]()
     return
 }
 

--- a/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,10 +24,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
@@ -36,10 +36,10 @@ pub trait FnOnce<Self, Args, Self_Output>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args, Self_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
@@ -48,51 +48,51 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
 #[lang_item("fn")]
 pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args, Self_Clause1_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
 where
-    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+    TraitClause0: (Self: Fn<Args, Clause0_Clause1_Clause1_Output>),
 = <opaque>
 
 // Full name: core::ops::function::FnMut::call_mut
 pub extern "rust-call" fn call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
 where
-    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+    TraitClause0: (Self: FnMut<Args, Clause0_Clause1_Output>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
 pub extern "rust-call" fn call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 // Full name: test_crate::Trait
 pub trait Trait<Self, Self_Foo>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Foo>
-    parent_clause2 : [@TraitClause2]: Fn<Self_Foo, (), ()>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Foo: Sized)
+    proof ImpliedClause2: (Self_Foo: Fn<(), ()>)
     fn call<'_0_1> = test_crate::Trait::call<'_0_1, Self, Self_Foo>[Self]
     vtable: test_crate::Trait::{vtable}<Self_Foo>
 }
 
 pub fn test_crate::Trait::call<'_0, Self, Clause0_Foo>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self, Clause0_Foo>,
+    TraitClause0: (Self: Trait<Clause0_Foo>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<F> for F}::call
 pub fn {impl Trait<F> for F}::call<'_0, F>(self_1: &'_0 F)
 where
-    [@TraitClause0]: Fn<F, (), ()>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (F: Fn<(), ()>),
+    TraitClause1: (F: Sized),
 {
     let _0: (); // return
     let self_1: &'1 F; // arg #1
@@ -104,7 +104,7 @@ where
     _2 = &(*self_1)
     storage_live(_3)
     _3 = ()
-    _0 = @TraitClause0::call<'4>(move _2, move _3)
+    _0 = TraitClause0::call<'4>(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     return
@@ -113,14 +113,14 @@ where
 // Full name: test_crate::{impl Trait<F> for F}
 impl<F> Trait<F> for F
 where
-    [@TraitClause0]: Fn<F, (), ()>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (F: Fn<(), ()>),
+    TraitClause1: (F: Sized),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause0
-    fn call<'_0_1> = {impl Trait<F> for F}::call<'_0_1, F>[@TraitClause0, @TraitClause1]
-    vtable: {impl Trait<F> for F}::{vtable}<F>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (F: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (F: Sized) = TraitClause1
+    proof ImpliedClause2: (F: Fn<(), ()>) = TraitClause0
+    fn call<'_0_1> = {impl Trait<F> for F}::call<'_0_1, F>[TraitClause0, TraitClause1]
+    vtable: {impl Trait<F> for F}::{vtable}<F>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::use_foo

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -8,8 +8,8 @@ pub trait MetaSized<Self>
 #[lang_item("Borrow")]
 pub trait Borrow<Self, Borrowed>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Borrowed>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Borrowed: MetaSized)
     fn borrow<'_0_1> = borrow<'_0_1, Self, Borrowed>[Self]
     vtable: core::borrow::Borrow::{vtable}<Borrowed>
 }
@@ -17,14 +17,14 @@ pub trait Borrow<Self, Borrowed>
 // Full name: core::borrow::Borrow::borrow
 pub fn borrow<'_0, Self, Borrowed>(_1: &'_0 Self) -> &'_0 Borrowed
 where
-    [@TraitClause0]: Borrow<Self, Borrowed>,
+    TraitClause0: (Self: Borrow<Borrowed>),
 = <opaque>
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -32,7 +32,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -40,7 +40,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for &'_0 T}::clone
@@ -50,7 +50,7 @@ pub fn {impl Clone for &'_0 T}::clone<'_0, '_1, T>(_1: &'_1 &'_0 T) -> &'_0 T
 
 // Full name: core::clone::impls::{impl Clone for &'_0 T}
 impl<'_0, T> Clone for &'_0 T {
-    parent_clause0 = {built_in impl Sized for &'_ T}
+    proof ImpliedClause0: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
     fn clone<'_0_1> = {impl Clone for &'_0 T}::clone<'_0, '_0_1, T>
     non-dyn-compatible
 }
@@ -59,15 +59,15 @@ impl<'_0, T> Clone for &'_0 T {
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 // Full name: core::marker::{impl Copy for &'_0 T}
 impl<'_0, T> Copy for &'_0 T {
-    parent_clause0 = {built_in impl MetaSized for &'_ T}
-    parent_clause1 = {impl Clone for &'_0 T}<'_, T>
+    proof ImpliedClause0: (&'_ T: MetaSized) = {built_in impl MetaSized for &'_ T}
+    proof ImpliedClause1: (&'_ T: Clone) = {impl Clone for &'_0 T}<'_, T>
     non-dyn-compatible
 }
 
@@ -87,40 +87,40 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::{impl Clone for Option<T>[@TraitClause0]}::clone
-pub fn {impl Clone for Option<T>[@TraitClause0]}::clone<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> Option<T>[@TraitClause0]
+// Full name: core::option::{impl Clone for Option<T>[TraitClause0]}::clone
+pub fn {impl Clone for Option<T>[TraitClause0]}::clone<'_0, T>(_1: &'_0 Option<T>[TraitClause0]) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 = <opaque>
 
-// Full name: core::option::{impl Clone for Option<T>[@TraitClause0]}
-impl<T> Clone for Option<T>[@TraitClause0]
+// Full name: core::option::{impl Clone for Option<T>[TraitClause0]}
+impl<T> Clone for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
-    parent_clause0 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    fn clone<'_0_1> = {impl Clone for Option<T>[@TraitClause0]}::clone<'_0_1, T>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    fn clone<'_0_1> = {impl Clone for Option<T>[TraitClause0]}::clone<'_0_1, T>[TraitClause0, TraitClause1, TraitClause2]
     non-dyn-compatible
 }
 
-// Full name: core::option::{impl Copy for Option<T>[@TraitClause0]}
-impl<T> Copy for Option<T>[@TraitClause0]
+// Full name: core::option::{impl Copy for Option<T>[TraitClause0]}
+impl<T> Copy for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    parent_clause1 = {impl Clone for Option<T>[@TraitClause0]}<T>[@TraitClause0, @TraitClause1::parent_clause1, {built_in impl Destruct for T}]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Clone) = {impl Clone for Option<T>[TraitClause0]}<T>[TraitClause0, TraitClause1::ImpliedClause1, {built_in impl Destruct for T}]
     non-dyn-compatible
 }
 
@@ -128,9 +128,9 @@ where
 #[lang_item("ToOwned")]
 pub trait ToOwned<Self, Self_Owned>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Owned>
-    parent_clause2 : [@TraitClause2]: Borrow<Self_Owned, Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Owned: Sized)
+    proof ImpliedClause2: (Self_Owned: Borrow<Self>)
     fn to_owned<'_0_1> = to_owned<'_0_1, Self, Self_Owned>[Self]
     non-dyn-compatible
 }
@@ -139,31 +139,31 @@ pub trait ToOwned<Self, Self_Owned>
 #[lang_item("to_owned_method")]
 pub fn to_owned<'_0, Self, Clause0_Owned>(_1: &'_0 Self) -> Clause0_Owned
 where
-    [@TraitClause0]: ToOwned<Self, Clause0_Owned>,
+    TraitClause0: (Self: ToOwned<Clause0_Owned>),
 = <opaque>
 
 trait test_crate::Foo<'a, Self, Self_Item>
 where
-    Self_Item : 'a,
+    TypeOutlives0: Self_Item: 'a,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Copy<Self>
-    parent_clause2 : [@TraitClause2]: Sized<Self_Item>
-    parent_clause3 : [@TraitClause3]: Clone<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Copy)
+    proof ImpliedClause2: (Self_Item: Sized)
+    proof ImpliedClause3: (Self_Item: Clone)
     fn use_item_required = test_crate::Foo::use_item_required<'a, Self, Self_Item>[Self]
-    fn use_item_provided<Clause0_Item, [@TraitClause0_1]: test_crate::Foo<'a, Self_Item, Clause0_Item>> = test_crate::Foo::use_item_provided<'a, Self, Self_Item, Clause0_Item>[Self, @TraitClause0_1]
+    fn use_item_provided<Clause0_Item, TraitClause0_1: (Self_Item: test_crate::Foo<'a, Clause0_Item>)> = test_crate::Foo::use_item_provided<'a, Self, Self_Item, Clause0_Item>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 fn test_crate::Foo::use_item_required<'a, Self, Clause0_Item>(_1: Clause0_Item) -> Clause0_Item
 where
-    [@TraitClause0]: test_crate::Foo<'a, Self, Clause0_Item>,
+    TraitClause0: (Self: test_crate::Foo<'a, Clause0_Item>),
 = <method_without_default_body>
 
 fn test_crate::Foo::use_item_provided<'a, Self, Clause0_Item, Clause1_Item>(x_1: Clause0_Item) -> Clause0_Item
 where
-    [@TraitClause0]: test_crate::Foo<'a, Self, Clause0_Item>,
-    [@TraitClause1]: test_crate::Foo<'a, Clause0_Item, Clause1_Item>,
+    TraitClause0: (Self: test_crate::Foo<'a, Clause0_Item>),
+    TraitClause1: (Clause0_Item: test_crate::Foo<'a, Clause1_Item>),
 {
     let _0: Clause0_Item; // return
     let x_1: Clause0_Item; // arg #1
@@ -175,7 +175,7 @@ where
 // Full name: test_crate::{impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_required
 fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_required<'a, T>(x_1: Option<&'a T>[{built_in impl Sized for &'a T}]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
     let x_1: Option<&'9 T>[{built_in impl Sized for &'9 T}]; // arg #1
@@ -187,8 +187,8 @@ where
 // Full name: test_crate::{impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_provided
 fn {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_provided<'a, T, Clause1_Item>(x_1: Option<&'a T>[{built_in impl Sized for &'a T}]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}], Clause1_Item>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Option<&'a T>[{built_in impl Sized for &'a T}]: test_crate::Foo<'a, Clause1_Item>),
 {
     let _0: Option<&'a T>[{built_in impl Sized for &'a T}]; // return
     let x_1: Option<&'a T>[{built_in impl Sized for &'a T}]; // arg #1
@@ -200,23 +200,23 @@ where
 // Full name: test_crate::{impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}
 impl<'a, T> test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for &'_ T}
-    parent_clause1 = {impl Copy for &'_0 T}<'_, T>
-    parent_clause2 = {built_in impl Sized for Option<&'_ T>[{built_in impl Sized for &'_ T}]}
-    parent_clause3 = {impl Clone for Option<T>[@TraitClause0]}<&'_ T>[{built_in impl Sized for &'_ T}, {impl Clone for &'_0 T}<'_, T>, {built_in impl Destruct for &'_ T}]
-    fn use_item_required = {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_required<'a, T>[@TraitClause0]
-    fn use_item_provided<Clause0_Item, [@TraitClause0_1]: test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}], Clause0_Item>> = {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_provided<'a, T, Clause0_Item>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: (&'_ T: MetaSized) = {built_in impl MetaSized for &'_ T}
+    proof ImpliedClause1: (&'_ T: Copy) = {impl Copy for &'_0 T}<'_, T>
+    proof ImpliedClause2: (Option<&'_ T>[{built_in impl Sized for &'_ T}]: Sized) = {built_in impl Sized for Option<&'_ T>[{built_in impl Sized for &'_ T}]}
+    proof ImpliedClause3: (Option<&'_ T>[{built_in impl Sized for &'_ T}]: Clone) = {impl Clone for Option<T>[TraitClause0]}<&'_ T>[{built_in impl Sized for &'_ T}, {impl Clone for &'_0 T}<'_, T>, {built_in impl Destruct for &'_ T}]
+    fn use_item_required = {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_required<'a, T>[TraitClause0]
+    fn use_item_provided<Clause0_Item, TraitClause0_1: (Option<&'a T>[{built_in impl Sized for &'a T}]: test_crate::Foo<'a, Clause0_Item>)> = {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}::use_item_provided<'a, T, Clause0_Item>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required
-fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required<'a, T>(x_1: T) -> T
+// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_required
+fn {impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_required<'a, T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
+    TypeOutlives0: T: 'a,
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -225,13 +225,13 @@ where
     return
 }
 
-// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided
-fn {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided<'a, T, Clause2_Item>(x_1: T) -> T
+// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_provided
+fn {impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_provided<'a, T, Clause2_Item>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
-    [@TraitClause2]: test_crate::Foo<'a, T, Clause2_Item>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
+    TraitClause2: (T: test_crate::Foo<'a, Clause2_Item>),
+    TypeOutlives0: T: 'a,
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -240,28 +240,28 @@ where
     return
 }
 
-// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}
-impl<'a, T> test_crate::Foo<'a, T> for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}
+impl<'a, T> test_crate::Foo<'a, T> for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
+    TypeOutlives0: T: 'a,
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    parent_clause1 = {impl Copy for Option<T>[@TraitClause0]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = @TraitClause0
-    parent_clause3 = @TraitClause1::parent_clause1
-    fn use_item_required = {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_required<'a, T>[@TraitClause0, @TraitClause1]
-    fn use_item_provided<Clause0_Item, [@TraitClause0_1]: test_crate::Foo<'a, T, Clause0_Item>> = {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}::use_item_provided<'a, T, Clause0_Item>[@TraitClause0, @TraitClause1, @TraitClause0_1]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Copy) = {impl Copy for Option<T>[TraitClause0]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: (T: Sized) = TraitClause0
+    proof ImpliedClause3: (T: Clone) = TraitClause1::ImpliedClause1
+    fn use_item_required = {impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_required<'a, T>[TraitClause0, TraitClause1]
+    fn use_item_provided<Clause0_Item, TraitClause0_1: (T: test_crate::Foo<'a, Clause0_Item>)> = {impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}::use_item_provided<'a, T, Clause0_Item>[TraitClause0, TraitClause1, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::external_use_item
 fn external_use_item<'a, T, Clause1_Item, Clause2_Item>(x_1: Clause1_Item) -> Clause1_Item
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: test_crate::Foo<'a, T, Clause1_Item>,
-    [@TraitClause2]: test_crate::Foo<'a, Clause1_Item, Clause2_Item>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: test_crate::Foo<'a, Clause1_Item>),
+    TraitClause2: (Clause1_Item: test_crate::Foo<'a, Clause2_Item>),
 {
     let _0: Clause1_Item; // return
     let x_1: Clause1_Item; // arg #1
@@ -273,10 +273,10 @@ where
     storage_live(_3)
     storage_live(_4)
     _4 = copy x_1
-    _3 = @TraitClause1::use_item_provided<Clause2_Item>[@TraitClause2](move _4)
+    _3 = TraitClause1::use_item_provided<Clause2_Item>[TraitClause2](move _4)
     _2 = &_3
     storage_dead(_4)
-    _0 = @TraitClause2::parent_clause1::parent_clause1::clone<'20>(move _2)
+    _0 = TraitClause2::ImpliedClause1::ImpliedClause1::clone<'20>(move _2)
     storage_dead(_2)
     storage_dead(_3)
     return
@@ -293,7 +293,7 @@ fn call_fn()
     storage_live(_1)
     storage_live(_2)
     _2 = Option::None {  }
-    _1 = external_use_item<'18, &'18 bool, Option<&'18 bool>[{built_in impl Sized for &'18 bool}], &'33 bool>[{built_in impl Sized for &'18 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'18, bool>[{built_in impl Sized for bool}], {impl test_crate::Foo<'a, T> for Option<T>[@TraitClause0]}<'18, &'33 bool>[{built_in impl Sized for &'33 bool}, {impl Copy for &'_0 T}<'33, bool>]](move _2)
+    _1 = external_use_item<'18, &'18 bool, Option<&'18 bool>[{built_in impl Sized for &'18 bool}], &'33 bool>[{built_in impl Sized for &'18 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'18, bool>[{built_in impl Sized for bool}], {impl test_crate::Foo<'a, T> for Option<T>[TraitClause0]}<'18, &'33 bool>[{built_in impl Sized for &'33 bool}, {impl Copy for &'_0 T}<'33, bool>]](move _2)
     storage_dead(_2)
     storage_dead(_1)
     _0 = ()
@@ -303,10 +303,10 @@ fn call_fn()
 // Full name: test_crate::type_equality
 fn type_equality<'a, I, J, Clause2_Item>(x_1: Clause2_Item) -> Clause2_Item
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<J>,
-    [@TraitClause2]: test_crate::Foo<'a, I, Clause2_Item>,
-    [@TraitClause3]: test_crate::Foo<'a, J, Clause2_Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (J: Sized),
+    TraitClause2: (I: test_crate::Foo<'a, Clause2_Item>),
+    TraitClause3: (J: test_crate::Foo<'a, Clause2_Item>),
 {
     let _0: Clause2_Item; // return
     let x_1: Clause2_Item; // arg #1
@@ -318,24 +318,24 @@ where
 
 trait test_crate::loopy::Bar<Self, Self_BarTy>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_BarTy>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_BarTy: Sized)
     vtable: test_crate::loopy::Bar::{vtable}<Self_BarTy>
 }
 
 // Full name: test_crate::loopy::{impl test_crate::loopy::Bar<bool> for ()}
 impl test_crate::loopy::Bar<bool> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     vtable: {impl test_crate::loopy::Bar<bool> for ()}::{vtable}
 }
 
 trait test_crate::loopy::Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::FooTy>
-    parent_clause2 : [@TraitClause2]: test_crate::loopy::Foo<Self::FooTy>
-    parent_clause3 : [@TraitClause3]: test_crate::loopy::Bar<Self::FooTy, Self::Self_Clause3_BarTy>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::FooTy: Sized)
+    proof ImpliedClause2: (Self::FooTy: test_crate::loopy::Foo)
+    proof ImpliedClause3: (Self::FooTy: test_crate::loopy::Bar<Self::Self_Clause3_BarTy>)
     type FooTy
     type Self_Clause3_BarTy
     vtable: test_crate::loopy::Foo::{vtable}<Self::FooTy>
@@ -343,10 +343,10 @@ trait test_crate::loopy::Foo<Self>
 
 // Full name: test_crate::loopy::{impl test_crate::loopy::Foo for ()}
 impl test_crate::loopy::Foo for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {impl test_crate::loopy::Foo for ()}
-    parent_clause3 = {impl test_crate::loopy::Bar<bool> for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): test_crate::loopy::Foo) = {impl test_crate::loopy::Foo for ()}
+    proof ImpliedClause3: ((): test_crate::loopy::Bar<bool>) = {impl test_crate::loopy::Bar<bool> for ()}
     type FooTy = ()
     type Self_Clause3_BarTy = bool
     vtable: {impl test_crate::loopy::Foo for ()}::{vtable}
@@ -355,11 +355,11 @@ impl test_crate::loopy::Foo for () {
 // Full name: test_crate::loopy::Baz
 trait Baz<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Baz<T, T>
-    parent_clause3 : [@TraitClause3]: test_crate::loopy::Bar<T, Self::Self_Clause3_BarTy>
-    parent_clause4 : [@TraitClause4]: Sized<Self::BazTy>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: Baz<T>)
+    proof ImpliedClause3: (T: test_crate::loopy::Bar<Self::Self_Clause3_BarTy>)
+    proof ImpliedClause4: (Self::BazTy: Sized)
     type BazTy
     type Self_Clause3_BarTy
     vtable: test_crate::loopy::Baz::{vtable}<T, Self::BazTy>
@@ -367,11 +367,11 @@ trait Baz<Self, T>
 
 // Full name: test_crate::loopy::{impl Baz<()> for ()}
 impl Baz<()> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {impl Baz<()> for ()}
-    parent_clause3 = {impl test_crate::loopy::Bar<bool> for ()}
-    parent_clause4 = {built_in impl Sized for usize}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Baz<()>) = {impl Baz<()> for ()}
+    proof ImpliedClause3: ((): test_crate::loopy::Bar<bool>) = {impl test_crate::loopy::Bar<bool> for ()}
+    proof ImpliedClause4: (usize: Sized) = {built_in impl Sized for usize}
     type BazTy = usize
     type Self_Clause3_BarTy = bool
     vtable: {impl Baz<()> for ()}::{vtable}
@@ -379,33 +379,33 @@ impl Baz<()> for () {
 
 trait test_crate::loopy_with_generics::Bar<'a, Self, T, U, Self_BarTy>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<U>
-    parent_clause3 : [@TraitClause3]: Sized<Self_BarTy>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (U: Sized)
+    proof ImpliedClause3: (Self_BarTy: Sized)
     vtable: test_crate::loopy_with_generics::Bar::{vtable}<'a, T, U, Self_BarTy>
 }
 
 // Full name: test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()}
 impl<'a, T> test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for u8}
-    parent_clause2 = @TraitClause0
-    parent_clause3 = {built_in impl Sized for &'_ T}
-    vtable: {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()}::{vtable}<'a, T>[@TraitClause0]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (u8: Sized) = {built_in impl Sized for u8}
+    proof ImpliedClause2: (T: Sized) = TraitClause0
+    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
+    vtable: {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()}::{vtable}<'a, T>[TraitClause0]
 }
 
 trait test_crate::loopy_with_generics::Foo<'b, Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self::FooTy>
-    parent_clause3 : [@TraitClause3]: test_crate::loopy_with_generics::Foo<'b, Self::FooTy, T>
-    parent_clause4 : [@TraitClause4]: test_crate::loopy_with_generics::Bar<'b, Self::FooTy, u8, Option<T>[Self::parent_clause1], Self::Self_Clause4_BarTy>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self::FooTy: Sized)
+    proof ImpliedClause3: (Self::FooTy: test_crate::loopy_with_generics::Foo<'b, T>)
+    proof ImpliedClause4: (Self::FooTy: test_crate::loopy_with_generics::Bar<'b, u8, Option<T>[Self::ImpliedClause1], Self::Self_Clause4_BarTy>)
     type FooTy
     type Self_Clause4_BarTy
     vtable: test_crate::loopy_with_generics::Foo::{vtable}<'b, T, Self::FooTy>
@@ -413,11 +413,11 @@ trait test_crate::loopy_with_generics::Foo<'b, Self, T>
 
 // Full name: test_crate::loopy_with_generics::{impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}
 impl test_crate::loopy_with_generics::Foo<'static, u16> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for u16}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}
-    parent_clause4 = {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()}<'_, Option<u16>[{built_in impl Sized for u16}]>[{built_in impl Sized for Option<u16>[{built_in impl Sized for u16}]}]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (u16: Sized) = {built_in impl Sized for u16}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): test_crate::loopy_with_generics::Foo<'_, u16>) = {impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}
+    proof ImpliedClause4: ((): test_crate::loopy_with_generics::Bar<'_, u8, Option<u16>[{built_in impl Sized for u16}], &'_ Option<u16>[{built_in impl Sized for u16}]>) = {impl test_crate::loopy_with_generics::Bar<'a, u8, T, &'a T> for ()}<'_, Option<u16>[{built_in impl Sized for u16}]>[{built_in impl Sized for Option<u16>[{built_in impl Sized for u16}]}]
     type FooTy = ()
     type Self_Clause4_BarTy = &'_ Option<u16>[{built_in impl Sized for u16}]
     vtable: {impl test_crate::loopy_with_generics::Foo<'static, u16> for ()}::{vtable}
@@ -426,10 +426,10 @@ impl test_crate::loopy_with_generics::Foo<'static, u16> for () {
 // Full name: test_crate::cow::Cow
 enum Cow<'a, B, Clause1_Owned>
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B, Clause1_Owned>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned<Clause1_Owned>),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
   Borrowed(&'a B),
   Owned(Clause1_Owned),
@@ -437,27 +437,27 @@ where
 
 trait test_crate::params::Foo<'a, Self, T, Self_X, Self_Item>
 where
-    T : 'a,
-    Self_X : 'a,
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: Self_X: 'a,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self_X>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self_X: Sized)
+    proof ImpliedClause3: (Self_Item: Sized)
     vtable: test_crate::params::Foo::{vtable}<'a, T, Self_X, Self_Item>
 }
 
-// Full name: test_crate::params::{impl test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}
-impl<'a, T> test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()
+// Full name: test_crate::params::{impl test_crate::params::Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}
+impl<'a, T> test_crate::params::Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    parent_clause2 = {built_in impl Sized for &'_ ()}
-    parent_clause3 = {impl test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}<'a, T>[@TraitClause0]::parent_clause3
-    vtable: {impl test_crate::params::Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}::{vtable}<'a, T>[@TraitClause0]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    proof ImpliedClause2: (&'_ (): Sized) = {built_in impl Sized for &'_ ()}
+    proof ImpliedClause3: (&'a (Option<T>[TraitClause0], &'a ()): Sized) = {impl test_crate::params::Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}<'a, T>[TraitClause0]::ImpliedClause3
+    vtable: {impl test_crate::params::Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}::{vtable}<'a, T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
@@ -47,10 +47,10 @@ pub trait FnOnce<Self, Args, Self_Output>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args, Self_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
@@ -59,60 +59,60 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
 #[lang_item("fn")]
 pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args, Self_Clause1_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
 where
-    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+    TraitClause0: (Self: Fn<Args, Clause0_Clause1_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
 where
-    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+    TraitClause0: (Self: FnMut<Args, Clause0_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 // Full name: test_crate::PrimeField
 pub trait PrimeField<Self, Self_Repr>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Repr>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Repr: Sized)
     vtable: test_crate::PrimeField::{vtable}<Self_Repr>
 }
 
 // Full name: test_crate::SqrtTables
 pub struct SqrtTables<F>
 where
-    [@TraitClause0]: Sized<F>,
+    TraitClause0: (F: Sized),
 {
   F,
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::closure
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::closure
 struct closure<F, Clause1_Repr>
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {}
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common
 pub fn sqrt_common<F, Clause1_Repr>()
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
     let _0: (); // return
-    let _closure_1: closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // local
+    let _closure_1: closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // local
 
     _0 = ()
     storage_live(_closure_1)
@@ -122,21 +122,21 @@ where
     return
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::closure::{impl Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::drop_in_place<F, Clause1_Repr>(_1: *mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::closure::{impl Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::drop_in_place<F, Clause1_Repr>(_1: *mut closure<F, Clause1_Repr>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 = <missing>
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call<'_0, F, Clause1_Repr>(_1: &'_0 closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], tupled_args_2: ((),))
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call<'_0, F, Clause1_Repr>(_1: &'_0 closure<F, Clause1_Repr>[TraitClause0, TraitClause1], tupled_args_2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
     let _0: (); // return
-    let _1: &'1 closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: ((),); // arg #2
     let _x_3: (); // local
 
@@ -147,92 +147,92 @@ where
     return
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, Clause1_Repr>(state_1: &'_0 mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], args_2: ((),))
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_mut<'_0, F, Clause1_Repr>(state_1: &'_0 mut closure<F, Clause1_Repr>[TraitClause0, TraitClause1], args_2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
     let _0: (); // return
-    let state_1: &'_0 mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_0 mut closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // arg #1
     let args_2: ((),); // arg #2
-    let _3: &'0 closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // anonymous local
 
     _0 = ()
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call<'2, F, Clause1_Repr>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call<'2, F, Clause1_Repr>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_once<F, Clause1_Repr>(_1: closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1], _2: ((),))
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_once<F, Clause1_Repr>(_1: closure<F, Clause1_Repr>[TraitClause0, TraitClause1], _2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
     let _0: (); // return
-    let _1: closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // arg #1
     let _2: ((),); // arg #2
-    let _3: &'1 mut closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 mut closure<F, Clause1_Repr>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut<'3, F, Clause1_Repr>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::drop_in_place<F, Clause1_Repr>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_mut<'3, F, Clause1_Repr>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::drop_in_place<F, Clause1_Repr>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-impl<F, Clause1_Repr> FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+impl<F, Clause1_Repr> FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ((),)}
-    parent_clause2 = {built_in impl Tuple for ((),)}
-    parent_clause3 = {built_in impl Sized for ()}
-    fn call_once = {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_once<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<F, Clause1_Repr>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause2: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
+    fn call_once = {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_once<F, Clause1_Repr>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-impl<F, Clause1_Repr> FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+impl<F, Clause1_Repr> FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
-    fn call_mut<'_0_1> = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call_mut<'_0_1, F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<F, Clause1_Repr>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (closure<F, Clause1_Repr>[TraitClause0, TraitClause1]: FnOnce<((),), ()>) = {impl FnOnce<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}<F, Clause1_Repr>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    fn call_mut<'_0_1> = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call_mut<'_0_1, F, Clause1_Repr>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::{impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-impl<F, Clause1_Repr> Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::{impl Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+impl<F, Clause1_Repr> Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
-    fn call<'_0_1> = {impl Fn<((),), ()> for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::call<'_0_1, F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<F, Clause1_Repr>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (closure<F, Clause1_Repr>[TraitClause0, TraitClause1]: FnMut<((),), ()>) = {impl FnMut<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}<F, Clause1_Repr>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    fn call<'_0_1> = {impl Fn<((),), ()> for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::call<'_0_1, F, Clause1_Repr>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{SqrtTables<F>[@TraitClause0]}::sqrt_common::closure::{impl Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}
-impl<F, Clause1_Repr> Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{SqrtTables<F>[TraitClause0]}::sqrt_common::closure::{impl Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}
+impl<F, Clause1_Repr> Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: PrimeField<F, Clause1_Repr>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: PrimeField<Clause1_Repr>),
 {
-    fn drop_in_place = {impl Destruct for closure<F, Clause1_Repr>[@TraitClause0, @TraitClause1]}::drop_in_place<F, Clause1_Repr>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for closure<F, Clause1_Repr>[TraitClause0, TraitClause1]}::drop_in_place<F, Clause1_Repr>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,15 +25,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -52,39 +52,39 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Iterator
 trait Iterator<Self, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Item: Sized)
     vtable: test_crate::Iterator::{vtable}<Self_Item>
 }
 
 // Full name: test_crate::IntoIterator
 trait IntoIterator<Self, Self_Item, Self_IntoIter>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Item>
-    parent_clause2 : [@TraitClause2]: Sized<Self_IntoIter>
-    parent_clause3 : [@TraitClause3]: Iterator<Self_IntoIter, Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Item: Sized)
+    proof ImpliedClause2: (Self_IntoIter: Sized)
+    proof ImpliedClause3: (Self_IntoIter: Iterator<Self_Item>)
     vtable: test_crate::IntoIterator::{vtable}<Self_Item, Self_IntoIter>
 }
 
 // Full name: test_crate::{impl IntoIterator<Clause1_Item, I> for I}
 impl<I, Clause1_Item> IntoIterator<Clause1_Item, I> for I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I, Clause1_Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator<Clause1_Item>),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1::parent_clause1
-    parent_clause2 = @TraitClause0
-    parent_clause3 = @TraitClause1
-    vtable: {impl IntoIterator<Clause1_Item, I> for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (I: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (Clause1_Item: Sized) = TraitClause1::ImpliedClause1
+    proof ImpliedClause2: (I: Sized) = TraitClause0
+    proof ImpliedClause3: (I: Iterator<Clause1_Item>) = TraitClause1
+    vtable: {impl IntoIterator<Clause1_Item, I> for I}::{vtable}<I>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::callee
 fn callee<T, Clause1_Item>(t_1: Clause1_Item) -> Clause1_Item
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Iterator<T, Clause1_Item>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Iterator<Clause1_Item>),
 {
     let _0: Clause1_Item; // return
     let t_1: Clause1_Item; // arg #1
@@ -97,9 +97,9 @@ where
 // Full name: test_crate::caller
 fn caller<T, Clause1_Item, Clause2_Item, Clause2_IntoIter>(t_1: Clause1_Item) -> Clause2_Item
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Iterator<T, Clause1_Item>,
-    [@TraitClause2]: IntoIterator<T, Clause2_Item, Clause2_IntoIter>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Iterator<Clause1_Item>),
+    TraitClause2: (T: IntoIterator<Clause2_Item, Clause2_IntoIter>),
 {
     let _0: Clause2_Item; // return
     let t_1: Clause1_Item; // arg #1
@@ -107,7 +107,7 @@ where
 
     storage_live(_2)
     _2 = move t_1
-    _0 = callee<T, Clause1_Item>[@TraitClause0, @TraitClause1](move _2)
+    _0 = callee<T, Clause1_Item>[TraitClause0, TraitClause1](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for Clause1_Item}::drop_in_place] t_1
     return
@@ -116,8 +116,8 @@ where
 // Full name: test_crate::X
 trait X<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
     fn method<'_0_1> = method<'_0_1, Self, Self_Assoc>[Self]
     vtable: test_crate::X::{vtable}<Self_Assoc>
 }
@@ -125,30 +125,30 @@ trait X<Self, Self_Assoc>
 // Full name: test_crate::X::method
 fn method<'_0, Self, Clause0_Assoc>(_1: &'_0 Self) -> Clause0_Assoc
 where
-    [@TraitClause0]: X<Self, Clause0_Assoc>,
+    TraitClause0: (Self: X<Clause0_Assoc>),
 = <method_without_default_body>
 
 // Full name: test_crate::A
 trait A<Self, Self_Clause1_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: X<Self, Self_Clause1_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: X<Self_Clause1_Assoc>)
     vtable: test_crate::A::{vtable}<Self_Clause1_Assoc>
 }
 
 // Full name: test_crate::B
 trait B<Self, Self_Clause1_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: X<Self, Self_Clause1_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: X<Self_Clause1_Assoc>)
     vtable: test_crate::B::{vtable}<Self_Clause1_Assoc>
 }
 
 // Full name: test_crate::a
 fn a<T, Clause1_Clause1_Assoc>(x_1: T) -> Clause1_Clause1_Assoc
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: A<T, Clause1_Clause1_Assoc>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: A<Clause1_Clause1_Assoc>),
 {
     let _0: Clause1_Clause1_Assoc; // return
     let x_1: T; // arg #1
@@ -156,7 +156,7 @@ where
 
     storage_live(_2)
     _2 = &x_1
-    _0 = @TraitClause1::parent_clause1::method<'3>(move _2)
+    _0 = TraitClause1::ImpliedClause1::method<'3>(move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
@@ -165,8 +165,8 @@ where
 // Full name: test_crate::b
 fn b<T, Clause1_Clause1_Assoc>(x_1: T) -> Clause1_Clause1_Assoc
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: B<T, Clause1_Clause1_Assoc>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: B<Clause1_Clause1_Assoc>),
 {
     let _0: Clause1_Clause1_Assoc; // return
     let x_1: T; // arg #1
@@ -174,7 +174,7 @@ where
 
     storage_live(_2)
     _2 = &x_1
-    _0 = @TraitClause1::parent_clause1::method<'3>(move _2)
+    _0 = TraitClause1::ImpliedClause1::method<'3>(move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
@@ -183,10 +183,10 @@ where
 // Full name: test_crate::x
 fn x<T, Clause1_Clause1_Assoc, Clause2_Clause1_Assoc>(x_1: T) -> (Clause1_Clause1_Assoc, Clause1_Clause1_Assoc)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: A<T, Clause1_Clause1_Assoc>,
-    [@TraitClause2]: B<T, Clause2_Clause1_Assoc>,
-    [@TraitClause3]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: A<Clause1_Clause1_Assoc>),
+    TraitClause2: (T: B<Clause2_Clause1_Assoc>),
+    TraitClause3: (T: Copy),
 {
     let _0: (Clause1_Clause1_Assoc, Clause1_Clause1_Assoc); // return
     let x_1: T; // arg #1
@@ -198,12 +198,12 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = copy x_1
-    _2 = a<T, Clause1_Clause1_Assoc>[@TraitClause0, @TraitClause1](move _3)
+    _2 = a<T, Clause1_Clause1_Assoc>[TraitClause0, TraitClause1](move _3)
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
     _5 = copy x_1
-    _4 = b<T, Clause2_Clause1_Assoc>[@TraitClause0, @TraitClause2](move _5)
+    _4 = b<T, Clause2_Clause1_Assoc>[TraitClause0, TraitClause2](move _5)
     storage_dead(_5)
     _0 = (move _2, move _4)
     conditional_drop[{built_in impl Destruct for Clause1_Clause1_Assoc}::drop_in_place] _4

--- a/charon/tests/ui/associated_types/gat-used-in-method.out
+++ b/charon/tests/ui/associated_types/gat-used-in-method.out
@@ -8,27 +8,27 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo
 trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type T<A, [@TraitClause0_1]: Sized<A>>
+    proof ImpliedClause0: (Self: MetaSized)
+    type T<A>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::T>
-
-    fn f<A, [@TraitClause0_1]: Sized<A>> = f<Self, A>[Self, @TraitClause0_1]
+        TraitClause0_1: (A: Sized),
+        proof ImpliedClause0: (Self::T: Sized);
+    fn f<A, TraitClause0_1: (A: Sized)> = f<Self, A>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::f
-fn f<Self, A>(_1: @TraitClause0::T)
+fn f<Self, A>(_1: TraitClause0::T)
 where
-    [@TraitClause0]: Foo<Self>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (Self: Foo),
+    TraitClause1: (A: Sized),
 = <method_without_default_body>
 
 

--- a/charon/tests/ui/associated_types/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,23 +25,23 @@ where
 // Full name: test_crate::HasType
 trait HasType<Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type: Sized)
     vtable: test_crate::HasType::{vtable}<Self_Type>
 }
 
 // Full name: test_crate::HasMethod
 trait HasMethod<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn method<Clause0_Type, [@TraitClause0_1]: HasType<Self, Clause0_Type>> = test_crate::HasMethod::method<Self, Clause0_Type>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn method<Clause0_Type, TraitClause0_1: (Self: HasType<Clause0_Type>)> = test_crate::HasMethod::method<Self, Clause0_Type>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 fn test_crate::HasMethod::method<Self, Clause1_Type>()
 where
-    [@TraitClause0]: HasMethod<Self>,
-    [@TraitClause1]: HasType<Self, Clause1_Type>,
+    TraitClause0: (Self: HasMethod),
+    TraitClause1: (Self: HasType<Clause1_Type>),
 {
     let _0: (); // return
 
@@ -50,11 +50,11 @@ where
     return
 }
 
-// Full name: test_crate::{impl HasMethod for Option<T>[@TraitClause0]}::method
-fn {impl HasMethod for Option<T>[@TraitClause0]}::method<T, Clause1_Type>()
+// Full name: test_crate::{impl HasMethod for Option<T>[TraitClause0]}::method
+fn {impl HasMethod for Option<T>[TraitClause0]}::method<T, Clause1_Type>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasType<Option<T>[@TraitClause0], Clause1_Type>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Option<T>[TraitClause0]: HasType<Clause1_Type>),
 {
     let _0: (); // return
 
@@ -63,13 +63,13 @@ where
     return
 }
 
-// Full name: test_crate::{impl HasMethod for Option<T>[@TraitClause0]}
-impl<T> HasMethod for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl HasMethod for Option<T>[TraitClause0]}
+impl<T> HasMethod for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    fn method<Clause0_Type, [@TraitClause0_1]: HasType<Option<T>[@TraitClause0], Clause0_Type>> = {impl HasMethod for Option<T>[@TraitClause0]}::method<T, Clause0_Type>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    fn method<Clause0_Type, TraitClause0_1: (Option<T>[TraitClause0]: HasType<Clause0_Type>)> = {impl HasMethod for Option<T>[TraitClause0]}::method<T, Clause0_Type>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/associated_types/impl-with-dyn-assoc-ty.out
+++ b/charon/tests/ui/associated_types/impl-with-dyn-assoc-ty.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,25 +24,25 @@ struct test_crate::DynableTrait::{vtable}<Ty0> {
 // Full name: test_crate::DynableTrait
 trait DynableTrait<Self, Self_DynableTraitType>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_DynableTraitType>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_DynableTraitType: Sized)
     vtable: test_crate::DynableTrait::{vtable}<Self_DynableTraitType>
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self, Self_TraitType, Self_Clause2_DynableTraitType>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Self_TraitType>
-    parent_clause2 : [@TraitClause2]: DynableTrait<Self_TraitType, Self_Clause2_DynableTraitType>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_TraitType: MetaSized)
+    proof ImpliedClause2: (Self_TraitType: DynableTrait<Self_Clause2_DynableTraitType>)
     vtable: test_crate::Trait::{vtable}<Self_TraitType>
 }
 
 // Full name: test_crate::{impl Trait<(dyn DynableTrait<()> + 'static), ()> for ()}
 impl Trait<(dyn DynableTrait<()> + 'static), ()> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl MetaSized for (dyn DynableTrait<()>)}
-    parent_clause2 = DynableTrait<(dyn DynableTrait<()>), ()>
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((dyn DynableTrait<()>): MetaSized) = {built_in impl MetaSized for (dyn DynableTrait<()>)}
+    proof ImpliedClause2: ((dyn DynableTrait<()>): DynableTrait<()>) = DynableTrait<(dyn DynableTrait<()>), ()>
     vtable: {impl Trait<(dyn DynableTrait<()> + 'static), ()> for ()}::{vtable}
 }
 

--- a/charon/tests/ui/associated_types/issue-1036-failed-assoc-ty-lifting.out
+++ b/charon/tests/ui/associated_types/issue-1036-failed-assoc-ty-lifting.out
@@ -8,35 +8,35 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::T1
 trait T1<Self, Self_A>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_A>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_A: Sized)
     vtable: test_crate::T1::{vtable}<Self_A>
 }
 
 // Full name: test_crate::T2
 trait T2<Self, Self_Clause1_A>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: T1<Self, Self_Clause1_A>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: T1<Self_Clause1_A>)
     vtable: test_crate::T2::{vtable}<Self_Clause1_A>
 }
 
 // Full name: test_crate::{impl T2<Clause1_A> for I}
 impl<I, Clause1_A> T2<Clause1_A> for I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: T1<I, Clause1_A>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: T1<Clause1_A>),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1
-    vtable: {impl T2<Clause1_A> for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (I: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (I: T1<Clause1_A>) = TraitClause1
+    vtable: {impl T2<Clause1_A> for I}::{vtable}<I>[TraitClause0, TraitClause1]
 }
 
 

--- a/charon/tests/ui/associated_types/issue-1068-double-visit.out
+++ b/charon/tests/ui/associated_types/issue-1068-double-visit.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -21,66 +21,66 @@ pub struct Witness2 {}
 // Full name: test_crate::HasType1
 pub trait HasType1<Self, Self_Type1>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type1>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type1: Sized)
     vtable: test_crate::HasType1::{vtable}<Self_Type1>
 }
 
 // Full name: test_crate::{impl HasType1<()> for Witness1}
 impl HasType1<()> for Witness1 {
-    parent_clause0 = {built_in impl MetaSized for Witness1}
-    parent_clause1 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (Witness1: MetaSized) = {built_in impl MetaSized for Witness1}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
     vtable: {impl HasType1<()> for Witness1}::{vtable}
 }
 
 // Full name: test_crate::HasType2
 pub trait HasType2<Self, Self_Type2>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type2>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type2: Sized)
     vtable: test_crate::HasType2::{vtable}<Self_Type2>
 }
 
 // Full name: test_crate::Comparator
 pub struct Comparator<A, Clause1_Type1>
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: HasType1<A, Clause1_Type1>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: HasType1<Clause1_Type1>),
 {
   A,
 }
 
 // Full name: test_crate::{impl HasType2<Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]> for Witness2}
 impl HasType2<Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]> for Witness2 {
-    parent_clause0 = {built_in impl MetaSized for Witness2}
-    parent_clause1 = {built_in impl Sized for Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]}
+    proof ImpliedClause0: (Witness2: MetaSized) = {built_in impl MetaSized for Witness2}
+    proof ImpliedClause1: (Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]: Sized) = {built_in impl Sized for Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]}
     vtable: {impl HasType2<Comparator<Witness1, ()>[{built_in impl Sized for Witness1}, {impl HasType1<()> for Witness1}]> for Witness2}::{vtable}
 }
 
 // Full name: test_crate::HasType3
 pub trait HasType3<Self, Self_Type3>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type3>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type3: Sized)
     vtable: test_crate::HasType3::{vtable}<Self_Type3>
 }
 
 // Full name: test_crate::{impl HasType3<Clause1_Type2> for T}
 impl<T, Clause1_Type2> HasType3<Clause1_Type2> for T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasType2<T, Clause1_Type2>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasType2<Clause1_Type2>),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1::parent_clause1
-    vtable: {impl HasType3<Clause1_Type2> for T}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (Clause1_Type2: Sized) = TraitClause1::ImpliedClause1
+    vtable: {impl HasType3<Clause1_Type2> for T}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::check
 fn check<D, Clause1_Type3>()
 where
-    [@TraitClause0]: Sized<D>,
-    [@TraitClause1]: HasType3<D, Clause1_Type3>,
+    TraitClause0: (D: Sized),
+    TraitClause1: (D: HasType3<Clause1_Type3>),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/issue-1068-gat-with-assoc-ty.out
@@ -1,4 +1,4 @@
-error: Could not compute the value of (Self::Item::[@TraitClause1])::Size on a GAT: lifting associated types can fail in the presence of GATs. To fix this, `--exclude` this trait.
+error: Could not compute the value of Self::Item::ImpliedClause1::Size on a GAT: lifting associated types can fail in the presence of GATs. To fix this, `--exclude` this trait.
  --> tests/ui/associated_types/issue-1068-gat-with-assoc-ty.rs:7:1
   |
 7 | / pub trait Bar {

--- a/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.out
+++ b/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,27 +25,27 @@ where
 // Full name: test_crate::Foo
 trait Foo<'a, Self, T, Self_X, Self_Item>
 where
-    T : 'a,
-    Self_X : 'a,
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: Self_X: 'a,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self_X>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self_X: Sized)
+    proof ImpliedClause3: (Self_Item: Sized)
     vtable: test_crate::Foo::{vtable}<'a, T, Self_X, Self_Item>
 }
 
-// Full name: test_crate::{impl Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}
-impl<'a, T> Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()
+// Full name: test_crate::{impl Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}
+impl<'a, T> Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    parent_clause2 = {built_in impl Sized for &'_ ()}
-    parent_clause3 = {impl Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}<'a, T>[@TraitClause0]::parent_clause3
-    vtable: {impl Foo<'a, Option<T>[@TraitClause0], &'a (), &'a (Option<T>[@TraitClause0], &'a ())> for ()}::{vtable}<'a, T>[@TraitClause0]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    proof ImpliedClause2: (&'_ (): Sized) = {built_in impl Sized for &'_ ()}
+    proof ImpliedClause3: (&'a (Option<T>[TraitClause0], &'a ()): Sized) = {impl Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}<'a, T>[TraitClause0]::ImpliedClause3
+    vtable: {impl Foo<'a, Option<T>[TraitClause0], &'a (), &'a (Option<T>[TraitClause0], &'a ())> for ()}::{vtable}<'a, T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/associated_types/issue-968-default-assoc-const.out
+++ b/charon/tests/ui/associated_types/issue-968-default-assoc-const.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::ToU64
 pub trait ToU64<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn to_u64 = to_u64<Self>[Self]
     vtable: test_crate::ToU64::{vtable}
 }
@@ -23,15 +23,15 @@ pub trait ToU64<Self>
 // Full name: test_crate::ToU64::to_u64
 pub fn to_u64<Self>(_1: Self) -> u64
 where
-    [@TraitClause0]: ToU64<Self>,
+    TraitClause0: (Self: ToU64),
 = <method_without_default_body>
 
 // Full name: test_crate::WithConstTy
 pub trait WithConstTy<Self, Self_W, const LEN : usize>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_W>
-    parent_clause2 : [@TraitClause2]: ToU64<Self_W>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_W: Sized)
+    proof ImpliedClause2: (Self_W: ToU64)
     const LEN2 : usize
     non-dyn-compatible
 }

--- a/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
+++ b/charon/tests/ui/associated_types/lift-assoc-ty-in-alias.out
@@ -8,23 +8,23 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasAssoc
 pub trait HasAssoc<Self, Self_Assoc>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
     vtable: test_crate::HasAssoc::{vtable}<Self_Assoc>
 }
 
 // Full name: test_crate::Alias
 pub type Alias<B, Clause1_Assoc>
 where
-    [@TraitClause0]: Sized<B>,
-    [@TraitClause1]: HasAssoc<B, Clause1_Assoc>, = Clause1_Assoc
+    TraitClause0: (B: Sized),
+    TraitClause1: (B: HasAssoc<Clause1_Assoc>), = Clause1_Assoc
 
 
 

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -11,7 +11,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<u8> for u8}::eq
@@ -27,7 +27,7 @@ impl PartialEq<u8> for u8 {
 // Full name: core::cmp::impls::{impl PartialEq<&'_0 B> for &'_1 A}::eq
 pub fn {impl PartialEq<&'_0 B> for &'_1 A}::eq<'_0, '_1, '_2, '_3, A, B>(_1: &'_2 &'_1 A, _2: &'_3 &'_0 B) -> bool
 where
-    [@TraitClause0]: PartialEq<A, B>,
+    TraitClause0: (A: PartialEq<B>),
 = <opaque>
 
 // Full name: core::marker::MetaSized
@@ -38,7 +38,7 @@ pub trait MetaSized<Self>
 #[lang_item("structural_peq")]
 pub trait StructuralPartialEq<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::marker::StructuralPartialEq::{vtable}
 }
 
@@ -50,7 +50,7 @@ enum Enum {
 
 // Full name: test_crate::{impl StructuralPartialEq for Enum}
 impl StructuralPartialEq for Enum {
-    parent_clause0 = {built_in impl MetaSized for Enum}
+    proof ImpliedClause0: (Enum: MetaSized) = {built_in impl MetaSized for Enum}
     vtable: {impl StructuralPartialEq for Enum}::{vtable}
 }
 

--- a/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
+++ b/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,32 +27,32 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::IntoIterator
 pub trait IntoIterator<Self, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Item: Sized)
     vtable: test_crate::IntoIterator::{vtable}<Self_Item>
 }
 
 // Full name: test_crate::FromIterator
 pub trait FromIterator<Self, A>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<A>
-    fn from_iter<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: IntoIterator<T, A>> = test_crate::FromIterator::from_iter<Self, A, T>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (A: Sized)
+    fn from_iter<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: IntoIterator<A>)> = test_crate::FromIterator::from_iter<Self, A, T>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn test_crate::FromIterator::from_iter<Self, A, T>(_1: T) -> Self
 where
-    [@TraitClause0]: FromIterator<Self, A>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: IntoIterator<T, A>,
+    TraitClause0: (Self: FromIterator<A>),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: IntoIterator<A>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl FromIterator<()> for ()}::from_iter
 pub fn {impl FromIterator<()> for ()}::from_iter<I>(iter_1: I)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: IntoIterator<I, ()>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: IntoIterator<()>),
 {
     let _0: (); // return
     let iter_1: I; // arg #1
@@ -65,9 +65,9 @@ where
 
 // Full name: test_crate::{impl FromIterator<()> for ()}
 impl FromIterator<()> for () {
-    parent_clause0 = {built_in impl Sized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
-    fn from_iter<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I, ()>> = {impl FromIterator<()> for ()}::from_iter<I>[@TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    fn from_iter<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator<()>)> = {impl FromIterator<()> for ()}::from_iter<I>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/associated_types/pointee_metadata.out
+++ b/charon/tests/ui/associated_types/pointee_metadata.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -40,14 +40,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -63,7 +63,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -73,7 +73,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -82,8 +82,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -92,14 +92,14 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::partial_cmp
 #[lang_item("cmp_partialord_cmp")]
 pub fn partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::fmt::Error
@@ -109,8 +109,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -127,13 +127,13 @@ pub trait Debug<Self>
 // Full name: core::fmt::Debug::fmt
 pub fn fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -143,28 +143,28 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: core::hash::Hash::hash
 pub fn hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::marker::Send
@@ -175,8 +175,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -196,15 +196,15 @@ pub trait Unpin<Self>
 #[lang_item("pointee_trait")]
 pub trait Pointee<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self::Metadata>
-    parent_clause1 : [@TraitClause1]: Debug<Self::Metadata>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Metadata>
-    parent_clause3 : [@TraitClause3]: Send<Self::Metadata>
-    parent_clause4 : [@TraitClause4]: Sync<Self::Metadata>
-    parent_clause5 : [@TraitClause5]: Ord<Self::Metadata>
-    parent_clause6 : [@TraitClause6]: Hash<Self::Metadata>
-    parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
-    parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
+    proof ImpliedClause0: (Self::Metadata: Sized)
+    proof ImpliedClause1: (Self::Metadata: Debug)
+    proof ImpliedClause2: (Self::Metadata: Copy)
+    proof ImpliedClause3: (Self::Metadata: Send)
+    proof ImpliedClause4: (Self::Metadata: Sync)
+    proof ImpliedClause5: (Self::Metadata: Ord)
+    proof ImpliedClause6: (Self::Metadata: Hash)
+    proof ImpliedClause7: (Self::Metadata: Unpin)
+    proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
 }

--- a/charon/tests/ui/associated_types/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/associated_types/quantified-trait-type-constraint.out
@@ -8,23 +8,23 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<'a, Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type: Sized)
     vtable: test_crate::Trait::{vtable}<'a, Self_Type>
 }
 
 // Full name: test_crate::foo
 fn foo<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: for<'a> Trait<'a, T, &'_ ()>,
+    TraitClause0: (T: Sized),
+    TraitClause1: for<'a> (T: Trait<'a, &'_ ()>),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/associated_types/supertrait-item-bound-has-assoc-ty.out
+++ b/charon/tests/ui/associated_types/supertrait-item-bound-has-assoc-ty.out
@@ -8,53 +8,53 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::WithTarget
 pub trait WithTarget<Self, Self_Target>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Target>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Target: Sized)
     vtable: test_crate::WithTarget::{vtable}<Self_Target>
 }
 
 // Full name: test_crate::ParentTrait
 pub trait ParentTrait<Self, Self_FromParent, Self_Clause2_Target>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_FromParent>
-    parent_clause2 : [@TraitClause2]: WithTarget<Self_FromParent, Self_Clause2_Target>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_FromParent: Sized)
+    proof ImpliedClause2: (Self_FromParent: WithTarget<Self_Clause2_Target>)
     vtable: test_crate::ParentTrait::{vtable}<Self_FromParent>
 }
 
 // Full name: test_crate::ChildTrait
 pub trait ChildTrait<Self, Self_Clause1_FromParent, Self_Clause1_Clause2_Target>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: ParentTrait<Self, Self_Clause1_FromParent, Self_Clause1_Clause2_Target>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: ParentTrait<Self_Clause1_FromParent, Self_Clause1_Clause2_Target>)
     fn convert = test_crate::ChildTrait::convert<Self, Self_Clause1_FromParent, Self_Clause1_Clause2_Target>[Self]
     non-dyn-compatible
 }
 
 pub fn test_crate::ChildTrait::convert<Self, Clause0_Clause1_FromParent, Clause0_Clause1_Clause2_Target>(_1: Clause0_Clause1_FromParent) -> Clause0_Clause1_Clause2_Target
 where
-    [@TraitClause0]: ChildTrait<Self, Clause0_Clause1_FromParent, Clause0_Clause1_Clause2_Target>,
+    TraitClause0: (Self: ChildTrait<Clause0_Clause1_FromParent, Clause0_Clause1_Clause2_Target>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl WithTarget<u32> for u32}
 impl WithTarget<u32> for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
     vtable: {impl WithTarget<u32> for u32}::{vtable}
 }
 
 // Full name: test_crate::{impl ParentTrait<u32, u32> for u32}
 impl ParentTrait<u32, u32> for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for u32}
-    parent_clause2 = {impl WithTarget<u32> for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause2: (u32: WithTarget<u32>) = {impl WithTarget<u32> for u32}
     vtable: {impl ParentTrait<u32, u32> for u32}::{vtable}
 }
 
@@ -70,8 +70,8 @@ pub fn {impl ChildTrait<u32, u32> for u32}::convert(x_1: u32) -> u32
 
 // Full name: test_crate::{impl ChildTrait<u32, u32> for u32}
 impl ChildTrait<u32, u32> for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {impl ParentTrait<u32, u32> for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: ParentTrait<u32, u32>) = {impl ParentTrait<u32, u32> for u32}
     fn convert = {impl ChildTrait<u32, u32> for u32}::convert
     non-dyn-compatible
 }

--- a/charon/tests/ui/associated_types/try-trait.out
+++ b/charon/tests/ui/associated_types/try-trait.out
@@ -6,14 +6,14 @@ pub trait FromResidual<Self, R>
 // Full name: test_crate::Try
 pub trait Try<Self, Self_Output, Self_Residual>
 {
-    parent_clause0 : [@TraitClause0]: FromResidual<Self, Self_Residual>
+    proof ImpliedClause0: (Self: FromResidual<Self_Residual>)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Residual
 pub trait Residual<Self, O, Self_TryType>
 {
-    parent_clause0 : [@TraitClause0]: Try<Self_TryType, O, Self>
+    proof ImpliedClause0: (Self_TryType: Try<O, Self>)
     vtable: test_crate::Residual::{vtable}<O, Self_TryType>
 }
 

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -49,7 +49,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<bool> for bool}::eq
@@ -66,7 +66,7 @@ impl PartialEq<bool> for bool {
 #[lang_item("Default")]
 pub trait Default<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn default = core::default::Default::default<Self>[Self]
     non-dyn-compatible
 }
@@ -74,7 +74,7 @@ pub trait Default<Self>
 #[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 where
-    [@TraitClause0]: Default<Self>,
+    TraitClause0: (Self: Default),
 = <opaque>
 
 // Full name: core::default::{impl Default for bool}::default
@@ -83,7 +83,7 @@ pub fn {impl Default for bool}::default() -> bool
 
 // Full name: core::default::{impl Default for bool}
 impl Default for bool {
-    parent_clause0 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (bool: Sized) = {built_in impl Sized for bool}
     fn default = {impl Default for bool}::default
     non-dyn-compatible
 }
@@ -107,63 +107,63 @@ pub opaque type String
 // Full name: test_crate::Struct
 struct Struct<A>
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 {
   A,
 }
 
-// Full name: test_crate::{impl Default for Struct<A>[@TraitClause0]}::default
-pub fn {impl Default for Struct<A>[@TraitClause0]}::default<A>() -> Struct<A>[@TraitClause0]
+// Full name: test_crate::{impl Default for Struct<A>[TraitClause0]}::default
+pub fn {impl Default for Struct<A>[TraitClause0]}::default<A>() -> Struct<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Default<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Default),
 {
-    let _0: Struct<A>[@TraitClause0]; // return
+    let _0: Struct<A>[TraitClause0]; // return
     let _1: A; // anonymous local
 
     storage_live(_1)
-    _1 = @TraitClause1::default()
+    _1 = TraitClause1::default()
     _0 = Struct { 0: move _1 }
     conditional_drop[{built_in impl Destruct for A}::drop_in_place] _1
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::{impl Default for Struct<A>[@TraitClause0]}
-impl<A> Default for Struct<A>[@TraitClause0]
+// Full name: test_crate::{impl Default for Struct<A>[TraitClause0]}
+impl<A> Default for Struct<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Default<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Default),
 {
-    parent_clause0 = {built_in impl Sized for Struct<A>[@TraitClause0]}
-    fn default = {impl Default for Struct<A>[@TraitClause0]}::default<A>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Struct<A>[TraitClause0]: Sized) = {built_in impl Sized for Struct<A>[TraitClause0]}
+    fn default = {impl Default for Struct<A>[TraitClause0]}::default<A>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self, B, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<B>
-    parent_clause2 : [@TraitClause2]: Sized<Self_Item>
-    fn method<C, [@TraitClause0_1]: Sized<C>> = test_crate::Trait::method<Self, B, C, Self_Item>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (B: Sized)
+    proof ImpliedClause2: (Self_Item: Sized)
+    fn method<C, TraitClause0_1: (C: Sized)> = test_crate::Trait::method<Self, B, C, Self_Item>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::method<Self, B, C, Clause0_Item>()
 where
-    [@TraitClause0]: Trait<Self, B, Clause0_Item>,
-    [@TraitClause1]: Sized<C>,
+    TraitClause0: (Self: Trait<B, Clause0_Item>),
+    TraitClause1: (C: Sized),
 = <method_without_default_body>
 
-// Full name: test_crate::{impl Trait<B, (A, B)> for Struct<A>[@TraitClause0]}::method
-fn {impl Trait<B, (A, B)> for Struct<A>[@TraitClause0]}::method<A, B, C>()
+// Full name: test_crate::{impl Trait<B, (A, B)> for Struct<A>[TraitClause0]}::method
+fn {impl Trait<B, (A, B)> for Struct<A>[TraitClause0]}::method<A, B, C>()
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Clone<A>,
-    [@TraitClause3]: PartialEq<B, bool>,
-    [@TraitClause4]: Sized<C>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (A: Clone),
+    TraitClause3: (B: PartialEq<bool>),
+    TraitClause4: (C: Sized),
 {
     let _0: (); // return
 
@@ -172,18 +172,18 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<B, (A, B)> for Struct<A>[@TraitClause0]}
-impl<A, B> Trait<B, (A, B)> for Struct<A>[@TraitClause0]
+// Full name: test_crate::{impl Trait<B, (A, B)> for Struct<A>[TraitClause0]}
+impl<A, B> Trait<B, (A, B)> for Struct<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Clone<A>,
-    [@TraitClause3]: PartialEq<B, bool>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (A: Clone),
+    TraitClause3: (B: PartialEq<bool>),
 {
-    parent_clause0 = {built_in impl MetaSized for Struct<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause1
-    parent_clause2 = {built_in impl Sized for (A, B)}
-    fn method<C, [@TraitClause0_1]: Sized<C>> = {impl Trait<B, (A, B)> for Struct<A>[@TraitClause0]}::method<A, B, C>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause0_1]
+    proof ImpliedClause0: (Struct<A>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Struct<A>[TraitClause0]}
+    proof ImpliedClause1: (B: Sized) = TraitClause1
+    proof ImpliedClause2: ((A, B): Sized) = {built_in impl Sized for (A, B)}
+    fn method<C, TraitClause0_1: (C: Sized)> = {impl Trait<B, (A, B)> for Struct<A>[TraitClause0]}::method<A, B, C>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -199,9 +199,9 @@ fn main()
     storage_live(_x_1)
     _x_1 = (const 0 : u8, const false)
     storage_live(_y_2)
-    _y_2 = {impl Default for Struct<A>[@TraitClause0]}::default<bool>[{built_in impl Sized for bool}, {impl Default for bool}]()
+    _y_2 = {impl Default for Struct<A>[TraitClause0]}::default<bool>[{built_in impl Sized for bool}, {impl Default for bool}]()
     storage_live(_3)
-    _3 = {impl Trait<B, (A, B)> for Struct<A>[@TraitClause0]}::method<u8, bool, String>[{built_in impl Sized for u8}, {built_in impl Sized for bool}, {impl Clone for u8}, {impl PartialEq<bool> for bool}, {built_in impl Sized for String}]()
+    _3 = {impl Trait<B, (A, B)> for Struct<A>[TraitClause0]}::method<u8, bool, String>[{built_in impl Sized for u8}, {built_in impl Sized for bool}, {impl Clone for u8}, {impl PartialEq<bool> for bool}, {built_in impl Sized for String}]()
     storage_dead(_3)
     _0 = ()
     storage_dead(_y_2)

--- a/charon/tests/ui/closure-as-fn.out
+++ b/charon/tests/ui/closure-as-fn.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::main::closure
@@ -181,10 +181,10 @@ fn main()
 
 // Full name: test_crate::main::{impl FnOnce<()> for closure}
 impl FnOnce<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for closure}::call_once
     non-dyn-compatible
@@ -192,20 +192,20 @@ impl FnOnce<()> for closure {
 
 // Full name: test_crate::main::{impl FnMut<()> for closure}
 impl FnMut<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<()> for closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<()>) = {impl FnOnce<()> for closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<()> for closure}
 impl Fn<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<()> for closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<()>) = {impl FnMut<()> for closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call<'_0_1> = {impl Fn<()> for closure}::call<'_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Tuple<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,10 +24,10 @@ pub trait Sized<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
@@ -36,10 +36,10 @@ pub trait FnOnce<Self, Args, Self_Output>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args, Self_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
@@ -55,20 +55,20 @@ pub trait Destruct<Self>
 // Full name: core::array::{[T; N]}::map
 pub fn map<T, F, U, const N : usize>(_1: [T; N], _2: F) -> [U; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<U>,
-    [@TraitClause3]: FnMut<F, (T,), U>,
-    [@TraitClause4]: Destruct<F>,
-    [@TraitClause5]: Destruct<U>,
-    [@TraitClause6]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (U: Sized),
+    TraitClause3: (F: FnMut<(T,), U>),
+    TraitClause4: (F: Destruct),
+    TraitClause5: (U: Destruct),
+    TraitClause6: (T: Destruct),
 = <opaque>
 
 // Full name: core::clone::Clone
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -76,7 +76,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u32}::clone
@@ -85,7 +85,7 @@ pub fn {impl Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
 
 // Full name: core::clone::impls::{impl Clone for u32}
 impl Clone for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
     fn clone<'_0_1> = {impl Clone for u32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -97,43 +97,43 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("fn")]
 pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args, Self_Clause1_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
 where
-    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+    TraitClause0: (Self: Fn<Args, Clause0_Clause1_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
 where
-    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+    TraitClause0: (Self: FnMut<Args, Clause0_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::Option::{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[@TraitClause0])
+// Full name: core::option::Option::{impl Destruct for Option<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_in_place
@@ -174,14 +174,14 @@ pub fn incr_u32(x_1: u32) -> u32
 }
 
 // Full name: test_crate::map_option
-pub fn map_option<T, F>(x_1: Option<T>[@TraitClause0], f_2: F) -> Option<T>[@TraitClause0]
+pub fn map_option<T, F>(x_1: Option<T>[TraitClause0], f_2: F) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Fn<F, (T,), T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (F: Fn<(T,), T>),
 {
-    let _0: Option<T>[@TraitClause0]; // return
-    let x_1: Option<T>[@TraitClause0]; // arg #1
+    let _0: Option<T>[TraitClause0]; // return
+    let x_1: Option<T>[TraitClause0]; // arg #1
     let f_2: F; // arg #2
     let x_3: T; // local
     let _4: T; // anonymous local
@@ -203,7 +203,7 @@ where
             storage_live(_7)
             _7 = move x_3
             _6 = (move _7,)
-            _4 = @TraitClause2::call<'3>(move _5, move _6)
+            _4 = TraitClause2::call<'3>(move _5, move _6)
             conditional_drop[{built_in impl Destruct for T}::drop_in_place] _7
             storage_dead(_7)
             storage_dead(_6)
@@ -216,18 +216,18 @@ where
         },
     }
     conditional_drop[{built_in impl Destruct for F}::drop_in_place] f_2
-    conditional_drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] x_1
     return
 }
 
 // Full name: test_crate::map_option_pointer_ref
-pub fn map_option_pointer_ref<'a, T, F>(x_1: &'a Option<T>[@TraitClause0], f_2: fn<'_0_1>(&'_0_1 T) -> T) -> Option<T>[@TraitClause0]
+pub fn map_option_pointer_ref<'a, T, F>(x_1: &'a Option<T>[TraitClause0], f_2: fn<'_0_1>(&'_0_1 T) -> T) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
 {
-    let _0: Option<T>[@TraitClause0]; // return
-    let x_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let _0: Option<T>[TraitClause0]; // return
+    let x_1: &'1 Option<T>[TraitClause0]; // arg #1
     let f_2: fn<'_0_1>(&'_0_1 T) -> T; // arg #2
     let x_3: &'3 T; // local
     let _4: T; // anonymous local
@@ -365,30 +365,30 @@ pub fn test_closure_u32(x_1: u32) -> u32
 
 // Full name: test_crate::test_closure_u32::{impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure}
 impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_closure_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure}::call_once
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_u32::{impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}
 impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
-    parent_clause1 = {impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
+    proof ImpliedClause1: (test_crate::test_closure_u32::closure: FnOnce<(u32,), u32>) = {impl FnOnce<(u32,), u32> for test_crate::test_closure_u32::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_u32::{impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}
 impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
-    parent_clause1 = {impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32::closure}
+    proof ImpliedClause1: (test_crate::test_closure_u32::closure: FnMut<(u32,), u32>) = {impl FnMut<(u32,), u32> for test_crate::test_closure_u32::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call<'_0_1>
     non-dyn-compatible
 }
@@ -510,30 +510,30 @@ pub fn test_closure_u32s(x_1: u32) -> u32
 
 // Full name: test_crate::test_closure_u32s::{impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
 impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
-    parent_clause1 = {built_in impl Sized for (u32, u32)}
-    parent_clause2 = {built_in impl Tuple for (u32, u32)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_closure_u32s::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
+    proof ImpliedClause1: ((u32, u32): Sized) = {built_in impl Sized for (u32, u32)}
+    proof ImpliedClause2: ((u32, u32): Tuple) = {built_in impl Tuple for (u32, u32)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call_once
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_u32s::{impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
 impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
-    parent_clause1 = {impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
-    parent_clause2 = {built_in impl Sized for (u32, u32)}
-    parent_clause3 = {built_in impl Tuple for (u32, u32)}
+    proof ImpliedClause0: (test_crate::test_closure_u32s::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
+    proof ImpliedClause1: (test_crate::test_closure_u32s::closure: FnOnce<(u32, u32), u32>) = {impl FnOnce<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
+    proof ImpliedClause2: ((u32, u32): Sized) = {built_in impl Sized for (u32, u32)}
+    proof ImpliedClause3: ((u32, u32): Tuple) = {built_in impl Tuple for (u32, u32)}
     fn call_mut<'_0_1> = {impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_u32s::{impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
 impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
-    parent_clause1 = {impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
-    parent_clause2 = {built_in impl Sized for (u32, u32)}
-    parent_clause3 = {built_in impl Tuple for (u32, u32)}
+    proof ImpliedClause0: (test_crate::test_closure_u32s::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_u32s::closure}
+    proof ImpliedClause1: (test_crate::test_closure_u32s::closure: FnMut<(u32, u32), u32>) = {impl FnMut<(u32, u32), u32> for test_crate::test_closure_u32s::closure}
+    proof ImpliedClause2: ((u32, u32): Sized) = {built_in impl Sized for (u32, u32)}
+    proof ImpliedClause3: ((u32, u32): Tuple) = {built_in impl Tuple for (u32, u32)}
     fn call<'_0_1> = {impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call<'_0_1>
     non-dyn-compatible
 }
@@ -640,30 +640,30 @@ pub fn test_closure_ref_u32<'a>(x_1: &'a u32) -> &'a u32
 
 // Full name: test_crate::test_closure_ref_u32::{impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}
 impl<'_0> FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
-    parent_clause1 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u32,)}
-    parent_clause3 = {built_in impl Sized for &'_ u32}
+    proof ImpliedClause0: (test_crate::test_closure_ref_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause3: (&'_ u32: Sized) = {built_in impl Sized for &'_ u32}
     fn call_once = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call_once<'_0>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}
 impl<'_0> FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
-    parent_clause1 = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_ref_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
+    proof ImpliedClause1: (test_crate::test_closure_ref_u32::closure: FnOnce<(&'_ u32,), &'_ u32>) = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}
 impl<'_0> Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
-    parent_clause1 = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_ref_u32::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::closure}
+    proof ImpliedClause1: (test_crate::test_closure_ref_u32::closure: FnMut<(&'_ u32,), &'_ u32>) = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
     fn call<'_0_1> = {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}::call<'_0, '_0_1>
     non-dyn-compatible
 }
@@ -676,22 +676,22 @@ impl Destruct for test_crate::test_closure_ref_u32::closure {
 
 struct test_crate::test_closure_ref_param::closure<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {}
 
-// Full name: test_crate::test_closure_ref_param::closure::{impl Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0])
+// Full name: test_crate::test_closure_ref_param::closure::{impl Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::drop_in_place<T>(_1: *mut test_crate::test_closure_ref_param::closure<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::closure<T>[@TraitClause0], tupled_args_2: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call
+fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::closure<T>[TraitClause0], tupled_args_2: (&'_0 T,)) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'0 T; // return
-    let _1: &'2 test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // arg #1
+    let _1: &'2 test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // arg #1
     let tupled_args_2: (&'_0 T,); // arg #2
     let x_3: &'3 T; // local
 
@@ -701,65 +701,65 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0], args_2: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_mut
+fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[TraitClause0], args_2: (&'_0 T,)) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'_0 T; // return
-    let state_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // arg #1
+    let state_1: &'_1 mut test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // arg #1
     let args_2: (&'_0 T,); // arg #2
-    let _3: &'0 test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // anonymous local
+    let _3: &'0 test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call<'_0, '2, T>[@TraitClause0](move _3, move args_2)
+    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call<'_0, '2, T>[TraitClause0](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_once
-fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_once<'_0, T>(_1: test_crate::test_closure_ref_param::closure<T>[@TraitClause0], _2: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_once
+fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_once<'_0, T>(_1: test_crate::test_closure_ref_param::closure<T>[TraitClause0], _2: (&'_0 T,)) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'0 T; // return
-    let _1: test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // arg #1
+    let _1: test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // arg #1
     let _2: (&'1 T,); // arg #2
-    let _3: &'3 mut test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // anonymous local
+    let _3: &'3 mut test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut<'_0, '9, T>[@TraitClause0](move _3, move _2)
-    drop[{impl Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] _1
+    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_mut<'_0, '9, T>[TraitClause0](move _3, move _2)
+    drop[{impl Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] _1
     return
 }
 
 fn test_crate::test_closure_ref_param::closure::as_fn<'_0, T>(arg1_1: &'_0 T) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'_0 T; // return
     let arg1_1: &'_0 T; // arg #1
     let args_2: (&'_0 T,); // local
-    let state_3: test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // local
+    let state_3: test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // local
 
     storage_live(args_2)
     storage_live(state_3)
     args_2 = (move arg1_1,)
     state_3 = test_crate::test_closure_ref_param::closure {  }
-    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_once<'_0, T>[@TraitClause0](move state_3, move args_2)
+    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0](move state_3, move args_2)
     return
 }
 
 // Full name: test_crate::test_closure_ref_param
 pub fn test_closure_ref_param<'_0, T>(x_1: &'_0 T) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
     let x_1: &'2 T; // arg #1
     let f_2: fn<'_0_1>(&'_0_1 T) -> &'_0_1 T; // local
-    let _3: test_crate::test_closure_ref_param::closure<T>[@TraitClause0]; // anonymous local
+    let _3: test_crate::test_closure_ref_param::closure<T>[TraitClause0]; // anonymous local
     let _4: &'3 T; // anonymous local
     let _5: fn<'_0_1>(&'_0_1 T) -> &'_0_1 T; // anonymous local
     let _6: &'4 T; // anonymous local
@@ -767,7 +767,7 @@ where
     storage_live(f_2)
     storage_live(_3)
     _3 = test_crate::test_closure_ref_param::closure {  }
-    f_2 = cast<for<'_0_1> test_crate::test_closure_ref_param::closure::as_fn<'_0_1, T>[@TraitClause0], fn<'_0_1>(&'_0_1 T) -> &'_0_1 T>(const test_crate::test_closure_ref_param::closure::as_fn<'6, T>[@TraitClause0])
+    f_2 = cast<for<'_0_1> test_crate::test_closure_ref_param::closure::as_fn<'_0_1, T>[TraitClause0], fn<'_0_1>(&'_0_1 T) -> &'_0_1 T>(const test_crate::test_closure_ref_param::closure::as_fn<'6, T>[TraitClause0])
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -783,82 +783,82 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-impl<'_0, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+impl<'_0, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for (&'_ T,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ T,)}
-    parent_clause3 = {built_in impl Sized for &'_ T}
-    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_once<'_0, T>[@TraitClause0]
+    proof ImpliedClause0: (test_crate::test_closure_ref_param::closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+    proof ImpliedClause1: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause2: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
+    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-impl<'_0, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+impl<'_0, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-    parent_clause1 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}<'_0, T>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for (&'_ T,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ T,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call_mut<'_0, '_0_1, T>[@TraitClause0]
+    proof ImpliedClause0: (test_crate::test_closure_ref_param::closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+    proof ImpliedClause1: (test_crate::test_closure_ref_param::closure<T>[TraitClause0]: FnOnce<(&'_ T,), &'_ T>) = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}<'_0, T>[TraitClause0]
+    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call_mut<'_0, '_0_1, T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-impl<'_0, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+impl<'_0, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-    parent_clause1 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}<'_0, T>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for (&'_ T,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ T,)}
-    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::call<'_0, '_0_1, T>[@TraitClause0]
+    proof ImpliedClause0: (test_crate::test_closure_ref_param::closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+    proof ImpliedClause1: (test_crate::test_closure_ref_param::closure<T>[TraitClause0]: FnMut<(&'_ T,), &'_ T>) = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}<'_0, T>[TraitClause0]
+    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::call<'_0, '_0_1, T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_param::closure::{impl Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}
-impl<T> Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]
+// Full name: test_crate::test_closure_ref_param::closure::{impl Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}
+impl<T> Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for test_crate::test_closure_ref_param::closure<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for test_crate::test_closure_ref_param::closure<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 pub trait Trait<'a, Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}<'a>
 }
 
 struct test_crate::test_closure_ref_early_bound::closure<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {}
 
-// Full name: test_crate::test_closure_ref_early_bound::closure::{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, T>(_1: *mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::test_closure_ref_early_bound::closure::{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, T>(_1: *mut test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 = <missing>
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1], tupled_args_2: (&'_1 T,)) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
     let _0: &'0 T; // return
-    let _1: &'3 test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'3 test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (&'_1 T,); // arg #2
     let y_3: &'5 T; // local
 
@@ -868,69 +868,69 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, T>(state_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], args_2: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, T>(state_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1], args_2: (&'_1 T,)) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
     let _0: &'_1 T; // return
-    let state_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_2 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (&'_1 T,); // arg #2
-    let _3: &'1 test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '7, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '7, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, T>(_1: test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1], _2: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>(_1: test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1], _2: (&'_1 T,)) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
     let _0: &'0 T; // return
-    let _1: test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (&'2 T,); // arg #2
-    let _3: &'5 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'5 mut test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '17, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '17, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
 fn test_crate::test_closure_ref_early_bound::closure::as_fn<'a, '_1, T>(arg1_1: &'_1 T) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
     let _0: &'_1 T; // return
     let arg1_1: &'_1 T; // arg #1
     let args_2: (&'_1 T,); // local
-    let state_3: test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]; // local
+    let state_3: test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]; // local
 
     storage_live(args_2)
     storage_live(state_3)
     args_2 = (move arg1_1,)
     state_3 = test_crate::test_closure_ref_early_bound::closure {  }
-    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, T>[@TraitClause0, @TraitClause1](move state_3, move args_2)
+    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1](move state_3, move args_2)
     return
 }
 
 // Full name: test_crate::test_closure_ref_early_bound
 pub fn test_closure_ref_early_bound<'a, T>(x_1: &'a T) -> &'a T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
     let _0: &'1 T; // return
     let x_1: &'2 T; // arg #1
     let f_2: fn<'_0_1>(&'_0_1 T) -> &'_0_1 T; // local
-    let _3: test_crate::test_closure_ref_early_bound::closure<'5, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: test_crate::test_closure_ref_early_bound::closure<'5, T>[TraitClause0, TraitClause1]; // anonymous local
     let _4: &'7 T; // anonymous local
     let _5: fn<'_0_1>(&'_0_1 T) -> &'_0_1 T; // anonymous local
     let _6: &'8 T; // anonymous local
@@ -938,7 +938,7 @@ where
     storage_live(f_2)
     storage_live(_3)
     _3 = test_crate::test_closure_ref_early_bound::closure {  }
-    f_2 = cast<for<'_0_1> test_crate::test_closure_ref_early_bound::closure::as_fn<'11, '_0_1, T>[@TraitClause0, @TraitClause1], fn<'_0_1>(&'_0_1 T) -> &'_0_1 T>(const test_crate::test_closure_ref_early_bound::closure::as_fn<'11, '14, T>[@TraitClause0, @TraitClause1])
+    f_2 = cast<for<'_0_1> test_crate::test_closure_ref_early_bound::closure::as_fn<'11, '_0_1, T>[TraitClause0, TraitClause1], fn<'_0_1>(&'_0_1 T) -> &'_0_1 T>(const test_crate::test_closure_ref_early_bound::closure::as_fn<'11, '14, T>[TraitClause0, TraitClause1])
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -954,55 +954,55 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for (&'_ T,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ T,)}
-    parent_clause3 = {built_in impl Sized for &'_ T}
-    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause2: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
+    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}<'a, '_1, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ T,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ T,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ T,), &'_ T>) = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}<'a, '_1, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ T,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ T,)}
-    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]: FnMut<(&'_ T,), &'_ T>) = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
+    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
+    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::closure::{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}
-impl<'a, T> Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::closure::{impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, T> Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<'a, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait<'a>),
 {
-    fn drop_in_place = {impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::test_closure_ref_early_bound::closure<'a, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -1105,30 +1105,30 @@ pub fn test_map_option2(x_1: Option<u32>[{built_in impl Sized for u32}]) -> Opti
 
 // Full name: test_crate::test_map_option2::{impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure}
 impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option2::closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_map_option2::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option2::closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure}::call_once
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_map_option2::{impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}
 impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option2::closure}
-    parent_clause1 = {impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_map_option2::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option2::closure}
+    proof ImpliedClause1: (test_crate::test_map_option2::closure: FnOnce<(u32,), u32>) = {impl FnOnce<(u32,), u32> for test_crate::test_map_option2::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_map_option2::{impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}
 impl Fn<(u32,), u32> for test_crate::test_map_option2::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option2::closure}
-    parent_clause1 = {impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_map_option2::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option2::closure}
+    proof ImpliedClause1: (test_crate::test_map_option2::closure: FnMut<(u32,), u32>) = {impl FnMut<(u32,), u32> for test_crate::test_map_option2::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call<'_0_1>
     non-dyn-compatible
 }
@@ -1142,7 +1142,7 @@ impl Destruct for test_crate::test_map_option2::closure {
 // Full name: test_crate::id
 pub fn id<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -1191,8 +1191,8 @@ pub fn test_map_option_id2(x_1: Option<u32>[{built_in impl Sized for u32}]) -> O
 // Full name: test_crate::id_clone
 pub fn id_clone<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -1200,7 +1200,7 @@ where
 
     storage_live(_2)
     _2 = &x_1
-    _0 = @TraitClause1::clone<'3>(move _2)
+    _0 = TraitClause1::clone<'3>(move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
@@ -1231,8 +1231,8 @@ pub fn test_id_clone(x_1: u32) -> u32
 // Full name: test_crate::test_id_clone_param
 pub fn test_id_clone_param<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -1241,7 +1241,7 @@ where
     let _4: T; // anonymous local
 
     storage_live(f_2)
-    f_2 = cast<id_clone<T>[@TraitClause0, @TraitClause1], fn(T) -> T>(const id_clone<T>[@TraitClause0, @TraitClause1])
+    f_2 = cast<id_clone<T>[TraitClause0, TraitClause1], fn(T) -> T>(const id_clone<T>[TraitClause0, TraitClause1])
     storage_live(_3)
     _3 = copy f_2
     storage_live(_4)
@@ -1326,30 +1326,30 @@ fn {impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure}::call_on
 
 // Full name: test_crate::test_map_option3::{impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure}
 impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option3::closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_map_option3::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option3::closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure}::call_once
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_map_option3::{impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}
 impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option3::closure}
-    parent_clause1 = {impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_map_option3::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option3::closure}
+    proof ImpliedClause1: (test_crate::test_map_option3::closure: FnOnce<(u32,), u32>) = {impl FnOnce<(u32,), u32> for test_crate::test_map_option3::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_map_option3::{impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}
 impl Fn<(u32,), u32> for test_crate::test_map_option3::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_map_option3::closure}
-    parent_clause1 = {impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_map_option3::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_map_option3::closure}
+    proof ImpliedClause1: (test_crate::test_map_option3::closure: FnMut<(u32,), u32>) = {impl FnMut<(u32,), u32> for test_crate::test_map_option3::closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call<'_0_1>
     non-dyn-compatible
 }
@@ -1459,30 +1459,30 @@ fn {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::cal
 
 // Full name: test_crate::test_regions::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}
 impl<'_0, '_1> FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions::closure}
-    parent_clause1 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_regions::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::closure}
+    proof ImpliedClause1: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause2: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call_once<'_0, '_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_regions::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}
 impl<'_0, '_1> FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions::closure}
-    parent_clause1 = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_regions::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::closure}
+    proof ImpliedClause1: (test_crate::test_regions::closure: FnOnce<(&'_ &'_ u32,), u32>) = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_regions::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}
 impl<'_0, '_1> Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions::closure}
-    parent_clause1 = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_regions::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::closure}
+    proof ImpliedClause1: (test_crate::test_regions::closure: FnMut<(&'_ &'_ u32,), u32>) = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
     fn call<'_0_1> = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
@@ -1589,30 +1589,30 @@ pub fn test_regions_casted<'a>(x_1: &'a u32) -> u32
 
 // Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}
 impl<'_0, '_1> FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
-    parent_clause1 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_regions_casted::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
+    proof ImpliedClause1: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause2: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call_once<'_0, '_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_regions_casted::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}
 impl<'_0, '_1> FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
-    parent_clause1 = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_regions_casted::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
+    proof ImpliedClause1: (test_crate::test_regions_casted::closure: FnOnce<(&'_ &'_ u32,), u32>) = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_regions_casted::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}
 impl<'_0, '_1> Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
-    parent_clause1 = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ &'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause0: (test_crate::test_regions_casted::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::closure}
+    proof ImpliedClause1: (test_crate::test_regions_casted::closure: FnMut<(&'_ &'_ u32,), u32>) = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
+    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
     fn call<'_0_1> = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::closure}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
@@ -1734,30 +1734,30 @@ fn {impl FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, 
 
 // Full name: test_crate::test_closure_capture::{impl FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}
 impl<'_0, '_1> FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (test_crate::test_closure_capture::closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     fn call_once = {impl FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call_once<'_0, '_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_capture::{impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}
 impl<'_0, '_1> FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
-    parent_clause1 = {impl FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_capture::closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
+    proof ImpliedClause1: (test_crate::test_closure_capture::closure<'_0, '_1>: FnOnce<(u32,), u32>) = {impl FnOnce<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_closure_capture::{impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}
 impl<'_0, '_1> Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
-    parent_clause1 = {impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (test_crate::test_closure_capture::closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_capture::closure<'_0, '_1>}
+    proof ImpliedClause1: (test_crate::test_closure_capture::closure<'_0, '_1>: FnMut<(u32,), u32>) = {impl FnMut<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,), u32> for test_crate::test_closure_capture::closure<'_0, '_1>}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
@@ -1770,18 +1770,18 @@ impl<'_0, '_1> Destruct for test_crate::test_closure_capture::closure<'_0, '_1> 
 
 struct test_crate::test_closure_clone::closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {}
 
-// Full name: test_crate::test_closure_clone::{impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: (T,)) -> T
+// Full name: test_crate::test_closure_clone::{impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1], tupled_args_2: (T,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: &'1 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (T,); // arg #2
     let x_3: T; // local
     let _4: &'3 T; // anonymous local
@@ -1790,7 +1790,7 @@ where
     x_3 = move tupled_args_2.0
     storage_live(_4)
     _4 = &x_3
-    _0 = @TraitClause1::clone<'5>(move _4)
+    _0 = TraitClause1::clone<'5>(move _4)
     storage_dead(_4)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_3
     return
@@ -1799,14 +1799,14 @@ where
 // Full name: test_crate::test_closure_clone
 pub fn test_closure_clone<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let x_1: T; // arg #1
-    let f_2: test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // local
-    let _3: &'1 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
-    let _4: &'2 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let f_2: test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // local
+    let _3: &'1 test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // anonymous local
+    let _4: &'2 test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // anonymous local
     let _5: (T,); // anonymous local
     let _6: T; // anonymous local
 
@@ -1820,7 +1820,7 @@ where
     storage_live(_6)
     _6 = move x_1
     _5 = (move _6,)
-    _0 = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'4, T>[@TraitClause0, @TraitClause1](move _3, move _5)
+    _0 = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call<'4, T>[TraitClause0, TraitClause1](move _3, move _5)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] _6
     storage_dead(_6)
     storage_dead(_5)
@@ -1831,97 +1831,97 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_clone::closure::{impl Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::test_closure_clone::closure::{impl Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::test_closure_clone::{impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], args_2: (T,)) -> T
+// Full name: test_crate::test_closure_clone::{impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1], args_2: (T,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let state_1: &'_0 mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_0 mut test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (T,); // arg #2
-    let _3: &'0 test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call<'2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::test_closure_clone::{impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1], _2: (T,)) -> T
+// Full name: test_crate::test_closure_clone::{impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_once<T>(_1: test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1], _2: (T,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (T,); // arg #2
-    let _3: &'1 mut test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 mut test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'3, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_mut<'3, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::test_closure_clone::{impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_clone::{impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for (T,)}
-    parent_clause2 = {built_in impl Tuple for (T,)}
-    parent_clause3 = @TraitClause0
-    fn call_once = {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause2: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
+    fn call_once = {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_clone::{impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_clone::{impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (T,)}
-    parent_clause3 = {built_in impl Tuple for (T,)}
-    fn call_mut<'_0_1> = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]: FnOnce<(T,), T>) = {impl FnOnce<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause3: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call_mut<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_clone::{impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_clone::{impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (T,)}
-    parent_clause3 = {built_in impl Tuple for (T,)}
-    fn call<'_0_1> = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]: FnMut<(T,), T>) = {impl FnMut<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause3: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    fn call<'_0_1> = {impl Fn<(T,), T> for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::call<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test_closure_clone::closure::{impl Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test_closure_clone::closure::{impl Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::test_closure_clone::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::test_closure_clone::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -1968,20 +1968,20 @@ fn {impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure}::call_once
 
 // Full name: test_crate::test_array_map::{impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure}
 impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_array_map::closure}
-    parent_clause1 = {built_in impl Sized for (i32,)}
-    parent_clause2 = {built_in impl Tuple for (i32,)}
-    parent_clause3 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (test_crate::test_array_map::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_array_map::closure}
+    proof ImpliedClause1: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause2: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    proof ImpliedClause3: (i32: Sized) = {built_in impl Sized for i32}
     fn call_once = {impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure}::call_once
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_array_map::{impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}
 impl FnMut<(i32,), i32> for test_crate::test_array_map::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_array_map::closure}
-    parent_clause1 = {impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure}
-    parent_clause2 = {built_in impl Sized for (i32,)}
-    parent_clause3 = {built_in impl Tuple for (i32,)}
+    proof ImpliedClause0: (test_crate::test_array_map::closure: MetaSized) = {built_in impl MetaSized for test_crate::test_array_map::closure}
+    proof ImpliedClause1: (test_crate::test_array_map::closure: FnOnce<(i32,), i32>) = {impl FnOnce<(i32,), i32> for test_crate::test_array_map::closure}
+    proof ImpliedClause2: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause3: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
     fn call_mut<'_0_1> = {impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
@@ -2107,20 +2107,20 @@ fn {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'
 
 // Full name: test_crate::test_fnmut_with_ref::{impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}
 impl<'_0, '_1> FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::closure<'_0>}
-    parent_clause1 = {built_in impl Sized for (&'_ usize,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ usize,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (test_crate::test_fnmut_with_ref::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::closure<'_0>}
+    proof ImpliedClause1: ((&'_ usize,): Sized) = {built_in impl Sized for (&'_ usize,)}
+    proof ImpliedClause2: ((&'_ usize,): Tuple) = {built_in impl Tuple for (&'_ usize,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     fn call_once = {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_once<'_0, '_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}
 impl<'_0, '_1> FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::closure<'_0>}
-    parent_clause1 = {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ usize,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ usize,)}
+    proof ImpliedClause0: (test_crate::test_fnmut_with_ref::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::closure<'_0>}
+    proof ImpliedClause1: (test_crate::test_fnmut_with_ref::closure<'_0>: FnOnce<(&'_ usize,), ()>) = {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ usize,): Sized) = {built_in impl Sized for (&'_ usize,)}
+    proof ImpliedClause3: ((&'_ usize,): Tuple) = {built_in impl Tuple for (&'_ usize,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Tuple<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,10 +24,10 @@ pub trait Sized<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -37,12 +37,12 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::marker::Destruct
@@ -56,31 +56,31 @@ pub trait Destruct<Self>
 // Full name: core::array::from_fn
 pub fn from_fn<T, F, const N : usize>(_1: F) -> [T; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: FnMut<F, (usize,)>,
-    [@TraitClause4]: Destruct<F>,
-    @TraitClause3::parent_clause1::Output = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (F: FnMut<(usize,)>),
+    TraitClause4: (F: Destruct),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = T,
 = <opaque>
 
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Ops
 trait Ops<Self, const K : usize>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn of_usize = of_usize<Self, K>[Self]
     non-dyn-compatible
 }
@@ -88,41 +88,41 @@ trait Ops<Self, const K : usize>
 // Full name: test_crate::Ops::of_usize
 fn of_usize<Self, const K : usize>(_1: usize) -> Self
 where
-    [@TraitClause0]: Ops<Self, K>,
+    TraitClause0: (Self: Ops<K>),
 = <method_without_default_body>
 
 // Full name: test_crate::test::closure
 struct closure<T, const K : usize>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {}
 
-// Full name: test_crate::test::closure::{impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}::drop_in_place<T, const K : usize>(_1: *mut closure<T, K>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::test::closure::{impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}::drop_in_place<T, const K : usize>(_1: *mut closure<T, K>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 = <missing>
 
-// Full name: test_crate::test::closure::{impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}
-impl<T, const K : usize> Destruct for closure<T, K>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test::closure::{impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}
+impl<T, const K : usize> Destruct for closure<T, K>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
-    fn drop_in_place = {impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}::drop_in_place<T, K>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}::drop_in_place<T, K>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test::{impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T, const K : usize>(_1: &'_0 mut closure<T, K>[@TraitClause0, @TraitClause1], tupled_args_2: (usize,)) -> T
+// Full name: test_crate::test::{impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_mut<'_0, T, const K : usize>(_1: &'_0 mut closure<T, K>[TraitClause0, TraitClause1], tupled_args_2: (usize,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
     let _0: T; // return
-    let _1: &'1 mut closure<T, K>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 mut closure<T, K>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (usize,); // arg #2
     let i_3: usize; // local
     let _4: usize; // anonymous local
@@ -131,70 +131,70 @@ where
     i_3 = move tupled_args_2.0
     storage_live(_4)
     _4 = copy i_3
-    _0 = @TraitClause1::of_usize(move _4)
+    _0 = TraitClause1::of_usize(move _4)
     storage_dead(_4)
     return
 }
 
-// Full name: test_crate::test::{impl FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_once<T, const K : usize>(_1: closure<T, K>[@TraitClause0, @TraitClause1], _2: (usize,)) -> T
+// Full name: test_crate::test::{impl FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_once<T, const K : usize>(_1: closure<T, K>[TraitClause0, TraitClause1], _2: (usize,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
     let _0: T; // return
-    let _1: closure<T, K>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: closure<T, K>[TraitClause0, TraitClause1]; // arg #1
     let _2: (usize,); // arg #2
-    let _3: &'1 mut closure<T, K>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 mut closure<T, K>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut<'3, T, K>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}::drop_in_place<T, K>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_mut<'3, T, K>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}::drop_in_place<T, K>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::test::{impl FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}
-impl<T, const K : usize> FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test::{impl FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}
+impl<T, const K : usize> FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T, K>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for (usize,)}
-    parent_clause2 = {built_in impl Tuple for (usize,)}
-    parent_clause3 = @TraitClause0
+    proof ImpliedClause0: (closure<T, K>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<T, K>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause2: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
     type Output = T
-    fn call_once = {impl FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_once<T, K>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_once<T, K>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::test::{impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}
-impl<T, const K : usize> FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::test::{impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}
+impl<T, const K : usize> FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T, K>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}<T, K>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (usize,)}
-    parent_clause3 = {built_in impl Tuple for (usize,)}
-    fn call_mut<'_0_1> = {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}::call_mut<'_0_1, T, K>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<T, K>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<T, K>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (closure<T, K>[TraitClause0, TraitClause1]: FnOnce<(usize,)>) = {impl FnOnce<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}<T, K>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause3: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
+    fn call_mut<'_0_1> = {impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}::call_mut<'_0_1, T, K>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::test
 fn test<T, const K : usize>() -> [T; 1 : usize]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ops<T, K>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ops<K>),
 {
     let _0: [T; 1 : usize]; // return
-    let _1: closure<T, K>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _1: closure<T, K>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_1)
     _1 = closure {  }
-    _0 = from_fn<T, closure<T, K>[@TraitClause0, @TraitClause1], 1 : usize>[@TraitClause0, {built_in impl Sized for closure<T, K>[@TraitClause0, @TraitClause1]}, {built_in impl Destruct for T}, {impl FnMut<(usize,)> for closure<T, K>[@TraitClause0, @TraitClause1]}<T, K>[@TraitClause0, @TraitClause1], {impl Destruct for closure<T, K>[@TraitClause0, @TraitClause1]}<T, K>[@TraitClause0, @TraitClause1]](move _1)
+    _0 = from_fn<T, closure<T, K>[TraitClause0, TraitClause1], 1 : usize>[TraitClause0, {built_in impl Sized for closure<T, K>[TraitClause0, TraitClause1]}, {built_in impl Destruct for T}, {impl FnMut<(usize,)> for closure<T, K>[TraitClause0, TraitClause1]}<T, K>[TraitClause0, TraitClause1], {impl Destruct for closure<T, K>[TraitClause0, TraitClause1]}<T, K>[TraitClause0, TraitClause1]](move _1)
     storage_dead(_1)
     return
 }

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Default")]
 pub trait Default<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn default = core::default::Default::default<Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Default<Self>
 #[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 where
-    [@TraitClause0]: Default<Self>,
+    TraitClause0: (Self: Default),
 = <opaque>
 
 // Full name: core::default::{impl Default for u32}::default
@@ -51,7 +51,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -68,7 +68,7 @@ pub enum AssertKind {
 #[lang_item("slice_len_fn")]
 pub fn len<'_0, T>(_1: &'_0 [T]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::function_call
@@ -242,7 +242,7 @@ pub fn {impl Default for Foo}::default() -> Foo
 
 // Full name: test_crate::{impl Default for Foo}
 impl Default for Foo {
-    parent_clause0 = {built_in impl Sized for Foo}
+    proof ImpliedClause0: (Foo: Sized) = {built_in impl Sized for Foo}
     fn default = {impl Default for Foo}::default
     non-dyn-compatible
 }
@@ -272,7 +272,7 @@ pub fn {impl Default for Bar}::default() -> Bar
 
 // Full name: test_crate::{impl Default for Bar}
 impl Default for Bar {
-    parent_clause0 = {built_in impl Sized for Bar}
+    proof ImpliedClause0: (Bar: Sized) = {built_in impl Sized for Bar}
     fn default = {impl Default for Bar}::default
     non-dyn-compatible
 }
@@ -280,7 +280,7 @@ impl Default for Bar {
 // Full name: test_crate::eat
 fn eat<T>(_1: T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: T; // arg #1

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -122,8 +122,8 @@ pub fn mk_pair0(x_1: u32, y_2: u32) -> (u32, u32)
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
   x: T1,
   y: T2,
@@ -199,17 +199,17 @@ pub const P3: Pair<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized
 // Full name: test_crate::Wrap
 pub struct Wrap<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   value: T,
 }
 
-// Full name: test_crate::{Wrap<T>[@TraitClause0]}::new
-pub fn new<T>(value_1: T) -> Wrap<T>[@TraitClause0]
+// Full name: test_crate::{Wrap<T>[TraitClause0]}::new
+pub fn new<T>(value_1: T) -> Wrap<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Wrap<T>[@TraitClause0]; // return
+    let _0: Wrap<T>[TraitClause0]; // return
     let value_1: T; // arg #1
     let _2: T; // anonymous local
 
@@ -417,15 +417,15 @@ pub static S4: Pair<u32, u32>[{built_in impl Sized for u32}, {built_in impl Size
 // Full name: test_crate::V
 pub struct V<T, const N : usize>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   x: [T; N],
 }
 
-// Full name: test_crate::{V<T, N>[@TraitClause0]}::LEN
+// Full name: test_crate::{V<T, N>[TraitClause0]}::LEN
 pub fn LEN<T, const N : usize>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
@@ -433,20 +433,20 @@ where
     return
 }
 
-// Full name: test_crate::{V<T, N>[@TraitClause0]}::LEN
+// Full name: test_crate::{V<T, N>[TraitClause0]}::LEN
 pub const LEN<T, const N : usize>: usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
  = LEN()
 
 // Full name: test_crate::use_v
 pub fn use_v<T, const N : usize>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
-    _0 = copy LEN<T, N>[@TraitClause0]
+    _0 = copy LEN<T, N>[TraitClause0]
     return
 }
 

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -26,8 +26,8 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
@@ -36,45 +36,45 @@ pub trait Iterator<Self>
 // Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
 pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: core::slice::iter::Chunks
 pub opaque type Chunks<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}
-impl<'a, T> Iterator for Chunks<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}
+impl<'a, T> Iterator for Chunks<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Chunks<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ [T]}
+    proof ImpliedClause0: (Chunks<'_, T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Chunks<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ [T]: Sized) = {built_in impl Sized for &'_ [T]}
     type Item = &'a [T]
-    fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    vtable: {impl Iterator for Chunks<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 // Full name: core::slice::{[T]}::chunks
-pub fn chunks<'_0, T>(_1: &'_0 [T], _2: usize) -> Chunks<'_0, T>[@TraitClause0]
+pub fn chunks<'_0, T>(_1: &'_0 [T], _2: usize) -> Chunks<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::f1
@@ -226,7 +226,7 @@ fn f2<'_0, '_1>(a_1: &'_0 [u8], result_2: &'_1 mut [i16]) -> usize
     _6 = &(*a_1) with_metadata(copy a_1.metadata)
     _5 = chunks<'25, u8>[{built_in impl Sized for u8}](move _6, const 3 : usize)
     storage_dead(_6)
-    _4 = {impl IntoIterator for I}::into_iter<Chunks<'26, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'26, u8>[{built_in impl Sized for u8}]}, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'26, u8>[{built_in impl Sized for u8}]](move _5)
+    _4 = {impl IntoIterator for I}::into_iter<Chunks<'26, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'26, u8>[{built_in impl Sized for u8}]}, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'26, u8>[{built_in impl Sized for u8}]](move _5)
     storage_dead(_5)
     storage_live(iter_7)
     iter_7 = move _4
@@ -236,7 +236,7 @@ fn f2<'_0, '_1>(a_1: &'_0 [u8], result_2: &'_1 mut [i16]) -> usize
         storage_live(_10)
         _10 = &mut iter_7
         _9 = &two-phase-mut (*_10)
-        _8 = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'35, '37, u8>[{built_in impl Sized for u8}](move _9)
+        _8 = {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'35, '37, u8>[{built_in impl Sized for u8}](move _9)
         storage_dead(_9)
         match _8 {
             Option::None => {

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -44,7 +44,7 @@ pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 
 // Full name: core::clone::impls::{impl Clone for usize}
 impl Clone for usize {
-    parent_clause0 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
     fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -55,7 +55,7 @@ pub fn {impl Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
 
 // Full name: core::clone::impls::{impl Clone for u32}
 impl Clone for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
     fn clone<'_0_1> = {impl Clone for u32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -71,7 +71,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Ordering
@@ -86,7 +86,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -96,7 +96,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -104,7 +104,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<i32> for i32}::eq
@@ -143,7 +143,7 @@ pub fn {impl PartialOrd<i32> for i32}::partial_cmp<'_0, '_1>(_1: &'_0 i32, _2: &
 
 // Full name: core::cmp::impls::{impl PartialOrd<i32> for i32}
 impl PartialOrd<i32> for i32 {
-    parent_clause0 = {impl PartialEq<i32> for i32}
+    proof ImpliedClause0: (i32: PartialEq<i32>) = {impl PartialEq<i32> for i32}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<i32> for i32}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<i32> for i32}::{vtable}
 }
@@ -154,7 +154,7 @@ pub fn {impl PartialOrd<usize> for usize}::partial_cmp<'_0, '_1>(_1: &'_0 usize,
 
 // Full name: core::cmp::impls::{impl PartialOrd<usize> for usize}
 impl PartialOrd<usize> for usize {
-    parent_clause0 = {impl PartialEq<usize> for usize}
+    proof ImpliedClause0: (usize: PartialEq<usize>) = {impl PartialEq<usize> for usize}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<usize> for usize}::{vtable}
 }
@@ -165,7 +165,7 @@ pub fn {impl PartialOrd<u32> for u32}::partial_cmp<'_0, '_1>(_1: &'_0 u32, _2: &
 
 // Full name: core::cmp::impls::{impl PartialOrd<u32> for u32}
 impl PartialOrd<u32> for u32 {
-    parent_clause0 = {impl PartialEq<u32> for u32}
+    proof ImpliedClause0: (u32: PartialEq<u32>) = {impl PartialEq<u32> for u32}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<u32> for u32}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<u32> for u32}::{vtable}
 }
@@ -174,9 +174,9 @@ impl PartialOrd<u32> for u32 {
 #[lang_item("range_step")]
 pub trait Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
-    parent_clause2 : [@TraitClause2]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Clone)
+    proof ImpliedClause2: (Self: PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -185,17 +185,17 @@ pub trait Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 // Full name: core::iter::range::{impl Step for usize}::backward_checked
@@ -212,9 +212,9 @@ pub fn {impl Step for usize}::steps_between<'_0, '_1>(_1: &'_0 usize, _2: &'_1 u
 
 // Full name: core::iter::range::{impl Step for usize}
 impl Step for usize {
-    parent_clause0 = {built_in impl Sized for usize}
-    parent_clause1 = {impl Clone for usize}
-    parent_clause2 = {impl PartialOrd<usize> for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
+    proof ImpliedClause1: (usize: Clone) = {impl Clone for usize}
+    proof ImpliedClause2: (usize: PartialOrd<usize>) = {impl PartialOrd<usize> for usize}
     fn steps_between<'_0_1, '_1_1> = {impl Step for usize}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for usize}::forward_checked
     fn backward_checked = {impl Step for usize}::backward_checked
@@ -235,9 +235,9 @@ pub fn {impl Step for u32}::steps_between<'_0, '_1>(_1: &'_0 u32, _2: &'_1 u32) 
 
 // Full name: core::iter::range::{impl Step for u32}
 impl Step for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
-    parent_clause1 = {impl Clone for u32}
-    parent_clause2 = {impl PartialOrd<u32> for u32}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause1: (u32: Clone) = {impl Clone for u32}
+    proof ImpliedClause2: (u32: PartialOrd<u32>) = {impl PartialOrd<u32> for u32}
     fn steps_between<'_0_1, '_1_1> = {impl Step for u32}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for u32}::forward_checked
     fn backward_checked = {impl Step for u32}::backward_checked
@@ -258,9 +258,9 @@ pub fn {impl Step for i32}::steps_between<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i32) 
 
 // Full name: core::iter::range::{impl Step for i32}
 impl Step for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
-    parent_clause1 = {impl Clone for i32}
-    parent_clause2 = {impl PartialOrd<i32> for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
+    proof ImpliedClause1: (i32: Clone) = {impl Clone for i32}
+    proof ImpliedClause2: (i32: PartialOrd<i32>) = {impl PartialOrd<i32> for i32}
     fn steps_between<'_0_1, '_1_1> = {impl Step for i32}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for i32}::forward_checked
     fn backward_checked = {impl Step for i32}::backward_checked
@@ -271,7 +271,7 @@ impl Step for i32 {
 #[lang_item("Range")]
 pub struct Range<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
@@ -281,55 +281,55 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}::next
-pub fn {impl Iterator for Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[@TraitClause0]) -> Option<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}::next
+pub fn {impl Iterator for Range<A>[TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[TraitClause0]) -> Option<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 = <opaque>
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}
-impl<A> Iterator for Range<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}
+impl<A> Iterator for Range<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 {
-    parent_clause0 = {built_in impl MetaSized for Range<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (Range<A>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Range<A>[TraitClause0]}
+    proof ImpliedClause1: (A: Sized) = TraitClause0
     type Item = A
-    fn next<'_0_1> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = {impl Iterator for Range<A>[TraitClause0]}::next<'_0_1, A>[TraitClause0, TraitClause1]
+    vtable: {impl Iterator for Range<A>[TraitClause0]}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
 pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 pub trait core::slice::index::private_slice_index::Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
 // Full name: core::slice::index::private_slice_index::{impl core::slice::index::private_slice_index::Sealed for usize}
 impl core::slice::index::private_slice_index::Sealed for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     vtable: {impl core::slice::index::private_slice_index::Sealed for usize}::{vtable}
 }
 
@@ -337,10 +337,10 @@ impl core::slice::index::private_slice_index::Sealed for usize {
 #[lang_item("SliceIndex")]
 pub trait SliceIndex<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::slice::index::private_slice_index::Sealed<Self>
-    parent_clause2 : [@TraitClause2]: MetaSized<T>
-    parent_clause3 : [@TraitClause3]: MetaSized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: core::slice::index::private_slice_index::Sealed)
+    proof ImpliedClause2: (T: MetaSized)
+    proof ImpliedClause3: (Self::Output: MetaSized)
     type Output
     fn get<'_0_1> = core::slice::index::SliceIndex::get<'_0_1, Self, T>[Self]
     fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut<'_0_1, Self, T>[Self]
@@ -351,89 +351,89 @@ pub trait SliceIndex<Self, T>
     vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
-pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 @TraitClause0::Output>[{built_in impl Sized for &'_0 @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 TraitClause0::Output>[{built_in impl Sized for &'_0 TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut @TraitClause0::Output>[{built_in impl Sized for &'_0 mut @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut TraitClause0::Output>[{built_in impl Sized for &'_0 mut TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::index_mut
 pub fn {impl SliceIndex<[T]> for usize}::index_mut<'_0, T>(_1: usize, _2: &'_0 mut [T]) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::index
 pub fn {impl SliceIndex<[T]> for usize}::index<'_0, T>(_1: usize, _2: &'_0 [T]) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_unchecked_mut
 pub unsafe fn {impl SliceIndex<[T]> for usize}::get_unchecked_mut<T>(_1: usize, _2: *mut [T]) -> *mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_unchecked
 pub unsafe fn {impl SliceIndex<[T]> for usize}::get_unchecked<T>(_1: usize, _2: *const [T]) -> *const T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get_mut
 pub fn {impl SliceIndex<[T]> for usize}::get_mut<'_0, T>(_1: usize, _2: &'_0 mut [T]) -> Option<&'_0 mut T>[{built_in impl Sized for &'_0 mut T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}::get
 pub fn {impl SliceIndex<[T]> for usize}::get<'_0, T>(_1: usize, _2: &'_0 [T]) -> Option<&'_0 T>[{built_in impl Sized for &'_0 T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for usize}
 impl<T> SliceIndex<[T]> for usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl core::slice::index::private_slice_index::Sealed for usize}
-    parent_clause2 = {built_in impl MetaSized for [T]}
-    parent_clause3 = @TraitClause0::parent_clause0
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause1: (usize: core::slice::index::private_slice_index::Sealed) = {impl core::slice::index::private_slice_index::Sealed for usize}
+    proof ImpliedClause2: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause3: (T: MetaSized) = TraitClause0::ImpliedClause0
     type Output = T
-    fn get<'_0_1> = {impl SliceIndex<[T]> for usize}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<[T]> for usize}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<[T]> for usize}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<[T]> for usize}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<[T]> for usize}::{vtable}<T>[@TraitClause0]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for usize}::get<'_0_1, T>[TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::get_mut<'_0_1, T>[TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for usize}::get_unchecked<T>[TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for usize}::get_unchecked_mut<T>[TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for usize}::index<'_0_1, T>[TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for usize}::index_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl SliceIndex<[T]> for usize}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: alloc::alloc::Global
@@ -444,22 +444,22 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-pub fn alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::len<'_0, T, A>(_1: &'_0 Vec<T>[@TraitClause0, @TraitClause1]) -> usize
+pub fn alloc::vec::{Vec<T>[TraitClause0, TraitClause1]}::len<'_0, T, A>(_1: &'_0 Vec<T>[TraitClause0, TraitClause1]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::{impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut
-pub fn {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut<'_0, T, I, A>(_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause2], _2: I) -> &'_0 mut @TraitClause3::Output
+// Full name: alloc::vec::{impl IndexMut<I> for Vec<T>[TraitClause0, TraitClause2]}::index_mut
+pub fn {impl IndexMut<I> for Vec<T>[TraitClause0, TraitClause2]}::index_mut<'_0, T, I, A>(_1: &'_0 mut Vec<T>[TraitClause0, TraitClause2], _2: I) -> &'_0 mut TraitClause3::Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: SliceIndex<I, [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (I: SliceIndex<[T]>),
 = <opaque>
 
 // Full name: test_crate::test_loop1
@@ -1217,7 +1217,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
     storage_live(_4)
     storage_live(_5)
     _5 = Range { start: const 0 : i32, end: const 128 : i32 }
-    _4 = {impl IntoIterator for I}::into_iter<Range<i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Range<i32>[{built_in impl Sized for i32}]}, {impl Iterator for Range<A>[@TraitClause0]}<i32>[{built_in impl Sized for i32}, {impl Step for i32}]](move _5)
+    _4 = {impl IntoIterator for I}::into_iter<Range<i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Range<i32>[{built_in impl Sized for i32}]}, {impl Iterator for Range<A>[TraitClause0]}<i32>[{built_in impl Sized for i32}, {impl Step for i32}]](move _5)
     storage_dead(_5)
     storage_live(iter_6)
     iter_6 = move _4
@@ -1227,7 +1227,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_9)
         _9 = &mut iter_6
         _8 = &two-phase-mut (*_9)
-        _7 = {impl Iterator for Range<A>[@TraitClause0]}::next<'9, i32>[{built_in impl Sized for i32}, {impl Step for i32}](move _8)
+        _7 = {impl Iterator for Range<A>[TraitClause0]}::next<'9, i32>[{built_in impl Sized for i32}, {impl Step for i32}](move _8)
         storage_dead(_8)
         match _7 {
             Option::None => {
@@ -1252,7 +1252,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
     _13 = copy step_out_1
     _12 = Range { start: const 0 : usize, end: move _13 }
     storage_dead(_13)
-    _11 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _12)
+    _11 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _12)
     storage_dead(_12)
     storage_live(iter_14)
     iter_14 = move _11
@@ -1262,7 +1262,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_17)
         _17 = &mut iter_14
         _16 = &two-phase-mut (*_17)
-        _15 = {impl Iterator for Range<A>[@TraitClause0]}::next<'11, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _16)
+        _15 = {impl Iterator for Range<A>[TraitClause0]}::next<'11, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _16)
         storage_dead(_16)
         match _15 {
             Option::None => {
@@ -1277,7 +1277,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         _20 = copy step_in_2
         _19 = Range { start: const 0 : usize, end: move _20 }
         storage_dead(_20)
-        _18 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _19)
+        _18 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _19)
         storage_dead(_19)
         storage_live(iter_21)
         iter_21 = move _18
@@ -1287,7 +1287,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
             storage_live(_24)
             _24 = &mut iter_21
             _23 = &two-phase-mut (*_24)
-            _22 = {impl Iterator for Range<A>[@TraitClause0]}::next<'13, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _23)
+            _22 = {impl Iterator for Range<A>[TraitClause0]}::next<'13, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _23)
             storage_dead(_23)
             match _22 {
                 Option::None => {
@@ -1350,7 +1350,7 @@ pub fn loop_inside_if(b_1: bool, n_2: u32) -> u32
         _7 = copy n_2
         _6 = Range { start: const 0 : u32, end: move _7 }
         storage_dead(_7)
-        _5 = {impl IntoIterator for I}::into_iter<Range<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for Range<u32>[{built_in impl Sized for u32}]}, {impl Iterator for Range<A>[@TraitClause0]}<u32>[{built_in impl Sized for u32}, {impl Step for u32}]](move _6)
+        _5 = {impl IntoIterator for I}::into_iter<Range<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for Range<u32>[{built_in impl Sized for u32}]}, {impl Iterator for Range<A>[TraitClause0]}<u32>[{built_in impl Sized for u32}, {impl Step for u32}]](move _6)
         storage_dead(_6)
         storage_live(iter_8)
         iter_8 = move _5
@@ -1360,7 +1360,7 @@ pub fn loop_inside_if(b_1: bool, n_2: u32) -> u32
             storage_live(_11)
             _11 = &mut iter_8
             _10 = &two-phase-mut (*_11)
-            _9 = {impl Iterator for Range<A>[@TraitClause0]}::next<'4, u32>[{built_in impl Sized for u32}, {impl Step for u32}](move _10)
+            _9 = {impl Iterator for Range<A>[TraitClause0]}::next<'4, u32>[{built_in impl Sized for u32}, {impl Step for u32}](move _10)
             storage_dead(_10)
             match _9 {
                 Option::None => {
@@ -1532,7 +1532,7 @@ pub fn clear<'_0>(v_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_i
         storage_live(_5)
         storage_live(_6)
         _6 = &(*v_1)
-        _5 = alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::len<'8, u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}](move _6)
+        _5 = alloc::vec::{Vec<T>[TraitClause0, TraitClause1]}::len<'8, u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}](move _6)
         storage_dead(_6)
         _3 = move _4 < move _5
         if move _3 {
@@ -1546,7 +1546,7 @@ pub fn clear<'_0>(v_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_i
         _8 = &mut (*v_1)
         storage_live(_9)
         _9 = copy i_2
-        _7 = {impl IndexMut<I> for Vec<T>[@TraitClause0, @TraitClause2]}::index_mut<'10, u32, usize, Global>[{built_in impl Sized for u32}, {built_in impl Sized for usize}, {built_in impl Sized for Global}, {impl SliceIndex<[T]> for usize}<u32>[{built_in impl Sized for u32}]](move _8, move _9)
+        _7 = {impl IndexMut<I> for Vec<T>[TraitClause0, TraitClause2]}::index_mut<'10, u32, usize, Global>[{built_in impl Sized for u32}, {built_in impl Sized for usize}, {built_in impl Sized for Global}, {impl SliceIndex<[T]> for usize}<u32>[{built_in impl Sized for u32}]](move _8, move _9)
         storage_dead(_9)
         storage_dead(_8)
         (*_7) = const 0 : u32
@@ -1567,9 +1567,9 @@ pub fn clear<'_0>(v_1: &'_0 mut Vec<u32>[{built_in impl Sized for u32}, {built_i
 // Full name: test_crate::List
 pub enum List<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  Cons(T, alloc::boxed::Box<List<T>[@TraitClause0]>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}]),
+  Cons(T, alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]),
   Nil,
 }
 
@@ -1628,18 +1628,18 @@ pub fn get_elem_mut<'_0>(ls_1: &'_0 mut List<usize>[{built_in impl Sized for usi
 }
 
 // Full name: test_crate::list_nth_mut_loop_with_id
-pub fn list_nth_mut_loop_with_id<'_0, T>(ls_1: &'_0 mut List<T>[@TraitClause0], i_2: u32) -> &'_0 mut T
+pub fn list_nth_mut_loop_with_id<'_0, T>(ls_1: &'_0 mut List<T>[TraitClause0], i_2: u32) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
-    let ls_1: &'3 mut List<T>[@TraitClause0]; // arg #1
+    let ls_1: &'3 mut List<T>[TraitClause0]; // arg #1
     let i_2: u32; // arg #2
     let x_3: &'4 mut T; // local
-    let tl_4: &'6 mut alloc::boxed::Box<List<T>[@TraitClause0]>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl_4: &'6 mut alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
-    let _7: &'7 mut List<T>[@TraitClause0]; // anonymous local
+    let _7: &'7 mut List<T>[TraitClause0]; // anonymous local
     let _8: u32; // anonymous local
 
     storage_live(_8)

--- a/charon/tests/ui/control-flow/simple-fallthrough.out
+++ b/charon/tests/ui/control-flow/simple-fallthrough.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),

--- a/charon/tests/ui/control-flow/ullbc-control-flow.out
+++ b/charon/tests/ui/control-flow/ullbc-control-flow.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -44,7 +44,7 @@ pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 
 // Full name: core::clone::impls::{impl Clone for usize}
 impl Clone for usize {
-    parent_clause0 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
     fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -60,7 +60,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Ordering
@@ -75,7 +75,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -85,7 +85,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -93,7 +93,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<i32> for i32}::eq
@@ -122,7 +122,7 @@ pub fn {impl PartialOrd<i32> for i32}::partial_cmp<'_0, '_1>(_1: &'_0 i32, _2: &
 
 // Full name: core::cmp::impls::{impl PartialOrd<i32> for i32}
 impl PartialOrd<i32> for i32 {
-    parent_clause0 = {impl PartialEq<i32> for i32}
+    proof ImpliedClause0: (i32: PartialEq<i32>) = {impl PartialEq<i32> for i32}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<i32> for i32}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<i32> for i32}::{vtable}
 }
@@ -133,7 +133,7 @@ pub fn {impl PartialOrd<usize> for usize}::partial_cmp<'_0, '_1>(_1: &'_0 usize,
 
 // Full name: core::cmp::impls::{impl PartialOrd<usize> for usize}
 impl PartialOrd<usize> for usize {
-    parent_clause0 = {impl PartialEq<usize> for usize}
+    proof ImpliedClause0: (usize: PartialEq<usize>) = {impl PartialEq<usize> for usize}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<usize> for usize}::{vtable}
 }
@@ -142,9 +142,9 @@ impl PartialOrd<usize> for usize {
 #[lang_item("range_step")]
 pub trait Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
-    parent_clause2 : [@TraitClause2]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Clone)
+    proof ImpliedClause2: (Self: PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -153,17 +153,17 @@ pub trait Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 // Full name: core::iter::range::{impl Step for usize}::backward_checked
@@ -180,9 +180,9 @@ pub fn {impl Step for usize}::steps_between<'_0, '_1>(_1: &'_0 usize, _2: &'_1 u
 
 // Full name: core::iter::range::{impl Step for usize}
 impl Step for usize {
-    parent_clause0 = {built_in impl Sized for usize}
-    parent_clause1 = {impl Clone for usize}
-    parent_clause2 = {impl PartialOrd<usize> for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
+    proof ImpliedClause1: (usize: Clone) = {impl Clone for usize}
+    proof ImpliedClause2: (usize: PartialOrd<usize>) = {impl PartialOrd<usize> for usize}
     fn steps_between<'_0_1, '_1_1> = {impl Step for usize}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for usize}::forward_checked
     fn backward_checked = {impl Step for usize}::backward_checked
@@ -203,9 +203,9 @@ pub fn {impl Step for i32}::steps_between<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i32) 
 
 // Full name: core::iter::range::{impl Step for i32}
 impl Step for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
-    parent_clause1 = {impl Clone for i32}
-    parent_clause2 = {impl PartialOrd<i32> for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
+    proof ImpliedClause1: (i32: Clone) = {impl Clone for i32}
+    proof ImpliedClause2: (i32: PartialOrd<i32>) = {impl PartialOrd<i32> for i32}
     fn steps_between<'_0_1, '_1_1> = {impl Step for i32}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for i32}::forward_checked
     fn backward_checked = {impl Step for i32}::backward_checked
@@ -216,7 +216,7 @@ impl Step for i32 {
 #[lang_item("Range")]
 pub struct Range<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
@@ -226,44 +226,44 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}::next
-pub fn {impl Iterator for Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[@TraitClause0]) -> Option<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}::next
+pub fn {impl Iterator for Range<A>[TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[TraitClause0]) -> Option<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 = <opaque>
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}
-impl<A> Iterator for Range<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}
+impl<A> Iterator for Range<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 {
-    parent_clause0 = {built_in impl MetaSized for Range<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (Range<A>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Range<A>[TraitClause0]}
+    proof ImpliedClause1: (A: Sized) = TraitClause0
     type Item = A
-    fn next<'_0_1> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = {impl Iterator for Range<A>[TraitClause0]}::next<'_0_1, A>[TraitClause0, TraitClause1]
+    vtable: {impl Iterator for Range<A>[TraitClause0]}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
 pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: test_crate::nested_loops_enum
@@ -312,7 +312,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_4);
         storage_live(_5);
         _5 = Range { start: const 0 : i32, end: const 128 : i32 };
-        _4 = {impl IntoIterator for I}::into_iter<Range<i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Range<i32>[{built_in impl Sized for i32}]}, {impl Iterator for Range<A>[@TraitClause0]}<i32>[{built_in impl Sized for i32}, {impl Step for i32}]](move _5) -> bb2 (unwind: bb1);
+        _4 = {impl IntoIterator for I}::into_iter<Range<i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Range<i32>[{built_in impl Sized for i32}]}, {impl Iterator for Range<A>[TraitClause0]}<i32>[{built_in impl Sized for i32}, {impl Step for i32}]](move _5) -> bb2 (unwind: bb1);
     }
 
     bb1: {
@@ -332,7 +332,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_9);
         _9 = &mut iter_6;
         _8 = &two-phase-mut (*_9);
-        _7 = {impl Iterator for Range<A>[@TraitClause0]}::next<'9, i32>[{built_in impl Sized for i32}, {impl Step for i32}](move _8) -> bb4 (unwind: bb1);
+        _7 = {impl Iterator for Range<A>[TraitClause0]}::next<'9, i32>[{built_in impl Sized for i32}, {impl Step for i32}](move _8) -> bb4 (unwind: bb1);
     }
 
     bb4: {
@@ -352,7 +352,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         _14 = copy step_out_1;
         _13 = Range { start: const 0 : usize, end: move _14 };
         storage_dead(_14);
-        _12 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _13) -> bb8 (unwind: bb1);
+        _12 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _13) -> bb8 (unwind: bb1);
     }
 
     bb6: {
@@ -380,7 +380,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_18);
         _18 = &mut iter_15;
         _17 = &two-phase-mut (*_18);
-        _16 = {impl Iterator for Range<A>[@TraitClause0]}::next<'11, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _17) -> bb10 (unwind: bb1);
+        _16 = {impl Iterator for Range<A>[TraitClause0]}::next<'11, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _17) -> bb10 (unwind: bb1);
     }
 
     bb10: {
@@ -407,7 +407,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         _22 = copy step_in_2;
         _21 = Range { start: const 0 : usize, end: move _22 };
         storage_dead(_22);
-        _20 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[@TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _21) -> bb14 (unwind: bb1);
+        _20 = {impl IntoIterator for I}::into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, {impl Iterator for Range<A>[TraitClause0]}<usize>[{built_in impl Sized for usize}, {impl Step for usize}]](move _21) -> bb14 (unwind: bb1);
     }
 
     bb13: {
@@ -427,7 +427,7 @@ pub fn nested_loops_enum(step_out_1: usize, step_in_2: usize) -> usize
         storage_live(_26);
         _26 = &mut iter_23;
         _25 = &two-phase-mut (*_26);
-        _24 = {impl Iterator for Range<A>[@TraitClause0]}::next<'13, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _25) -> bb16 (unwind: bb1);
+        _24 = {impl Iterator for Range<A>[TraitClause0]}::next<'13, usize>[{built_in impl Sized for usize}, {impl Step for usize}](move _25) -> bb16 (unwind: bb1);
     }
 
     bb16: {

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -24,7 +24,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -32,16 +32,16 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<Self>> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, @TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (Self: Destruct)> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <method_without_default_body>
 
 // Full name: core::marker::Destruct::drop_in_place
@@ -50,8 +50,8 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 
 pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
-    [@TraitClause0]: Clone<Self>,
-    [@TraitClause1]: Destruct<Self>,
+    TraitClause0: (Self: Clone),
+    TraitClause1: (Self: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut Self; // arg #1
@@ -60,8 +60,8 @@ where
 
     _0 = ()
     storage_live(_3)
-    _3 = @TraitClause0::clone<'5>(move source_2)
-    drop[@TraitClause1::drop_in_place] (*self_1)
+    _3 = TraitClause0::clone<'5>(move source_2)
+    drop[TraitClause1::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -80,7 +80,7 @@ pub fn {impl Clone for usize}::clone<'_0>(self_1: &'_0 usize) -> usize
 // Full name: core::clone::impls::{impl Clone for usize}::clone_from
 pub fn {impl Clone for usize}::clone_from<'_0, '_1>(self_1: &'_0 mut usize, source_2: &'_1 usize)
 where
-    [@TraitClause0]: Destruct<usize>,
+    TraitClause0: (usize: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut usize; // arg #1
@@ -90,7 +90,7 @@ where
     _0 = ()
     storage_live(_3)
     _3 = {impl Clone for usize}::clone<'5>(move source_2)
-    drop[@TraitClause0::drop_in_place] (*self_1)
+    drop[TraitClause0::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -98,9 +98,9 @@ where
 
 // Full name: core::clone::impls::{impl Clone for usize}
 impl Clone for usize {
-    parent_clause0 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
     fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<usize>> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[@TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (usize: Destruct)> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -117,8 +117,8 @@ pub struct NonNull<T> {
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -151,16 +151,16 @@ pub struct Arguments<'a> {
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 // Full name: core::intrinsics::ctpop
 pub fn ctpop<T>(x_1: T) -> u32
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <intrinsic:ctpop>
 
 // Full name: core::panicking::panic_nounwind_fmt::compiletime
@@ -176,19 +176,19 @@ fn compiletime<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 // Full name: core::intrinsics::size_of
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <intrinsic:size_of>
 
 // Full name: core::intrinsics::align_of
 pub fn align_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <intrinsic:align_of>
 
 // Full name: core::marker::{impl Copy for usize}
 impl Copy for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl Clone for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause1: (usize: Clone) = {impl Clone for usize}
     non-dyn-compatible
 }
 
@@ -268,7 +268,7 @@ pub struct Alignment {
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -282,11 +282,11 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
 
-    _0 = size_of<Self>[@TraitClause0::parent_clause0]()
+    _0 = size_of<Self>[TraitClause0::ImpliedClause0]()
     return
 }
 
@@ -294,18 +294,18 @@ where
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
 
-    _0 = align_of<Self>[@TraitClause0::parent_clause0]()
+    _0 = align_of<Self>[TraitClause0::ImpliedClause0]()
     return
 }
 
@@ -313,7 +313,7 @@ where
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::panicking::panic_nounwind_fmt
@@ -402,7 +402,7 @@ fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(align_1:
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -455,14 +455,14 @@ fn unwrap_failed() -> !
     panic(core::panicking::panic)
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::unwrap
+// Full name: core::option::{Option<T>[TraitClause0]}::unwrap
 #[lang_item("option_unwrap")]
-pub fn unwrap<T>(self_1: Option<T>[@TraitClause0]) -> T
+pub fn unwrap<T>(self_1: Option<T>[TraitClause0]) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let val_0: T; // return
-    let self_1: Option<T>[@TraitClause0]; // arg #1
+    let self_1: Option<T>[TraitClause0]; // arg #1
     let _2: !; // anonymous local
 
     storage_live(_2)
@@ -480,13 +480,13 @@ where
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: Alignment; // return
     let _1: Option<Alignment>[{built_in impl Sized for Alignment}]; // anonymous local
 
     storage_live(_1)
-    _1 = new(const @TraitClause0::ALIGN)
+    _1 = new(const TraitClause0::ALIGN)
     _0 = unwrap<Alignment>[{built_in impl Sized for Alignment}](move _1)
     storage_dead(_1)
     return
@@ -495,41 +495,41 @@ where
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: bool; // return
 
-    _0 = const @TraitClause0::SIZE == const 0 : usize
+    _0 = const TraitClause0::SIZE == const 0 : usize
     return
 }
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: Layout; // return
 
-    _0 = from_size_align_unchecked(const @TraitClause0::SIZE, const @TraitClause0::ALIGN)
+    _0 = from_size_align_unchecked(const TraitClause0::SIZE, const TraitClause0::ALIGN)
     return
 }
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 pub fn core::num::{usize}::MAX() -> usize
@@ -559,7 +559,7 @@ pub const core::num::{isize}::MAX: isize = core::num::{isize}::MAX()
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local
@@ -568,7 +568,7 @@ where
     let _4: usize; // anonymous local
 
     storage_live(_1)
-    _1 = const @TraitClause0::SIZE
+    _1 = const TraitClause0::SIZE
     switch copy _1 {
         0 : usize => {
             _0 = copy core::num::{usize}::MAX
@@ -593,21 +593,21 @@ where
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -618,7 +618,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(_1: *const (), _2: *mut ()
 #[lang_item("ptr_copy_nonoverlapping")]
 pub unsafe fn copy_nonoverlapping<T>(src_1: *const T, dst_2: *mut T, count_3: usize)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let src_1: *const T; // arg #1
@@ -638,7 +638,7 @@ where
         _5 = cast<*const T, *const ()>(copy src_1)
         storage_live(_6)
         _6 = cast<*mut T, *mut ()>(copy dst_2)
-        _4 = core::ptr::copy_nonoverlapping::precondition_check(move _5, move _6, const {impl SizedTypeProperties for T}<T>[@TraitClause0]::SIZE, const {impl SizedTypeProperties for T}<T>[@TraitClause0]::ALIGN, copy count_3)
+        _4 = core::ptr::copy_nonoverlapping::precondition_check(move _5, move _6, const {impl SizedTypeProperties for T}<T>[TraitClause0]::SIZE, const {impl SizedTypeProperties for T}<T>[TraitClause0]::ALIGN, copy count_3)
         storage_dead(_6)
         storage_dead(_5)
     } else {
@@ -650,7 +650,7 @@ where
 // Full name: test_crate::write
 fn write<'_0, '_1, T>(x_1: &'_0 mut T, y_2: &'_1 T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let x_1: &'1 mut T; // arg #1
@@ -665,7 +665,7 @@ where
     _4 = &raw const (*y_2)
     storage_live(_5)
     _5 = &raw mut (*x_1)
-    _3 = copy_nonoverlapping<T>[@TraitClause0](move _4, move _5, const 1 : usize)
+    _3 = copy_nonoverlapping<T>[TraitClause0](move _4, move _5, const 1 : usize)
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -19,7 +19,7 @@ pub struct Global {}
 // Full name: test_crate::choose
 pub fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
     let b_1: bool; // arg #1
@@ -171,26 +171,26 @@ pub fn use_incr()
 // Full name: test_crate::CList
 pub enum CList<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  CCons(T, alloc::boxed::Box<CList<T>[@TraitClause0]>[{built_in impl MetaSized for CList<T>[@TraitClause0]}, {built_in impl Sized for Global}]),
+  CCons(T, alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]),
   CNil,
 }
 
 // Full name: test_crate::list_nth
-pub fn list_nth<'a, T>(l_1: &'a CList<T>[@TraitClause0], i_2: u32) -> &'a T
+pub fn list_nth<'a, T>(l_1: &'a CList<T>[TraitClause0], i_2: u32) -> &'a T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
-    let l_1: &'3 CList<T>[@TraitClause0]; // arg #1
+    let l_1: &'3 CList<T>[TraitClause0]; // arg #1
     let i_2: u32; // arg #2
     let x_3: &'4 T; // local
-    let tl_4: &'6 alloc::boxed::Box<CList<T>[@TraitClause0]>[{built_in impl MetaSized for CList<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl_4: &'6 alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
     let _7: &'7 T; // anonymous local
-    let _8: &'8 CList<T>[@TraitClause0]; // anonymous local
+    let _8: &'8 CList<T>[TraitClause0]; // anonymous local
     let _9: u32; // anonymous local
     let _10: u32; // anonymous local
     let _11: u32; // anonymous local
@@ -225,7 +225,7 @@ where
         _11 = copy _10 panic.- const 1 : u32
         _9 = move _11
         storage_dead(_10)
-        _7 = list_nth<'10, T>[@TraitClause0](move _8, move _9)
+        _7 = list_nth<'10, T>[TraitClause0](move _8, move _9)
         _0 = &(*_7)
         storage_dead(_9)
         storage_dead(_8)
@@ -238,24 +238,24 @@ where
 }
 
 // Full name: test_crate::list_nth_mut
-pub fn list_nth_mut<'a, T>(l_1: &'a mut CList<T>[@TraitClause0], i_2: u32) -> &'a mut T
+pub fn list_nth_mut<'a, T>(l_1: &'a mut CList<T>[TraitClause0], i_2: u32) -> &'a mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
-    let l_1: &'3 mut CList<T>[@TraitClause0]; // arg #1
+    let l_1: &'3 mut CList<T>[TraitClause0]; // arg #1
     let i_2: u32; // arg #2
     let _3: &'4 mut T; // anonymous local
     let _4: &'5 mut T; // anonymous local
     let x_5: &'6 mut T; // local
-    let tl_6: &'8 mut alloc::boxed::Box<CList<T>[@TraitClause0]>[{built_in impl MetaSized for CList<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl_6: &'8 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _7: &'9 mut T; // anonymous local
     let _8: &'10 mut T; // anonymous local
     let _9: bool; // anonymous local
     let _10: u32; // anonymous local
     let _11: &'11 mut T; // anonymous local
     let _12: &'12 mut T; // anonymous local
-    let _13: &'13 mut CList<T>[@TraitClause0]; // anonymous local
+    let _13: &'13 mut CList<T>[TraitClause0]; // anonymous local
     let _14: u32; // anonymous local
     let _15: u32; // anonymous local
     let _16: u32; // anonymous local
@@ -297,7 +297,7 @@ where
         _16 = copy _15 panic.- const 1 : u32
         _14 = move _16
         storage_dead(_15)
-        _12 = list_nth_mut<'15, T>[@TraitClause0](move _13, move _14)
+        _12 = list_nth_mut<'15, T>[TraitClause0](move _13, move _14)
         _8 = &mut (*_12)
         storage_dead(_14)
         storage_dead(_13)
@@ -318,19 +318,19 @@ where
 }
 
 // Full name: test_crate::list_nth_mut1
-pub fn list_nth_mut1<'a, T>(l_1: &'a mut CList<T>[@TraitClause0], i_2: u32) -> &'a mut T
+pub fn list_nth_mut1<'a, T>(l_1: &'a mut CList<T>[TraitClause0], i_2: u32) -> &'a mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
-    let l_1: &'3 mut CList<T>[@TraitClause0]; // arg #1
+    let l_1: &'3 mut CList<T>[TraitClause0]; // arg #1
     let i_2: u32; // arg #2
     let x_3: &'4 mut T; // local
-    let tl_4: &'6 mut alloc::boxed::Box<CList<T>[@TraitClause0]>[{built_in impl MetaSized for CList<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl_4: &'6 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
     let _7: u32; // anonymous local
-    let _8: &'7 mut CList<T>[@TraitClause0]; // anonymous local
+    let _8: &'7 mut CList<T>[TraitClause0]; // anonymous local
 
     storage_live(_7)
     loop {
@@ -415,17 +415,17 @@ pub fn i32_id(i_1: i32) -> i32
 }
 
 // Full name: test_crate::list_tail
-pub fn list_tail<'a, T>(l_1: &'a mut CList<T>[@TraitClause0]) -> &'a mut CList<T>[@TraitClause0]
+pub fn list_tail<'a, T>(l_1: &'a mut CList<T>[TraitClause0]) -> &'a mut CList<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: &'1 mut CList<T>[@TraitClause0]; // return
-    let l_1: &'2 mut CList<T>[@TraitClause0]; // arg #1
-    let _2: &'3 mut CList<T>[@TraitClause0]; // anonymous local
-    let _3: &'4 mut CList<T>[@TraitClause0]; // anonymous local
-    let tl_4: &'6 mut alloc::boxed::Box<CList<T>[@TraitClause0]>[{built_in impl MetaSized for CList<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
-    let _5: &'7 mut CList<T>[@TraitClause0]; // anonymous local
-    let _6: &'8 mut CList<T>[@TraitClause0]; // anonymous local
+    let _0: &'1 mut CList<T>[TraitClause0]; // return
+    let l_1: &'2 mut CList<T>[TraitClause0]; // arg #1
+    let _2: &'3 mut CList<T>[TraitClause0]; // anonymous local
+    let _3: &'4 mut CList<T>[TraitClause0]; // anonymous local
+    let tl_4: &'6 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let _5: &'7 mut CList<T>[TraitClause0]; // anonymous local
+    let _6: &'8 mut CList<T>[TraitClause0]; // anonymous local
 
     storage_live(_2)
     storage_live(_3)
@@ -436,7 +436,7 @@ where
             storage_live(_5)
             storage_live(_6)
             _6 = &two-phase-mut (*(*tl_4))
-            _5 = list_tail<'10, T>[@TraitClause0](move _6)
+            _5 = list_tail<'10, T>[TraitClause0](move _6)
             _3 = &mut (*_5)
             storage_dead(_6)
             storage_dead(_5)
@@ -456,14 +456,14 @@ where
 // Full name: test_crate::Counter
 pub trait Counter<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn incr<'_0_1> = test_crate::Counter::incr<'_0_1, Self>[Self]
     vtable: test_crate::Counter::{vtable}
 }
 
 pub fn test_crate::Counter::incr<'_0, Self>(_1: &'_0 mut Self) -> usize
 where
-    [@TraitClause0]: Counter<Self>,
+    TraitClause0: (Self: Counter),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Counter for usize}::incr
@@ -486,7 +486,7 @@ pub fn {impl Counter for usize}::incr<'_0>(self_1: &'_0 mut usize) -> usize
 
 // Full name: test_crate::{impl Counter for usize}
 impl Counter for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     fn incr<'_0_1> = {impl Counter for usize}::incr<'_0_1>
     vtable: {impl Counter for usize}::{vtable}
 }
@@ -494,8 +494,8 @@ impl Counter for usize {
 // Full name: test_crate::use_counter
 pub fn use_counter<'a, T>(cnt_1: &'a mut T) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Counter<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Counter),
 {
     let _0: usize; // return
     let cnt_1: &'1 mut T; // arg #1
@@ -503,7 +503,7 @@ where
 
     storage_live(_2)
     _2 = &two-phase-mut (*cnt_1)
-    _0 = @TraitClause1::incr<'4>(move _2)
+    _0 = TraitClause1::incr<'4>(move _2)
     storage_dead(_2)
     return
 }

--- a/charon/tests/ui/desugar_drops_to_calls.out
+++ b/charon/tests/ui/desugar_drops_to_calls.out
@@ -16,7 +16,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,15 +35,15 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("drop")]
 pub trait Drop<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Destruct<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
     fn drop<'_0_1> = core::ops::drop::Drop::drop<'_0_1, Self>[Self]
     vtable: core::ops::drop::Drop::{vtable}
 }
 
 pub fn core::ops::drop::Drop::drop<'_0, Self>(_1: &'_0 mut Self)
 where
-    [@TraitClause0]: Drop<Self>,
+    TraitClause0: (Self: Drop),
 = <opaque>
 
 // Full name: std::io::stdio::_print
@@ -64,13 +64,13 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::string::String
@@ -85,18 +85,18 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: test_crate::use_string
@@ -129,15 +129,15 @@ fn use_vec(_1: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for 
     storage_live(drop_arg_2)
     drop_arg_2 = &raw mut _1
     storage_live(drop_ret_3)
-    drop_ret_3 = {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_2)
+    drop_ret_3 = {impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_2)
     return
 }
 
 // Full name: test_crate::drop_unknown
 fn drop_unknown<T>(_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
     let _1: T; // arg #1
@@ -149,7 +149,7 @@ where
     storage_live(drop_arg_2)
     drop_arg_2 = &raw mut _1
     storage_live(drop_ret_3)
-    drop_ret_3 = @TraitClause1::drop_in_place(move drop_arg_2)
+    drop_ret_3 = TraitClause1::drop_in_place(move drop_arg_2)
     return
 }
 
@@ -212,11 +212,11 @@ unsafe fn {impl Destruct for Point}::drop_in_place(_1: *mut Point)
     storage_live(drop_arg_5)
     drop_arg_5 = &raw mut ((*_2)).x
     storage_live(drop_ret_6)
-    drop_ret_6 = {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_5)
+    drop_ret_6 = {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_5)
     storage_live(drop_arg_7)
     drop_arg_7 = &raw mut ((*_2)).y
     storage_live(drop_ret_8)
-    drop_ret_8 = {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_7)
+    drop_ret_8 = {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}](move drop_arg_7)
     return
 }
 
@@ -228,8 +228,8 @@ impl Destruct for Point {
 
 // Full name: test_crate::{impl Drop for Point}
 impl Drop for Point {
-    parent_clause0 = {built_in impl MetaSized for Point}
-    parent_clause1 = {impl Destruct for Point}
+    proof ImpliedClause0: (Point: MetaSized) = {built_in impl MetaSized for Point}
+    proof ImpliedClause1: (Point: Destruct) = {impl Destruct for Point}
     fn drop<'_0_1> = {impl Drop for Point}::drop<'_0_1>
     vtable: {impl Drop for Point}::{vtable}
 }

--- a/charon/tests/ui/desugar_drops_to_calls_mono.out
+++ b/charon/tests/ui/desugar_drops_to_calls_mono.out
@@ -18,7 +18,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -67,8 +67,8 @@ opaque type core::ops::drop::Drop::{vtable}
 #[lang_item("drop")]
 pub trait Drop<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Destruct<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
     vtable: core::ops::drop::Drop::{vtable}
 }
 
@@ -193,8 +193,8 @@ unsafe fn {impl Destruct for Point}::drop_in_place(_1: *mut Point)
 
 // Full name: test_crate::{impl Drop for Point}
 impl Drop for Point {
-    parent_clause0 = {built_in impl MetaSized for Point}
-    parent_clause1 = {impl Destruct for Point}
+    proof ImpliedClause0: (Point: MetaSized) = {built_in impl MetaSized for Point}
+    proof ImpliedClause1: (Point: Destruct) = {impl Destruct for Point}
     vtable: {impl Drop for Point}::{vtable}
 }
 

--- a/charon/tests/ui/drop_after_overflow.out
+++ b/charon/tests/ui/drop_after_overflow.out
@@ -27,14 +27,14 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("drop")]
 pub trait Drop<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn drop<'_0_1> = core::ops::drop::Drop::drop<'_0_1, Self>[Self]
     vtable: core::ops::drop::Drop::{vtable}
 }
 
 pub fn core::ops::drop::Drop::drop<'_0, Self>(_1: &'_0 mut Self)
 where
-    [@TraitClause0]: Drop<Self>,
+    TraitClause0: (Self: Drop),
 = <opaque>
 
 // Full name: std::io::stdio::_print
@@ -111,7 +111,7 @@ impl Destruct for Foo {
 
 // Full name: test_crate::{impl Drop for Foo}
 impl Drop for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
     fn drop<'_0_1> = {impl Drop for Foo}::drop<'_0_1>
     vtable: {impl Drop for Foo}::{vtable}
 }

--- a/charon/tests/ui/dyn-trait.out
+++ b/charon/tests/ui/dyn-trait.out
@@ -14,7 +14,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::fmt::Error
@@ -30,7 +30,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -38,8 +38,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -56,14 +56,14 @@ pub trait Display<Self>
 // Full name: core::fmt::Display::fmt
 pub fn fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Display<Self>,
+    TraitClause0: (Self: Display),
 = <opaque>
 
 // Full name: core::marker::Tuple
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -73,10 +73,10 @@ opaque type core::ops::function::Fn::{vtable}<Args, Ty0>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -86,49 +86,49 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn::call
-pub extern "rust-call" fn call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
 // Full name: core::ops::function::FnMut::call_mut
-pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
-pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -145,16 +145,16 @@ pub opaque type String
 // Full name: alloc::string::{impl ToString for T}::to_string
 pub fn {impl ToString for T}::to_string<'_0, T>(_1: &'_0 T) -> String
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Display<T>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (T: Display),
 = <opaque>
 
 // Full name: test_crate::construct
 fn construct<T>(_1: T) -> alloc::boxed::Box<(dyn Display + 'static)>[{built_in impl MetaSized for (dyn Display + 'static)}, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Display<T>,
-    T : 'static,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Display),
+    TypeOutlives0: T: 'static,
 = <opaque>
 
 // Full name: test_crate::destruct
@@ -176,13 +176,13 @@ fn combine()
 = <opaque>
 
 // Full name: test_crate::foo
-fn foo<'_0, '_1, T>(_1: &'_0 (dyn for<'a> Fn<(&'a T,), parent_clause1::parent_clause1::Output = T> + 'static), _2: &'_1 (dyn PartialEq<Option<T>[@TraitClause0]> + '_1))
+fn foo<'_0, '_1, T>(_1: &'_0 (dyn for<'a> Fn<(&'a T,), ImpliedClause1::ImpliedClause1::Output = T> + 'static), _2: &'_1 (dyn PartialEq<Option<T>[TraitClause0]> + '_1))
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let _1: &'7 (dyn for<'a> Fn<(&'a T,), parent_clause1::parent_clause1::Output = T> + '8); // arg #1
-    let _2: &'13 (dyn PartialEq<Option<T>[@TraitClause0]> + '14); // arg #2
+    let _1: &'7 (dyn for<'a> Fn<(&'a T,), ImpliedClause1::ImpliedClause1::Output = T> + '8); // arg #1
+    let _2: &'13 (dyn PartialEq<Option<T>[TraitClause0]> + '14); // arg #2
 
     _0 = ()
     _0 = ()
@@ -190,10 +190,10 @@ where
 }
 
 // Full name: test_crate::bar
-fn bar<'_0>(_1: &'_0 (dyn for<'_0_2> Fn<(&'_0_2 (dyn Display + '_0_2),), parent_clause1::parent_clause1::Output = ()> + '_0))
+fn bar<'_0>(_1: &'_0 (dyn for<'_0_2> Fn<(&'_0_2 (dyn Display + '_0_2),), ImpliedClause1::ImpliedClause1::Output = ()> + '_0))
 {
     let _0: (); // return
-    let _1: &'12 (dyn for<'_0_2> Fn<(&'_0_2 (dyn Display + '_0_2),), parent_clause1::parent_clause1::Output = ()> + '13); // arg #1
+    let _1: &'12 (dyn for<'_0_2> Fn<(&'_0_2 (dyn Display + '_0_2),), ImpliedClause1::ImpliedClause1::Output = ()> + '13); // arg #1
 
     _0 = ()
     _0 = ()

--- a/charon/tests/ui/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn-with-diamond-supertraits.out
@@ -14,7 +14,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -29,15 +29,15 @@ struct test_crate::Super::{vtable}<T> {
 // Full name: test_crate::Super
 trait Super<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn super_method<'_0_1> = test_crate::Super::super_method<'_0_1, Self, T>[Self]
     vtable: test_crate::Super::{vtable}<T>
 }
 
 fn test_crate::Super::super_method<'_0, Self, T>(_1: &'_0 Self, _2: T) -> i32
 where
-    [@TraitClause0]: Super<Self, T>,
+    TraitClause0: (Self: Super<T>),
 = <method_without_default_body>
 
 struct test_crate::Internal::{vtable}<Ty0> {
@@ -51,23 +51,23 @@ struct test_crate::Internal::{vtable}<Ty0> {
 // Full name: test_crate::Internal
 trait Internal<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Internal>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Internal: Sized)
     type Internal
     fn internal_method<'_0_1> = test_crate::Internal::internal_method<'_0_1, Self>[Self]
     vtable: test_crate::Internal::{vtable}<Self::Internal>
 }
 
-fn test_crate::Internal::internal_method<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Internal
+fn test_crate::Internal::internal_method<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Internal
 where
-    [@TraitClause0]: Internal<Self>,
+    TraitClause0: (Self: Internal),
 = <method_without_default_body>
 
 struct test_crate::Left::{vtable}<Ty0, Ty1> {
   size: usize,
   align: usize,
-  drop: unsafe fn(*mut (dyn Left<parent_clause1::Internal = Ty0, Left = Ty1>)),
-  method_left_method: fn<'_0_1>(&'_0_1 (dyn Left<parent_clause1::Internal = Ty0, Left = Ty1>)) -> Ty1,
+  drop: unsafe fn(*mut (dyn Left<ImpliedClause1::Internal = Ty0, Left = Ty1>)),
+  method_left_method: fn<'_0_1>(&'_0_1 (dyn Left<ImpliedClause1::Internal = Ty0, Left = Ty1>)) -> Ty1,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
   super_trait_1: &'static test_crate::Internal::{vtable}<Ty0>,
 }
@@ -75,24 +75,24 @@ struct test_crate::Left::{vtable}<Ty0, Ty1> {
 // Full name: test_crate::Left
 trait Left<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Internal<Self>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Left>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Internal)
+    proof ImpliedClause2: (Self::Left: Sized)
     type Left
     fn left_method<'_0_1> = test_crate::Left::left_method<'_0_1, Self>[Self]
-    vtable: test_crate::Left::{vtable}<Self::Left, Self::parent_clause1::Internal>
+    vtable: test_crate::Left::{vtable}<Self::Left, Self::ImpliedClause1::Internal>
 }
 
-fn test_crate::Left::left_method<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Left
+fn test_crate::Left::left_method<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Left
 where
-    [@TraitClause0]: Left<Self>,
+    TraitClause0: (Self: Left),
 = <method_without_default_body>
 
 struct test_crate::Right::{vtable}<T, Ty0, Ty1> {
   size: usize,
   align: usize,
-  drop: unsafe fn(*mut (dyn Right<T, parent_clause1::Internal = Ty0, Right = Ty1>)),
-  method_right_method: fn<'_0_1>(&'_0_1 (dyn Right<T, parent_clause1::Internal = Ty0, Right = Ty1>)) -> Ty1,
+  drop: unsafe fn(*mut (dyn Right<T, ImpliedClause1::Internal = Ty0, Right = Ty1>)),
+  method_right_method: fn<'_0_1>(&'_0_1 (dyn Right<T, ImpliedClause1::Internal = Ty0, Right = Ty1>)) -> Ty1,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
   super_trait_1: &'static test_crate::Internal::{vtable}<Ty0>,
   super_trait_2: &'static test_crate::Super::{vtable}<T>,
@@ -101,26 +101,26 @@ struct test_crate::Right::{vtable}<T, Ty0, Ty1> {
 // Full name: test_crate::Right
 trait Right<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Internal<Self>
-    parent_clause2 : [@TraitClause2]: Super<Self, T>
-    parent_clause3 : [@TraitClause3]: Sized<T>
-    parent_clause4 : [@TraitClause4]: Sized<Self::Right>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Internal)
+    proof ImpliedClause2: (Self: Super<T>)
+    proof ImpliedClause3: (T: Sized)
+    proof ImpliedClause4: (Self::Right: Sized)
     type Right
     fn right_method<'_0_1> = test_crate::Right::right_method<'_0_1, Self, T>[Self]
-    vtable: test_crate::Right::{vtable}<T, Self::Right, Self::parent_clause1::Internal>
+    vtable: test_crate::Right::{vtable}<T, Self::Right, Self::ImpliedClause1::Internal>
 }
 
-fn test_crate::Right::right_method<'_0, Self, T>(_1: &'_0 Self) -> @TraitClause0::Right
+fn test_crate::Right::right_method<'_0, Self, T>(_1: &'_0 Self) -> TraitClause0::Right
 where
-    [@TraitClause0]: Right<Self, T>,
+    TraitClause0: (Self: Right<T>),
 = <method_without_default_body>
 
 struct test_crate::Join::{vtable}<T, Ty0, Ty1, Ty2, Ty3> {
   size: usize,
   align: usize,
-  drop: unsafe fn(*mut (dyn Join<T, parent_clause1::parent_clause1::Internal = Ty0, parent_clause1::parent_clause1::Internal = Ty1, parent_clause1::Left = Ty2, parent_clause2::Right = Ty3>)),
-  method_join_method: fn<'_0_1>(&'_0_1 (dyn Join<T, parent_clause1::parent_clause1::Internal = Ty0, parent_clause1::parent_clause1::Internal = Ty1, parent_clause1::Left = Ty2, parent_clause2::Right = Ty3>)) -> (Ty2, Ty3),
+  drop: unsafe fn(*mut (dyn Join<T, ImpliedClause1::ImpliedClause1::Internal = Ty0, ImpliedClause1::ImpliedClause1::Internal = Ty1, ImpliedClause1::Left = Ty2, ImpliedClause2::Right = Ty3>)),
+  method_join_method: fn<'_0_1>(&'_0_1 (dyn Join<T, ImpliedClause1::ImpliedClause1::Internal = Ty0, ImpliedClause1::ImpliedClause1::Internal = Ty1, ImpliedClause1::Left = Ty2, ImpliedClause2::Right = Ty3>)) -> (Ty2, Ty3),
   super_trait_0: &'static core::marker::MetaSized::{vtable},
   super_trait_1: &'static test_crate::Left::{vtable}<Ty2, Ty1>,
   super_trait_2: &'static test_crate::Right::{vtable}<T, Ty3, Ty1>,
@@ -129,17 +129,17 @@ struct test_crate::Join::{vtable}<T, Ty0, Ty1, Ty2, Ty3> {
 // Full name: test_crate::Join
 trait Join<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Left<Self>
-    parent_clause2 : [@TraitClause2]: Right<Self, T>
-    parent_clause3 : [@TraitClause3]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Left)
+    proof ImpliedClause2: (Self: Right<T>)
+    proof ImpliedClause3: (T: Sized)
     fn join_method<'_0_1> = test_crate::Join::join_method<'_0_1, Self, T>[Self]
-    vtable: test_crate::Join::{vtable}<T, Self::parent_clause1::Left, Self::parent_clause1::parent_clause1::Internal, Self::parent_clause2::Right, Self::parent_clause1::parent_clause1::Internal>
+    vtable: test_crate::Join::{vtable}<T, Self::ImpliedClause1::Left, Self::ImpliedClause1::ImpliedClause1::Internal, Self::ImpliedClause2::Right, Self::ImpliedClause1::ImpliedClause1::Internal>
 }
 
-fn test_crate::Join::join_method<'_0, Self, T>(_1: &'_0 Self) -> (@TraitClause0::parent_clause1::Left, @TraitClause0::parent_clause2::Right)
+fn test_crate::Join::join_method<'_0, Self, T>(_1: &'_0 Self) -> (TraitClause0::ImpliedClause1::Left, TraitClause0::ImpliedClause2::Right)
 where
-    [@TraitClause0]: Join<Self, T>,
+    TraitClause0: (Self: Join<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Super<i32> for i32}::super_method
@@ -208,8 +208,8 @@ static {impl Super<i32> for i32}::{vtable}: test_crate::Super::{vtable}<i32> = {
 
 // Full name: test_crate::{impl Super<i32> for i32}
 impl Super<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     fn super_method<'_0_1> = {impl Super<i32> for i32}::super_method<'_0_1>
     vtable: {impl Super<i32> for i32}::{vtable}
 }
@@ -277,8 +277,8 @@ static {impl Internal for i32}::{vtable}: test_crate::Internal::{vtable}<i32> = 
 
 // Full name: test_crate::{impl Internal for i32}
 impl Internal for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     type Internal = i32
     fn internal_method<'_0_1> = {impl Internal for i32}::internal_method<'_0_1>
     vtable: {impl Internal for i32}::{vtable}
@@ -302,28 +302,28 @@ fn {impl Left for i32}::left_method<'_0>(self_1: &'_0 i32) -> i32
 }
 
 // Full name: test_crate::{impl Left for i32}::left_method::{vtable_method}
-fn {impl Left for i32}::left_method::{vtable_method}<'_0>(_1: &'_0 (dyn Left<parent_clause1::Internal = i32, Left = i32>)) -> i32
+fn {impl Left for i32}::left_method::{vtable_method}<'_0>(_1: &'_0 (dyn Left<ImpliedClause1::Internal = i32, Left = i32>)) -> i32
 {
     let _0: i32; // return
-    let _1: &'_0 (dyn Left<parent_clause1::Internal = i32, Left = i32> + '0); // arg #1
+    let _1: &'_0 (dyn Left<ImpliedClause1::Internal = i32, Left = i32> + '0); // arg #1
     let _2: &'_0 i32; // anonymous local
 
     storage_live(_2)
-    _2 = concretize<&'_0 (dyn Left<parent_clause1::Internal = i32, Left = i32> + '1), &'_0 i32>(move _1)
+    _2 = concretize<&'_0 (dyn Left<ImpliedClause1::Internal = i32, Left = i32> + '1), &'_0 i32>(move _1)
     _0 = {impl Left for i32}::left_method<'_0>(move _2)
     return
 }
 
 // Full name: test_crate::{impl Left for i32}::{vtable_drop_shim}
-unsafe fn {impl Left for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Left<parent_clause1::Internal = i32, Left = i32>))
+unsafe fn {impl Left for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Left<ImpliedClause1::Internal = i32, Left = i32>))
 {
     let ret_0: (); // return
-    let dyn_self_1: *mut (dyn Left<parent_clause1::Internal = i32, Left = i32> + '0); // arg #1
+    let dyn_self_1: *mut (dyn Left<ImpliedClause1::Internal = i32, Left = i32> + '0); // arg #1
     let target_self_2: *mut i32; // local
 
     ret_0 = ()
     storage_live(target_self_2)
-    target_self_2 = concretize<*mut (dyn Left<parent_clause1::Internal = i32, Left = i32> + '1), *mut i32>(move dyn_self_1)
+    target_self_2 = concretize<*mut (dyn Left<ImpliedClause1::Internal = i32, Left = i32> + '1), *mut i32>(move dyn_self_1)
     return
 }
 
@@ -350,9 +350,9 @@ static {impl Left for i32}::{vtable}: test_crate::Left::{vtable}<i32, i32> = {im
 
 // Full name: test_crate::{impl Left for i32}
 impl Left for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {impl Internal for i32}
-    parent_clause2 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Internal) = {impl Internal for i32}
+    proof ImpliedClause2: (i32: Sized) = {built_in impl Sized for i32}
     type Left = i32
     fn left_method<'_0_1> = {impl Left for i32}::left_method<'_0_1>
     vtable: {impl Left for i32}::{vtable}
@@ -406,28 +406,28 @@ fn {impl Right<i32> for i32}::right_method<'_0>(self_1: &'_0 i32) -> i32
 }
 
 // Full name: test_crate::{impl Right<i32> for i32}::right_method::{vtable_method}
-fn {impl Right<i32> for i32}::right_method::{vtable_method}<'_0>(_1: &'_0 (dyn Right<i32, parent_clause1::Internal = i32, Right = i32>)) -> i32
+fn {impl Right<i32> for i32}::right_method::{vtable_method}<'_0>(_1: &'_0 (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32>)) -> i32
 {
     let _0: i32; // return
-    let _1: &'_0 (dyn Right<i32, parent_clause1::Internal = i32, Right = i32> + '0); // arg #1
+    let _1: &'_0 (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32> + '0); // arg #1
     let _2: &'_0 i32; // anonymous local
 
     storage_live(_2)
-    _2 = concretize<&'_0 (dyn Right<i32, parent_clause1::Internal = i32, Right = i32> + '1), &'_0 i32>(move _1)
+    _2 = concretize<&'_0 (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32> + '1), &'_0 i32>(move _1)
     _0 = {impl Right<i32> for i32}::right_method<'_0>(move _2)
     return
 }
 
 // Full name: test_crate::{impl Right<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Right<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32>))
+unsafe fn {impl Right<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32>))
 {
     let ret_0: (); // return
-    let dyn_self_1: *mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32> + '0); // arg #1
+    let dyn_self_1: *mut (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32> + '0); // arg #1
     let target_self_2: *mut i32; // local
 
     ret_0 = ()
     storage_live(target_self_2)
-    target_self_2 = concretize<*mut (dyn Right<i32, parent_clause1::Internal = i32, Right = i32> + '1), *mut i32>(move dyn_self_1)
+    target_self_2 = concretize<*mut (dyn Right<i32, ImpliedClause1::Internal = i32, Right = i32> + '1), *mut i32>(move dyn_self_1)
     return
 }
 
@@ -457,11 +457,11 @@ static {impl Right<i32> for i32}::{vtable}: test_crate::Right::{vtable}<i32, i32
 
 // Full name: test_crate::{impl Right<i32> for i32}
 impl Right<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {impl Internal for i32}
-    parent_clause2 = {impl Super<i32> for i32}
-    parent_clause3 = {built_in impl Sized for i32}
-    parent_clause4 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Internal) = {impl Internal for i32}
+    proof ImpliedClause2: (i32: Super<i32>) = {impl Super<i32> for i32}
+    proof ImpliedClause3: (i32: Sized) = {built_in impl Sized for i32}
+    proof ImpliedClause4: (i32: Sized) = {built_in impl Sized for i32}
     type Right = i32
     fn right_method<'_0_1> = {impl Right<i32> for i32}::right_method<'_0_1>
     vtable: {impl Right<i32> for i32}::{vtable}
@@ -494,28 +494,28 @@ fn {impl Join<i32> for i32}::join_method<'_0>(self_1: &'_0 i32) -> (i32, i32)
 }
 
 // Full name: test_crate::{impl Join<i32> for i32}::join_method::{vtable_method}
-fn {impl Join<i32> for i32}::join_method::{vtable_method}<'_0>(_1: &'_0 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32>)) -> (i32, i32)
+fn {impl Join<i32> for i32}::join_method::{vtable_method}<'_0>(_1: &'_0 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32>)) -> (i32, i32)
 {
     let _0: (i32, i32); // return
-    let _1: &'_0 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '0); // arg #1
+    let _1: &'_0 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '0); // arg #1
     let _2: &'_0 i32; // anonymous local
 
     storage_live(_2)
-    _2 = concretize<&'_0 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '1), &'_0 i32>(move _1)
+    _2 = concretize<&'_0 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '1), &'_0 i32>(move _1)
     _0 = {impl Join<i32> for i32}::join_method<'_0>(move _2)
     return
 }
 
 // Full name: test_crate::{impl Join<i32> for i32}::{vtable_drop_shim}
-unsafe fn {impl Join<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32>))
+unsafe fn {impl Join<i32> for i32}::{vtable_drop_shim}(dyn_self_1: *mut (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32>))
 {
     let ret_0: (); // return
-    let dyn_self_1: *mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '0); // arg #1
+    let dyn_self_1: *mut (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '0); // arg #1
     let target_self_2: *mut i32; // local
 
     ret_0 = ()
     storage_live(target_self_2)
-    target_self_2 = concretize<*mut (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '1), *mut i32>(move dyn_self_1)
+    target_self_2 = concretize<*mut (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '1), *mut i32>(move dyn_self_1)
     return
 }
 
@@ -545,10 +545,10 @@ static {impl Join<i32> for i32}::{vtable}: test_crate::Join::{vtable}<i32, i32, 
 
 // Full name: test_crate::{impl Join<i32> for i32}
 impl Join<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {impl Left for i32}
-    parent_clause2 = {impl Right<i32> for i32}
-    parent_clause3 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Left) = {impl Left for i32}
+    proof ImpliedClause2: (i32: Right<i32>) = {impl Right<i32> for i32}
+    proof ImpliedClause3: (i32: Sized) = {built_in impl Sized for i32}
     fn join_method<'_0_1> = {impl Join<i32> for i32}::join_method<'_0_1>
     vtable: {impl Join<i32> for i32}::{vtable}
 }
@@ -557,11 +557,11 @@ impl Join<i32> for i32 {
 fn main()
 {
     let _0: (); // return
-    let v_1: &'3 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '4); // local
+    let v_1: &'3 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '4); // local
     let _2: &'6 i32; // anonymous local
     let _3: &'7 i32; // anonymous local
     let _4: (i32, i32); // anonymous local
-    let _5: &'8 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '9); // anonymous local
+    let _5: &'8 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '9); // anonymous local
     let _6: &'10 i32; // anonymous local
     let _7: &'11 i32; // anonymous local
     let _8: &'19 i32; // anonymous local
@@ -581,7 +581,7 @@ fn main()
     _6 = move _7
     _3 = &(*_6)
     _2 = &(*_3)
-    v_1 = unsize_cast<&'6 i32, &'12 (dyn Join<i32, parent_clause1::parent_clause1::Internal = i32, parent_clause1::Left = i32, parent_clause2::Right = i32> + '13), &{impl Join<i32> for i32}::{vtable}>(move _2)
+    v_1 = unsize_cast<&'6 i32, &'12 (dyn Join<i32, ImpliedClause1::ImpliedClause1::Internal = i32, ImpliedClause1::Left = i32, ImpliedClause2::Right = i32> + '13), &{impl Join<i32> for i32}::{vtable}>(move _2)
     storage_dead(_2)
     storage_dead(_3)
     storage_live(_4)

--- a/charon/tests/ui/explicit-drop-bounds.out
+++ b/charon/tests/ui/explicit-drop-bounds.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -40,68 +40,68 @@ impl Destruct for String {
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Destruct<Self>
-    parent_clause3 : [@TraitClause3]: Destruct<T>
-    parent_clause4 : [@TraitClause4]: Sized<Self::Type>
-    parent_clause5 : [@TraitClause5]: Destruct<Self::Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self: Destruct)
+    proof ImpliedClause3: (T: Destruct)
+    proof ImpliedClause4: (Self::Type: Sized)
+    proof ImpliedClause5: (Self::Type: Destruct)
     type Type
-    fn foo<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Destruct<U>> = test_crate::Trait::foo<Self, T, U>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn foo<U, TraitClause0_1: (U: Sized), TraitClause1_1: (U: Destruct)> = test_crate::Trait::foo<Self, T, U>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::foo<Self, T, U>(x_1: U)
 where
-    [@TraitClause0]: Trait<Self, T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Destruct<U>,
+    TraitClause0: (Self: Trait<T>),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: Destruct),
 {
     let _0: (); // return
     let x_1: U; // arg #1
 
     _0 = ()
     _0 = ()
-    drop[@TraitClause2::drop_in_place] x_1
+    drop[TraitClause2::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::{impl Trait<u32> for ()}::foo
 fn {impl Trait<u32> for ()}::foo<U>(x_1: U)
 where
-    [@TraitClause0]: Sized<U>,
-    [@TraitClause1]: Destruct<U>,
+    TraitClause0: (U: Sized),
+    TraitClause1: (U: Destruct),
 {
     let _0: (); // return
     let x_1: U; // arg #1
 
     _0 = ()
     _0 = ()
-    drop[@TraitClause1::drop_in_place] x_1
+    drop[TraitClause1::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::{impl Trait<u32> for ()}
 impl Trait<u32> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for u32}
-    parent_clause2 = {built_in impl Destruct for ()}
-    parent_clause3 = {built_in impl Destruct for u32}
-    parent_clause4 = {built_in impl Sized for String}
-    parent_clause5 = {impl Destruct for String}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause2: ((): Destruct) = {built_in impl Destruct for ()}
+    proof ImpliedClause3: (u32: Destruct) = {built_in impl Destruct for u32}
+    proof ImpliedClause4: (String: Sized) = {built_in impl Sized for String}
+    proof ImpliedClause5: (String: Destruct) = {impl Destruct for String}
     type Type = String
-    fn foo<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Destruct<U>> = {impl Trait<u32> for ()}::foo<U>[@TraitClause0_1, @TraitClause1_1]
+    fn foo<U, TraitClause0_1: (U: Sized), TraitClause1_1: (U: Destruct)> = {impl Trait<u32> for ()}::foo<U>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::use_trait
 fn use_trait<T, X>(_x_1: T, _y_2: X)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<X>,
-    [@TraitClause2]: Trait<X, T>,
-    [@TraitClause3]: Destruct<T>,
-    [@TraitClause4]: Destruct<X>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (X: Sized),
+    TraitClause2: (X: Trait<T>),
+    TraitClause3: (T: Destruct),
+    TraitClause4: (X: Destruct),
 {
     let _0: (); // return
     let _x_1: T; // arg #1
@@ -109,8 +109,8 @@ where
 
     _0 = ()
     _0 = ()
-    drop[@TraitClause4::drop_in_place] _y_2
-    drop[@TraitClause3::drop_in_place] _x_1
+    drop[TraitClause4::drop_in_place] _y_2
+    drop[TraitClause3::drop_in_place] _x_1
     return
 }
 

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -8,13 +8,13 @@ pub trait MetaSized<Self>
 #[lang_item("Cell")]
 pub opaque type Cell<T>
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -22,7 +22,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -31,28 +31,28 @@ pub trait Clone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
-// Full name: core::cell::{Cell<T>[@TraitClause0::parent_clause0]}::get
-pub fn get<'_0, T>(_1: &'_0 Cell<T>[@TraitClause0::parent_clause0]) -> T
+// Full name: core::cell::{Cell<T>[TraitClause0::ImpliedClause0]}::get
+pub fn get<'_0, T>(_1: &'_0 Cell<T>[TraitClause0::ImpliedClause0]) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <opaque>
 
-// Full name: core::cell::{Cell<T>[@TraitClause0]}::get_mut
-pub fn get_mut<'_0, T>(_1: &'_0 mut Cell<T>[@TraitClause0]) -> &'_0 mut T
+// Full name: core::cell::{Cell<T>[TraitClause0]}::get_mut
+pub fn get_mut<'_0, T>(_1: &'_0 mut Cell<T>[TraitClause0]) -> &'_0 mut T
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <opaque>
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u32}::clone
@@ -61,15 +61,15 @@ pub fn {impl Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
 
 // Full name: core::clone::impls::{impl Clone for u32}
 impl Clone for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
     fn clone<'_0_1> = {impl Clone for u32}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::marker::{impl Copy for u32}
 impl Copy for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {impl Clone for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: Clone) = {impl Clone for u32}
     non-dyn-compatible
 }
 
@@ -87,7 +87,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("mem_swap")]
 pub fn core::mem::swap<'_0, '_1, T>(_1: &'_0 mut T, _2: &'_1 mut T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::num::niche_types::NonZeroU32Inner
@@ -99,50 +99,50 @@ pub fn {impl Clone for NonZeroU32Inner}::clone<'_0>(_1: &'_0 NonZeroU32Inner) ->
 
 // Full name: core::num::niche_types::{impl Clone for NonZeroU32Inner}
 impl Clone for NonZeroU32Inner {
-    parent_clause0 = {built_in impl Sized for NonZeroU32Inner}
+    proof ImpliedClause0: (NonZeroU32Inner: Sized) = {built_in impl Sized for NonZeroU32Inner}
     fn clone<'_0_1> = {impl Clone for NonZeroU32Inner}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::num::niche_types::{impl Copy for NonZeroU32Inner}
 impl Copy for NonZeroU32Inner {
-    parent_clause0 = {built_in impl MetaSized for NonZeroU32Inner}
-    parent_clause1 = {impl Clone for NonZeroU32Inner}
+    proof ImpliedClause0: (NonZeroU32Inner: MetaSized) = {built_in impl MetaSized for NonZeroU32Inner}
+    proof ImpliedClause1: (NonZeroU32Inner: Clone) = {impl Clone for NonZeroU32Inner}
     non-dyn-compatible
 }
 
 // Full name: core::num::nonzero::private::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::num::nonzero::private::Sealed::{vtable}
 }
 
 // Full name: core::num::nonzero::ZeroablePrimitive
 pub trait ZeroablePrimitive<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Copy<Self>
-    parent_clause2 : [@TraitClause2]: Sealed<Self>
-    parent_clause3 : [@TraitClause3]: Sized<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: Copy<Self::NonZeroInner>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Copy)
+    proof ImpliedClause2: (Self: Sealed)
+    proof ImpliedClause3: (Self::NonZeroInner: Sized)
+    proof ImpliedClause4: (Self::NonZeroInner: Copy)
     type NonZeroInner
     non-dyn-compatible
 }
 
 // Full name: core::num::nonzero::{impl Sealed for u32}
 impl Sealed for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
     vtable: {impl Sealed for u32}::{vtable}
 }
 
 // Full name: core::num::nonzero::{impl ZeroablePrimitive for u32}
 impl ZeroablePrimitive for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
-    parent_clause1 = {impl Copy for u32}
-    parent_clause2 = {impl Sealed for u32}
-    parent_clause3 = {built_in impl Sized for NonZeroU32Inner}
-    parent_clause4 = {impl Copy for NonZeroU32Inner}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause1: (u32: Copy) = {impl Copy for u32}
+    proof ImpliedClause2: (u32: Sealed) = {impl Sealed for u32}
+    proof ImpliedClause3: (NonZeroU32Inner: Sized) = {built_in impl Sized for NonZeroU32Inner}
+    proof ImpliedClause4: (NonZeroU32Inner: Copy) = {impl Copy for NonZeroU32Inner}
     type NonZeroInner = NonZeroU32Inner
     non-dyn-compatible
 }
@@ -151,30 +151,30 @@ impl ZeroablePrimitive for u32 {
 #[lang_item("NonZero")]
 pub opaque type NonZero<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ZeroablePrimitive<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ZeroablePrimitive),
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-pub fn core::num::nonzero::{NonZero<T>[@TraitClause0, @TraitClause1]}::new<T>(_1: T) -> Option<NonZero<T>[@TraitClause0, @TraitClause1]>[{built_in impl Sized for NonZero<T>[@TraitClause0, @TraitClause1]}]
+pub fn core::num::nonzero::{NonZero<T>[TraitClause0, TraitClause1]}::new<T>(_1: T) -> Option<NonZero<T>[TraitClause0, TraitClause1]>[{built_in impl Sized for NonZero<T>[TraitClause0, TraitClause1]}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ZeroablePrimitive<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ZeroablePrimitive),
 = <opaque>
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::unwrap
+// Full name: core::option::{Option<T>[TraitClause0]}::unwrap
 #[lang_item("option_unwrap")]
-pub fn unwrap<T>(_1: Option<T>[@TraitClause0]) -> T
+pub fn unwrap<T>(_1: Option<T>[TraitClause0]) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -195,33 +195,33 @@ impl Destruct for Global {
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 #[lang_item("vec_new")]
-pub fn alloc::vec::{Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}::new<T>() -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn alloc::vec::{Vec<T>[TraitClause0, {built_in impl Sized for Global}]}::new<T>() -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push
-pub fn push<'_0, T, A>(_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], _2: T)
+// Full name: alloc::vec::{Vec<T>[TraitClause0, TraitClause1]}::push
+pub fn push<'_0, T, A>(_1: &'_0 mut Vec<T>[TraitClause0, TraitClause1], _2: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Destruct),
 = <opaque>
 
 pub fn test_crate::swap<'a, T>(x_1: &'a mut T, y_2: &'a mut T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let x_1: &'1 mut T; // arg #1
@@ -234,7 +234,7 @@ where
     _3 = &two-phase-mut (*x_1)
     storage_live(_4)
     _4 = &two-phase-mut (*y_2)
-    _0 = core::mem::swap<'7, '8, T>[@TraitClause0](move _3, move _4)
+    _0 = core::mem::swap<'7, '8, T>[TraitClause0](move _3, move _4)
     storage_dead(_4)
     storage_dead(_3)
     return
@@ -251,7 +251,7 @@ pub fn test_new_non_zero_u32(x_1: u32) -> NonZero<u32>[{built_in impl Sized for 
     storage_live(_2)
     storage_live(_3)
     _3 = copy x_1
-    _2 = core::num::nonzero::{NonZero<T>[@TraitClause0, @TraitClause1]}::new<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}](move _3)
+    _2 = core::num::nonzero::{NonZero<T>[TraitClause0, TraitClause1]}::new<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}](move _3)
     storage_dead(_3)
     _0 = unwrap<NonZero<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}]>[{built_in impl Sized for NonZero<u32>[{built_in impl Sized for u32}, {impl ZeroablePrimitive for u32}]}](move _2)
     storage_dead(_2)
@@ -268,7 +268,7 @@ pub fn test_vec_push()
 
     _0 = ()
     storage_live(v_1)
-    v_1 = alloc::vec::{Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}::new<u32>[{built_in impl Sized for u32}]()
+    v_1 = alloc::vec::{Vec<T>[TraitClause0, {built_in impl Sized for Global}]}::new<u32>[{built_in impl Sized for u32}]()
     storage_live(_2)
     storage_live(_3)
     _3 = &two-phase-mut v_1
@@ -276,7 +276,7 @@ pub fn test_vec_push()
     storage_dead(_3)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] v_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] v_1
     storage_dead(v_1)
     return
 }

--- a/charon/tests/ui/filtering/inner-items.out
+++ b/charon/tests/ui/filtering/inner-items.out
@@ -27,13 +27,13 @@ fn inner1()
 // Full name: test_crate::foo::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::foo::Trait::{vtable}
 }
 
 // Full name: test_crate::foo::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     vtable: {impl Trait for ()}::{vtable}
 }
 

--- a/charon/tests/ui/filtering/opacity.out
+++ b/charon/tests/ui/filtering/opacity.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,8 +16,8 @@ pub trait Sized<Self>
 #[lang_item("From")]
 pub trait From<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
     fn from = core::convert::From::from<Self, T>[Self]
     non-dyn-compatible
 }
@@ -25,20 +25,20 @@ pub trait From<Self, T>
 #[lang_item("from_fn")]
 pub fn core::convert::From::from<Self, T>(_1: T) -> Self
 where
-    [@TraitClause0]: From<Self, T>,
+    TraitClause0: (Self: From<T>),
 = <opaque>
 
 // Full name: core::convert::{impl Into<U> for T}::into
 pub fn {impl Into<U> for T}::into<T, U>(self_1: T) -> U
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: From<U, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: From<T>),
 {
     let _0: U; // return
     let self_1: T; // arg #1
 
-    _0 = @TraitClause2::from(move self_1)
+    _0 = TraitClause2::from(move self_1)
     return
 }
 
@@ -54,8 +54,8 @@ pub fn {impl From<u32> for u64}::from(small_1: u32) -> u64
 
 // Full name: core::convert::num::{impl From<u32> for u64}
 impl From<u32> for u64 {
-    parent_clause0 = {built_in impl Sized for u64}
-    parent_clause1 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u64: Sized) = {built_in impl Sized for u64}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
     fn from = {impl From<u32> for u64}::from
     non-dyn-compatible
 }
@@ -64,19 +64,19 @@ impl From<u32> for u64 {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::is_some
-pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: core::option::{Option<T>[TraitClause0]}::is_some
+pub fn is_some<'_0, T>(self_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
     let _2: isize; // anonymous local
 
     storage_live(_2)

--- a/charon/tests/ui/filtering/opaque-trait.out
+++ b/charon/tests/ui/filtering/opaque-trait.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const CONST1 : usize
     const CONST2 : usize
     const CONST3 : usize
@@ -26,7 +26,7 @@ trait Trait<Self>
 
 fn test_crate::Trait::CONST1<Self>() -> usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: usize; // return
 
@@ -36,12 +36,12 @@ where
 
 const test_crate::Trait::CONST1<Self>: usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
  = test_crate::Trait::CONST1()
 
 fn test_crate::Trait::CONST2<Self>() -> usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: usize; // return
 
@@ -51,12 +51,12 @@ where
 
 const test_crate::Trait::CONST2<Self>: usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
  = test_crate::Trait::CONST2()
 
 fn test_crate::Trait::CONST3<Self>() -> usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: usize; // return
 
@@ -66,12 +66,12 @@ where
 
 const test_crate::Trait::CONST3<Self>: usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
  = test_crate::Trait::CONST3()
 
 fn test_crate::Trait::method1<Self>()
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: (); // return
 
@@ -82,7 +82,7 @@ where
 
 fn test_crate::Trait::method2<Self>()
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: (); // return
 
@@ -149,7 +149,7 @@ const {impl Trait for ()}::CONST1: usize = {impl Trait for ()}::CONST1()
 
 // Full name: test_crate::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     const CONST1 = {impl Trait for ()}::CONST1
     const CONST2 = {impl Trait for ()}::CONST2
     const CONST3 = {impl Trait for ()}::CONST3
@@ -192,7 +192,7 @@ fn {impl Trait for u8}::method1()
 
 // Full name: test_crate::{impl Trait for u8}
 impl Trait for u8 {
-    parent_clause0 = {built_in impl MetaSized for u8}
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
     const CONST1 = test_crate::Trait::CONST1<u8>[{impl Trait for u8}]
     const CONST2 = {impl Trait for u8}::CONST2
     const CONST3 = test_crate::Trait::CONST3<u8>[{impl Trait for u8}]
@@ -204,8 +204,8 @@ impl Trait for u8 {
 // Full name: test_crate::use_method
 fn use_method<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
 {
     let _0: (); // return
     let _1: (); // anonymous local
@@ -213,10 +213,10 @@ where
 
     _0 = ()
     storage_live(_1)
-    _1 = @TraitClause1::method1()
+    _1 = TraitClause1::method1()
     storage_dead(_1)
     storage_live(_2)
-    _2 = const @TraitClause1::CONST1
+    _2 = const TraitClause1::CONST1
     storage_dead(_2)
     _0 = ()
     return

--- a/charon/tests/ui/filtering/opaque_attribute.out
+++ b/charon/tests/ui/filtering/opaque_attribute.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,14 +25,14 @@ where
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn get_bool<'_0_1> = test_crate::BoolTrait::get_bool<'_0_1, Self>[Self]
     vtable: test_crate::BoolTrait::{vtable}
 }
 
 pub fn test_crate::BoolTrait::get_bool<'_0, Self>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 = <opaque>
 
 // Full name: test_crate::{impl BoolTrait for bool}::get_bool
@@ -47,19 +47,19 @@ pub fn {impl BoolTrait for bool}::get_bool<'_0>(self_1: &'_0 bool) -> bool
 
 // Full name: test_crate::{impl BoolTrait for bool}
 impl BoolTrait for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
     fn get_bool<'_0_1> = {impl BoolTrait for bool}::get_bool<'_0_1>
     vtable: {impl BoolTrait for bool}::{vtable}
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::get_bool
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}::get_bool
+pub fn {impl BoolTrait for Option<T>[TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: BoolTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: BoolTrait),
 {
     let _0: bool; // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
     let x_2: &'3 T; // local
     let _3: &'4 T; // anonymous local
 
@@ -71,7 +71,7 @@ where
             x_2 = &((*self_1) as variant Option::Some).0
             storage_live(_3)
             _3 = &(*x_2)
-            _0 = @TraitClause1::get_bool<'6>(move _3)
+            _0 = TraitClause1::get_bool<'6>(move _3)
             storage_dead(_3)
             storage_dead(x_2)
             return
@@ -81,22 +81,22 @@ where
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}
-impl<T> BoolTrait for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}
+impl<T> BoolTrait for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: BoolTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: BoolTrait),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    fn get_bool<'_0_1> = {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0_1, T>[@TraitClause0, @TraitClause1]
-    vtable: {impl BoolTrait for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    fn get_bool<'_0_1> = {impl BoolTrait for Option<T>[TraitClause0]}::get_bool<'_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl BoolTrait for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::test_bool_trait_option
-pub fn test_bool_trait_option<T>(_1: Option<T>[@TraitClause0]) -> bool
+pub fn test_bool_trait_option<T>(_1: Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: BoolTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: BoolTrait),
 = <opaque>
 
 // Full name: test_crate::Test

--- a/charon/tests/ui/filtering/start_from.out
+++ b/charon/tests/ui/filtering/start_from.out
@@ -65,13 +65,13 @@ fn {impl Trait1 for Type1}::method()
 // Full name: test_crate::hidden_module::Trait2
 trait Trait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::hidden_module::Trait2::{vtable}
 }
 
 // Full name: test_crate::hidden_module::{impl Trait2 for Type1}
 impl Trait2 for Type1 {
-    parent_clause0 = {built_in impl MetaSized for Type1}
+    proof ImpliedClause0: (Type1: MetaSized) = {built_in impl MetaSized for Type1}
     vtable: {impl Trait2 for Type1}::{vtable}
 }
 

--- a/charon/tests/ui/filtering/start_from_attribute.out
+++ b/charon/tests/ui/filtering/start_from_attribute.out
@@ -30,13 +30,13 @@ fn {impl Trait1 for Type1}::method()
 // Full name: test_crate::module2::Trait2
 trait Trait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::module2::Trait2::{vtable}
 }
 
 // Full name: test_crate::module2::{impl Trait2 for Type1}
 impl Trait2 for Type1 {
-    parent_clause0 = {built_in impl MetaSized for Type1}
+    proof ImpliedClause0: (Type1: MetaSized) = {built_in impl MetaSized for Type1}
     vtable: {impl Trait2 for Type1}::{vtable}
 }
 

--- a/charon/tests/ui/filtering/start_from_pub.out
+++ b/charon/tests/ui/filtering/start_from_pub.out
@@ -40,14 +40,14 @@ pub struct Type1 {}
 // Full name: test_crate::module2::Trait1
 pub trait Trait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn method = test_crate::module2::Trait1::method<Self>[Self]
     non-dyn-compatible
 }
 
 pub fn test_crate::module2::Trait1::method<Self>()
 where
-    [@TraitClause0]: Trait1<Self>,
+    TraitClause0: (Self: Trait1),
 = <method_without_default_body>
 
 // Full name: test_crate::module2::{impl Trait1 for Type1}::method

--- a/charon/tests/ui/find-sized-clause.out
+++ b/charon/tests/ui/find-sized-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,17 +25,17 @@ where
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
-// Full name: test_crate::{impl Trait for Option<T>[@TraitClause0]}
-impl<T> Trait for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl Trait for Option<T>[TraitClause0]}
+impl<T> Trait for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    vtable: {impl Trait for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    vtable: {impl Trait for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/foreign-type-alias.out
+++ b/charon/tests/ui/foreign-type-alias.out
@@ -8,22 +8,22 @@ pub trait MetaSized<Self>
 #[lang_item("Borrow")]
 pub trait Borrow<Self, Borrowed>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Borrowed>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Borrowed: MetaSized)
     fn borrow<'_0_1> = core::borrow::Borrow::borrow<'_0_1, Self, Borrowed>[Self]
     vtable: core::borrow::Borrow::{vtable}<Borrowed>
 }
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(_1: &'_0 Self) -> &'_0 Borrowed
 where
-    [@TraitClause0]: Borrow<Self, Borrowed>,
+    TraitClause0: (Self: Borrow<Borrowed>),
 = <opaque>
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,7 +31,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -40,7 +40,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -51,77 +51,77 @@ pub struct Global {}
 #[lang_item("ToOwned")]
 pub trait ToOwned<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Owned>
-    parent_clause2 : [@TraitClause2]: Borrow<Self::Owned, Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Owned: Sized)
+    proof ImpliedClause2: (Self::Owned: Borrow<Self>)
     type Owned
     fn to_owned<'_0_1> = alloc::borrow::ToOwned::to_owned<'_0_1, Self>[Self]
     non-dyn-compatible
 }
 
 #[lang_item("to_owned_method")]
-pub fn alloc::borrow::ToOwned::to_owned<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Owned
+pub fn alloc::borrow::ToOwned::to_owned<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Owned
 where
-    [@TraitClause0]: ToOwned<Self>,
+    TraitClause0: (Self: ToOwned),
 = <opaque>
 
 // Full name: alloc::borrow::Cow
 #[lang_item("Cow")]
 pub enum Cow<'a, B>
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
   Borrowed(&'a B),
-  Owned(@TraitClause1::Owned),
+  Owned(TraitClause1::Owned),
 }
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
-pub fn {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(_1: &'_0 Vec<T>[@TraitClause0, @TraitClause1]) -> &'_0 [T]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow
+pub fn {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow<'_0, T, A>(_1: &'_0 Vec<T>[TraitClause0, TraitClause1]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}
+impl<T, A> Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl MetaSized for [T]}
-    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Vec<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for Vec<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow<'_0_1, T, A>[TraitClause0, TraitClause1]
+    vtable: {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::{vtable}<T, A>[TraitClause0, TraitClause1]
 }
 
 // Full name: alloc::slice::{impl ToOwned for [T]}::to_owned
-pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(_1: &'_0 [T]) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(_1: &'_0 [T]) -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <opaque>
 
 // Full name: alloc::slice::{impl ToOwned for [T]}
 impl<T> ToOwned for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = {built_in impl Sized for Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}
-    parent_clause2 = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
-    type Owned = Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
-    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: (Vec<T>[TraitClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for Vec<T>[TraitClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause2: (Vec<T>[TraitClause0, {built_in impl Sized for Global}]: Borrow<[T]>) = {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}<T, Global>[TraitClause0, {built_in impl Sized for Global}]
+    type Owned = Vec<T>[TraitClause0, {built_in impl Sized for Global}]
+    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -131,19 +131,19 @@ pub type Usize = usize
 // Full name: type_alias::Generic
 pub type Generic<'a, T>
 where
-    [@TraitClause0]: Sized<T>, = &'a T
+    TraitClause0: (T: Sized), = &'a T
 
 // Full name: type_alias::Generic2
 pub type Generic2<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[@TraitClause0, @TraitClause1]]
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone), = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[TraitClause0, TraitClause1]]
 
 // Full name: type_alias::GenericWithoutBound
 pub type GenericWithoutBound<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToOwned<[T]>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, @TraitClause1]
+    TraitClause0: (T: Sized),
+    TraitClause1: ([T]: ToOwned), = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, TraitClause1]
 
 
 

--- a/charon/tests/ui/gat-causes-unhandled-ty-clause.out
+++ b/charon/tests/ui/gat-causes-unhandled-ty-clause.out
@@ -8,15 +8,15 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Assoc: Sized)
     type Assoc
     vtable: test_crate::HasAssoc::{vtable}<Self::Assoc>
 }
@@ -24,24 +24,24 @@ trait HasAssoc<Self>
 // Full name: test_crate::HasGAT
 trait HasGAT<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Friend>
-    parent_clause2 : [@TraitClause2]: HasAssoc<Self::Friend>
-    type GAT<T, [@TraitClause0_1]: Sized<T>>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Friend: Sized)
+    proof ImpliedClause2: (Self::Friend: HasAssoc)
+    type GAT<T>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::GAT>
-
+        TraitClause0_1: (T: Sized),
+        proof ImpliedClause0: (Self::GAT: Sized);
     type Friend
     non-dyn-compatible
 }
 
 // Full name: test_crate::floatify
-fn floatify<C>() -> @TraitClause1::parent_clause2::Assoc
+fn floatify<C>() -> TraitClause1::ImpliedClause2::Assoc
 where
-    [@TraitClause0]: Sized<C>,
-    [@TraitClause1]: HasGAT<C>,
+    TraitClause0: (C: Sized),
+    TraitClause1: (C: HasGAT),
 {
-    let _0: @TraitClause1::parent_clause2::Assoc; // return
+    let _0: TraitClause1::ImpliedClause2::Assoc; // return
 
     panic(core::panicking::panic)
 }

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -23,7 +23,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,8 +31,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -48,22 +48,22 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for &'_0 T}::fmt
 pub fn {impl Debug for &'_0 T}::fmt<'_0, '_1, '_2, '_3, T>(_1: &'_1 &'_0 T, _2: &'_2 mut Formatter<'_3>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<T>,
+    TraitClause0: (T: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for &'_0 T}
 impl<'_0, T> Debug for &'_0 T
 where
-    [@TraitClause0]: Debug<T>,
+    TraitClause0: (T: Debug),
 {
-    fn fmt<'_0_1, '_1_1, '_2_1> = {impl Debug for &'_0 T}::fmt<'_0, '_0_1, '_1_1, '_2_1, T>[@TraitClause0]
-    vtable: {impl Debug for &'_0 T}::{vtable}<'_0, T>[@TraitClause0]
+    fn fmt<'_0_1, '_1_1, '_2_1> = {impl Debug for &'_0 T}::fmt<'_0, '_0_1, '_1_1, '_2_1, T>[TraitClause0]
+    vtable: {impl Debug for &'_0 T}::{vtable}<'_0, T>[TraitClause0]
 }
 
 // Full name: core::fmt::num::{impl Debug for i32}::fmt
@@ -79,15 +79,15 @@ impl Debug for i32 {
 // Full name: core::fmt::rt::{Argument<'_0>}::new_debug
 pub fn new_debug<'_0, '_1, T>(_1: &'_1 T) -> Argument<'_1>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Debug<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Debug),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -97,20 +97,20 @@ where
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::iter::{impl IntoIterator for &'a [T]}::into_iter
-pub fn {impl IntoIterator for &'a [T]}::into_iter<'a, T>(_1: &'a [T]) -> Iter<'a, T>[@TraitClause0]
+pub fn {impl IntoIterator for &'a [T]}::into_iter<'a, T>(_1: &'a [T]) -> Iter<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: std::io::stdio::_eprint
@@ -120,17 +120,17 @@ pub fn _eprint<'_0>(_1: Arguments<'_0>)
 // Full name: test_crate::debug_slice
 fn debug_slice<'_0, T>(slice_1: &'_0 [T])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Debug<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Debug),
 {
     let _0: (); // return
     let slice_1: &'1 [T]; // arg #1
-    let _2: Iter<'3, T>[@TraitClause0]; // anonymous local
+    let _2: Iter<'3, T>[TraitClause0]; // anonymous local
     let _3: &'4 [T]; // anonymous local
-    let iter_4: Iter<'5, T>[@TraitClause0]; // local
+    let iter_4: Iter<'5, T>[TraitClause0]; // local
     let _5: Option<&'12 T>[{built_in impl Sized for &'12 T}]; // anonymous local
-    let _6: &'17 mut Iter<'18, T>[@TraitClause0]; // anonymous local
-    let _7: &'19 mut Iter<'20, T>[@TraitClause0]; // anonymous local
+    let _6: &'17 mut Iter<'18, T>[TraitClause0]; // anonymous local
+    let _7: &'19 mut Iter<'20, T>[TraitClause0]; // anonymous local
     let x_8: &'21 T; // local
     let _9: (); // anonymous local
     let _10: Arguments<'23>; // anonymous local
@@ -150,7 +150,7 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = copy slice_1
-    _2 = {impl IntoIterator for &'a [T]}::into_iter<'47, T>[@TraitClause0](move _3)
+    _2 = {impl IntoIterator for &'a [T]}::into_iter<'47, T>[TraitClause0](move _3)
     storage_dead(_3)
     storage_live(iter_4)
     iter_4 = move _2
@@ -160,7 +160,7 @@ where
         storage_live(_7)
         _7 = &mut iter_4
         _6 = &two-phase-mut (*_7)
-        _5 = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'49, '51, T>[@TraitClause0](move _6)
+        _5 = {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'49, '51, T>[TraitClause0](move _6)
         storage_dead(_6)
         match _5 {
             Option::None => {
@@ -182,7 +182,7 @@ where
         storage_live(_14)
         storage_live(_15)
         _15 = &(*args_11.0)
-        _14 = new_debug<'59, '69, &'60 T>[{built_in impl Sized for &'60 T}, {impl Debug for &'_0 T}<'60, T>[@TraitClause1]](move _15)
+        _14 = new_debug<'59, '69, &'60 T>[{built_in impl Sized for &'60 T}, {impl Debug for &'_0 T}<'60, T>[TraitClause1]](move _15)
         storage_dead(_15)
         args_13 = [move _14]
         storage_dead(_14)

--- a/charon/tests/ui/hide-marker-traits.out
+++ b/charon/tests/ui/hide-marker-traits.out
@@ -18,7 +18,7 @@ trait Idx<Self>
 // Full name: test_crate::IndexVec
 pub struct IndexVec<I>
 where
-    [@TraitClause0]: Idx<I>,
+    TraitClause0: (I: Idx),
 {
   i: I,
 }
@@ -26,9 +26,9 @@ where
 // Full name: test_crate::Vector
 pub struct Vector<I>
 where
-    [@TraitClause0]: Idx<I>,
+    TraitClause0: (I: Idx),
 {
-  vector: IndexVec<I>[@TraitClause0],
+  vector: IndexVec<I>[TraitClause0],
 }
 
 // Full name: test_crate::foo

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u32}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
 
 // Full name: core::clone::impls::{impl Clone for u32}
 impl Clone for u32 {
-    parent_clause0 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: Sized) = {built_in impl Sized for u32}
     fn clone<'_0_1> = {impl Clone for u32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -45,7 +45,7 @@ pub fn {impl Clone for &'_0 T}::clone<'_0, '_1, T>(_1: &'_1 &'_0 T) -> &'_0 T
 
 // Full name: core::clone::impls::{impl Clone for &'_0 T}
 impl<'_0, T> Clone for &'_0 T {
-    parent_clause0 = {built_in impl Sized for &'_ T}
+    proof ImpliedClause0: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
     fn clone<'_0_1> = {impl Clone for &'_0 T}::clone<'_0, '_0_1, T>
     non-dyn-compatible
 }
@@ -65,7 +65,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -73,34 +73,34 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Type>
-    parent_clause2 : [@TraitClause2]: Clone<Self::Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Type: Sized)
+    proof ImpliedClause2: (Self::Type: Clone)
     type Type
     fn get_ty<'_0_1> = test_crate::Foo::get_ty<'_0_1, Self>[Self]
     vtable: test_crate::Foo::{vtable}<Self::Type>
 }
 
-pub fn test_crate::Foo::get_ty<'_0, Self>(_1: &'_0 Self) -> &'_0 @TraitClause0::Type
+pub fn test_crate::Foo::get_ty<'_0, Self>(_1: &'_0 Self) -> &'_0 TraitClause0::Type
 where
-    [@TraitClause0]: Foo<Self>,
+    TraitClause0: (Self: Foo),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Foo for ()}::get_ty
@@ -131,9 +131,9 @@ pub fn {impl Foo for ()}::get_ty<'_0>(self_1: &'_0 ()) -> &'_0 u32
 
 // Full name: test_crate::{impl Foo for ()}
 impl Foo for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for u32}
-    parent_clause2 = {impl Clone for u32}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause2: (u32: Clone) = {impl Clone for u32}
     type Type = u32
     fn get_ty<'_0_1> = {impl Foo for ()}::get_ty<'_0_1>
     vtable: {impl Foo for ()}::{vtable}
@@ -182,17 +182,17 @@ fn use_foo()
 // Full name: test_crate::RPITIT
 pub trait RPITIT<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::make_foo_ty>
-    parent_clause2 : [@TraitClause2]: Foo<Self::make_foo_ty>
-    type make_foo_ty
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::make_foo_ty: Sized)
+    proof ImpliedClause2: (Self::make_foo_ty: Foo)
+    type make_foo_ty = ()
     fn make_foo = test_crate::RPITIT::make_foo<Self>[Self]
     non-dyn-compatible
 }
 
 pub fn test_crate::RPITIT::make_foo<Self>()
 where
-    [@TraitClause0]: RPITIT<Self>,
+    TraitClause0: (Self: RPITIT),
 {
     let _0: (); // return
 
@@ -213,9 +213,9 @@ pub fn {impl RPITIT for ()}::make_foo()
 
 // Full name: test_crate::{impl RPITIT for ()}
 impl RPITIT for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {impl Foo for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Foo) = {impl Foo for ()}
     type make_foo_ty = ()
     fn make_foo = {impl RPITIT for ()}::make_foo
     non-dyn-compatible
@@ -224,34 +224,34 @@ impl RPITIT for () {
 // Full name: test_crate::use_tait
 fn use_tait<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: RPITIT<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: RPITIT),
 {
     let _0: (); // return
-    let foo_1: @TraitClause1::make_foo_ty; // local
-    let _2: @TraitClause1::parent_clause2::Type; // anonymous local
-    let _3: &'1 @TraitClause1::parent_clause2::Type; // anonymous local
-    let _4: &'2 @TraitClause1::parent_clause2::Type; // anonymous local
-    let _5: &'4 @TraitClause1::make_foo_ty; // anonymous local
+    let foo_1: TraitClause1::make_foo_ty; // local
+    let _2: TraitClause1::ImpliedClause2::Type; // anonymous local
+    let _3: &'1 TraitClause1::ImpliedClause2::Type; // anonymous local
+    let _4: &'2 TraitClause1::ImpliedClause2::Type; // anonymous local
+    let _5: &'4 TraitClause1::make_foo_ty; // anonymous local
 
     _0 = ()
     storage_live(foo_1)
-    foo_1 = @TraitClause1::make_foo()
+    foo_1 = TraitClause1::make_foo()
     storage_live(_2)
     storage_live(_3)
     storage_live(_4)
     storage_live(_5)
     _5 = &foo_1
-    _4 = @TraitClause1::parent_clause2::get_ty<'6>(move _5)
+    _4 = TraitClause1::ImpliedClause2::get_ty<'6>(move _5)
     _3 = &(*_4) with_metadata(copy _4.metadata)
     storage_dead(_5)
-    _2 = @TraitClause1::parent_clause2::parent_clause2::clone<'8>(move _3)
+    _2 = TraitClause1::ImpliedClause2::ImpliedClause2::clone<'8>(move _3)
     storage_dead(_3)
-    conditional_drop[{built_in impl Destruct for @TraitClause1::parent_clause2::Type}::drop_in_place] _2
+    conditional_drop[{built_in impl Destruct for TraitClause1::ImpliedClause2::Type}::drop_in_place] _2
     storage_dead(_4)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for @TraitClause1::make_foo_ty}::drop_in_place] foo_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::make_foo_ty}::drop_in_place] foo_1
     storage_dead(foo_1)
     return
 }
@@ -259,8 +259,8 @@ where
 // Full name: test_crate::WrapClone
 pub struct WrapClone<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   T,
 }
@@ -268,27 +268,27 @@ where
 // Full name: test_crate::wrap::closure
 struct closure<U>
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 {}
 
 // Full name: test_crate::wrap
-pub fn wrap<U>() -> closure<U>[@TraitClause0]
+pub fn wrap<U>() -> closure<U>[TraitClause0]
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 {
-    let _0: closure<U>[@TraitClause0]; // return
+    let _0: closure<U>[TraitClause0]; // return
 
     _0 = closure {  }
     return
 }
 
-// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once
-fn {impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once<'_0, U>(_1: closure<U>[@TraitClause0], tupled_args_2: (&'_0 U,)) -> WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
+// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for closure<U>[TraitClause0]}::call_once
+fn {impl FnOnce<(&'_ U,)> for closure<U>[TraitClause0]}::call_once<'_0, U>(_1: closure<U>[TraitClause0], tupled_args_2: (&'_0 U,)) -> WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 {
     let _0: WrapClone<&'8 U>[{built_in impl Sized for &'8 U}, {impl Clone for &'_0 T}<'8, U>]; // return
-    let _1: closure<U>[@TraitClause0]; // arg #1
+    let _1: closure<U>[TraitClause0]; // arg #1
     let tupled_args_2: (&'_0 U,); // arg #2
     let x_3: &'13 U; // local
     let _4: &'14 U; // anonymous local
@@ -302,32 +302,32 @@ where
     return
 }
 
-// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}
-impl<'_0, U> FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]
+// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for closure<U>[TraitClause0]}
+impl<'_0, U> FnOnce<(&'_ U,)> for closure<U>[TraitClause0]
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<U>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for (&'_ U,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ U,)}
-    parent_clause3 = {built_in impl Sized for WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]}
+    proof ImpliedClause0: (closure<U>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<U>[TraitClause0]}
+    proof ImpliedClause1: ((&'_ U,): Sized) = {built_in impl Sized for (&'_ U,)}
+    proof ImpliedClause2: ((&'_ U,): Tuple) = {built_in impl Tuple for (&'_ U,)}
+    proof ImpliedClause3: (WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]: Sized) = {built_in impl Sized for WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]}
     type Output = WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]
-    fn call_once = {impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once<'_0, U>[@TraitClause0]
+    fn call_once = {impl FnOnce<(&'_ U,)> for closure<U>[TraitClause0]}::call_once<'_0, U>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::wrap::closure::{impl Destruct for closure<U>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for closure<U>[@TraitClause0]}::drop_in_place<U>(_1: *mut closure<U>[@TraitClause0])
+// Full name: test_crate::wrap::closure::{impl Destruct for closure<U>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for closure<U>[TraitClause0]}::drop_in_place<U>(_1: *mut closure<U>[TraitClause0])
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 = <missing>
 
-// Full name: test_crate::wrap::closure::{impl Destruct for closure<U>[@TraitClause0]}
-impl<U> Destruct for closure<U>[@TraitClause0]
+// Full name: test_crate::wrap::closure::{impl Destruct for closure<U>[TraitClause0]}
+impl<U> Destruct for closure<U>[TraitClause0]
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 {
-    fn drop_in_place = {impl Destruct for closure<U>[@TraitClause0]}::drop_in_place<U>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for closure<U>[TraitClause0]}::drop_in_place<U>[TraitClause0]
     non-dyn-compatible
 }
 
@@ -366,14 +366,14 @@ pub fn use_wrap()
     _6 = &(*_7)
     _5 = &(*_6)
     _4 = (move _5,)
-    _2 = {impl FnOnce<(&'_ U,)> for closure<U>[@TraitClause0]}::call_once<'23, u32>[{built_in impl Sized for u32}](move _3, move _4)
+    _2 = {impl FnOnce<(&'_ U,)> for closure<U>[TraitClause0]}::call_once<'23, u32>[{built_in impl Sized for u32}](move _3, move _4)
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
     storage_dead(_6)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{impl Destruct for closure<U>[@TraitClause0]}::drop_in_place<u32>[{built_in impl Sized for u32}]] f_1
+    conditional_drop[{impl Destruct for closure<U>[TraitClause0]}::drop_in_place<u32>[{built_in impl Sized for u32}]] f_1
     storage_dead(f_1)
     return
 }

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -34,12 +34,12 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <missing>
 
 // Full name: core::bool::{bool}::then_some
-pub fn then_some<T>(self_1: bool, t_2: T) -> Option<T>[@TraitClause0]
+pub fn then_some<T>(self_1: bool, t_2: T) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
-    let _0: Option<T>[@TraitClause0]; // return
+    let _0: Option<T>[TraitClause0]; // return
     let self_1: bool; // arg #1
     let t_2: T; // arg #2
     let _3: T; // anonymous local
@@ -47,7 +47,7 @@ where
     if copy self_1 {
     } else {
         _0 = Option::None {  }
-        drop[@TraitClause1::drop_in_place] t_2
+        drop[TraitClause1::drop_in_place] t_2
         return
     }
     storage_live(_3)
@@ -70,14 +70,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <method_without_default_body>
 
 // Full name: core::cmp::PartialEq::ne
 #[lang_item("cmp_partialeq_ne")]
 pub fn ne<'_0, '_1, Self, Rhs>(self_1: &'_0 Self, other_2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 {
     let _0: bool; // return
     let self_1: &'1 Self; // arg #1
@@ -85,7 +85,7 @@ where
     let _3: bool; // anonymous local
 
     storage_live(_3)
-    _3 = @TraitClause0::eq<'6, '7>(move self_1, move other_2)
+    _3 = TraitClause0::eq<'6, '7>(move self_1, move other_2)
     _0 = ~(move _3)
     storage_dead(_3)
     return
@@ -141,7 +141,7 @@ pub struct Global {}
 // Full name: alloc::raw_vec::RawVecInner
 struct RawVecInner<A>
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 {
   ptr: Unique<u8>,
   cap: UsizeNoHighBit,
@@ -151,10 +151,10 @@ where
 // Full name: alloc::raw_vec::RawVec
 struct RawVec<T, A>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 {
-  inner: RawVecInner<A>[@TraitClause1],
+  inner: RawVecInner<A>[TraitClause1],
   _marker: PhantomData<T>,
 }
 
@@ -162,18 +162,18 @@ where
 #[lang_item("Vec")]
 pub struct Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 {
-  buf: RawVec<T, type_error("removed allocator parameter")>[@TraitClause0, @TraitClause1],
+  buf: RawVec<T, type_error("removed allocator parameter")>[TraitClause0, TraitClause1],
   len: usize,
 }
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: issue_114_opaque_bodies_aux::inline_always
@@ -206,7 +206,7 @@ pub fn inline_never() -> u32
 // Full name: issue_114_opaque_bodies_aux::inline_generic
 pub fn inline_generic<T>() -> u32
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: u32; // return
 
@@ -296,7 +296,7 @@ fn vec(_x_1: Vec<u32>[{built_in impl Sized for u32}, {built_in impl Sized for Gl
 
     _0 = ()
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] _x_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] _x_1
     return
 }
 
@@ -312,8 +312,8 @@ fn max() -> usize
 // Full name: test_crate::partial_eq
 fn partial_eq<T>(_x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: PartialEq<T, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: PartialEq<T>),
 {
     let _0: (); // return
     let _x_1: T; // arg #1

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,15 +24,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::TrivialClone
 #[lang_item("trivial_clone")]
 pub trait TrivialClone<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -40,8 +40,8 @@ pub trait TrivialClone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -60,22 +60,22 @@ pub fn {impl Clone for Foo}::clone<'_0>(self_1: &'_0 Foo) -> Foo
 
 // Full name: test_crate::{impl Clone for Foo}
 impl Clone for Foo {
-    parent_clause0 = {built_in impl Sized for Foo}
+    proof ImpliedClause0: (Foo: Sized) = {built_in impl Sized for Foo}
     fn clone<'_0_1> = {impl Clone for Foo}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl TrivialClone for Foo}
 impl TrivialClone for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {impl Clone for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Foo: Clone) = {impl Clone for Foo}
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Copy for Foo}
 impl Copy for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {impl Clone for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Foo: Clone) = {impl Clone for Foo}
     non-dyn-compatible
 }
 
@@ -101,8 +101,8 @@ fn copy_foo(x_1: Foo)
 // Full name: test_crate::copy_generic
 fn copy_generic<T>(x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
     let x_1: T; // arg #1
@@ -123,23 +123,23 @@ where
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Ty>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Ty>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Ty: Sized)
+    proof ImpliedClause2: (Self::Ty: Copy)
     type Ty
     vtable: test_crate::Trait::{vtable}<Self::Ty>
 }
 
 // Full name: test_crate::copy_assoc_ty
-fn copy_assoc_ty<T>(x_1: @TraitClause1::Ty)
+fn copy_assoc_ty<T>(x_1: TraitClause1::Ty)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
 {
     let _0: (); // return
-    let x_1: @TraitClause1::Ty; // arg #1
-    let y_2: @TraitClause1::Ty; // local
-    let z_3: @TraitClause1::Ty; // local
+    let x_1: TraitClause1::Ty; // arg #1
+    let y_2: TraitClause1::Ty; // local
+    let z_3: TraitClause1::Ty; // local
 
     _0 = ()
     storage_live(y_2)

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,26 +16,26 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::Option::{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[@TraitClause0])
+// Full name: core::option::Option::{impl Destruct for Option<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
 // Full name: test_crate::discriminant_value
-fn discriminant_value<'_0, T>(opt_1: &'_0 Option<T>[@TraitClause0]) -> isize
+fn discriminant_value<'_0, T>(opt_1: &'_0 Option<T>[TraitClause0]) -> isize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: isize; // return
-    let opt_1: &'1 Option<T>[@TraitClause0]; // arg #1
-    let _2: &'2 Option<T>[@TraitClause0]; // anonymous local
+    let opt_1: &'1 Option<T>[TraitClause0]; // arg #1
+    let _2: &'2 Option<T>[TraitClause0]; // anonymous local
 
     storage_live(_2)
     _2 = &(*opt_1)
@@ -45,37 +45,37 @@ where
 }
 
 // Full name: test_crate::is_some
-fn is_some<T>(opt_1: Option<T>[@TraitClause0]) -> bool
+fn is_some<T>(opt_1: Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let opt_1: Option<T>[@TraitClause0]; // arg #1
+    let opt_1: Option<T>[TraitClause0]; // arg #1
     let _2: isize; // anonymous local
-    let _3: &'1 Option<T>[@TraitClause0]; // anonymous local
-    let _4: &'2 Option<T>[@TraitClause0]; // anonymous local
+    let _3: &'1 Option<T>[TraitClause0]; // anonymous local
+    let _4: &'2 Option<T>[TraitClause0]; // anonymous local
 
     storage_live(_2)
     storage_live(_3)
     storage_live(_4)
     _4 = &opt_1
     _3 = &(*_4)
-    _2 = discriminant_value<'4, T>[@TraitClause0](move _3)
+    _2 = discriminant_value<'4, T>[TraitClause0](move _3)
     storage_dead(_3)
     _0 = move _2 != const 0 : isize
     storage_dead(_2)
     storage_dead(_4)
-    drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] opt_1
+    drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] opt_1
     return
 }
 
 // Full name: test_crate::my_is_some
-fn my_is_some<T>(opt_1: Option<T>[@TraitClause0]) -> isize
+fn my_is_some<T>(opt_1: Option<T>[TraitClause0]) -> isize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: isize; // return
-    let opt_1: Option<T>[@TraitClause0]; // arg #1
+    let opt_1: Option<T>[TraitClause0]; // arg #1
 
     match opt_1 {
         Option::None => {
@@ -85,7 +85,7 @@ where
             _0 = const 1 : isize
         },
     }
-    drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] opt_1
+    drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] opt_1
     return
 }
 

--- a/charon/tests/ui/issue-159-heterogeneous-recursive-definitions.out
+++ b/charon/tests/ui/issue-159-heterogeneous-recursive-definitions.out
@@ -7,7 +7,7 @@ pub trait MetaSized<Self>
 // Full name: test_crate::Ops
 trait Ops<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn ZERO = test_crate::Ops::ZERO<Self>[Self]
     fn ntt_multiply = test_crate::Ops::ntt_multiply<Self>[Self]
     non-dyn-compatible
@@ -15,12 +15,12 @@ trait Ops<Self>
 
 fn test_crate::Ops::ZERO<Self>() -> Self
 where
-    [@TraitClause0]: Ops<Self>,
+    TraitClause0: (Self: Ops),
 = <method_without_default_body>
 
 fn test_crate::Ops::ntt_multiply<Self>() -> Self
 where
-    [@TraitClause0]: Ops<Self>,
+    TraitClause0: (Self: Ops),
 = <method_without_default_body>
 
 // Full name: test_crate::Portable
@@ -54,7 +54,7 @@ fn {impl Ops for Portable}::ntt_multiply() -> Portable
 
 // Full name: test_crate::{impl Ops for Portable}
 impl Ops for Portable {
-    parent_clause0 = {built_in impl MetaSized for Portable}
+    proof ImpliedClause0: (Portable: MetaSized) = {built_in impl MetaSized for Portable}
     fn ZERO = {impl Ops for Portable}::ZERO
     fn ntt_multiply = {impl Ops for Portable}::ntt_multiply
     non-dyn-compatible

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -46,29 +46,29 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: alloc::vec::from_elem
 #[lang_item("vec_from_elem")]
-pub fn from_elem<T>(_1: T, _2: usize) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn from_elem<T>(_1: T, _2: usize) -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <opaque>
 
 // Full name: test_crate::foo
@@ -101,9 +101,9 @@ fn foo()
     storage_live(_v2_2)
     _v2_2 = from_elem<i32>[{built_in impl Sized for i32}, {impl Clone for i32}](const 1 : i32, const 10 : usize)
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]] _v2_2
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]] _v2_2
     storage_dead(_v2_2)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]] _v_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]] _v_1
     storage_dead(_v_1)
     return
 }
@@ -141,7 +141,7 @@ pub fn bar()
     y_5 = unsize_cast<alloc::boxed::Box<[Foo; 1 : usize]>[{built_in impl MetaSized for [Foo; 1 : usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}], 1 : usize>(move x_4)
     ret_3 = into_vec<Foo, Global>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}](move y_5)
     _1 = move ret_3
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<Foo, Global>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}]] _1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<Foo, Global>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}]] _1
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,22 +48,22 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Rng
@@ -146,10 +146,10 @@ fn {impl FnOnce<()> for closure<'_0>}::call_once<'_0>(_1: closure<'_0>, _2: ())
 
 // Full name: test_crate::new::{impl FnOnce<()> for closure<'_0>}
 impl<'_0> FnOnce<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for closure<'_0>}::call_once<'_0>
     non-dyn-compatible
@@ -157,10 +157,10 @@ impl<'_0> FnOnce<()> for closure<'_0> {
 
 // Full name: test_crate::new::{impl FnMut<()> for closure<'_0>}
 impl<'_0> FnMut<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<()> for closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<()>) = {impl FnOnce<()> for closure<'_0>}<'_0>
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,41 +25,41 @@ where
 // Full name: test_crate::FromResidual
 pub trait FromResidual<Self, R>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<R>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (R: Sized)
     vtable: test_crate::FromResidual::{vtable}<R>
 }
 
 // Full name: test_crate::Try
 pub trait Try<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FromResidual<Self, ()>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Residual>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FromResidual<()>)
+    proof ImpliedClause2: (Self::Residual: Sized)
     type Residual
     vtable: test_crate::Try::{vtable}<Self::Residual>
 }
 
-// Full name: test_crate::{impl FromResidual<()> for Option<T>[@TraitClause0]}
-impl<T> FromResidual<()> for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl FromResidual<()> for Option<T>[TraitClause0]}
+impl<T> FromResidual<()> for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for ()}
-    vtable: {impl FromResidual<()> for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    vtable: {impl FromResidual<()> for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
-// Full name: test_crate::{impl Try for Option<T>[@TraitClause0]}
-impl<T> Try for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl Try for Option<T>[TraitClause0]}
+impl<T> Try for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    parent_clause1 = {impl FromResidual<()> for Option<T>[@TraitClause0]}<T>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: FromResidual<()>) = {impl FromResidual<()> for Option<T>[TraitClause0]}<T>[TraitClause0]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
     type Residual = ()
-    vtable: {impl Try for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    vtable: {impl Try for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,10 +24,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -37,41 +37,41 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
-pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
-pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::S
 pub struct S<'a, K>
 where
-    [@TraitClause0]: Sized<K>,
-    K : 'a,
+    TraitClause0: (K: Sized),
+    TypeOutlives0: K: 'a,
 {
   x: &'a K,
 }
 
-pub fn test_crate::{S<'a, K>[@TraitClause0]}::f<'a, K, F>()
+pub fn test_crate::{S<'a, K>[TraitClause0]}::f<'a, K, F>()
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: for<'_0_1> FnMut<F, (&'_0_1 u32,)>,
-    for<'_0_1> @TraitClause2::parent_clause1::Output = (),
+    TraitClause0: (K: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: for<'_0_1> (F: FnMut<(&'_0_1 u32,)>),
+    TypeConstraint0: for<'_0_1> TraitClause2::ImpliedClause1::Output = (),
 {
     let _0: (); // return
 
@@ -80,13 +80,13 @@ where
     return
 }
 
-// Full name: test_crate::{S<'a, K>[@TraitClause0]}::g
+// Full name: test_crate::{S<'a, K>[TraitClause0]}::g
 pub fn g<'a, K, F>()
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: for<'b> FnMut<F, (&'b u32,)>,
-    for<'b> @TraitClause2::parent_clause1::Output = (),
+    TraitClause0: (K: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: for<'b> (F: FnMut<(&'b u32,)>),
+    TypeConstraint0: for<'b> TraitClause2::ImpliedClause1::Output = (),
 {
     let _0: (); // return
 
@@ -100,9 +100,9 @@ pub struct T {}
 
 pub fn test_crate::{T}::f<F>()
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: for<'_0_1> FnMut<F, (&'_0_1 u32,)>,
-    for<'_0_1> @TraitClause1::parent_clause1::Output = (),
+    TraitClause0: (F: Sized),
+    TraitClause1: for<'_0_1> (F: FnMut<(&'_0_1 u32,)>),
+    TypeConstraint0: for<'_0_1> TraitClause1::ImpliedClause1::Output = (),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,16 +27,16 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
 // Full name: core::option::Option::Some
-fn Some<T>(_1: T) -> Option<T>[@TraitClause0]
+fn Some<T>(_1: T) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: alloc::string::String
@@ -104,19 +104,19 @@ fn Foo(_1: u32, _2: String) -> Foo
 // Full name: test_crate::Bar
 enum Bar<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
   Variant(&'a T),
 }
 
 // Full name: test_crate::Bar::Variant
-fn Variant<'a, T>(_1: &'a T) -> Bar<'a, T>[@TraitClause0]
+fn Variant<'a, T>(_1: &'a T) -> Bar<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
-    let _0: Bar<'a, T>[@TraitClause0]; // return
+    let _0: Bar<'a, T>[TraitClause0]; // return
     let _1: &'a T; // arg #1
 
     _0 = Bar::Variant { 0: move _1 }

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -26,7 +26,7 @@ where
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -34,10 +34,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -47,26 +47,26 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::iter::sources::from_fn::FromFn
 pub opaque type FromFn<F>
 where
-    [@TraitClause0]: Sized<F>,
+    TraitClause0: (F: Sized),
 
 // Full name: core::iter::sources::from_fn::from_fn
-pub fn from_fn<T, F>(_1: F) -> FromFn<F>[@TraitClause1]
+pub fn from_fn<T, F>(_1: F) -> FromFn<F>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: FnMut<F, ()>,
-    @TraitClause2::parent_clause1::Output = Option<T>[@TraitClause0],
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (F: FnMut<()>),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = Option<T>[TraitClause0],
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -80,14 +80,14 @@ pub trait Destruct<Self>
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::sparse_transitions::closure
@@ -125,10 +125,10 @@ fn {impl FnOnce<()> for closure<'a>}::call_once<'a>(_1: closure<'a>, _2: ()) -> 
 
 // Full name: test_crate::sparse_transitions::{impl FnOnce<()> for closure<'a>}
 impl<'a> FnOnce<()> for closure<'a> {
-    parent_clause0 = {built_in impl MetaSized for closure<'a>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for Option<u8>[{built_in impl Sized for u8}]}
+    proof ImpliedClause0: (closure<'a>: MetaSized) = {built_in impl MetaSized for closure<'a>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (Option<u8>[{built_in impl Sized for u8}]: Sized) = {built_in impl Sized for Option<u8>[{built_in impl Sized for u8}]}
     type Output = Option<u8>[{built_in impl Sized for u8}]
     fn call_once = {impl FnOnce<()> for closure<'a>}::call_once<'a>
     non-dyn-compatible
@@ -136,10 +136,10 @@ impl<'a> FnOnce<()> for closure<'a> {
 
 // Full name: test_crate::sparse_transitions::{impl FnMut<()> for closure<'a>}
 impl<'a> FnMut<()> for closure<'a> {
-    parent_clause0 = {built_in impl MetaSized for closure<'a>}
-    parent_clause1 = {impl FnOnce<()> for closure<'a>}<'a>
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure<'a>: MetaSized) = {built_in impl MetaSized for closure<'a>}
+    proof ImpliedClause1: (closure<'a>: FnOnce<()>) = {impl FnOnce<()> for closure<'a>}<'a>
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure<'a>}::call_mut<'a, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -26,8 +26,8 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
@@ -35,16 +35,16 @@ pub trait Iterator<Self>
 
 // Full name: core::iter::traits::iterator::Iterator::next
 #[lang_item("next")]
-pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::AssocType>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::AssocType: Sized)
     type AssocType
     vtable: test_crate::Trait::{vtable}<Self::AssocType>
 }
@@ -52,26 +52,26 @@ pub trait Trait<Self>
 // Full name: test_crate::Alias
 pub type Alias<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
-    [@TraitClause2]: Trait<T>,
-    [@TraitClause3]: Sized<@TraitClause2::AssocType>, = Option<@TraitClause1::AssocType>[@TraitClause3]
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
+    TraitClause2: (T: Trait),
+    TraitClause3: (TraitClause2::AssocType: Sized), = Option<TraitClause1::AssocType>[TraitClause3]
 
 // Full name: test_crate::C
 pub trait C<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::C::{vtable}<T>
 }
 
 // Full name: test_crate::S
 pub struct S<I, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Iterator<I>,
-    [@TraitClause3]: C<F, @TraitClause2::Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (I: Iterator),
+    TraitClause3: (F: C<TraitClause2::Item>),
 {
   I,
   F,
@@ -80,11 +80,11 @@ where
 // Full name: test_crate::S2
 pub type S2<I, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Iterator<I>,
-    [@TraitClause3]: Iterator<I>,
-    [@TraitClause4]: C<F, @TraitClause3::Item>, = S<I, F>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause4]
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (I: Iterator),
+    TraitClause3: (I: Iterator),
+    TraitClause4: (F: C<TraitClause3::Item>), = S<I, F>[TraitClause0, TraitClause1, TraitClause2, TraitClause4]
 
 
 

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,8 +16,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -51,7 +51,7 @@ impl Debug for TryFromSliceError {
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -60,8 +60,8 @@ pub trait Clone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -69,9 +69,9 @@ pub trait Copy<Self>
 #[lang_item("TryFrom")]
 pub trait TryFrom<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Error>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self::Error: Sized)
     type Error
     fn try_from = core::convert::TryFrom::try_from<Self, T>[Self]
     non-dyn-compatible
@@ -80,28 +80,28 @@ pub trait TryFrom<Self, T>
 // Full name: core::array::{impl TryFrom<&'_0 [T]> for [T; N]}::try_from
 pub fn {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, const N : usize>(_1: &'_0 [T]) -> Result<[T; N], TryFromSliceError>[{built_in impl Sized for [T; N]}, {built_in impl Sized for TryFromSliceError}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <opaque>
 
 // Full name: core::array::{impl TryFrom<&'_0 [T]> for [T; N]}
 impl<'_0, T, const N : usize> TryFrom<&'_0 [T]> for [T; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl Sized for [T; N]}
-    parent_clause1 = {built_in impl Sized for &'_ [T]}
-    parent_clause2 = {built_in impl Sized for TryFromSliceError}
+    proof ImpliedClause0: ([T; N]: Sized) = {built_in impl Sized for [T; N]}
+    proof ImpliedClause1: (&'_ [T]: Sized) = {built_in impl Sized for &'_ [T]}
+    proof ImpliedClause2: (TryFromSliceError: Sized) = {built_in impl Sized for TryFromSliceError}
     type Error = TryFromSliceError
-    fn try_from = {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
+    fn try_from = {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, N>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -110,43 +110,43 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
 
 #[lang_item("try_from_fn")]
-pub fn core::convert::TryFrom::try_from<Self, T>(_1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause0::parent_clause0, @TraitClause0::parent_clause2]
+pub fn core::convert::TryFrom::try_from<Self, T>(_1: T) -> Result<Self, TraitClause0::Error>[TraitClause0::ImpliedClause0, TraitClause0::ImpliedClause2]
 where
-    [@TraitClause0]: TryFrom<Self, T>,
+    TraitClause0: (Self: TryFrom<T>),
 = <opaque>
 
 // Full name: core::convert::{impl TryInto<U> for T}::try_into
-pub fn {impl TryInto<U> for T}::try_into<T, U>(_1: T) -> Result<U, @TraitClause2::Error>[@TraitClause1, @TraitClause2::parent_clause2]
+pub fn {impl TryInto<U> for T}::try_into<T, U>(_1: T) -> Result<U, TraitClause2::Error>[TraitClause1, TraitClause2::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: TryFrom<U, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: TryFrom<T>),
 = <opaque>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::marker::{impl Copy for u8}
 impl Copy for u8 {
-    parent_clause0 = {built_in impl MetaSized for u8}
-    parent_clause1 = {impl Clone for u8}
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
+    proof ImpliedClause1: (u8: Clone) = {impl Clone for u8}
     non-dyn-compatible
 }
 
-// Full name: core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap
-pub fn unwrap<T, E>(_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
+// Full name: core::result::{Result<T, E>[TraitClause0, TraitClause1]}::unwrap
+pub fn unwrap<T, E>(_1: Result<T, E>[TraitClause0, TraitClause1]) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Debug<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Debug),
 = <opaque>
 
 // Full name: test_crate::trait_error

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,8 +16,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -51,7 +51,7 @@ impl Debug for TryFromSliceError {
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -60,8 +60,8 @@ pub trait Clone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -69,9 +69,9 @@ pub trait Copy<Self>
 #[lang_item("TryFrom")]
 pub trait TryFrom<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Error>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self::Error: Sized)
     type Error
     fn try_from = core::convert::TryFrom::try_from<Self, T>[Self]
     non-dyn-compatible
@@ -80,28 +80,28 @@ pub trait TryFrom<Self, T>
 // Full name: core::array::{impl TryFrom<&'_0 [T]> for [T; N]}::try_from
 pub fn {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, const N : usize>(_1: &'_0 [T]) -> Result<[T; N], TryFromSliceError>[{built_in impl Sized for [T; N]}, {built_in impl Sized for TryFromSliceError}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <opaque>
 
 // Full name: core::array::{impl TryFrom<&'_0 [T]> for [T; N]}
 impl<'_0, T, const N : usize> TryFrom<&'_0 [T]> for [T; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl Sized for [T; N]}
-    parent_clause1 = {built_in impl Sized for &'_ [T]}
-    parent_clause2 = {built_in impl Sized for TryFromSliceError}
+    proof ImpliedClause0: ([T; N]: Sized) = {built_in impl Sized for [T; N]}
+    proof ImpliedClause1: (&'_ [T]: Sized) = {built_in impl Sized for &'_ [T]}
+    proof ImpliedClause2: (TryFromSliceError: Sized) = {built_in impl Sized for TryFromSliceError}
     type Error = TryFromSliceError
-    fn try_from = {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, N>[@TraitClause0, @TraitClause1]
+    fn try_from = {impl TryFrom<&'_0 [T]> for [T; N]}::try_from<'_0, T, N>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -110,43 +110,43 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
 
 #[lang_item("try_from_fn")]
-pub fn core::convert::TryFrom::try_from<Self, T>(_1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause0::parent_clause0, @TraitClause0::parent_clause2]
+pub fn core::convert::TryFrom::try_from<Self, T>(_1: T) -> Result<Self, TraitClause0::Error>[TraitClause0::ImpliedClause0, TraitClause0::ImpliedClause2]
 where
-    [@TraitClause0]: TryFrom<Self, T>,
+    TraitClause0: (Self: TryFrom<T>),
 = <opaque>
 
 // Full name: core::convert::{impl TryInto<U> for T}::try_into
-pub fn {impl TryInto<U> for T}::try_into<T, U>(_1: T) -> Result<U, @TraitClause2::Error>[@TraitClause1, @TraitClause2::parent_clause2]
+pub fn {impl TryInto<U> for T}::try_into<T, U>(_1: T) -> Result<U, TraitClause2::Error>[TraitClause1, TraitClause2::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: TryFrom<U, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: TryFrom<T>),
 = <opaque>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::marker::{impl Copy for u8}
 impl Copy for u8 {
-    parent_clause0 = {built_in impl MetaSized for u8}
-    parent_clause1 = {impl Clone for u8}
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
+    proof ImpliedClause1: (u8: Clone) = {impl Clone for u8}
     non-dyn-compatible
 }
 
-// Full name: core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap
-pub fn unwrap<T, E>(_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
+// Full name: core::result::{Result<T, E>[TraitClause0, TraitClause1]}::unwrap
+pub fn unwrap<T, E>(_1: Result<T, E>[TraitClause0, TraitClause1]) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Debug<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Debug),
 = <opaque>
 
 // Full name: test_crate::trait_error

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Tuple<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,10 +24,10 @@ pub trait Sized<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -37,12 +37,12 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::marker::Destruct
@@ -55,21 +55,21 @@ pub trait Destruct<Self>
 
 pub fn core::array::{[T; N]}::map<T, F, U, const N : usize>(_1: [T; N], _2: F) -> [U; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<U>,
-    [@TraitClause3]: FnMut<F, (T,)>,
-    [@TraitClause4]: Destruct<F>,
-    [@TraitClause5]: Destruct<U>,
-    [@TraitClause6]: Destruct<T>,
-    @TraitClause3::parent_clause1::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (U: Sized),
+    TraitClause3: (F: FnMut<(T,)>),
+    TraitClause4: (F: Destruct),
+    TraitClause5: (U: Destruct),
+    TraitClause6: (T: Destruct),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = U,
 = <opaque>
 
 // Full name: core::clone::Clone
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -77,7 +77,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -86,7 +86,7 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -102,7 +102,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Ordering
@@ -117,7 +117,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -127,7 +127,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -135,7 +135,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<u8> for u8}::eq
@@ -154,7 +154,7 @@ pub fn {impl PartialOrd<u8> for u8}::partial_cmp<'_0, '_1>(_1: &'_0 u8, _2: &'_1
 
 // Full name: core::cmp::impls::{impl PartialOrd<u8> for u8}
 impl PartialOrd<u8> for u8 {
-    parent_clause0 = {impl PartialEq<u8> for u8}
+    proof ImpliedClause0: (u8: PartialEq<u8>) = {impl PartialEq<u8> for u8}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<u8> for u8}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<u8> for u8}::{vtable}
 }
@@ -167,9 +167,9 @@ pub opaque type Arguments<'a>
 #[lang_item("range_step")]
 pub trait Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
-    parent_clause2 : [@TraitClause2]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Clone)
+    proof ImpliedClause2: (Self: PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -178,17 +178,17 @@ pub trait Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 // Full name: core::iter::range::{impl Step for u8}::backward_checked
@@ -205,9 +205,9 @@ pub fn {impl Step for u8}::steps_between<'_0, '_1>(_1: &'_0 u8, _2: &'_1 u8) -> 
 
 // Full name: core::iter::range::{impl Step for u8}
 impl Step for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
-    parent_clause1 = {impl Clone for u8}
-    parent_clause2 = {impl PartialOrd<u8> for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
+    proof ImpliedClause1: (u8: Clone) = {impl Clone for u8}
+    proof ImpliedClause2: (u8: PartialOrd<u8>) = {impl PartialOrd<u8> for u8}
     fn steps_between<'_0_1, '_1_1> = {impl Step for u8}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for u8}::forward_checked
     fn backward_checked = {impl Step for u8}::backward_checked
@@ -218,7 +218,7 @@ impl Step for u8 {
 #[lang_item("Range")]
 pub struct Range<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
@@ -228,57 +228,57 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}::next
-pub fn {impl Iterator for Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[@TraitClause0]) -> Option<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}::next
+pub fn {impl Iterator for Range<A>[TraitClause0]}::next<'_0, A>(_1: &'_0 mut Range<A>[TraitClause0]) -> Option<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 = <opaque>
 
-// Full name: core::iter::range::{impl Iterator for Range<A>[@TraitClause0]}
-impl<A> Iterator for Range<A>[@TraitClause0]
+// Full name: core::iter::range::{impl Iterator for Range<A>[TraitClause0]}
+impl<A> Iterator for Range<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Step<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Step),
 {
-    parent_clause0 = {built_in impl MetaSized for Range<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (Range<A>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Range<A>[TraitClause0]}
+    proof ImpliedClause1: (A: Sized) = TraitClause0
     type Item = A
-    fn next<'_0_1> = {impl Iterator for Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Iterator for Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = {impl Iterator for Range<A>[TraitClause0]}::next<'_0_1, A>[TraitClause0, TraitClause1]
+    vtable: {impl Iterator for Range<A>[TraitClause0]}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 // Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
 pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::panicking::AssertKind
@@ -291,7 +291,7 @@ pub enum AssertKind {
 #[lang_item("slice_len_fn")]
 pub fn core::slice::{[T]}::len<'_0, T>(_1: &'_0 [T]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::map::closure
@@ -338,10 +338,10 @@ fn {impl FnOnce<(i32,)> for closure}::call_once(_1: closure, _2: (i32,)) -> i32
 
 // Full name: test_crate::map::{impl FnOnce<(i32,)> for closure}
 impl FnOnce<(i32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (i32,)}
-    parent_clause2 = {built_in impl Tuple for (i32,)}
-    parent_clause3 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause2: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    proof ImpliedClause3: (i32: Sized) = {built_in impl Sized for i32}
     type Output = i32
     fn call_once = {impl FnOnce<(i32,)> for closure}::call_once
     non-dyn-compatible
@@ -349,10 +349,10 @@ impl FnOnce<(i32,)> for closure {
 
 // Full name: test_crate::map::{impl FnMut<(i32,)> for closure}
 impl FnMut<(i32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(i32,)> for closure}
-    parent_clause2 = {built_in impl Sized for (i32,)}
-    parent_clause3 = {built_in impl Tuple for (i32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(i32,)>) = {impl FnOnce<(i32,)> for closure}
+    proof ImpliedClause2: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause3: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
     fn call_mut<'_0_1> = {impl FnMut<(i32,)> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
@@ -404,7 +404,7 @@ fn cbd(prf_input_1: [u8; 33 : usize])
     storage_live(_2)
     storage_live(_3)
     _3 = Range { start: const 0 : u8, end: const 3 : u8 }
-    _2 = {impl IntoIterator for I}::into_iter<Range<u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Range<u8>[{built_in impl Sized for u8}]}, {impl Iterator for Range<A>[@TraitClause0]}<u8>[{built_in impl Sized for u8}, {impl Step for u8}]](move _3)
+    _2 = {impl IntoIterator for I}::into_iter<Range<u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Range<u8>[{built_in impl Sized for u8}]}, {impl Iterator for Range<A>[TraitClause0]}<u8>[{built_in impl Sized for u8}, {impl Step for u8}]](move _3)
     storage_dead(_3)
     storage_live(iter_4)
     iter_4 = move _2
@@ -414,7 +414,7 @@ fn cbd(prf_input_1: [u8; 33 : usize])
         storage_live(_7)
         _7 = &mut iter_4
         _6 = &two-phase-mut (*_7)
-        _5 = {impl Iterator for Range<A>[@TraitClause0]}::next<'4, u8>[{built_in impl Sized for u8}, {impl Step for u8}](move _6)
+        _5 = {impl Iterator for Range<A>[TraitClause0]}::next<'4, u8>[{built_in impl Sized for u8}, {impl Step for u8}](move _6)
         storage_dead(_6)
         match _5 {
             Option::None => {

--- a/charon/tests/ui/issue-70-override-provided-method.2.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2.out
@@ -7,7 +7,7 @@ pub trait MetaSized<Self>
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn required<'_0_1> = test_crate::Trait::required<'_0_1, Self>[Self]
     fn provided1<'_0_1> = test_crate::Trait::provided1<'_0_1, Self>[Self]
     fn provided2<'_0_1> = test_crate::Trait::provided2<'_0_1, Self>[Self]
@@ -16,12 +16,12 @@ trait Trait<Self>
 
 fn test_crate::Trait::required<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 = <method_without_default_body>
 
 fn test_crate::Trait::provided1<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -34,13 +34,13 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = &(*self_1) with_metadata(copy self_1.metadata)
-    _2 = @TraitClause0::required<'5>(move _3)
+    _2 = TraitClause0::required<'5>(move _3)
     storage_dead(_3)
     storage_dead(_2)
     storage_live(_4)
     storage_live(_5)
     _5 = &(*self_1) with_metadata(copy self_1.metadata)
-    _4 = @TraitClause0::provided2<'7>(move _5)
+    _4 = TraitClause0::provided2<'7>(move _5)
     storage_dead(_5)
     storage_dead(_4)
     _0 = ()
@@ -49,7 +49,7 @@ where
 
 fn test_crate::Trait::provided2<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -62,13 +62,13 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = &(*self_1) with_metadata(copy self_1.metadata)
-    _2 = @TraitClause0::required<'5>(move _3)
+    _2 = TraitClause0::required<'5>(move _3)
     storage_dead(_3)
     storage_dead(_2)
     storage_live(_4)
     storage_live(_5)
     _5 = &(*self_1) with_metadata(copy self_1.metadata)
-    _4 = @TraitClause0::provided1<'7>(move _5)
+    _4 = TraitClause0::provided1<'7>(move _5)
     storage_dead(_5)
     storage_dead(_4)
     _0 = ()
@@ -153,7 +153,7 @@ fn {impl Trait for Foo}::required<'_0>(self_1: &'_0 Foo)
 
 // Full name: test_crate::{impl Trait for Foo}
 impl Trait for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
     fn required<'_0_1> = {impl Trait for Foo}::required<'_0_1>
     fn provided1<'_0_1> = {impl Trait for Foo}::provided1<'_0_1>
     fn provided2<'_0_1> = {impl Trait for Foo}::provided2<'_0_1>
@@ -230,7 +230,7 @@ fn {impl Trait for Bar}::provided1<'_0>(self_1: &'_0 Bar)
 
 // Full name: test_crate::{impl Trait for Bar}
 impl Trait for Bar {
-    parent_clause0 = {built_in impl MetaSized for Bar}
+    proof ImpliedClause0: (Bar: MetaSized) = {built_in impl MetaSized for Bar}
     fn required<'_0_1> = {impl Trait for Bar}::required<'_0_1>
     fn provided1<'_0_1> = {impl Trait for Bar}::provided1<'_0_1>
     fn provided2<'_0_1> = {impl Trait for Bar}::provided2<'_0_1>

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -39,15 +39,15 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -67,53 +67,53 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::{impl Clone for Option<T>[@TraitClause0]}::clone
-pub fn {impl Clone for Option<T>[@TraitClause0]}::clone<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> Option<T>[@TraitClause0]
+// Full name: core::option::{impl Clone for Option<T>[TraitClause0]}::clone
+pub fn {impl Clone for Option<T>[TraitClause0]}::clone<'_0, T>(_1: &'_0 Option<T>[TraitClause0]) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 = <opaque>
 
-// Full name: core::option::{impl Clone for Option<T>[@TraitClause0]}
-impl<T> Clone for Option<T>[@TraitClause0]
+// Full name: core::option::{impl Clone for Option<T>[TraitClause0]}
+impl<T> Clone for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
-    parent_clause0 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    fn clone<'_0_1> = {impl Clone for Option<T>[@TraitClause0]}::clone<'_0_1, T>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    fn clone<'_0_1> = {impl Clone for Option<T>[TraitClause0]}::clone<'_0_1, T>[TraitClause0, TraitClause1, TraitClause2]
     non-dyn-compatible
 }
 
 // Full name: test_crate::GenericTrait
 trait GenericTrait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Clone<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: Clone)
     fn other_method = test_crate::GenericTrait::other_method<Self, T>[Self]
-    fn provided<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: PartialEq<U, T>> = test_crate::GenericTrait::provided<Self, T, U>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn provided<U, TraitClause0_1: (U: Sized), TraitClause1_1: (U: PartialEq<T>)> = test_crate::GenericTrait::provided<Self, T, U>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 fn test_crate::GenericTrait::other_method<Self, T>()
 where
-    [@TraitClause0]: GenericTrait<Self, T>,
+    TraitClause0: (Self: GenericTrait<T>),
 = <method_without_default_body>
 
 fn test_crate::GenericTrait::provided<Self, T, U>(x_1: T, y_2: U)
 where
-    [@TraitClause0]: GenericTrait<Self, T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: PartialEq<U, T>,
+    TraitClause0: (Self: GenericTrait<T>),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: PartialEq<T>),
 {
     let _0: (); // return
     let x_1: T; // arg #1
@@ -128,11 +128,11 @@ where
     _4 = &y_2
     storage_live(_5)
     _5 = &x_1
-    _3 = @TraitClause2::eq<'6, '7>(move _4, move _5)
+    _3 = TraitClause2::eq<'6, '7>(move _4, move _5)
     if move _3 {
         storage_dead(_5)
         storage_dead(_4)
-        _0 = @TraitClause0::other_method()
+        _0 = TraitClause0::other_method()
     } else {
         storage_dead(_5)
         storage_dead(_4)
@@ -147,16 +147,16 @@ where
 // Full name: test_crate::Override
 struct Override<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::other_method
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::other_method<T>()
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::other_method
+fn {impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::other_method<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
 
@@ -165,20 +165,20 @@ where
     return
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided<T, U>(x_1: Option<T>[@TraitClause0], y_2: U)
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::provided
+fn {impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::provided<T, U>(x_1: Option<T>[TraitClause0], y_2: U)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
-    [@TraitClause2]: Sized<U>,
-    [@TraitClause3]: PartialEq<U, Option<T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
+    TraitClause2: (U: Sized),
+    TraitClause3: (U: PartialEq<Option<T>[TraitClause0]>),
 {
     let _0: (); // return
-    let x_1: Option<T>[@TraitClause0]; // arg #1
+    let x_1: Option<T>[TraitClause0]; // arg #1
     let y_2: U; // arg #2
     let _3: bool; // anonymous local
     let _4: &'1 U; // anonymous local
-    let _5: &'3 Option<T>[@TraitClause0]; // anonymous local
+    let _5: &'3 Option<T>[TraitClause0]; // anonymous local
 
     _0 = ()
     storage_live(_3)
@@ -186,11 +186,11 @@ where
     _4 = &y_2
     storage_live(_5)
     _5 = &x_1
-    _3 = @TraitClause3::eq<'6, '7>(move _4, move _5)
+    _3 = TraitClause3::eq<'6, '7>(move _4, move _5)
     if move _3 {
         storage_dead(_5)
         storage_dead(_4)
-        _0 = {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::other_method<T>[@TraitClause0, @TraitClause1]()
+        _0 = {impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::other_method<T>[TraitClause0, TraitClause1]()
     } else {
         storage_dead(_5)
         storage_dead(_4)
@@ -201,33 +201,33 @@ where
     return
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}
-impl<T> GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}
+impl<T> GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for Override<T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    parent_clause2 = {impl Clone for Option<T>[@TraitClause0]}<T>[@TraitClause0, @TraitClause1::parent_clause1, {built_in impl Destruct for T}]
-    fn other_method = {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::other_method<T>[@TraitClause0, @TraitClause1]
-    fn provided<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: PartialEq<U, Option<T>[@TraitClause0]>> = {impl GenericTrait<Option<T>[@TraitClause0]> for Override<T>[@TraitClause0]}::provided<T, U>[@TraitClause0, @TraitClause1, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Override<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Override<T>[TraitClause0]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    proof ImpliedClause2: (Option<T>[TraitClause0]: Clone) = {impl Clone for Option<T>[TraitClause0]}<T>[TraitClause0, TraitClause1::ImpliedClause1, {built_in impl Destruct for T}]
+    fn other_method = {impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::other_method<T>[TraitClause0, TraitClause1]
+    fn provided<U, TraitClause0_1: (U: Sized), TraitClause1_1: (U: PartialEq<Option<T>[TraitClause0]>)> = {impl GenericTrait<Option<T>[TraitClause0]> for Override<T>[TraitClause0]}::provided<T, U>[TraitClause0, TraitClause1, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::NoOverride
 struct NoOverride<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::other_method
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::other_method<T>()
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::other_method
+fn {impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::other_method<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
 
@@ -236,20 +236,20 @@ where
     return
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided
-fn {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided<T, U>(x_1: Option<T>[@TraitClause0], y_2: U)
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::provided
+fn {impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::provided<T, U>(x_1: Option<T>[TraitClause0], y_2: U)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
-    [@TraitClause2]: Sized<U>,
-    [@TraitClause3]: PartialEq<U, Option<T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
+    TraitClause2: (U: Sized),
+    TraitClause3: (U: PartialEq<Option<T>[TraitClause0]>),
 {
     let _0: (); // return
-    let x_1: Option<T>[@TraitClause0]; // arg #1
+    let x_1: Option<T>[TraitClause0]; // arg #1
     let y_2: U; // arg #2
     let _3: bool; // anonymous local
     let _4: &'1 U; // anonymous local
-    let _5: &'3 Option<T>[@TraitClause0]; // anonymous local
+    let _5: &'3 Option<T>[TraitClause0]; // anonymous local
 
     _0 = ()
     storage_live(_3)
@@ -257,11 +257,11 @@ where
     _4 = &y_2
     storage_live(_5)
     _5 = &x_1
-    _3 = @TraitClause3::eq<'6, '7>(move _4, move _5)
+    _3 = TraitClause3::eq<'6, '7>(move _4, move _5)
     if move _3 {
         storage_dead(_5)
         storage_dead(_4)
-        _0 = {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::other_method<T>[@TraitClause0, @TraitClause1]()
+        _0 = {impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::other_method<T>[TraitClause0, TraitClause1]()
     } else {
         storage_dead(_5)
         storage_dead(_4)
@@ -269,21 +269,21 @@ where
     }
     storage_dead(_3)
     conditional_drop[{built_in impl Destruct for U}::drop_in_place] y_2
-    conditional_drop[{built_in impl Destruct for Option<T>[@TraitClause0]}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for Option<T>[TraitClause0]}::drop_in_place] x_1
     return
 }
 
-// Full name: test_crate::{impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}
-impl<T> GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]
+// Full name: test_crate::{impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}
+impl<T> GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for NoOverride<T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    parent_clause2 = {impl Clone for Option<T>[@TraitClause0]}<T>[@TraitClause0, @TraitClause1::parent_clause1, {built_in impl Destruct for T}]
-    fn other_method = {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::other_method<T>[@TraitClause0, @TraitClause1]
-    fn provided<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: PartialEq<U, Option<T>[@TraitClause0]>> = {impl GenericTrait<Option<T>[@TraitClause0]> for NoOverride<T>[@TraitClause0]}::provided<T, U>[@TraitClause0, @TraitClause1, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (NoOverride<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for NoOverride<T>[TraitClause0]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    proof ImpliedClause2: (Option<T>[TraitClause0]: Clone) = {impl Clone for Option<T>[TraitClause0]}<T>[TraitClause0, TraitClause1::ImpliedClause1, {built_in impl Destruct for T}]
+    fn other_method = {impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::other_method<T>[TraitClause0, TraitClause1]
+    fn provided<U, TraitClause0_1: (U: Sized), TraitClause1_1: (U: PartialEq<Option<T>[TraitClause0]>)> = {impl GenericTrait<Option<T>[TraitClause0]> for NoOverride<T>[TraitClause0]}::provided<T, U>[TraitClause0, TraitClause1, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -11,7 +11,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Ordering
@@ -30,7 +30,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -38,7 +38,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -48,7 +48,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -56,7 +56,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<i32> for i32}::eq
@@ -77,15 +77,15 @@ pub fn {impl PartialOrd<u32> for u32}::partial_cmp<'_0, '_1>(_1: &'_0 u32, _2: &
 #[lang_item("structural_peq")]
 pub trait StructuralPartialEq<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::marker::StructuralPartialEq::{vtable}
 }
 
-// Full name: core::option::{impl PartialEq<Option<T>[@TraitClause0]> for Option<T>[@TraitClause0]}::eq
-pub fn {impl PartialEq<Option<T>[@TraitClause0]> for Option<T>[@TraitClause0]}::eq<'_0, '_1, T>(_1: &'_0 Option<T>[@TraitClause0], _2: &'_1 Option<T>[@TraitClause0]) -> bool
+// Full name: core::option::{impl PartialEq<Option<T>[TraitClause0]> for Option<T>[TraitClause0]}::eq
+pub fn {impl PartialEq<Option<T>[TraitClause0]> for Option<T>[TraitClause0]}::eq<'_0, '_1, T>(_1: &'_0 Option<T>[TraitClause0], _2: &'_1 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: PartialEq<T, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: PartialEq<T>),
 = <opaque>
 
 // Full name: test_crate::main
@@ -126,7 +126,7 @@ fn main()
     storage_live(_3)
     _4 = move _7
     _3 = &(*_4)
-    _1 = {impl PartialEq<Option<T>[@TraitClause0]> for Option<T>[@TraitClause0]}::eq<'9, '10, i32>[{built_in impl Sized for i32}, {impl PartialEq<i32> for i32}](move _2, move _3)
+    _1 = {impl PartialEq<Option<T>[TraitClause0]> for Option<T>[TraitClause0]}::eq<'9, '10, i32>[{built_in impl Sized for i32}, {impl PartialEq<i32> for i32}](move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     storage_dead(_1)
@@ -141,7 +141,7 @@ struct Foo {
 
 // Full name: test_crate::{impl StructuralPartialEq for Foo}
 impl StructuralPartialEq for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
     vtable: {impl StructuralPartialEq for Foo}::{vtable}
 }
 
@@ -199,7 +199,7 @@ pub fn {impl PartialOrd<Foo> for Foo}::partial_cmp<'_0, '_1>(self_1: &'_0 Foo, o
 
 // Full name: test_crate::{impl PartialOrd<Foo> for Foo}
 impl PartialOrd<Foo> for Foo {
-    parent_clause0 = {impl PartialEq<Foo> for Foo}
+    proof ImpliedClause0: (Foo: PartialEq<Foo>) = {impl PartialEq<Foo> for Foo}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<Foo> for Foo}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<Foo> for Foo}::{vtable}
 }

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Hasher::{vtable}
 }
 
@@ -24,30 +24,30 @@ pub struct DefaultHasher {}
 
 // Full name: test_crate::{impl Hasher for DefaultHasher}
 impl Hasher for DefaultHasher {
-    parent_clause0 = {built_in impl MetaSized for DefaultHasher}
+    proof ImpliedClause0: (DefaultHasher: MetaSized) = {built_in impl MetaSized for DefaultHasher}
     vtable: {impl Hasher for DefaultHasher}::{vtable}
 }
 
 // Full name: test_crate::Hash
 pub trait Hash<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = test_crate::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = test_crate::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn test_crate::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Hash for u32}::hash
 pub fn {impl Hash for u32}::hash<'_0, '_1, H>(self_1: &'_0 u32, _state_2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 {
     let _0: (); // return
     let self_1: &'1 u32; // arg #1
@@ -60,8 +60,8 @@ where
 
 // Full name: test_crate::{impl Hash for u32}
 impl Hash for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for u32}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for u32}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,15 +24,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::TrivialClone
 #[lang_item("trivial_clone")]
 pub trait TrivialClone<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -40,8 +40,8 @@ pub trait TrivialClone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -63,22 +63,22 @@ pub fn {impl Clone for Foo}::clone<'_0>(self_1: &'_0 Foo) -> Foo
 
 // Full name: test_crate::{impl Clone for Foo}
 impl Clone for Foo {
-    parent_clause0 = {built_in impl Sized for Foo}
+    proof ImpliedClause0: (Foo: Sized) = {built_in impl Sized for Foo}
     fn clone<'_0_1> = {impl Clone for Foo}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Copy for Foo}
 impl Copy for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {impl Clone for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Foo: Clone) = {impl Clone for Foo}
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl TrivialClone for Foo}
 impl TrivialClone for Foo {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {impl Clone for Foo}
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Foo: Clone) = {impl Clone for Foo}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
+++ b/charon/tests/ui/issue-93-recursive-traits-with-assoc-types.out
@@ -8,16 +8,16 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait1
 pub trait Trait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::T>
-    parent_clause2 : [@TraitClause2]: Trait2<Self::T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::T: Sized)
+    proof ImpliedClause2: (Self::T: Trait2)
     type T
     vtable: test_crate::Trait1::{vtable}<Self::T>
 }
@@ -25,11 +25,11 @@ pub trait Trait1<Self>
 // Full name: test_crate::Trait2
 pub trait Trait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Trait1<Self>
-    parent_clause2 : [@TraitClause2]: Sized<Self::U>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Trait1)
+    proof ImpliedClause2: (Self::U: Sized)
     type U
-    vtable: test_crate::Trait2::{vtable}<Self::U, Self::parent_clause1::T>
+    vtable: test_crate::Trait2::{vtable}<Self::U, Self::ImpliedClause1::T>
 }
 
 

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -8,16 +8,16 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait1
 pub trait Trait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::T>
-    parent_clause2 : [@TraitClause2]: Trait2<Self::T>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self::T: Sized)
+    proof ImpliedClause2: (Self::T: Trait2)
     type T
     non-dyn-compatible
 }
@@ -25,35 +25,35 @@ pub trait Trait1<Self>
 // Full name: test_crate::Trait2
 pub trait Trait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Trait1<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Trait1)
     non-dyn-compatible
 }
 
 // Full name: test_crate::T1
 pub trait T1<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: T2<T, Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: T2<Self>)
     non-dyn-compatible
 }
 
 // Full name: test_crate::T2
 pub trait T2<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: T1<T, Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: T1<Self>)
     non-dyn-compatible
 }
 
 // Full name: test_crate::T3
 pub trait T3<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::T>
-    parent_clause2 : [@TraitClause2]: T5<Self::T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::T: Sized)
+    proof ImpliedClause2: (Self::T: T5)
     type T
     vtable: test_crate::T3::{vtable}<Self::T>
 }
@@ -61,17 +61,17 @@ pub trait T3<Self>
 // Full name: test_crate::T4
 pub trait T4<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: T3<Self>
-    vtable: test_crate::T4::{vtable}<Self::parent_clause1::T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: T3)
+    vtable: test_crate::T4::{vtable}<Self::ImpliedClause1::T>
 }
 
 // Full name: test_crate::T5
 pub trait T5<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::T>
-    parent_clause2 : [@TraitClause2]: T4<Self::T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::T: Sized)
+    proof ImpliedClause2: (Self::T: T4)
     type T
     vtable: test_crate::T5::{vtable}<Self::T>
 }
@@ -79,9 +79,9 @@ pub trait T5<Self>
 // Full name: test_crate::T6
 pub trait T6<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: T7<T>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: T7)
     fn f = f<Self, T>[Self]
     non-dyn-compatible
 }
@@ -89,8 +89,8 @@ pub trait T6<Self, T>
 // Full name: test_crate::T7
 pub trait T7<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: T6<Self, Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: T6<Self>)
     fn g = g<Self>[Self]
     non-dyn-compatible
 }
@@ -98,13 +98,13 @@ pub trait T7<Self>
 // Full name: test_crate::T7::g
 pub fn g<Self>(_1: u64)
 where
-    [@TraitClause0]: T7<Self>,
+    TraitClause0: (Self: T7),
 = <method_without_default_body>
 
 // Full name: test_crate::T6::f
 pub fn f<Self, T>(x_1: u64)
 where
-    [@TraitClause0]: T6<Self, T>,
+    TraitClause0: (Self: T6<T>),
 {
     let _0: (); // return
     let x_1: u64; // arg #1
@@ -113,7 +113,7 @@ where
     _0 = ()
     storage_live(_2)
     _2 = copy x_1
-    _0 = @TraitClause0::parent_clause2::g(move _2)
+    _0 = TraitClause0::ImpliedClause2::g(move _2)
     storage_dead(_2)
     return
 }

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -8,33 +8,33 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Ord
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Ord::{vtable}
 }
 
 // Full name: test_crate::AVLTree
 pub struct AVLTree<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   x: T,
 }
 
-// Full name: test_crate::{AVLTree<T>[@TraitClause0]}::insert
-pub fn insert<'_0, T>(self_1: &'_0 mut AVLTree<T>[@TraitClause0])
+// Full name: test_crate::{AVLTree<T>[TraitClause0]}::insert
+pub fn insert<'_0, T>(self_1: &'_0 mut AVLTree<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ord<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ord),
 {
     let _0: (); // return
-    let self_1: &'1 mut AVLTree<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 mut AVLTree<T>[TraitClause0]; // arg #1
 
     _0 = ()
     panic(core::panicking::panic)
@@ -42,7 +42,7 @@ where
 
 // Full name: test_crate::{impl Ord for u32}
 impl Ord for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
     vtable: {impl Ord for u32}::{vtable}
 }
 

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,25 +16,25 @@ pub trait Sized<Self>
 #[lang_item("ArrayIntoIter")]
 pub opaque type IntoIter<T, const N : usize>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 
-// Full name: core::array::iter::IntoIter::{impl Destruct for IntoIter<T, N>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for IntoIter<T, N>[@TraitClause0]}::drop_in_place<T, const N : usize>(_1: *mut IntoIter<T, N>[@TraitClause0])
+// Full name: core::array::iter::IntoIter::{impl Destruct for IntoIter<T, N>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for IntoIter<T, N>[TraitClause0]}::drop_in_place<T, const N : usize>(_1: *mut IntoIter<T, N>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::array::iter::{impl IntoIterator for [T; N]}::into_iter
-pub fn {impl IntoIterator for [T; N]}::into_iter<T, const N : usize>(_1: [T; N]) -> IntoIter<T, N>[@TraitClause0]
+pub fn {impl IntoIterator for [T; N]}::into_iter<T, const N : usize>(_1: [T; N]) -> IntoIter<T, N>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -44,8 +44,8 @@ where
 #[lang_item("FromResidual")]
 pub trait FromResidual<Self, R>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<R>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (R: Sized)
     fn from_residual = from_residual<Self, R>[Self]
     non-dyn-compatible
 }
@@ -54,8 +54,8 @@ pub trait FromResidual<Self, R>
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
 where
-    [@TraitClause0]: Sized<B>,
-    [@TraitClause1]: Sized<C>,
+    TraitClause0: (B: Sized),
+    TraitClause1: (C: Sized),
 {
   Continue(C),
   Break(B),
@@ -65,10 +65,10 @@ where
 #[lang_item("Try")]
 pub trait Try<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FromResidual<Self, Self::Residual>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Output>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Residual>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FromResidual<Self::Residual>)
+    proof ImpliedClause2: (Self::Output: Sized)
+    proof ImpliedClause3: (Self::Residual: Sized)
     type Output
     type Residual
     fn from_output = from_output<Self>[Self]
@@ -79,13 +79,13 @@ pub trait Try<Self>
 // Full name: core::ops::try_trait::Residual
 pub trait Residual<Self, O>
 where
-    Self::parent_clause3::Output = O,
-    Self::parent_clause3::Residual = Self,
+    TypeConstraint0: Self::ImpliedClause3::Output = O,
+    TypeConstraint1: Self::ImpliedClause3::Residual = Self,
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<O>
-    parent_clause2 : [@TraitClause2]: Sized<Self::TryType>
-    parent_clause3 : [@TraitClause3]: Try<Self::TryType>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (O: Sized)
+    proof ImpliedClause2: (Self::TryType: Sized)
+    proof ImpliedClause3: (Self::TryType: Try)
     type TryType
     non-dyn-compatible
 }
@@ -94,7 +94,7 @@ where
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -102,10 +102,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -115,12 +115,12 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::marker::Destruct
@@ -135,9 +135,9 @@ pub trait Destruct<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<Self>> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, @TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (Self: Destruct)> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -145,8 +145,8 @@ pub trait Clone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -154,8 +154,8 @@ pub trait Copy<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -164,18 +164,18 @@ where
 // Full name: core::num::nonzero::private::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::num::nonzero::private::Sealed::{vtable}
 }
 
 // Full name: core::num::nonzero::ZeroablePrimitive
 pub trait ZeroablePrimitive<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Copy<Self>
-    parent_clause2 : [@TraitClause2]: Sealed<Self>
-    parent_clause3 : [@TraitClause3]: Sized<Self::NonZeroInner>
-    parent_clause4 : [@TraitClause4]: Copy<Self::NonZeroInner>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Copy)
+    proof ImpliedClause2: (Self: Sealed)
+    proof ImpliedClause3: (Self::NonZeroInner: Sized)
+    proof ImpliedClause4: (Self::NonZeroInner: Copy)
     type NonZeroInner
     non-dyn-compatible
 }
@@ -184,12 +184,12 @@ pub trait ZeroablePrimitive<Self>
 #[lang_item("NonZero")]
 pub opaque type NonZero<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ZeroablePrimitive<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ZeroablePrimitive),
 
 // Full name: core::num::nonzero::{impl Sealed for usize}
 impl Sealed for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     vtable: {impl Sealed for usize}::{vtable}
 }
 
@@ -199,7 +199,7 @@ pub opaque type NonZeroUsizeInner
 // Full name: core::num::niche_types::{impl Clone for NonZeroUsizeInner}::clone_from
 pub fn {impl Clone for NonZeroUsizeInner}::clone_from<'_0, '_1>(_1: &'_0 mut NonZeroUsizeInner, _2: &'_1 NonZeroUsizeInner)
 where
-    [@TraitClause0]: Destruct<NonZeroUsizeInner>,
+    TraitClause0: (NonZeroUsizeInner: Destruct),
 = <opaque>
 
 // Full name: core::num::niche_types::{impl Clone for NonZeroUsizeInner}::clone
@@ -208,16 +208,16 @@ pub fn {impl Clone for NonZeroUsizeInner}::clone<'_0>(_1: &'_0 NonZeroUsizeInner
 
 // Full name: core::num::niche_types::{impl Clone for NonZeroUsizeInner}
 impl Clone for NonZeroUsizeInner {
-    parent_clause0 = {built_in impl Sized for NonZeroUsizeInner}
+    proof ImpliedClause0: (NonZeroUsizeInner: Sized) = {built_in impl Sized for NonZeroUsizeInner}
     fn clone<'_0_1> = {impl Clone for NonZeroUsizeInner}::clone<'_0_1>
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<NonZeroUsizeInner>> = {impl Clone for NonZeroUsizeInner}::clone_from<'_0_1, '_1_1>[@TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (NonZeroUsizeInner: Destruct)> = {impl Clone for NonZeroUsizeInner}::clone_from<'_0_1, '_1_1>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: core::num::niche_types::{impl Copy for NonZeroUsizeInner}
 impl Copy for NonZeroUsizeInner {
-    parent_clause0 = {built_in impl MetaSized for NonZeroUsizeInner}
-    parent_clause1 = {impl Clone for NonZeroUsizeInner}
+    proof ImpliedClause0: (NonZeroUsizeInner: MetaSized) = {built_in impl MetaSized for NonZeroUsizeInner}
+    proof ImpliedClause1: (NonZeroUsizeInner: Clone) = {impl Clone for NonZeroUsizeInner}
     non-dyn-compatible
 }
 
@@ -228,31 +228,31 @@ pub fn {impl Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
 // Full name: core::clone::impls::{impl Clone for usize}::clone_from
 pub fn {impl Clone for usize}::clone_from<'_0, '_1>(_1: &'_0 mut usize, _2: &'_1 usize)
 where
-    [@TraitClause0]: Destruct<usize>,
+    TraitClause0: (usize: Destruct),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for usize}
 impl Clone for usize {
-    parent_clause0 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
     fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<usize>> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[@TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (usize: Destruct)> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: core::marker::{impl Copy for usize}
 impl Copy for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl Clone for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause1: (usize: Clone) = {impl Clone for usize}
     non-dyn-compatible
 }
 
 // Full name: core::num::nonzero::{impl ZeroablePrimitive for usize}
 impl ZeroablePrimitive for usize {
-    parent_clause0 = {built_in impl Sized for usize}
-    parent_clause1 = {impl Copy for usize}
-    parent_clause2 = {impl Sealed for usize}
-    parent_clause3 = {built_in impl Sized for NonZeroUsizeInner}
-    parent_clause4 = {impl Copy for NonZeroUsizeInner}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
+    proof ImpliedClause1: (usize: Copy) = {impl Copy for usize}
+    proof ImpliedClause2: (usize: Sealed) = {impl Sealed for usize}
+    proof ImpliedClause3: (NonZeroUsizeInner: Sized) = {built_in impl Sized for NonZeroUsizeInner}
+    proof ImpliedClause4: (NonZeroUsizeInner: Copy) = {impl Copy for NonZeroUsizeInner}
     type NonZeroInner = NonZeroUsizeInner
     non-dyn-compatible
 }
@@ -260,115 +260,115 @@ impl ZeroablePrimitive for usize {
 // Full name: core::iter::adapters::zip::Zip
 pub opaque type Zip<A, B>
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
 
 // Full name: core::iter::adapters::take_while::TakeWhile
 pub opaque type TakeWhile<I, P>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<P>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (P: Sized),
 
 // Full name: core::iter::adapters::take::Take
 pub opaque type Take<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::step_by::StepBy
 pub opaque type StepBy<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::skip_while::SkipWhile
 pub opaque type SkipWhile<I, P>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<P>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (P: Sized),
 
 // Full name: core::iter::adapters::skip::Skip
 pub opaque type Skip<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::scan::Scan
 pub opaque type Scan<I, St, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<F>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (St: Sized),
+    TraitClause2: (F: Sized),
 
 // Full name: core::iter::adapters::rev::Rev
 pub opaque type Rev<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 
 // Full name: core::iter::adapters::map_while::MapWhile
 pub opaque type MapWhile<I, P>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<P>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (P: Sized),
 
 // Full name: core::iter::adapters::map::Map
 pub opaque type Map<I, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
 
 // Full name: core::iter::adapters::inspect::Inspect
 pub opaque type Inspect<I, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
 
 // Full name: core::iter::adapters::fuse::Fuse
 pub opaque type Fuse<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::filter_map::FilterMap
 pub opaque type FilterMap<I, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
 
 // Full name: core::iter::adapters::filter::Filter
 pub opaque type Filter<I, P>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<P>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (P: Sized),
 
 // Full name: core::iter::adapters::enumerate::Enumerate
 #[lang_item("Enumerate")]
 pub opaque type Enumerate<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::cycle::Cycle
 pub opaque type Cycle<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::copied::Copied
 pub opaque type Copied<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::cloned::Cloned
 pub opaque type Cloned<I>
 where
-    [@TraitClause0]: Sized<I>,
+    TraitClause0: (I: Sized),
 
 // Full name: core::iter::adapters::chain::Chain
 pub opaque type Chain<A, B>
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
 
 // Full name: core::default::Default
 #[lang_item("Default")]
 pub trait Default<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn default = default<Self>[Self]
     non-dyn-compatible
 }
@@ -394,7 +394,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     fn lt<'_0_1, '_1_1> = core::cmp::PartialOrd::lt<'_0_1, '_1_1, Self, Rhs>[Self]
     fn le<'_0_1, '_1_1> = core::cmp::PartialOrd::le<'_0_1, '_1_1, Self, Rhs>[Self]
@@ -411,7 +411,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     fn assert_receiver_is_total_eq<'_0_1> = assert_receiver_is_total_eq<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -420,88 +420,88 @@ pub trait Eq<Self>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = core::cmp::Ord::cmp<'_0_1, '_1_1, Self>[Self]
-    fn max<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Destruct<Self>> = core::cmp::Ord::max<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Destruct<Self>> = core::cmp::Ord::min<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn clamp<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Destruct<Self>> = clamp<Self>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn max<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self: Destruct)> = core::cmp::Ord::max<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self: Destruct)> = core::cmp::Ord::min<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn clamp<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self: Destruct)> = clamp<Self>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: core::iter::adapters::array_chunks::ArrayChunks
 pub opaque type ArrayChunks<I, const N : usize>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 
 // Full name: core::iter::adapters::flatten::FlatMap
 pub opaque type FlatMap<I, U, F>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (U: IntoIterator),
 
 // Full name: core::iter::adapters::flatten::Flatten
 pub opaque type Flatten<I>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
-    [@TraitClause2]: IntoIterator<@TraitClause1::Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
+    TraitClause2: (TraitClause1::Item: IntoIterator),
 
 // Full name: core::iter::adapters::intersperse::Intersperse
 pub opaque type Intersperse<I>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
-    [@TraitClause2]: Clone<@TraitClause1::Item>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
+    TraitClause2: (TraitClause1::Item: Clone),
 
 // Full name: core::iter::adapters::intersperse::IntersperseWith
 pub opaque type IntersperseWith<I, G>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (G: Sized),
+    TraitClause2: (I: Iterator),
 
 // Full name: core::iter::adapters::map_windows::MapWindows
 pub opaque type MapWindows<I, F, const N : usize>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (I: Iterator),
 
 // Full name: core::iter::adapters::peekable::Peekable
 #[lang_item("IterPeekable")]
 pub opaque type Peekable<I>
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 
 // Full name: core::iter::adapters::zip::TrustedRandomAccessNoCoerce
 pub trait TrustedRandomAccessNoCoerce<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const MAY_HAVE_SIDE_EFFECT : bool
-    fn size<'_0_1, [@TraitClause0_1]: Iterator<Self>> = size<'_0_1, Self>[Self, @TraitClause0_1]
+    fn size<'_0_1, TraitClause0_1: (Self: Iterator)> = size<'_0_1, Self>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: core::iter::traits::accum::Sum
 pub trait Sum<Self, A>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<A>
-    fn sum<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (A: Sized)
+    fn sum<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: Iterator), TypeConstraint0: TraitClause1_1::Item = A> = core::iter::traits::accum::Sum::sum<Self, A, I>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: core::iter::traits::accum::Product
 pub trait Product<Self, A>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<A>
-    fn product<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Iterator<I>, @TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (A: Sized)
+    fn product<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: Iterator), TypeConstraint0: TraitClause1_1::Item = A> = core::iter::traits::accum::Product::product<Self, A, I>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -509,9 +509,9 @@ pub trait Product<Self, A>
 #[lang_item("FromIterator")]
 pub trait FromIterator<Self, A>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<A>
-    fn from_iter<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: IntoIterator<T>, @TraitClause1_1::Item = A> = from_iter<Self, A, T>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (A: Sized)
+    fn from_iter<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: IntoIterator), TypeConstraint0: TraitClause1_1::Item = A> = from_iter<Self, A, T>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -519,12 +519,12 @@ pub trait FromIterator<Self, A>
 #[lang_item("IntoIterator")]
 pub trait IntoIterator<Self>
 where
-    Self::parent_clause3::Item = Self::Item,
+    TypeConstraint0: Self::ImpliedClause3::Item = Self::Item,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: Sized<Self::IntoIter>
-    parent_clause3 : [@TraitClause3]: Iterator<Self::IntoIter>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    proof ImpliedClause2: (Self::IntoIter: Sized)
+    proof ImpliedClause3: (Self::IntoIter: Iterator)
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
@@ -534,12 +534,12 @@ where
 // Full name: core::iter::traits::collect::Extend
 pub trait Extend<Self, A>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<A>
-    fn extend<'_0_1, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: IntoIterator<T>, @TraitClause1_1::Item = A> = extend<'_0_1, Self, A, T>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (A: Sized)
+    fn extend<'_0_1, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: IntoIterator), TypeConstraint0: TraitClause1_1::Item = A> = extend<'_0_1, Self, A, T>[Self, TraitClause0_1, TraitClause1_1]
     fn extend_one<'_0_1> = extend_one<'_0_1, Self, A>[Self]
     fn extend_reserve<'_0_1> = extend_reserve<'_0_1, Self, A>[Self]
-    fn extend_one_unchecked<'_0_1, [@TraitClause0_1]: Sized<Self>> = extend_one_unchecked<'_0_1, Self, A>[Self, @TraitClause0_1]
+    fn extend_one_unchecked<'_0_1, TraitClause0_1: (Self: Sized)> = extend_one_unchecked<'_0_1, Self, A>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -547,1081 +547,1081 @@ pub trait Extend<Self, A>
 #[lang_item("DoubleEndedIterator")]
 pub trait DoubleEndedIterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Iterator<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Iterator)
     fn next_back<'_0_1> = next_back<'_0_1, Self>[Self]
     fn advance_back_by<'_0_1> = advance_back_by<'_0_1, Self>[Self]
     fn nth_back<'_0_1> = nth_back<'_0_1, Self>[Self]
-    fn try_rfold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: FnMut<F, (B, Self::parent_clause1::Item)>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = try_rfold<'_0_1, Self, B, F, R>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn rfold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (B, Self::parent_clause1::Item)>, @TraitClause3_1::parent_clause1::Output = B> = rfold<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn rfind<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 Self::parent_clause1::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = rfind<'_0_1, Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::parent_clause1::Item>
+    fn try_rfold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (Self: Sized), TraitClause4_1: (F: FnMut<(B, Self::ImpliedClause1::Item)>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = try_rfold<'_0_1, Self, B, F, R>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn rfold<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(B, Self::ImpliedClause1::Item)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = rfold<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn rfind<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 Self::ImpliedClause1::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = rfind<'_0_1, Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    vtable: core::iter::traits::double_ended::DoubleEndedIterator::{vtable}<Self::ImpliedClause1::Item>
 }
 
 // Full name: core::iter::traits::exact_size::ExactSizeIterator
 pub trait ExactSizeIterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Iterator<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Iterator)
     fn len<'_0_1> = len<'_0_1, Self>[Self]
     fn is_empty<'_0_1> = is_empty<'_0_1, Self>[Self]
-    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::parent_clause1::Item>
+    vtable: core::iter::traits::exact_size::ExactSizeIterator::{vtable}<Self::ImpliedClause1::Item>
 }
 
 // Full name: core::iter::traits::iterator::Iterator
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
-    fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::next_chunk<'_0_1, Self, N>[Self, @TraitClause0_1]
+    fn next_chunk<'_0_1, const N : usize, TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::next_chunk<'_0_1, Self, N>[Self, TraitClause0_1]
     fn size_hint<'_0_1> = core::iter::traits::iterator::Iterator::size_hint<'_0_1, Self>[Self]
-    fn count<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::count<Self>[Self, @TraitClause0_1]
-    fn last<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::last<Self>[Self, @TraitClause0_1]
+    fn count<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::count<Self>[Self, TraitClause0_1]
+    fn last<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::last<Self>[Self, TraitClause0_1]
     fn advance_by<'_0_1> = core::iter::traits::iterator::Iterator::advance_by<'_0_1, Self>[Self]
     fn nth<'_0_1> = core::iter::traits::iterator::Iterator::nth<'_0_1, Self>[Self]
-    fn step_by<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::step_by<Self>[Self, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Clone<Self::Item>> = core::iter::traits::iterator::Iterator::intersperse<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (Self::Item,)>, @TraitClause3_1::parent_clause1::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<F, (Self::Item,)>, @TraitClause2_1::parent_clause1::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (Self::Item,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn enumerate<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::enumerate<Self>[Self, @TraitClause0_1]
-    fn peekable<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::peekable<Self>[Self, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<P, (Self::Item,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn skip<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::skip<Self>[Self, @TraitClause0_1]
-    fn take<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::take<Self>[Self, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut St, Self::Item)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (Self::Item,)>, @TraitClause4_1::parent_clause1::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: IntoIterator<Self::Item>> = core::iter::traits::iterator::Iterator::flatten<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 [Self::Item; N],)>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, N>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn fuse<[@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::fuse<Self>[Self, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::by_ref<'_0_1, Self>[Self, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, Self::Item>, [@TraitClause2_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::collect<Self, B>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: Try<Self::Item>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = core::iter::traits::iterator::Iterator::try_collect<'_0_1, Self, B>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, Self::Item>, [@TraitClause2_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::collect_into<'_0_1, Self, E>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, Self::Item>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: DoubleEndedIterator<Self>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, T : 'a, Self::Item = &'a mut T, for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<P, (Self::Item,)>, @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: FnMut<F, (B, Self::Item)>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_1, Self, B, F, R>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (Self::Item,)>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_1, Self, F, R>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (B, Self::Item)>, @TraitClause3_1::parent_clause1::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<F, (Self::Item, Self::Item)>, @TraitClause2_1::parent_clause1::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<Self::Item>[Self::parent_clause1]>, [@TraitClause5_1]: FnMut<T2, (Self::Item, Self::Item)>, @TraitClause3_1::Output = Self::Item, @TraitClause5_1::parent_clause1::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_1, Self, R, T2>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<F, (Self::Item,)>, @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_1, Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<F, (Self::Item,)>, @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_1, Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_1, Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (Self::Item,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = core::iter::traits::iterator::Iterator::find_map<'_0_1, Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<Self::Item>[Self::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<T2, (&'_0_2 Self::Item,)>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_1, Self, R, T2>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: FnMut<P, (Self::Item,)>, @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_1, Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (Self::Item,)>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: ExactSizeIterator<Self>, [@TraitClause4_1]: DoubleEndedIterator<Self>, @TraitClause1_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_1, Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Ord<Self::Item>> = core::iter::traits::iterator::Iterator::max<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Ord<Self::Item>> = core::iter::traits::iterator::Iterator::min<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 Self::Item, &'_1_2 Self::Item)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Self>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 Self::Item,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 Self::Item, &'_1_2 Self::Item)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rev<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: DoubleEndedIterator<Self>> = core::iter::traits::iterator::Iterator::rev<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<Self>, [@TraitClause9_1]: Iterator<Self>, Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
-    fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: Iterator<Self>, T : 'a, Self::Item = &'a T> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: Iterator<Self>, T : 'a, Self::Item = &'a T> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cycle<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: Clone<Self>> = core::iter::traits::iterator::Iterator::cycle<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::array_chunks<Self, N>[Self, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: Sum<S, Self::Item>> = core::iter::traits::iterator::Iterator::sum<Self, S>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: Product<P, Self::Item>> = core::iter::traits::iterator::Iterator::product<Self, P>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<Self::Item>, [@TraitClause3_1]: Sized<Self>, @TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (Self::Item, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (Self::Item, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::eq<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (Self::Item, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::ne<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::lt<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::le<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::gt<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<Self::Item, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Self>> = core::iter::traits::iterator::Iterator::ge<Self, I>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<Self>, [@TraitClause1_1]: PartialOrd<Self::Item, Self::Item>> = core::iter::traits::iterator::Iterator::is_sorted<Self>[Self, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Self>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 Self::Item, &'_1_2 Self::Item)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<Self>, [@TraitClause3_1]: FnMut<F, (Self::Item,)>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn __iterator_get_unchecked<'_0_1, [@TraitClause0_1]: TrustedRandomAccessNoCoerce<Self>> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_1, Self>[Self, @TraitClause0_1]
+    fn step_by<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::step_by<Self>[Self, TraitClause0_1]
+    fn chain<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (U: IntoIterator), TypeConstraint0: TraitClause2_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::chain<Self, U>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (U: IntoIterator)> = core::iter::traits::iterator::Iterator::zip<Self, U>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn intersperse<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self::Item: Clone)> = core::iter::traits::iterator::Iterator::intersperse<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn intersperse_with<G, TraitClause0_1: (G: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (G: FnMut<()>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = Self::Item> = core::iter::traits::iterator::Iterator::intersperse_with<Self, G>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = core::iter::traits::iterator::Iterator::map<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn for_each<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = ()> = core::iter::traits::iterator::Iterator::for_each<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::filter<Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter_map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = core::iter::traits::iterator::Iterator::filter_map<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn enumerate<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::enumerate<Self>[Self, TraitClause0_1]
+    fn peekable<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::peekable<Self>[Self, TraitClause0_1]
+    fn skip_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::skip_while<Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn take_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::take_while<Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map_while<B, P, TraitClause0_1: (B: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (P: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = core::iter::traits::iterator::Iterator::map_while<Self, B, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn skip<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::skip<Self>[Self, TraitClause0_1]
+    fn take<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::take<Self>[Self, TraitClause0_1]
+    fn scan<St, B, F, TraitClause0_1: (St: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (F: Sized), TraitClause3_1: (Self: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 mut St, Self::Item)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = Option<B>[TraitClause1_1]> = core::iter::traits::iterator::Iterator::scan<Self, St, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flat_map<U, F, TraitClause0_1: (U: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (U: IntoIterator), TraitClause4_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = U> = core::iter::traits::iterator::Iterator::flat_map<Self, U, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flatten<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self::Item: IntoIterator)> = core::iter::traits::iterator::Iterator::flatten<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn map_windows<F, R, const N : usize, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: for<'_0_2> (F: FnMut<(&'_0_2 [Self::Item; N],)>), TypeConstraint0: for<'_0_2> TraitClause3_1::ImpliedClause1::Output = R> = core::iter::traits::iterator::Iterator::map_windows<Self, F, R, N>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn fuse<TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::fuse<Self>[Self, TraitClause0_1]
+    fn inspect<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (F: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = ()> = core::iter::traits::iterator::Iterator::inspect<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn by_ref<'_0_1, TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::by_ref<'_0_1, Self>[Self, TraitClause0_1]
+    fn collect<B, TraitClause0_1: (B: Sized), TraitClause1_1: (B: FromIterator<Self::Item>), TraitClause2_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::collect<Self, B>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_collect<'_0_1, B, TraitClause0_1: (B: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (Self::Item: Try), TraitClause3_1: (TraitClause2_1::Residual: Residual<B>), TraitClause4_1: (B: FromIterator<TraitClause2_1::Output>)> = core::iter::traits::iterator::Iterator::try_collect<'_0_1, Self, B>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn collect_into<'_0_1, E, TraitClause0_1: (E: Sized), TraitClause1_1: (E: Extend<Self::Item>), TraitClause2_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::collect_into<'_0_1, Self, E>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn partition<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (B: Default), TraitClause4_1: (B: Extend<Self::Item>), TraitClause5_1: for<'_0_2> (F: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::partition<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn partition_in_place<'a, T, P, TraitClause0_1: (T: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (Self: DoubleEndedIterator), TraitClause4_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeOutlives0: T: 'a, TypeConstraint0: Self::Item = &'a mut T, TypeConstraint1: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn is_partitioned<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (P: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::is_partitioned<Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (Self: Sized), TraitClause4_1: (F: FnMut<(B, Self::Item)>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = core::iter::traits::iterator::Iterator::try_fold<'_0_1, Self, B, F, R>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(Self::Item,)>), TraitClause4_1: (R: Try), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause4_1::Output = ()> = core::iter::traits::iterator::Iterator::try_for_each<'_0_1, Self, F, R>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn fold<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(B, Self::Item)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = core::iter::traits::iterator::Iterator::fold<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn reduce<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (F: FnMut<(Self::Item, Self::Item)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = Self::Item> = core::iter::traits::iterator::Iterator::reduce<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_reduce<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<Self::Item>[Self::ImpliedClause1]>), TraitClause5_1: (T2: FnMut<(Self::Item, Self::Item)>), TypeConstraint0: TraitClause3_1::Output = Self::Item, TypeConstraint1: TraitClause5_1::ImpliedClause1::Output = R> = core::iter::traits::iterator::Iterator::try_reduce<'_0_1, Self, R, T2>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn all<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::all<'_0_1, Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn any<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::any<'_0_1, Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::find<'_0_1, Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find_map<'_0_1, B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = core::iter::traits::iterator::Iterator::find_map<'_0_1, Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn try_find<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<Self::Item>[Self::ImpliedClause1]>), TraitClause5_1: for<'_0_2> (T2: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: TraitClause3_1::Output = bool, TypeConstraint1: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = R> = core::iter::traits::iterator::Iterator::try_find<'_0_1, Self, R, T2>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn position<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (P: FnMut<(Self::Item,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::position<'_0_1, Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rposition<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: FnMut<(Self::Item,)>), TraitClause2_1: (Self: Sized), TraitClause3_1: (Self: ExactSizeIterator), TraitClause4_1: (Self: DoubleEndedIterator), TypeConstraint0: TraitClause1_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::rposition<'_0_1, Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self::Item: Ord)> = core::iter::traits::iterator::Iterator::max<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self::Item: Ord)> = core::iter::traits::iterator::Iterator::min<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn max_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Self: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 Self::Item, &'_1_2 Self::Item)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = core::iter::traits::iterator::Iterator::max_by<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn min_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Self: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 Self::Item,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn min_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 Self::Item, &'_1_2 Self::Item)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = core::iter::traits::iterator::Iterator::min_by<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rev<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self: DoubleEndedIterator)> = core::iter::traits::iterator::Iterator::rev<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn unzip<A, B, FromA, FromB, TraitClause0_1: (A: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (FromA: Sized), TraitClause3_1: (FromB: Sized), TraitClause4_1: (FromA: Default), TraitClause5_1: (FromA: Extend<A>), TraitClause6_1: (FromB: Default), TraitClause7_1: (FromB: Extend<B>), TraitClause8_1: (Self: Sized), TraitClause9_1: (Self: Iterator), TypeConstraint0: Self::Item = (A, B)> = core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1, TraitClause6_1, TraitClause7_1, TraitClause8_1, TraitClause9_1]
+    fn copied<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy), TraitClause2_1: (Self: Sized), TraitClause3_1: (Self: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: Self::Item = &'a T> = core::iter::traits::iterator::Iterator::copied<'a, Self, T>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cloned<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone), TraitClause2_1: (Self: Sized), TraitClause3_1: (Self: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: Self::Item = &'a T> = core::iter::traits::iterator::Iterator::cloned<'a, Self, T>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cycle<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self: Clone)> = core::iter::traits::iterator::Iterator::cycle<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn array_chunks<const N : usize, TraitClause0_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::array_chunks<Self, N>[Self, TraitClause0_1]
+    fn sum<S, TraitClause0_1: (S: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (S: Sum<Self::Item>)> = core::iter::traits::iterator::Iterator::sum<Self, S>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn product<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: (P: Product<Self::Item>)> = core::iter::traits::iterator::Iterator::product<Self, P>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: Ord), TraitClause3_1: (Self: Sized), TypeConstraint0: TraitClause1_1::Item = Self::Item> = core::iter::traits::iterator::Iterator::cmp<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(Self::Item, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Ordering> = core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn partial_cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::partial_cmp<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn partial_cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(Self::Item, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn eq<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::eq<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn eq_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(Self::Item, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::eq_by<Self, I, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn ne<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::ne<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn lt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::lt<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn le<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::le<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn gt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::gt<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn ge<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (Self::Item: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Self: Sized)> = core::iter::traits::iterator::Iterator::ge<Self, I>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn is_sorted<TraitClause0_1: (Self: Sized), TraitClause1_1: (Self::Item: PartialOrd<Self::Item>)> = core::iter::traits::iterator::Iterator::is_sorted<Self>[Self, TraitClause0_1, TraitClause1_1]
+    fn is_sorted_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Self: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 Self::Item, &'_1_2 Self::Item)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = bool> = core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn is_sorted_by_key<F, K, TraitClause0_1: (F: Sized), TraitClause1_1: (K: Sized), TraitClause2_1: (Self: Sized), TraitClause3_1: (F: FnMut<(Self::Item,)>), TraitClause4_1: (K: PartialOrd<K>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = K> = core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn __iterator_get_unchecked<'_0_1, TraitClause0_1: (Self: TrustedRandomAccessNoCoerce)> = core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0_1, Self>[Self, TraitClause0_1]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::__iterator_get_unchecked<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: usize) -> T
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::__iterator_get_unchecked
+pub unsafe fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::__iterator_get_unchecked<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: usize) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::advance_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::advance_by<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::advance_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::advance_by<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::last
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::last<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Option<T>[@TraitClause0]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::last
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::last<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::count
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::count<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> usize
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::count
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::count<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_fold
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_fold<'_0, T, B, F, R, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: B, _3: F) -> R
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::try_fold
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_fold<'_0, T, B, F, R, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: B, _3: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, T)>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause5: (F: FnMut<(B, T)>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::fold
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::fold<T, Acc, Fold, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: Acc, _3: Fold) -> Acc
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::fold
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::fold<T, Acc, Fold, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: Acc, _3: Fold) -> Acc
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Acc>,
-    [@TraitClause2]: Sized<Fold>,
-    [@TraitClause3]: FnMut<Fold, (Acc, T)>,
-    @TraitClause3::parent_clause1::Output = Acc,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Acc: Sized),
+    TraitClause2: (Fold: Sized),
+    TraitClause3: (Fold: FnMut<(Acc, T)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = Acc,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::size_hint
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::size_hint<'_0, T, const N : usize>(_1: &'_0 IntoIter<T, N>[@TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::size_hint
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::size_hint<'_0, T, const N : usize>(_1: &'_0 IntoIter<T, N>[TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::next
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0]) -> Option<T>[@TraitClause0]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::next
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::next<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0]) -> Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by_key
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by_key<T, F, K, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by_key
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by_key<T, F, K, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<K>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (T,)>,
-    [@TraitClause5]: PartialOrd<K, K>,
-    @TraitClause4::parent_clause1::Output = K,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (K: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(T,)>),
+    TraitClause5: (K: PartialOrd<K>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = K,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 T, &'_1_1 T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 T, &'_1_1 T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<T, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (T: PartialOrd<T>),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::ge
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::ge<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::ge
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::ge<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::gt
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::gt<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::gt
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::gt<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::le
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::le<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::le
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::le<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::lt
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::lt<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::lt
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::lt<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::ne
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::ne<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::ne
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::ne<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialEq<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I, _3: F) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::eq_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::eq_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I, _3: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::eq
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::eq<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialEq<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I, _3: F) -> Ordering
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp_by<T, I, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I, _3: F) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp<T, I, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: I) -> Ordering
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp<T, I, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: I) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<T>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    @TraitClause2::Item = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (T: Ord),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
+    TypeConstraint0: TraitClause2::Item = T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::product
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::product<T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> P
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::product
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::product<T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> P
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (P: Product<T>),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::sum
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::sum<T, S, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> S
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::sum
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::sum<T, S, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> S
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<S>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (S: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (S: Sum<T>),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::array_chunks
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::array_chunks<T, const N : usize, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> ArrayChunks<IntoIter<T, N>[@TraitClause0], N>[@TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::array_chunks
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::array_chunks<T, const N : usize, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> ArrayChunks<IntoIter<T, N>[TraitClause0], N>[TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::cycle
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cycle<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Cycle<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::cycle
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::cycle<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Cycle<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: Clone<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Clone),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::cloned
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::cloned
 #[lang_item("iter_cloned")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cloned<'a, T, T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Cloned<IntoIter<T, N>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::cloned<'a, T, T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Cloned<IntoIter<T, N>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Clone<T>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<IntoIter<T, N>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Clone),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::copied
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::copied
 #[lang_item("iter_copied")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::copied<'a, T, T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Copied<IntoIter<T, N>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::copied<'a, T, T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Copied<IntoIter<T, N>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<IntoIter<T, N>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::unzip
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::unzip<T, A, B, FromA, FromB, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> (FromA, FromB)
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::unzip
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::unzip<T, A, B, FromA, FromB, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> (FromA, FromB)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<FromA>,
-    [@TraitClause4]: Sized<FromB>,
-    [@TraitClause5]: Default<FromA>,
-    [@TraitClause6]: Extend<FromA, A>,
-    [@TraitClause7]: Default<FromB>,
-    [@TraitClause8]: Extend<FromB, B>,
-    [@TraitClause9]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause10]: Iterator<IntoIter<T, N>[@TraitClause0]>,
-    {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = (A, B),
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (FromA: Sized),
+    TraitClause4: (FromB: Sized),
+    TraitClause5: (FromA: Default),
+    TraitClause6: (FromA: Extend<A>),
+    TraitClause7: (FromB: Default),
+    TraitClause8: (FromB: Extend<B>),
+    TraitClause9: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause10: (IntoIter<T, N>[TraitClause0]: Iterator),
+    TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = (A, B),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::rev
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::rev<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Rev<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::rev
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::rev<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Rev<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 T, &'_1_1 T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 T, &'_1_1 T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by_key<T, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by_key
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by_key<T, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 T, &'_1_1 T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 T, &'_1_1 T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by_key<T, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by_key
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by_key<T, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::min
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::min
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::min<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: Ord<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (T: Ord),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::max
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::max
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::max<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: Ord<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (T: Ord),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::rposition
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::rposition<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::rposition
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::rposition<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (T,)>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: ExactSizeIterator<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>,
-    @TraitClause2::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: FnMut<(T,)>),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: ExactSizeIterator),
+    TraitClause5: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::position
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::position<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::position
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::position<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_find
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_find<'_0, T, R, T2, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::try_find
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_find<'_0, T, R, T2, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<T2, (&'_0_1 T,)>,
-    @TraitClause4::Output = bool,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: for<'_0_1> (T2: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: TraitClause4::Output = bool,
+    TypeConstraint1: for<'_0_1> TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::find_map
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::find_map<'_0, T, B, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: F) -> Option<B>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::find_map
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::find_map<'_0, T, B, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: F) -> Option<B>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::find
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::find<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: P) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::find
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::find<'_0, T, P, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: P) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::any
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::any<'_0, T, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: F) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::any
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::any<'_0, T, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::all
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::all<'_0, T, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: F) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::all
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::all<'_0, T, F, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_reduce
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_reduce<'_0, T, R, T2, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::try_reduce
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_reduce<'_0, T, R, T2, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<T2, (T, T)>,
-    @TraitClause4::Output = T,
-    @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: (T2: FnMut<(T, T)>),
+    TypeConstraint0: TraitClause4::Output = T,
+    TypeConstraint1: TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::reduce
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::reduce<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::reduce
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::reduce<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (T, T)>,
-    @TraitClause3::parent_clause1::Output = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(T, T)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_for_each
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_for_each<'_0, T, F, R, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: F) -> R
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::try_for_each
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_for_each<'_0, T, F, R, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (T,)>,
-    [@TraitClause5]: Try<R>,
-    @TraitClause4::parent_clause1::Output = R,
-    @TraitClause5::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(T,)>),
+    TraitClause5: (R: Try),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause5::Output = (),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_partitioned
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_partitioned<T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> bool
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::is_partitioned
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_partitioned<T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition_in_place
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition_in_place<'a, T, T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> usize
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::partition_in_place
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::partition_in_place<'a, T, T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    T : 'a,
-    {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a mut T,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator),
+    TraitClause5: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a mut T,
+    TypeConstraint1: for<'_0_1> TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition<T, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> (B, B)
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::partition
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::partition<T, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> (B, B)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, T>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (B: Default),
+    TraitClause5: (B: Extend<T>),
+    TraitClause6: for<'_0_1> (F: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause6::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect_into
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect_into<'_0, T, E, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: &'_0 mut E) -> &'_0 mut E
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::collect_into
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::collect_into<'_0, T, E, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: &'_0 mut E) -> &'_0 mut E
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, T>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Extend<T>),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_collect
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_collect<'_0, T, B, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0]) -> @TraitClause4::TryType
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::try_collect
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_collect<'_0, T, B, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0]) -> TraitClause4::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: Try<T>,
-    [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
-    [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (T: Try),
+    TraitClause4: (TraitClause3::Residual: Residual<B>),
+    TraitClause5: (B: FromIterator<TraitClause3::Output>),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::collect
 #[lang_item("iterator_collect_fn")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect<T, B, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> B
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::collect<T, B, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, T>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (B: FromIterator<T>),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::by_ref
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::by_ref<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0]) -> &'_0 mut IntoIter<T, N>[@TraitClause0]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::by_ref
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::by_ref<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0]) -> &'_0 mut IntoIter<T, N>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::inspect
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::inspect<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Inspect<IntoIter<T, N>[@TraitClause0], F>[@TraitClause2, @TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::inspect
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::inspect<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Inspect<IntoIter<T, N>[TraitClause0], F>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (F: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::fuse
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::fuse<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Fuse<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::fuse
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::fuse<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Fuse<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_windows
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_windows<T, F, R, const N : usize, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> MapWindows<IntoIter<T, N>[@TraitClause0], F, N>[@TraitClause3, @TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::map_windows
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::map_windows<T, F, R, const N : usize, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> MapWindows<IntoIter<T, N>[TraitClause0], F, N>[TraitClause3, TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 [T; N],)>,
-    for<'_0_1> @TraitClause4::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: for<'_0_1> (F: FnMut<(&'_0_1 [T; N],)>),
+    TypeConstraint0: for<'_0_1> TraitClause4::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::flatten
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flatten<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Flatten<IntoIter<T, N>[@TraitClause0]>[@TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0], @TraitClause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::flatten
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::flatten<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Flatten<IntoIter<T, N>[TraitClause0]>[TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (T: IntoIterator),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::flat_map
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flat_map<T, U, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> FlatMap<IntoIter<T, N>[@TraitClause0], U, F>[@TraitClause3, @TraitClause1, @TraitClause2, @TraitClause4]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::flat_map
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::flat_map<T, U, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> FlatMap<IntoIter<T, N>[TraitClause0], U, F>[TraitClause3, TraitClause1, TraitClause2, TraitClause4]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (T,)>,
-    @TraitClause5::parent_clause1::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (U: IntoIterator),
+    TraitClause5: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = U,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::scan
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::scan<T, St, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: St, _3: F) -> Scan<IntoIter<T, N>[@TraitClause0], St, F>[@TraitClause4, @TraitClause1, @TraitClause3]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::scan
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::scan<T, St, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: St, _3: F) -> Scan<IntoIter<T, N>[TraitClause0], St, F>[TraitClause4, TraitClause1, TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<F>,
-    [@TraitClause4]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut St, T)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
+    TraitClause0: (T: Sized),
+    TraitClause1: (St: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (F: Sized),
+    TraitClause4: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 mut St, T)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = Option<B>[TraitClause2],
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::take
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::take<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: usize) -> Take<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::take
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::take<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: usize) -> Take<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: usize) -> Skip<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::skip
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::skip<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: usize) -> Skip<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_while
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_while<T, B, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> MapWhile<IntoIter<T, N>[@TraitClause0], P>[@TraitClause3, @TraitClause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::map_while
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::map_while<T, B, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> MapWhile<IntoIter<T, N>[TraitClause0], P>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (P: FnMut<(T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::take_while
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::take_while<T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> TakeWhile<IntoIter<T, N>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::take_while
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::take_while<T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> TakeWhile<IntoIter<T, N>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip_while
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip_while<T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> SkipWhile<IntoIter<T, N>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::skip_while
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::skip_while<T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> SkipWhile<IntoIter<T, N>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::peekable
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::peekable<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Peekable<IntoIter<T, N>[@TraitClause0]>[@TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::peekable
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::peekable<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Peekable<IntoIter<T, N>[TraitClause0]>[TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::enumerate
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::enumerate
 #[lang_item("enumerate_method")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::enumerate<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0]) -> Enumerate<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::enumerate<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0]) -> Enumerate<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter_map
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter_map<T, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> FilterMap<IntoIter<T, N>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::filter_map
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::filter_map<T, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> FilterMap<IntoIter<T, N>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::filter
 #[lang_item("iter_filter")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter<T, P, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: P) -> Filter<IntoIter<T, N>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::filter<T, P, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: P) -> Filter<IntoIter<T, N>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::for_each
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::for_each<T, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F)
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::for_each
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::for_each<T, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (T,)>,
-    @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::map
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::map
 #[lang_item("IteratorMap")]
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map<T, B, F, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: F) -> Map<IntoIter<T, N>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::map<T, B, F, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: F) -> Map<IntoIter<T, N>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (T,)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse_with
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse_with<T, G, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: G) -> IntersperseWith<IntoIter<T, N>[@TraitClause0], G>[@TraitClause2, @TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse_with
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse_with<T, G, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: G) -> IntersperseWith<IntoIter<T, N>[TraitClause0], G>[TraitClause2, TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (G: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (G: FnMut<()>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: T) -> Intersperse<IntoIter<T, N>[@TraitClause0]>[@TraitClause1, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0], @TraitClause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: T) -> Intersperse<IntoIter<T, N>[TraitClause0]>[TraitClause1, {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause2]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause2: (T: Clone),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::zip
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::zip<T, U, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: U) -> Zip<IntoIter<T, N>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::zip
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::zip<T, U, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: U) -> Zip<IntoIter<T, N>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::chain
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::chain<T, U, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: U) -> Chain<IntoIter<T, N>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::chain
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::chain<T, U, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: U) -> Chain<IntoIter<T, N>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<IntoIter<T, N>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (IntoIter<T, N>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
+    TypeConstraint0: TraitClause3::Item = T,
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::step_by
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::step_by<T, const N : usize>(_1: IntoIter<T, N>[@TraitClause0], _2: usize) -> StepBy<IntoIter<T, N>[@TraitClause0]>[@TraitClause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::step_by
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::step_by<T, const N : usize>(_1: IntoIter<T, N>[TraitClause0], _2: usize) -> StepBy<IntoIter<T, N>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::nth
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::nth<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0], _2: usize) -> Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::nth
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::nth<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0], _2: usize) -> Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk<'_0, T, const N : usize, const N : usize>(_1: &'_0 mut IntoIter<T, N>[@TraitClause0]) -> Result<[T; N], IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [T; N]}, {built_in impl Sized for IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]}]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}::next_chunk
+pub fn {impl Iterator for IntoIter<T, N>[TraitClause0]}::next_chunk<'_0, T, const N : usize, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0]) -> Result<[T; N], IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]>[{built_in impl Sized for [T; N]}, {built_in impl Sized for IntoIter<T, N>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<IntoIter<T, N>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (IntoIter<T, N>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[@TraitClause0]}
-impl<T, const N : usize> Iterator for IntoIter<T, N>[@TraitClause0]
+// Full name: core::array::iter::{impl Iterator for IntoIter<T, N>[TraitClause0]}
+impl<T, const N : usize> Iterator for IntoIter<T, N>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for IntoIter<T, N>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (IntoIter<T, N>[TraitClause0]: MetaSized) = {built_in impl MetaSized for IntoIter<T, N>[TraitClause0]}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
     type Item = T
-    fn next<'_0_1> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next<'_0_1, T, N>[@TraitClause0]
-    fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next_chunk<'_0_1, T, N, N>[@TraitClause0, @TraitClause0_1]
-    fn size_hint<'_0_1> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::size_hint<'_0_1, T, N>[@TraitClause0]
-    fn count = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::count<T, N>[@TraitClause0]
-    fn last = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::last<T, N>[@TraitClause0]
-    fn advance_by<'_0_1> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::advance_by<'_0_1, T, N>[@TraitClause0]
-    fn nth<'_0_1> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::nth<'_0_1, T, N>[@TraitClause0]
-    fn step_by<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::step_by<T, N>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::chain<T, U, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::zip<T, U, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: Clone<T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::intersperse_with<T, G, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (T,)>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map<T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (T,)>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::for_each<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter<T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::filter_map<T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn enumerate<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::enumerate<T, N>[@TraitClause0, @TraitClause0_1]
-    fn peekable<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::peekable<T, N>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip_while<T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::take_while<T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_while<T, B, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn skip<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::skip<T, N>[@TraitClause0, @TraitClause0_1]
-    fn take<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::take<T, N>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut St, T)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::scan<T, St, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (T,)>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flat_map<T, U, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::flatten<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 [T; N],)>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::map_windows<T, F, R, N, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn fuse<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::fuse<T, N>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::inspect<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::by_ref<'_0_1, T, N>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, T>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect<T, B, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: Try<T>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_collect<'_0_1, T, B, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, T>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::collect_into<'_0_1, T, E, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, T>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 T,)>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition<T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, T : 'a, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a mut T, for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partition_in_place<'a, T, T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_partitioned<T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, T)>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_fold<'_0_1, T, B, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (T,)>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_for_each<'_0_1, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<Acc, Fold, [@TraitClause0_1]: Sized<Acc>, [@TraitClause1_1]: Sized<Fold>, [@TraitClause2_1]: FnMut<Fold, (Acc, T)>, @TraitClause2_1::parent_clause1::Output = Acc> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::fold<T, Acc, Fold, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (T, T)>, @TraitClause2_1::parent_clause1::Output = T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::reduce<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<T2, (T, T)>, @TraitClause3_1::Output = T, @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_reduce<'_0_1, T, R, T2, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::all<'_0_1, T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::any<'_0_1, T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::find<'_0_1, T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::find_map<'_0_1, T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<T>[{impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<T2, (&'_0_2 T,)>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::try_find<'_0_1, T, R, T2, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::position<'_0_1, T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (T,)>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::rposition<'_0_1, T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: Ord<T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: Ord<T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 T,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by_key<T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 T, &'_1_2 T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::max_by<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 T,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by_key<T, B, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 T, &'_1_2 T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::min_by<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rev<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::rev<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause9_1]: Iterator<IntoIter<T, N>[@TraitClause0]>, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = (A, B)> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::unzip<T, A, B, FromA, FromB, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
-    fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: Iterator<IntoIter<T, N>[@TraitClause0]>, T : 'a, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::copied<'a, T, T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: Iterator<IntoIter<T, N>[@TraitClause0]>, T : 'a, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<T, N>[@TraitClause0]::Item = &'a T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cloned<'a, T, T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cycle<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: Clone<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cycle<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::array_chunks<T, N, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::sum<T, S, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: Product<P, T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::product<T, P, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<T>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>, @TraitClause1_1::Item = T> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::cmp_by<T, I, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::partial_cmp_by<T, I, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::eq_by<T, I, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::ne<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::lt<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::le<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::gt<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<IntoIter<T, N>[@TraitClause0]>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::ge<T, I, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<T, T>> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted<T, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 T, &'_1_2 T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by<T, F, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<IntoIter<T, N>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (T,)>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::is_sorted_by_key<T, F, K, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::__iterator_get_unchecked<'_0_1, T, N>[@TraitClause0]
-    vtable: {impl Iterator for IntoIter<T, N>[@TraitClause0]}::{vtable}<T, N>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::next<'_0_1, T, N>[TraitClause0]
+    fn next_chunk<'_0_1, const N : usize, TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::next_chunk<'_0_1, T, N, N>[TraitClause0, TraitClause0_1]
+    fn size_hint<'_0_1> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::size_hint<'_0_1, T, N>[TraitClause0]
+    fn count = {impl Iterator for IntoIter<T, N>[TraitClause0]}::count<T, N>[TraitClause0]
+    fn last = {impl Iterator for IntoIter<T, N>[TraitClause0]}::last<T, N>[TraitClause0]
+    fn advance_by<'_0_1> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::advance_by<'_0_1, T, N>[TraitClause0]
+    fn nth<'_0_1> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::nth<'_0_1, T, N>[TraitClause0]
+    fn step_by<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::step_by<T, N>[TraitClause0, TraitClause0_1]
+    fn chain<U, TraitClause0_1: (U: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator), TypeConstraint0: TraitClause2_1::Item = T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::chain<T, U, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::zip<T, U, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn intersperse<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (T: Clone)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn intersperse_with<G, TraitClause0_1: (G: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (G: FnMut<()>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::intersperse_with<T, G, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::map<T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn for_each<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::for_each<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter<P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::filter<T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter_map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::filter_map<T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn enumerate<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::enumerate<T, N>[TraitClause0, TraitClause0_1]
+    fn peekable<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::peekable<T, N>[TraitClause0, TraitClause0_1]
+    fn skip_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::skip_while<T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn take_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::take_while<T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map_while<B, P, TraitClause0_1: (B: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (P: FnMut<(T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::map_while<T, B, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn skip<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::skip<T, N>[TraitClause0, TraitClause0_1]
+    fn take<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::take<T, N>[TraitClause0, TraitClause0_1]
+    fn scan<St, B, F, TraitClause0_1: (St: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (F: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 mut St, T)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = Option<B>[TraitClause1_1]> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::scan<T, St, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flat_map<U, F, TraitClause0_1: (U: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (U: IntoIterator), TraitClause4_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = U> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::flat_map<T, U, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flatten<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (T: IntoIterator)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::flatten<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn map_windows<F, R, const N : usize, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: for<'_0_2> (F: FnMut<(&'_0_2 [T; N],)>), TypeConstraint0: for<'_0_2> TraitClause3_1::ImpliedClause1::Output = R> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::map_windows<T, F, R, N, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn fuse<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::fuse<T, N>[TraitClause0, TraitClause0_1]
+    fn inspect<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (F: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::inspect<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn by_ref<'_0_1, TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::by_ref<'_0_1, T, N>[TraitClause0, TraitClause0_1]
+    fn collect<B, TraitClause0_1: (B: Sized), TraitClause1_1: (B: FromIterator<T>), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::collect<T, B, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_collect<'_0_1, B, TraitClause0_1: (B: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (T: Try), TraitClause3_1: (TraitClause2_1::Residual: Residual<B>), TraitClause4_1: (B: FromIterator<TraitClause2_1::Output>)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_collect<'_0_1, T, B, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn collect_into<'_0_1, E, TraitClause0_1: (E: Sized), TraitClause1_1: (E: Extend<T>), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::collect_into<'_0_1, T, E, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn partition<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (B: Default), TraitClause4_1: (B: Extend<T>), TraitClause5_1: for<'_0_2> (F: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::partition<T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn partition_in_place<'a, T, P, TraitClause0_1: (T: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator), TraitClause4_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a mut T, TypeConstraint1: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::partition_in_place<'a, T, T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn is_partitioned<P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_partitioned<T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause4_1: (F: FnMut<(B, T)>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_fold<'_0_1, T, B, F, R, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(T,)>), TraitClause4_1: (R: Try), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause4_1::Output = ()> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_for_each<'_0_1, T, F, R, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn fold<Acc, Fold, TraitClause0_1: (Acc: Sized), TraitClause1_1: (Fold: Sized), TraitClause2_1: (Fold: FnMut<(Acc, T)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = Acc> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::fold<T, Acc, Fold, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn reduce<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(T, T)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::reduce<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_reduce<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: (T2: FnMut<(T, T)>), TypeConstraint0: TraitClause3_1::Output = T, TypeConstraint1: TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_reduce<'_0_1, T, R, T2, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn all<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::all<'_0_1, T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn any<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::any<'_0_1, T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::find<'_0_1, T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find_map<'_0_1, B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::find_map<'_0_1, T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn try_find<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<T>[{impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: for<'_0_2> (T2: FnMut<(&'_0_2 T,)>), TypeConstraint0: TraitClause3_1::Output = bool, TypeConstraint1: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::try_find<'_0_1, T, R, T2, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn position<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::position<'_0_1, T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rposition<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: FnMut<(T,)>), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: ExactSizeIterator), TraitClause4_1: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator), TypeConstraint0: TraitClause1_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::rposition<'_0_1, T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (T: Ord)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::max<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (T: Ord)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::min<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn max_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by_key<T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 T, &'_1_2 T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::max_by<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn min_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 T,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by_key<T, B, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn min_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 T, &'_1_2 T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::min_by<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rev<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: DoubleEndedIterator)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::rev<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn unzip<A, B, FromA, FromB, TraitClause0_1: (A: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (FromA: Sized), TraitClause3_1: (FromB: Sized), TraitClause4_1: (FromA: Default), TraitClause5_1: (FromA: Extend<A>), TraitClause6_1: (FromB: Default), TraitClause7_1: (FromB: Extend<B>), TraitClause8_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause9_1: (IntoIter<T, N>[TraitClause0]: Iterator), TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = (A, B)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::unzip<T, A, B, FromA, FromB, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1, TraitClause6_1, TraitClause7_1, TraitClause8_1, TraitClause9_1]
+    fn copied<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::copied<'a, T, T, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cloned<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for IntoIter<T, N>[TraitClause0]}<T, N>[TraitClause0]::Item = &'a T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::cloned<'a, T, T, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cycle<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Clone)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::cycle<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn array_chunks<const N : usize, TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::array_chunks<T, N, N>[TraitClause0, TraitClause0_1]
+    fn sum<S, TraitClause0_1: (S: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (S: Sum<T>)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::sum<T, S, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn product<P, TraitClause0_1: (P: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: (P: Product<T>)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::product<T, P, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: Ord), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized), TypeConstraint0: TraitClause1_1::Item = T> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Ordering> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::cmp_by<T, I, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn partial_cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn partial_cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::partial_cmp_by<T, I, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn eq<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::eq<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn eq_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::eq_by<T, I, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn ne<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::ne<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn lt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::lt<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn le<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::le<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn gt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::gt<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn ge<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (IntoIter<T, N>[TraitClause0]: Sized)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::ge<T, I, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn is_sorted<TraitClause0_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause1_1: (T: PartialOrd<T>)> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted<T, N>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn is_sorted_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 T, &'_1_2 T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by<T, F, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn is_sorted_by_key<F, K, TraitClause0_1: (F: Sized), TraitClause1_1: (K: Sized), TraitClause2_1: (IntoIter<T, N>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(T,)>), TraitClause4_1: (K: PartialOrd<K>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = K> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::is_sorted_by_key<T, F, K, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for IntoIter<T, N>[TraitClause0]}::__iterator_get_unchecked<'_0_1, T, N>[TraitClause0]
+    vtable: {impl Iterator for IntoIter<T, N>[TraitClause0]}::{vtable}<T, N>[TraitClause0]
 }
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 Self)
 where
-    [@TraitClause0]: Clone<Self>,
-    [@TraitClause1]: Destruct<Self>,
+    TraitClause0: (Self: Clone),
+    TraitClause1: (Self: Destruct),
 = <opaque>
 
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 #[lang_item("cmp_partialeq_ne")]
 pub fn core::cmp::PartialEq::ne<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq::assert_receiver_is_total_eq
 pub fn assert_receiver_is_total_eq<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Eq<Self>,
+    TraitClause0: (Self: Eq),
 = <opaque>
 
 #[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 #[lang_item("cmp_ord_max")]
 pub fn core::cmp::Ord::max<Self>(_1: Self, _2: Self) -> Self
 where
-    [@TraitClause0]: Ord<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Destruct<Self>,
+    TraitClause0: (Self: Ord),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (Self: Destruct),
 = <opaque>
 
 #[lang_item("cmp_ord_min")]
 pub fn core::cmp::Ord::min<Self>(_1: Self, _2: Self) -> Self
 where
-    [@TraitClause0]: Ord<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Destruct<Self>,
+    TraitClause0: (Self: Ord),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (Self: Destruct),
 = <opaque>
 
 // Full name: core::cmp::Ord::clamp
 pub fn clamp<Self>(_1: Self, _2: Self, _3: Self) -> Self
 where
-    [@TraitClause0]: Ord<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Destruct<Self>,
+    TraitClause0: (Self: Ord),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (Self: Destruct),
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 #[lang_item("cmp_partialord_lt")]
 pub fn core::cmp::PartialOrd::lt<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 #[lang_item("cmp_partialord_le")]
 pub fn core::cmp::PartialOrd::le<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 #[lang_item("cmp_partialord_gt")]
 pub fn core::cmp::PartialOrd::gt<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 #[lang_item("cmp_partialord_ge")]
 pub fn core::cmp::PartialOrd::ge<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::__chaining_lt
 pub fn __chaining_lt<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> ControlFlow<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::__chaining_le
 pub fn __chaining_le<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> ControlFlow<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::__chaining_gt
 pub fn __chaining_gt<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> ControlFlow<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::__chaining_ge
 pub fn __chaining_ge<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> ControlFlow<bool, ()>[{built_in impl Sized for bool}, {built_in impl Sized for ()}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::default::Default::default
 #[lang_item("default_fn")]
 pub fn default<Self>() -> Self
 where
-    [@TraitClause0]: Default<Self>,
+    TraitClause0: (Self: Default),
 = <opaque>
 
 // Full name: core::fmt::Arguments
@@ -1635,864 +1635,864 @@ pub fn {impl AddAssign<&'_0 i32> for i32}::add_assign<'_0, '_1>(_1: &'_1 mut i32
 // Full name: core::iter::adapters::zip::TrustedRandomAccessNoCoerce::size
 pub fn size<'_0, Self>(_1: &'_0 Self) -> usize
 where
-    [@TraitClause0]: TrustedRandomAccessNoCoerce<Self>,
-    [@TraitClause1]: Iterator<Self>,
+    TraitClause0: (Self: TrustedRandomAccessNoCoerce),
+    TraitClause1: (Self: Iterator),
 = <opaque>
 
 pub fn core::iter::traits::accum::Sum::sum<Self, A, I>(_1: I) -> Self
 where
-    [@TraitClause0]: Sum<Self, A>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Iterator<I>,
-    @TraitClause2::Item = A,
+    TraitClause0: (Self: Sum<A>),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: Iterator),
+    TypeConstraint0: TraitClause2::Item = A,
 = <opaque>
 
 pub fn core::iter::traits::accum::Product::product<Self, A, I>(_1: I) -> Self
 where
-    [@TraitClause0]: Product<Self, A>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Iterator<I>,
-    @TraitClause2::Item = A,
+    TraitClause0: (Self: Product<A>),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: Iterator),
+    TypeConstraint0: TraitClause2::Item = A,
 = <opaque>
 
 // Full name: core::iter::traits::collect::FromIterator::from_iter
 #[lang_item("from_iter_fn")]
 pub fn from_iter<Self, A, T>(_1: T) -> Self
 where
-    [@TraitClause0]: FromIterator<Self, A>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: IntoIterator<T>,
-    @TraitClause2::Item = A,
+    TraitClause0: (Self: FromIterator<A>),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: IntoIterator),
+    TypeConstraint0: TraitClause2::Item = A,
 = <opaque>
 
 #[lang_item("into_iter")]
-pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(_1: Self) -> @TraitClause0::IntoIter
+pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(_1: Self) -> TraitClause0::IntoIter
 where
-    [@TraitClause0]: IntoIterator<Self>,
+    TraitClause0: (Self: IntoIterator),
 = <opaque>
 
 // Full name: core::iter::traits::collect::{impl IntoIterator for I}::into_iter
 pub fn {impl IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Iterator<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: Iterator),
 = <opaque>
 
 // Full name: core::iter::traits::collect::Extend::extend
 pub fn extend<'_0, Self, A, T>(_1: &'_0 mut Self, _2: T)
 where
-    [@TraitClause0]: Extend<Self, A>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: IntoIterator<T>,
-    @TraitClause2::Item = A,
+    TraitClause0: (Self: Extend<A>),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: IntoIterator),
+    TypeConstraint0: TraitClause2::Item = A,
 = <opaque>
 
 // Full name: core::iter::traits::collect::Extend::extend_one
 pub fn extend_one<'_0, Self, A>(_1: &'_0 mut Self, _2: A)
 where
-    [@TraitClause0]: Extend<Self, A>,
+    TraitClause0: (Self: Extend<A>),
 = <opaque>
 
 // Full name: core::iter::traits::collect::Extend::extend_reserve
 pub fn extend_reserve<'_0, Self, A>(_1: &'_0 mut Self, _2: usize)
 where
-    [@TraitClause0]: Extend<Self, A>,
+    TraitClause0: (Self: Extend<A>),
 = <opaque>
 
 // Full name: core::iter::traits::collect::Extend::extend_one_unchecked
 pub unsafe fn extend_one_unchecked<'_0, Self, A>(_1: &'_0 mut Self, _2: A)
 where
-    [@TraitClause0]: Extend<Self, A>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Extend<A>),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::next_back
-pub fn next_back<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::parent_clause1::Item>[@TraitClause0::parent_clause1::parent_clause1]
+pub fn next_back<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::ImpliedClause1::Item>[TraitClause0::ImpliedClause1::ImpliedClause1]
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
+    TraitClause0: (Self: DoubleEndedIterator),
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::advance_back_by
 pub fn advance_back_by<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
+    TraitClause0: (Self: DoubleEndedIterator),
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::nth_back
-pub fn nth_back<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Option<@TraitClause0::parent_clause1::Item>[@TraitClause0::parent_clause1::parent_clause1]
+pub fn nth_back<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Option<TraitClause0::ImpliedClause1::Item>[TraitClause0::ImpliedClause1::ImpliedClause1]
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
+    TraitClause0: (Self: DoubleEndedIterator),
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::try_rfold
 pub fn try_rfold<'_0, Self, B, F, R>(_1: &'_0 mut Self, _2: B, _3: F) -> R
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<Self>,
-    [@TraitClause5]: FnMut<F, (B, @TraitClause0::parent_clause1::Item)>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (Self: DoubleEndedIterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (Self: Sized),
+    TraitClause5: (F: FnMut<(B, TraitClause0::ImpliedClause1::Item)>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::rfold
 pub fn rfold<Self, B, F>(_1: Self, _2: B, _3: F) -> B
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (B, @TraitClause0::parent_clause1::Item)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (Self: DoubleEndedIterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(B, TraitClause0::ImpliedClause1::Item)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
 // Full name: core::iter::traits::double_ended::DoubleEndedIterator::rfind
-pub fn rfind<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<@TraitClause0::parent_clause1::Item>[@TraitClause0::parent_clause1::parent_clause1]
+pub fn rfind<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<TraitClause0::ImpliedClause1::Item>[TraitClause0::ImpliedClause1::ImpliedClause1]
 where
-    [@TraitClause0]: DoubleEndedIterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 @TraitClause0::parent_clause1::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: DoubleEndedIterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 TraitClause0::ImpliedClause1::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
 // Full name: core::iter::traits::exact_size::ExactSizeIterator::len
 pub fn len<'_0, Self>(_1: &'_0 Self) -> usize
 where
-    [@TraitClause0]: ExactSizeIterator<Self>,
+    TraitClause0: (Self: ExactSizeIterator),
 = <opaque>
 
 // Full name: core::iter::traits::exact_size::ExactSizeIterator::is_empty
 pub fn is_empty<'_0, Self>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: ExactSizeIterator<Self>,
+    TraitClause0: (Self: ExactSizeIterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(_1: &'_0 mut Self) -> Result<[@TraitClause0::Item; N], IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]>[{built_in impl Sized for [@TraitClause0::Item; N]}, {built_in impl Sized for IntoIter<@TraitClause0::Item, N>[@TraitClause0::parent_clause1]}]
+pub fn core::iter::traits::iterator::Iterator::next_chunk<'_0, Self, const N : usize>(_1: &'_0 mut Self) -> Result<[TraitClause0::Item; N], IntoIter<TraitClause0::Item, N>[TraitClause0::ImpliedClause1]>[{built_in impl Sized for [TraitClause0::Item; N]}, {built_in impl Sized for IntoIter<TraitClause0::Item, N>[TraitClause0::ImpliedClause1]}]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::size_hint<'_0, Self>(_1: &'_0 Self) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::count<Self>(_1: Self) -> usize
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::last<Self>(_1: Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::last<Self>(_1: Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::advance_by<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::nth<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::step_by<Self>(_1: Self, _2: usize) -> StepBy<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::step_by<Self>(_1: Self, _2: usize) -> StepBy<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::chain<Self, U>(_1: Self, _2: U) -> Chain<Self, @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+pub fn core::iter::traits::iterator::Iterator::chain<Self, U>(_1: Self, _2: U) -> Chain<Self, TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = @TraitClause0::Item,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (U: IntoIterator),
+    TypeConstraint0: TraitClause3::Item = TraitClause0::Item,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::zip<Self, U>(_1: Self, _2: U) -> Zip<Self, @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+pub fn core::iter::traits::iterator::Iterator::zip<Self, U>(_1: Self, _2: U) -> Zip<Self, TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (U: IntoIterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::intersperse<Self>(_1: Self, _2: @TraitClause0::Item) -> Intersperse<Self>[@TraitClause1, @TraitClause0, @TraitClause2]
+pub fn core::iter::traits::iterator::Iterator::intersperse<Self>(_1: Self, _2: TraitClause0::Item) -> Intersperse<Self>[TraitClause1, TraitClause0, TraitClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Clone<@TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (TraitClause0::Item: Clone),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::intersperse_with<Self, G>(_1: Self, _2: G) -> IntersperseWith<Self, G>[@TraitClause2, @TraitClause1, @TraitClause0]
+pub fn core::iter::traits::iterator::Iterator::intersperse_with<Self, G>(_1: Self, _2: G) -> IntersperseWith<Self, G>[TraitClause2, TraitClause1, TraitClause0]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = @TraitClause0::Item,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (G: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (G: FnMut<()>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = TraitClause0::Item,
 = <opaque>
 
 #[lang_item("IteratorMap")]
-pub fn core::iter::traits::iterator::Iterator::map<Self, B, F>(_1: Self, _2: F) -> Map<Self, F>[@TraitClause3, @TraitClause2]
+pub fn core::iter::traits::iterator::Iterator::map<Self, B, F>(_1: Self, _2: F) -> Map<Self, F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::for_each<Self, F>(_1: Self, _2: F)
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
 #[lang_item("iter_filter")]
-pub fn core::iter::traits::iterator::Iterator::filter<Self, P>(_1: Self, _2: P) -> Filter<Self, P>[@TraitClause2, @TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::filter<Self, P>(_1: Self, _2: P) -> Filter<Self, P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(_1: Self, _2: F) -> FilterMap<Self, F>[@TraitClause3, @TraitClause2]
+pub fn core::iter::traits::iterator::Iterator::filter_map<Self, B, F>(_1: Self, _2: F) -> FilterMap<Self, F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
 #[lang_item("enumerate_method")]
-pub fn core::iter::traits::iterator::Iterator::enumerate<Self>(_1: Self) -> Enumerate<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::enumerate<Self>(_1: Self) -> Enumerate<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::peekable<Self>(_1: Self) -> Peekable<Self>[@TraitClause1, @TraitClause0]
+pub fn core::iter::traits::iterator::Iterator::peekable<Self>(_1: Self) -> Peekable<Self>[TraitClause1, TraitClause0]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(_1: Self, _2: P) -> SkipWhile<Self, P>[@TraitClause2, @TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::skip_while<Self, P>(_1: Self, _2: P) -> SkipWhile<Self, P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::take_while<Self, P>(_1: Self, _2: P) -> TakeWhile<Self, P>[@TraitClause2, @TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::take_while<Self, P>(_1: Self, _2: P) -> TakeWhile<Self, P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(_1: Self, _2: P) -> MapWhile<Self, P>[@TraitClause3, @TraitClause2]
+pub fn core::iter::traits::iterator::Iterator::map_while<Self, B, P>(_1: Self, _2: P) -> MapWhile<Self, P>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<P, (@TraitClause0::Item,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (P: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::skip<Self>(_1: Self, _2: usize) -> Skip<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::skip<Self>(_1: Self, _2: usize) -> Skip<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::take<Self>(_1: Self, _2: usize) -> Take<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::take<Self>(_1: Self, _2: usize) -> Take<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(_1: Self, _2: St, _3: F) -> Scan<Self, St, F>[@TraitClause4, @TraitClause1, @TraitClause3]
+pub fn core::iter::traits::iterator::Iterator::scan<Self, St, B, F>(_1: Self, _2: St, _3: F) -> Scan<Self, St, F>[TraitClause4, TraitClause1, TraitClause3]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<F>,
-    [@TraitClause4]: Sized<Self>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut St, @TraitClause0::Item)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (St: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (F: Sized),
+    TraitClause4: (Self: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 mut St, TraitClause0::Item)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = Option<B>[TraitClause2],
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(_1: Self, _2: F) -> FlatMap<Self, U, F>[@TraitClause3, @TraitClause1, @TraitClause2, @TraitClause4]
+pub fn core::iter::traits::iterator::Iterator::flat_map<Self, U, F>(_1: Self, _2: F) -> FlatMap<Self, U, F>[TraitClause3, TraitClause1, TraitClause2, TraitClause4]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause5::parent_clause1::Output = U,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (U: IntoIterator),
+    TraitClause5: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = U,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::flatten<Self>(_1: Self) -> Flatten<Self>[@TraitClause1, @TraitClause0, @TraitClause2]
+pub fn core::iter::traits::iterator::Iterator::flatten<Self>(_1: Self) -> Flatten<Self>[TraitClause1, TraitClause0, TraitClause2]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: IntoIterator<@TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (TraitClause0::Item: IntoIterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(_1: Self, _2: F) -> MapWindows<Self, F, N>[@TraitClause3, @TraitClause1, @TraitClause0]
+pub fn core::iter::traits::iterator::Iterator::map_windows<Self, F, R, const N : usize>(_1: Self, _2: F) -> MapWindows<Self, F, N>[TraitClause3, TraitClause1, TraitClause0]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 [@TraitClause0::Item; N],)>,
-    for<'_0_1> @TraitClause4::parent_clause1::Output = R,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: for<'_0_1> (F: FnMut<(&'_0_1 [TraitClause0::Item; N],)>),
+    TypeConstraint0: for<'_0_1> TraitClause4::ImpliedClause1::Output = R,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::fuse<Self>(_1: Self) -> Fuse<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::fuse<Self>(_1: Self) -> Fuse<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::inspect<Self, F>(_1: Self, _2: F) -> Inspect<Self, F>[@TraitClause2, @TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::inspect<Self, F>(_1: Self, _2: F) -> Inspect<Self, F>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (F: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::by_ref<'_0, Self>(_1: &'_0 mut Self) -> &'_0 mut Self
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
 #[lang_item("iterator_collect_fn")]
 pub fn core::iter::traits::iterator::Iterator::collect<Self, B>(_1: Self) -> B
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, @TraitClause0::Item>,
-    [@TraitClause3]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (B: FromIterator<TraitClause0::Item>),
+    TraitClause3: (Self: Sized),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::try_collect<'_0, Self, B>(_1: &'_0 mut Self) -> @TraitClause4::TryType
+pub fn core::iter::traits::iterator::Iterator::try_collect<'_0, Self, B>(_1: &'_0 mut Self) -> TraitClause4::TryType
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: Try<@TraitClause0::Item>,
-    [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
-    [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (TraitClause0::Item: Try),
+    TraitClause4: (TraitClause3::Residual: Residual<B>),
+    TraitClause5: (B: FromIterator<TraitClause3::Output>),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::collect_into<'_0, Self, E>(_1: Self, _2: &'_0 mut E) -> &'_0 mut E
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, @TraitClause0::Item>,
-    [@TraitClause3]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Extend<TraitClause0::Item>),
+    TraitClause3: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::partition<Self, B, F>(_1: Self, _2: F) -> (B, B)
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, @TraitClause0::Item>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (B: Default),
+    TraitClause5: (B: Extend<TraitClause0::Item>),
+    TraitClause6: for<'_0_1> (F: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause6::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::partition_in_place<'a, Self, T, P>(_1: Self, _2: P) -> usize
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: DoubleEndedIterator<Self>,
-    [@TraitClause5]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    T : 'a,
-    @TraitClause0::Item = &'a mut T,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (T: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (Self: DoubleEndedIterator),
+    TraitClause5: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: TraitClause0::Item = &'a mut T,
+    TypeConstraint1: for<'_0_1> TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::is_partitioned<Self, P>(_1: Self, _2: P) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<P, (@TraitClause0::Item,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (P: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::try_fold<'_0, Self, B, F, R>(_1: &'_0 mut Self, _2: B, _3: F) -> R
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<Self>,
-    [@TraitClause5]: FnMut<F, (B, @TraitClause0::Item)>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (Self: Sized),
+    TraitClause5: (F: FnMut<(B, TraitClause0::Item)>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::try_for_each<'_0, Self, F, R>(_1: &'_0 mut Self, _2: F) -> R
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (@TraitClause0::Item,)>,
-    [@TraitClause5]: Try<R>,
-    @TraitClause4::parent_clause1::Output = R,
-    @TraitClause5::Output = (),
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(TraitClause0::Item,)>),
+    TraitClause5: (R: Try),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause5::Output = (),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::fold<Self, B, F>(_1: Self, _2: B, _3: F) -> B
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (B, @TraitClause0::Item)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(B, TraitClause0::Item)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::reduce<Self, F>(_1: Self, _2: F) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::reduce<Self, F>(_1: Self, _2: F) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<F, (@TraitClause0::Item, @TraitClause0::Item)>,
-    @TraitClause3::parent_clause1::Output = @TraitClause0::Item,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (F: FnMut<(TraitClause0::Item, TraitClause0::Item)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = TraitClause0::Item,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::try_reduce<'_0, Self, R, T2>(_1: &'_0 mut Self, _2: T2) -> @TraitClause5::TryType
+pub fn core::iter::traits::iterator::Iterator::try_reduce<'_0, Self, R, T2>(_1: &'_0 mut Self, _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]>,
-    [@TraitClause6]: FnMut<T2, (@TraitClause0::Item, @TraitClause0::Item)>,
-    @TraitClause4::Output = @TraitClause0::Item,
-    @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]>),
+    TraitClause6: (T2: FnMut<(TraitClause0::Item, TraitClause0::Item)>),
+    TypeConstraint0: TraitClause4::Output = TraitClause0::Item,
+    TypeConstraint1: TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::all<'_0, Self, F>(_1: &'_0 mut Self, _2: F) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::any<'_0, Self, F>(_1: &'_0 mut Self, _2: F) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::find<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(_1: &'_0 mut Self, _2: F) -> Option<B>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::find_map<'_0, Self, B, F>(_1: &'_0 mut Self, _2: F) -> Option<B>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (@TraitClause0::Item,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, T2>(_1: &'_0 mut Self, _2: T2) -> @TraitClause5::TryType
+pub fn core::iter::traits::iterator::Iterator::try_find<'_0, Self, R, T2>(_1: &'_0 mut Self, _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<T2, (&'_0_1 @TraitClause0::Item,)>,
-    @TraitClause4::Output = bool,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]>),
+    TraitClause6: for<'_0_1> (T2: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause4::Output = bool,
+    TypeConstraint1: for<'_0_1> TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::position<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: FnMut<P, (@TraitClause0::Item,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (P: FnMut<(TraitClause0::Item,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::rposition<'_0, Self, P>(_1: &'_0 mut Self, _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (@TraitClause0::Item,)>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: ExactSizeIterator<Self>,
-    [@TraitClause5]: DoubleEndedIterator<Self>,
-    @TraitClause2::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: FnMut<(TraitClause0::Item,)>),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (Self: ExactSizeIterator),
+    TraitClause5: (Self: DoubleEndedIterator),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = bool,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::max<Self>(_1: Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::max<Self>(_1: Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Ord<@TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (TraitClause0::Item: Ord),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::min<Self>(_1: Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::min<Self>(_1: Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Ord<@TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (TraitClause0::Item: Ord),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(_1: Self, _2: F) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::max_by_key<Self, B, F>(_1: Self, _2: F) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Self>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Self: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::max_by<Self, F>(_1: Self, _2: F) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::max_by<Self, F>(_1: Self, _2: F) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 @TraitClause0::Item, &'_1_1 @TraitClause0::Item)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 TraitClause0::Item, &'_1_1 TraitClause0::Item)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(_1: Self, _2: F) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::min_by_key<Self, B, F>(_1: Self, _2: F) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Self>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 @TraitClause0::Item,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Self: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 TraitClause0::Item,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::min_by<Self, F>(_1: Self, _2: F) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::min_by<Self, F>(_1: Self, _2: F) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 @TraitClause0::Item, &'_1_1 @TraitClause0::Item)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 TraitClause0::Item, &'_1_1 TraitClause0::Item)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::rev<Self>(_1: Self) -> Rev<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::rev<Self>(_1: Self) -> Rev<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: DoubleEndedIterator<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (Self: DoubleEndedIterator),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::unzip<Self, A, B, FromA, FromB>(_1: Self) -> (FromA, FromB)
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<FromA>,
-    [@TraitClause4]: Sized<FromB>,
-    [@TraitClause5]: Default<FromA>,
-    [@TraitClause6]: Extend<FromA, A>,
-    [@TraitClause7]: Default<FromB>,
-    [@TraitClause8]: Extend<FromB, B>,
-    [@TraitClause9]: Sized<Self>,
-    [@TraitClause10]: Iterator<Self>,
-    @TraitClause0::Item = (A, B),
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (A: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (FromA: Sized),
+    TraitClause4: (FromB: Sized),
+    TraitClause5: (FromA: Default),
+    TraitClause6: (FromA: Extend<A>),
+    TraitClause7: (FromB: Default),
+    TraitClause8: (FromB: Extend<B>),
+    TraitClause9: (Self: Sized),
+    TraitClause10: (Self: Iterator),
+    TypeConstraint0: TraitClause0::Item = (A, B),
 = <opaque>
 
 #[lang_item("iter_copied")]
-pub fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(_1: Self) -> Copied<Self>[@TraitClause3]
+pub fn core::iter::traits::iterator::Iterator::copied<'a, Self, T>(_1: Self) -> Copied<Self>[TraitClause3]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: Iterator<Self>,
-    T : 'a,
-    @TraitClause0::Item = &'a T,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (Self: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: TraitClause0::Item = &'a T,
 = <opaque>
 
 #[lang_item("iter_cloned")]
-pub fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(_1: Self) -> Cloned<Self>[@TraitClause3]
+pub fn core::iter::traits::iterator::Iterator::cloned<'a, Self, T>(_1: Self) -> Cloned<Self>[TraitClause3]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Clone<T>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: Iterator<Self>,
-    T : 'a,
-    @TraitClause0::Item = &'a T,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Clone),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (Self: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: TraitClause0::Item = &'a T,
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::cycle<Self>(_1: Self) -> Cycle<Self>[@TraitClause1]
+pub fn core::iter::traits::iterator::Iterator::cycle<Self>(_1: Self) -> Cycle<Self>[TraitClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: Clone<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (Self: Clone),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>(_1: Self) -> ArrayChunks<Self, N>[@TraitClause1, @TraitClause0]
+pub fn core::iter::traits::iterator::Iterator::array_chunks<Self, const N : usize>(_1: Self) -> ArrayChunks<Self, N>[TraitClause1, TraitClause0]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::sum<Self, S>(_1: Self) -> S
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<S>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: Sum<S, @TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (S: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (S: Sum<TraitClause0::Item>),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::product<Self, P>(_1: Self) -> P
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: Product<P, @TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: (P: Product<TraitClause0::Item>),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::cmp<Self, I>(_1: Self, _2: I) -> Ordering
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<@TraitClause0::Item>,
-    [@TraitClause4]: Sized<Self>,
-    @TraitClause2::Item = @TraitClause0::Item,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: Ord),
+    TraitClause4: (Self: Sized),
+    TypeConstraint0: TraitClause2::Item = TraitClause0::Item,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::cmp_by<Self, I, F>(_1: Self, _2: I, _3: F) -> Ordering
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (@TraitClause0::Item, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Ordering,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(TraitClause0::Item, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Ordering,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::partial_cmp<Self, I>(_1: Self, _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::partial_cmp_by<Self, I, F>(_1: Self, _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (@TraitClause0::Item, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(TraitClause0::Item, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::eq<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::eq_by<Self, I, F>(_1: Self, _2: I, _3: F) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (@TraitClause0::Item, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(TraitClause0::Item, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::ne<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::lt<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::le<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::gt<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::ge<Self, I>(_1: Self, _2: I) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<@TraitClause0::Item, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (TraitClause0::Item: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Self: Sized),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::is_sorted<Self>(_1: Self) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<Self>,
-    [@TraitClause2]: PartialOrd<@TraitClause0::Item, @TraitClause0::Item>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: Sized),
+    TraitClause2: (TraitClause0::Item: PartialOrd<TraitClause0::Item>),
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::is_sorted_by<Self, F>(_1: Self, _2: F) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Self>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 @TraitClause0::Item, &'_1_1 @TraitClause0::Item)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Self: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 TraitClause0::Item, &'_1_1 TraitClause0::Item)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
 pub fn core::iter::traits::iterator::Iterator::is_sorted_by_key<Self, F, K>(_1: Self, _2: F) -> bool
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<K>,
-    [@TraitClause3]: Sized<Self>,
-    [@TraitClause4]: FnMut<F, (@TraitClause0::Item,)>,
-    [@TraitClause5]: PartialOrd<K, K>,
-    @TraitClause4::parent_clause1::Output = K,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (F: Sized),
+    TraitClause2: (K: Sized),
+    TraitClause3: (Self: Sized),
+    TraitClause4: (F: FnMut<(TraitClause0::Item,)>),
+    TraitClause5: (K: PartialOrd<K>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = K,
 = <opaque>
 
-pub unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> @TraitClause0::Item
+pub unsafe fn core::iter::traits::iterator::Iterator::__iterator_get_unchecked<'_0, Self>(_1: &'_0 mut Self, _2: usize) -> TraitClause0::Item
 where
-    [@TraitClause0]: Iterator<Self>,
-    [@TraitClause1]: TrustedRandomAccessNoCoerce<Self>,
+    TraitClause0: (Self: Iterator),
+    TraitClause1: (Self: TrustedRandomAccessNoCoerce),
 = <opaque>
 
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 = <opaque>
 
 // Full name: core::ops::function::FnMut::call_mut
-pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
-pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::ops::try_trait::Try::from_output
 #[lang_item("from_output")]
-pub fn from_output<Self>(_1: @TraitClause0::Output) -> Self
+pub fn from_output<Self>(_1: TraitClause0::Output) -> Self
 where
-    [@TraitClause0]: Try<Self>,
+    TraitClause0: (Self: Try),
 = <opaque>
 
 // Full name: core::ops::try_trait::Try::branch
 #[lang_item("branch")]
-pub fn branch<Self>(_1: Self) -> ControlFlow<@TraitClause0::Residual, @TraitClause0::Output>[@TraitClause0::parent_clause1::parent_clause1, @TraitClause0::parent_clause2]
+pub fn branch<Self>(_1: Self) -> ControlFlow<TraitClause0::Residual, TraitClause0::Output>[TraitClause0::ImpliedClause1::ImpliedClause1, TraitClause0::ImpliedClause2]
 where
-    [@TraitClause0]: Try<Self>,
+    TraitClause0: (Self: Try),
 = <opaque>
 
 // Full name: core::ops::try_trait::FromResidual::from_residual
 #[lang_item("from_residual")]
 pub fn from_residual<Self, R>(_1: R) -> Self
 where
-    [@TraitClause0]: FromResidual<Self, R>,
+    TraitClause0: (Self: FromResidual<R>),
 = <opaque>
 
 // Full name: core::panicking::AssertKind
@@ -2506,2586 +2506,2586 @@ pub enum AssertKind {
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a T, &'_1_1 &'a T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a T, &'_1_1 &'a T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: usize) -> &'a T
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::__iterator_get_unchecked
+pub unsafe fn {impl Iterator for Iter<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: usize) -> &'a T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::rposition
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::rposition
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (@TraitClause4::parent_clause1::Item,)>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: ExactSizeIterator<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>,
-    @TraitClause2::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: FnMut<(TraitClause4::ImpliedClause1::Item,)>),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: ExactSizeIterator),
+    TraitClause5: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::position
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::position
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::find_map
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: F) -> Option<B>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::find_map
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: F) -> Option<B>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::find
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: P) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::find
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: P) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::any
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::any
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::all
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::all
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::for_each
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::for_each<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F)
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::for_each
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::for_each<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a T,)>,
-    @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::fold
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::fold<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: B, _3: F) -> B
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::fold
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::fold<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: B, _3: F) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: FnMut<F, (B, &'a T)>,
-    @TraitClause3::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (F: FnMut<(B, &'a T)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::last
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::last<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::last
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::last<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::advance_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::advance_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::nth
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: usize) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::nth
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: usize) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::count
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::count<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> usize
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::count
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::count<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::size_hint
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 Iter<'a, T>[@TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::size_hint
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 Iter<'a, T>[TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> Result<[&'a T; N], IntoIter<&'a T, N>[{built_in impl Sized for &'a T}]>[{built_in impl Sized for [&'a T; N]}, {built_in impl Sized for IntoIter<&'a T, N>[{built_in impl Sized for &'a T}]}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::next_chunk
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> Result<[&'a T; N], IntoIter<&'a T, N>[{built_in impl Sized for &'a T}]>[{built_in impl Sized for [&'a T; N]}, {built_in impl Sized for IntoIter<&'a T, N>[{built_in impl Sized for &'a T}]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by_key
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by_key
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: Iter<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<K>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a T,)>,
-    [@TraitClause5]: PartialOrd<K, K>,
-    @TraitClause4::parent_clause1::Output = K,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (K: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a T,)>),
+    TraitClause5: (K: PartialOrd<K>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = K,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<&'a T, &'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a T: PartialOrd<&'a T>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::ge
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::ge<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::ge
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::ge<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::gt
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::gt<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::gt
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::gt<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::le
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::le<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::le
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::le<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::lt
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::lt<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::lt
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::lt<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::ne
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::ne<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::ne
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::ne<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::eq_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>(_1: Iter<'a, T>[@TraitClause0], _2: I, _3: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::eq_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>(_1: Iter<'a, T>[TraitClause0], _2: I, _3: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::eq
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::eq<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::eq
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::eq<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: Iter<'a, T>[@TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: Iter<'a, T>[TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a T, @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>(_1: Iter<'a, T>[@TraitClause0], _2: I, _3: F) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::cmp_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>(_1: Iter<'a, T>[TraitClause0], _2: I, _3: F) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a T, @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a T, TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp<'a, T, I>(_1: Iter<'a, T>[@TraitClause0], _2: I) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::cmp
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::cmp<'a, T, I>(_1: Iter<'a, T>[TraitClause0], _2: I) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<&'a T>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
-    @TraitClause2::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a T: Ord),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
+    TypeConstraint0: TraitClause2::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::product
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::product<'a, T, P>(_1: Iter<'a, T>[@TraitClause0]) -> P
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::product
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::product<'a, T, P>(_1: Iter<'a, T>[TraitClause0]) -> P
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, &'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: Product<&'a T>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::sum
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::sum<'a, T, S>(_1: Iter<'a, T>[@TraitClause0]) -> S
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::sum
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::sum<'a, T, S>(_1: Iter<'a, T>[TraitClause0]) -> S
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<S>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, &'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (S: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (S: Sum<&'a T>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::array_chunks
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: Iter<'a, T>[@TraitClause0]) -> ArrayChunks<Iter<'a, T>[@TraitClause0], N>[@TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::array_chunks
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: Iter<'a, T>[TraitClause0]) -> ArrayChunks<Iter<'a, T>[TraitClause0], N>[TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::cycle
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::cycle<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Cycle<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::cycle
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::cycle<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Cycle<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::cloned
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::cloned
 #[lang_item("iter_cloned")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>(_1: Iter<'a, T>[@TraitClause0]) -> Cloned<Iter<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>(_1: Iter<'a, T>[TraitClause0]) -> Cloned<Iter<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Clone<T>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<Iter<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Clone),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::copied
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::copied
 #[lang_item("iter_copied")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>(_1: Iter<'a, T>[@TraitClause0]) -> Copied<Iter<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>(_1: Iter<'a, T>[TraitClause0]) -> Copied<Iter<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<Iter<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::unzip
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: Iter<'a, T>[@TraitClause0]) -> (FromA, FromB)
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::unzip
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: Iter<'a, T>[TraitClause0]) -> (FromA, FromB)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<FromA>,
-    [@TraitClause4]: Sized<FromB>,
-    [@TraitClause5]: Default<FromA>,
-    [@TraitClause6]: Extend<FromA, A>,
-    [@TraitClause7]: Default<FromB>,
-    [@TraitClause8]: Extend<FromB, B>,
-    [@TraitClause9]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause10]: Iterator<Iter<'a, T>[@TraitClause0]>,
-    {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B),
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (FromA: Sized),
+    TraitClause4: (FromB: Sized),
+    TraitClause5: (FromA: Default),
+    TraitClause6: (FromA: Extend<A>),
+    TraitClause7: (FromB: Default),
+    TraitClause8: (FromB: Extend<B>),
+    TraitClause9: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause10: (Iter<'a, T>[TraitClause0]: Iterator),
+    TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::rev
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::rev<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Rev<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::rev
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::rev<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Rev<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::min_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::min_by<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a T, &'_1_1 &'a T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a T, &'_1_1 &'a T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::min_by_key
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::max_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::max_by<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a T, &'_1_1 &'a T)>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a T, &'_1_1 &'a T)>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::max_by_key
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::min
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::min<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::min
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::min<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a T: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::max
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::max<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::max
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::max<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a T: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::try_find
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::try_find
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<T2, (&'_0_1 &'a T,)>,
-    @TraitClause4::Output = bool,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: for<'_0_1> (T2: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: TraitClause4::Output = bool,
+    TypeConstraint1: for<'_0_1> TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::try_reduce
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::try_reduce
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<T2, (&'a T, &'a T)>,
-    @TraitClause4::Output = &'a T,
-    @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: (T2: FnMut<(&'a T, &'a T)>),
+    TypeConstraint0: TraitClause4::Output = &'a T,
+    TypeConstraint1: TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::reduce
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::reduce<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::reduce
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::reduce<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a T, &'a T)>,
-    @TraitClause3::parent_clause1::Output = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a T, &'a T)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::try_for_each
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: F) -> R
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::try_for_each
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a T,)>,
-    [@TraitClause5]: Try<R>,
-    @TraitClause4::parent_clause1::Output = R,
-    @TraitClause5::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a T,)>),
+    TraitClause5: (R: Try),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause5::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::try_fold
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut Iter<'a, T>[@TraitClause0], _2: B, _3: F) -> R
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::try_fold
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut Iter<'a, T>[TraitClause0], _2: B, _3: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, &'a T)>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause5: (F: FnMut<(B, &'a T)>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::is_partitioned
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> bool
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::is_partitioned
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a T,)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::partition_in_place
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> usize
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::partition_in_place
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    T : 'a,
-    {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TraitClause5: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T,
+    TypeConstraint1: for<'_0_1> TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::partition
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::partition<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> (B, B)
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::partition
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::partition<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> (B, B)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, &'a T>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (B: Default),
+    TraitClause5: (B: Extend<&'a T>),
+    TraitClause6: for<'_0_1> (F: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause6::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::collect_into
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::collect_into<'a, '_1, T, E>(_1: Iter<'a, T>[@TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::collect_into
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::collect_into<'a, '_1, T, E>(_1: Iter<'a, T>[TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, &'a T>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Extend<&'a T>),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::try_collect
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> @TraitClause4::TryType
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::try_collect
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> TraitClause4::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Try<&'a T>,
-    [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
-    [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (&'a T: Try),
+    TraitClause4: (TraitClause3::Residual: Residual<B>),
+    TraitClause5: (B: FromIterator<TraitClause3::Output>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::collect
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::collect
 #[lang_item("iterator_collect_fn")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::collect<'a, T, B>(_1: Iter<'a, T>[@TraitClause0]) -> B
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::collect<'a, T, B>(_1: Iter<'a, T>[TraitClause0]) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, &'a T>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (B: FromIterator<&'a T>),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::by_ref
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> &'_1 mut Iter<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::by_ref
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> &'_1 mut Iter<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::inspect
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::inspect<'a, T, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Inspect<Iter<'a, T>[@TraitClause0], F>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::inspect
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::inspect<'a, T, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Inspect<Iter<'a, T>[TraitClause0], F>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (F: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::fuse
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::fuse<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Fuse<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::fuse
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::fuse<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Fuse<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::map_windows
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> MapWindows<Iter<'a, T>[@TraitClause0], F, N>[@TraitClause3, @TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::map_windows
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: Iter<'a, T>[TraitClause0], _2: F) -> MapWindows<Iter<'a, T>[TraitClause0], F, N>[TraitClause3, TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 [&'a T; N],)>,
-    for<'_0_1> @TraitClause4::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: for<'_0_1> (F: FnMut<(&'_0_1 [&'a T; N],)>),
+    TypeConstraint0: for<'_0_1> TraitClause4::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::flatten
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::flatten<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Flatten<Iter<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::flatten
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::flatten<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Flatten<Iter<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<&'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a T: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::flat_map
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> FlatMap<Iter<'a, T>[@TraitClause0], U, F>[@TraitClause3, @TraitClause1, @TraitClause2, @TraitClause4]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::flat_map
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> FlatMap<Iter<'a, T>[TraitClause0], U, F>[TraitClause3, TraitClause1, TraitClause2, TraitClause4]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (&'a T,)>,
-    @TraitClause5::parent_clause1::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (U: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = U,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::scan
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: St, _3: F) -> Scan<Iter<'a, T>[@TraitClause0], St, F>[@TraitClause4, @TraitClause1, @TraitClause3]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::scan
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>(_1: Iter<'a, T>[TraitClause0], _2: St, _3: F) -> Scan<Iter<'a, T>[TraitClause0], St, F>[TraitClause4, TraitClause1, TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<F>,
-    [@TraitClause4]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut St, &'a T)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
+    TraitClause0: (T: Sized),
+    TraitClause1: (St: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (F: Sized),
+    TraitClause4: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 mut St, &'a T)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = Option<B>[TraitClause2],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::take
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::take<'a, T>(_1: Iter<'a, T>[@TraitClause0], _2: usize) -> Take<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::take
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::take<'a, T>(_1: Iter<'a, T>[TraitClause0], _2: usize) -> Take<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::skip
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::skip<'a, T>(_1: Iter<'a, T>[@TraitClause0], _2: usize) -> Skip<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::skip
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::skip<'a, T>(_1: Iter<'a, T>[TraitClause0], _2: usize) -> Skip<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::map_while
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> MapWhile<Iter<'a, T>[@TraitClause0], P>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::map_while
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::map_while<'a, T, B, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> MapWhile<Iter<'a, T>[TraitClause0], P>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (&'a T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (P: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::take_while
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::take_while<'a, T, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> TakeWhile<Iter<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::take_while
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::take_while<'a, T, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> TakeWhile<Iter<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::skip_while
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::skip_while<'a, T, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> SkipWhile<Iter<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::skip_while
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::skip_while<'a, T, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> SkipWhile<Iter<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::peekable
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::peekable<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Peekable<Iter<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::peekable
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::peekable<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Peekable<Iter<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::enumerate
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::enumerate
 #[lang_item("enumerate_method")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::enumerate<'a, T>(_1: Iter<'a, T>[@TraitClause0]) -> Enumerate<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::enumerate<'a, T>(_1: Iter<'a, T>[TraitClause0]) -> Enumerate<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::filter_map
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> FilterMap<Iter<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::filter_map
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> FilterMap<Iter<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a T,)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::filter
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::filter
 #[lang_item("iter_filter")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::filter<'a, T, P>(_1: Iter<'a, T>[@TraitClause0], _2: P) -> Filter<Iter<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::filter<'a, T, P>(_1: Iter<'a, T>[TraitClause0], _2: P) -> Filter<Iter<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a T,)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a T,)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::map
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::map
 #[lang_item("IteratorMap")]
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::map<'a, T, B, F>(_1: Iter<'a, T>[@TraitClause0], _2: F) -> Map<Iter<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::map<'a, T, B, F>(_1: Iter<'a, T>[TraitClause0], _2: F) -> Map<Iter<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a T,)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse_with
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>(_1: Iter<'a, T>[@TraitClause0], _2: G) -> IntersperseWith<Iter<'a, T>[@TraitClause0], G>[@TraitClause2, @TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse_with
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>(_1: Iter<'a, T>[TraitClause0], _2: G) -> IntersperseWith<Iter<'a, T>[TraitClause0], G>[TraitClause2, TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (G: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (G: FnMut<()>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse<'a, T>(_1: Iter<'a, T>[@TraitClause0], _2: &'a T) -> Intersperse<Iter<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse<'a, T>(_1: Iter<'a, T>[TraitClause0], _2: &'a T) -> Intersperse<Iter<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<&'a T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a T: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::zip
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::zip<'a, T, U>(_1: Iter<'a, T>[@TraitClause0], _2: U) -> Zip<Iter<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::zip
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::zip<'a, T, U>(_1: Iter<'a, T>[TraitClause0], _2: U) -> Zip<Iter<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::chain
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::chain<'a, T, U>(_1: Iter<'a, T>[@TraitClause0], _2: U) -> Chain<Iter<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::chain
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::chain<'a, T, U>(_1: Iter<'a, T>[TraitClause0], _2: U) -> Chain<Iter<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Iter<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
+    TypeConstraint0: TraitClause3::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::step_by
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::step_by<'a, T>(_1: Iter<'a, T>[@TraitClause0], _2: usize) -> StepBy<Iter<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::step_by
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::step_by<'a, T>(_1: Iter<'a, T>[TraitClause0], _2: usize) -> StepBy<Iter<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Iter<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Iter<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}
-impl<'a, T> Iterator for Iter<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}
+impl<'a, T> Iterator for Iter<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Iter<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ T}
+    proof ImpliedClause0: (Iter<'_, T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Iter<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
     type Item = &'a T
-    fn next<'_0_1> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    fn next_chunk<'_0_1, const N : usize> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next_chunk<'a, '_0_1, T, N>[@TraitClause0]
-    fn size_hint<'_0_1> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::size_hint<'a, '_0_1, T>[@TraitClause0]
-    fn count = {impl Iterator for Iter<'a, T>[@TraitClause0]}::count<'a, T>[@TraitClause0]
-    fn last = {impl Iterator for Iter<'a, T>[@TraitClause0]}::last<'a, T>[@TraitClause0]
-    fn advance_by<'_0_1> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::advance_by<'a, '_0_1, T>[@TraitClause0]
-    fn nth<'_0_1> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::nth<'a, '_0_1, T>[@TraitClause0]
-    fn step_by<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::step_by<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a T,)>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a T,)>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn enumerate<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::enumerate<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn peekable<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::peekable<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn skip<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::skip<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn take<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::take<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut St, &'a T)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a T,)>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 [&'a T; N],)>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn fuse<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a T>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a T>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a T>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a T>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, T : 'a, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T, for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a T)>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a T,)>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: FnMut<F, (B, &'a T)>, @TraitClause2_1::parent_clause1::Output = B> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a T, &'a T)>, @TraitClause2_1::parent_clause1::Output = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<T2, (&'a T, &'a T)>, @TraitClause3_1::Output = &'a T, @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a T,)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a T>[{impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<T2, (&'_0_2 &'a T,)>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a T,)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (@TraitClause3_1::parent_clause1::Item,)>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a T, &'_1_2 &'a T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a T,)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a T, &'_1_2 &'a T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rev<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::rev<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause9_1]: Iterator<Iter<'a, T>[@TraitClause0]>, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B)> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
-    fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Iter<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Iter<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cycle<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::cycle<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::array_chunks<'a, T, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a T>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a T> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a T, @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a T, @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Iter<'a, T>[@TraitClause0]>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a T, &'a T>> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a T, &'_1_2 &'a T)>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<Iter<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a T,)>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for Iter<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[@TraitClause0]
-    vtable: {impl Iterator for Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    fn next_chunk<'_0_1, const N : usize> = {impl Iterator for Iter<'a, T>[TraitClause0]}::next_chunk<'a, '_0_1, T, N>[TraitClause0]
+    fn size_hint<'_0_1> = {impl Iterator for Iter<'a, T>[TraitClause0]}::size_hint<'a, '_0_1, T>[TraitClause0]
+    fn count = {impl Iterator for Iter<'a, T>[TraitClause0]}::count<'a, T>[TraitClause0]
+    fn last = {impl Iterator for Iter<'a, T>[TraitClause0]}::last<'a, T>[TraitClause0]
+    fn advance_by<'_0_1> = {impl Iterator for Iter<'a, T>[TraitClause0]}::advance_by<'a, '_0_1, T>[TraitClause0]
+    fn nth<'_0_1> = {impl Iterator for Iter<'a, T>[TraitClause0]}::nth<'a, '_0_1, T>[TraitClause0]
+    fn step_by<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::step_by<'a, T>[TraitClause0, TraitClause0_1]
+    fn chain<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator), TypeConstraint0: TraitClause2_1::Item = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::chain<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::zip<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn intersperse<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a T: Clone)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn intersperse_with<G, TraitClause0_1: (G: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (G: FnMut<()>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for Iter<'a, T>[TraitClause0]}::map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn for_each<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for Iter<'a, T>[TraitClause0]}::for_each<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::filter<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter_map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Iter<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn enumerate<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::enumerate<'a, T>[TraitClause0, TraitClause0_1]
+    fn peekable<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::peekable<'a, T>[TraitClause0, TraitClause0_1]
+    fn skip_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::skip_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn take_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::take_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map_while<B, P, TraitClause0_1: (B: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (P: FnMut<(&'a T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Iter<'a, T>[TraitClause0]}::map_while<'a, T, B, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn skip<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::skip<'a, T>[TraitClause0, TraitClause0_1]
+    fn take<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::take<'a, T>[TraitClause0, TraitClause0_1]
+    fn scan<St, B, F, TraitClause0_1: (St: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (F: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 mut St, &'a T)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = Option<B>[TraitClause1_1]> = {impl Iterator for Iter<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flat_map<U, F, TraitClause0_1: (U: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (U: IntoIterator), TraitClause4_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = U> = {impl Iterator for Iter<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flatten<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a T: IntoIterator)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::flatten<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn map_windows<F, R, const N : usize, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: for<'_0_2> (F: FnMut<(&'_0_2 [&'a T; N],)>), TypeConstraint0: for<'_0_2> TraitClause3_1::ImpliedClause1::Output = R> = {impl Iterator for Iter<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn fuse<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::fuse<'a, T>[TraitClause0, TraitClause0_1]
+    fn inspect<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for Iter<'a, T>[TraitClause0]}::inspect<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn by_ref<'_0_1, TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::by_ref<'a, '_0_1, T>[TraitClause0, TraitClause0_1]
+    fn collect<B, TraitClause0_1: (B: Sized), TraitClause1_1: (B: FromIterator<&'a T>), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::collect<'a, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_collect<'_0_1, B, TraitClause0_1: (B: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (&'a T: Try), TraitClause3_1: (TraitClause2_1::Residual: Residual<B>), TraitClause4_1: (B: FromIterator<TraitClause2_1::Output>)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::try_collect<'a, '_0_1, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn collect_into<'_0_1, E, TraitClause0_1: (E: Sized), TraitClause1_1: (E: Extend<&'a T>), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::collect_into<'a, '_0_1, T, E>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn partition<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (B: Default), TraitClause4_1: (B: Extend<&'a T>), TraitClause5_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::partition<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn partition_in_place<'a, T, P, TraitClause0_1: (T: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator), TraitClause4_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T, TypeConstraint1: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn is_partitioned<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause4_1: (F: FnMut<(B, &'a T)>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = {impl Iterator for Iter<'a, T>[TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a T,)>), TraitClause4_1: (R: Try), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause4_1::Output = ()> = {impl Iterator for Iter<'a, T>[TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn fold<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (F: FnMut<(B, &'a T)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = B> = {impl Iterator for Iter<'a, T>[TraitClause0]}::fold<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn reduce<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a T, &'a T)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::reduce<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_reduce<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: (T2: FnMut<(&'a T, &'a T)>), TypeConstraint0: TraitClause3_1::Output = &'a T, TypeConstraint1: TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for Iter<'a, T>[TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn all<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::all<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn any<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::any<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::find<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find_map<'_0_1, B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a T,)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Iter<'a, T>[TraitClause0]}::find_map<'a, '_0_1, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn try_find<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a T>[{impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: for<'_0_2> (T2: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: TraitClause3_1::Output = bool, TypeConstraint1: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for Iter<'a, T>[TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn position<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a T,)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::position<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rposition<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: FnMut<(TraitClause3_1::ImpliedClause1::Item,)>), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: ExactSizeIterator), TraitClause4_1: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator), TypeConstraint0: TraitClause1_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::rposition<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a T: Ord)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::max<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a T: Ord)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::min<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn max_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for Iter<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a T, &'_1_2 &'a T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[TraitClause0]}::max_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn min_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a T,)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for Iter<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn min_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a T, &'_1_2 &'a T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[TraitClause0]}::min_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rev<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: DoubleEndedIterator)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::rev<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn unzip<A, B, FromA, FromB, TraitClause0_1: (A: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (FromA: Sized), TraitClause3_1: (FromB: Sized), TraitClause4_1: (FromA: Default), TraitClause5_1: (FromA: Extend<A>), TraitClause6_1: (FromB: Default), TraitClause7_1: (FromB: Extend<B>), TraitClause8_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause9_1: (Iter<'a, T>[TraitClause0]: Iterator), TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1, TraitClause6_1, TraitClause7_1, TraitClause8_1, TraitClause9_1]
+    fn copied<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cloned<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Iter<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cycle<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Clone)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::cycle<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn array_chunks<const N : usize, TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::array_chunks<'a, T, N>[TraitClause0, TraitClause0_1]
+    fn sum<S, TraitClause0_1: (S: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (S: Sum<&'a T>)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::sum<'a, T, S>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn product<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: Product<&'a T>)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::product<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: Ord), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized), TypeConstraint0: TraitClause1_1::Item = &'a T> = {impl Iterator for Iter<'a, T>[TraitClause0]}::cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Iter<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn partial_cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn partial_cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Iter<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn eq<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::eq<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn eq_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a T, TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn ne<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::ne<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn lt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::lt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn le<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::le<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn gt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::gt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn ge<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a T: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Iter<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::ge<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn is_sorted<TraitClause0_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a T: PartialOrd<&'a T>)> = {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn is_sorted_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a T, &'_1_2 &'a T)>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn is_sorted_by_key<F, K, TraitClause0_1: (F: Sized), TraitClause1_1: (K: Sized), TraitClause2_1: (Iter<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a T,)>), TraitClause4_1: (K: PartialOrd<K>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = K> = {impl Iterator for Iter<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for Iter<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[TraitClause0]
+    vtable: {impl Iterator for Iter<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 // Full name: core::slice::iter::Chunks
 pub opaque type Chunks<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: usize) -> &'a [T]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::__iterator_get_unchecked
+pub unsafe fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: usize) -> &'a [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::last
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::last<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::last
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::last<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: usize) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::nth
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: usize) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::count
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::count<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> usize
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::count
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::count<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::size_hint
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 Chunks<'a, T>[@TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::size_hint
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 Chunks<'a, T>[TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by_key
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<K>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    [@TraitClause5]: PartialOrd<K, K>,
-    @TraitClause4::parent_clause1::Output = K,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (K: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TraitClause5: (K: PartialOrd<K>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = K,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<&'a [T], &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: PartialOrd<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::ge
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ge<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::ge
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::ge<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::gt
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::gt<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::gt
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::gt<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::le
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::le<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::le
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::le<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::lt
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::lt<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::lt
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::lt<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::ne
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ne<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::ne
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::ne<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>(_1: Chunks<'a, T>[@TraitClause0], _2: I, _3: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::eq_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>(_1: Chunks<'a, T>[TraitClause0], _2: I, _3: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::eq
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::eq<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialEq<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: Chunks<'a, T>[@TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: Chunks<'a, T>[TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>(_1: Chunks<'a, T>[@TraitClause0], _2: I, _3: F) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>(_1: Chunks<'a, T>[TraitClause0], _2: I, _3: F) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp<'a, T, I>(_1: Chunks<'a, T>[@TraitClause0], _2: I) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp<'a, T, I>(_1: Chunks<'a, T>[TraitClause0], _2: I) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<&'a [T]>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    @TraitClause2::Item = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: Ord),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
+    TypeConstraint0: TraitClause2::Item = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::product
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::product<'a, T, P>(_1: Chunks<'a, T>[@TraitClause0]) -> P
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::product
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::product<'a, T, P>(_1: Chunks<'a, T>[TraitClause0]) -> P
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: Product<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::sum
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::sum<'a, T, S>(_1: Chunks<'a, T>[@TraitClause0]) -> S
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::sum
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::sum<'a, T, S>(_1: Chunks<'a, T>[TraitClause0]) -> S
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<S>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (S: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (S: Sum<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::array_chunks
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: Chunks<'a, T>[@TraitClause0]) -> ArrayChunks<Chunks<'a, T>[@TraitClause0], N>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::array_chunks
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: Chunks<'a, T>[TraitClause0]) -> ArrayChunks<Chunks<'a, T>[TraitClause0], N>[TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cycle
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cycle<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Cycle<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::cycle
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::cycle<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Cycle<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::cloned
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::cloned
 #[lang_item("iter_cloned")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Cloned<Chunks<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>(_1: Chunks<'a, T>[TraitClause0]) -> Cloned<Chunks<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Clone<T>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<Chunks<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Clone),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::copied
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::copied
 #[lang_item("iter_copied")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Copied<Chunks<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>(_1: Chunks<'a, T>[TraitClause0]) -> Copied<Chunks<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<Chunks<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::unzip
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: Chunks<'a, T>[@TraitClause0]) -> (FromA, FromB)
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::unzip
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: Chunks<'a, T>[TraitClause0]) -> (FromA, FromB)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<FromA>,
-    [@TraitClause4]: Sized<FromB>,
-    [@TraitClause5]: Default<FromA>,
-    [@TraitClause6]: Extend<FromA, A>,
-    [@TraitClause7]: Default<FromB>,
-    [@TraitClause8]: Extend<FromB, B>,
-    [@TraitClause9]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause10]: Iterator<Chunks<'a, T>[@TraitClause0]>,
-    {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B),
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (FromA: Sized),
+    TraitClause4: (FromB: Sized),
+    TraitClause5: (FromA: Default),
+    TraitClause6: (FromA: Extend<A>),
+    TraitClause7: (FromB: Default),
+    TraitClause8: (FromB: Extend<B>),
+    TraitClause9: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause10: (Chunks<'a, T>[TraitClause0]: Iterator),
+    TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::rev
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rev<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Rev<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::rev
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::rev<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Rev<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by_key
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by_key
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::min
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::min
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::min<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::max
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::max
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::max<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::rposition
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (&'a [T],)>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: ExactSizeIterator<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>,
-    @TraitClause2::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: FnMut<(&'a [T],)>),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: ExactSizeIterator),
+    TraitClause5: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::position
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::position
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_find
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::try_find
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<T2, (&'_0_1 &'a [T],)>,
-    @TraitClause4::Output = bool,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: for<'_0_1> (T2: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: TraitClause4::Output = bool,
+    TypeConstraint1: for<'_0_1> TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::find_map
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: F) -> Option<B>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::find_map
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: F) -> Option<B>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::find
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: P) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::find
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: P) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::any
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::any
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::all
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::all
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::try_reduce
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<T2, (&'a [T], &'a [T])>,
-    @TraitClause4::Output = &'a [T],
-    @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: (T2: FnMut<(&'a [T], &'a [T])>),
+    TypeConstraint0: TraitClause4::Output = &'a [T],
+    TypeConstraint1: TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::reduce
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::reduce<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T], &'a [T])>,
-    @TraitClause3::parent_clause1::Output = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T], &'a [T])>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::fold
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fold<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: B, _3: F) -> B
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::fold
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::fold<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: B, _3: F) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (B, &'a [T])>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(B, &'a [T])>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_for_each
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: F) -> R
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::try_for_each
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    [@TraitClause5]: Try<R>,
-    @TraitClause4::parent_clause1::Output = R,
-    @TraitClause5::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TraitClause5: (R: Try),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause5::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_fold
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: B, _3: F) -> R
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::try_fold
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: B, _3: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, &'a [T])>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause5: (F: FnMut<(B, &'a [T])>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_partitioned
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> bool
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::is_partitioned
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition_in_place
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> usize
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::partition_in_place
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    T : 'a,
-    {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TraitClause5: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T,
+    TypeConstraint1: for<'_0_1> TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> (B, B)
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::partition
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::partition<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> (B, B)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, &'a [T]>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (B: Default),
+    TraitClause5: (B: Extend<&'a [T]>),
+    TraitClause6: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause6::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into<'a, '_1, T, E>(_1: Chunks<'a, T>[@TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::collect_into
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::collect_into<'a, '_1, T, E>(_1: Chunks<'a, T>[TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, &'a [T]>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Extend<&'a [T]>),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_collect
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0]) -> @TraitClause4::TryType
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::try_collect
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut Chunks<'a, T>[TraitClause0]) -> TraitClause4::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Try<&'a [T]>,
-    [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
-    [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (&'a [T]: Try),
+    TraitClause4: (TraitClause3::Residual: Residual<B>),
+    TraitClause5: (B: FromIterator<TraitClause3::Output>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::collect
 #[lang_item("iterator_collect_fn")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect<'a, T, B>(_1: Chunks<'a, T>[@TraitClause0]) -> B
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::collect<'a, T, B>(_1: Chunks<'a, T>[TraitClause0]) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, &'a [T]>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (B: FromIterator<&'a [T]>),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::by_ref
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0]) -> &'_1 mut Chunks<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::by_ref
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0]) -> &'_1 mut Chunks<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::inspect
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::inspect<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Inspect<Chunks<'a, T>[@TraitClause0], F>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::inspect
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::inspect<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Inspect<Chunks<'a, T>[TraitClause0], F>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::fuse
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fuse<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Fuse<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::fuse
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::fuse<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Fuse<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> MapWindows<Chunks<'a, T>[@TraitClause0], F, N>[@TraitClause3, @TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::map_windows
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> MapWindows<Chunks<'a, T>[TraitClause0], F, N>[TraitClause3, TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 [&'a [T]; N],)>,
-    for<'_0_1> @TraitClause4::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: for<'_0_1> (F: FnMut<(&'_0_1 [&'a [T]; N],)>),
+    TypeConstraint0: for<'_0_1> TraitClause4::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Flatten<Chunks<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::flatten
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::flatten<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Flatten<Chunks<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::flat_map
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> FlatMap<Chunks<'a, T>[@TraitClause0], U, F>[@TraitClause3, @TraitClause1, @TraitClause2, @TraitClause4]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::flat_map
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> FlatMap<Chunks<'a, T>[TraitClause0], U, F>[TraitClause3, TraitClause1, TraitClause2, TraitClause4]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (&'a [T],)>,
-    @TraitClause5::parent_clause1::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (U: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = U,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::scan
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: St, _3: F) -> Scan<Chunks<'a, T>[@TraitClause0], St, F>[@TraitClause4, @TraitClause1, @TraitClause3]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::scan
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: St, _3: F) -> Scan<Chunks<'a, T>[TraitClause0], St, F>[TraitClause4, TraitClause1, TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<F>,
-    [@TraitClause4]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut St, &'a [T])>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
+    TraitClause0: (T: Sized),
+    TraitClause1: (St: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (F: Sized),
+    TraitClause4: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 mut St, &'a [T])>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = Option<B>[TraitClause2],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::take
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take<'a, T>(_1: Chunks<'a, T>[@TraitClause0], _2: usize) -> Take<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::take
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::take<'a, T>(_1: Chunks<'a, T>[TraitClause0], _2: usize) -> Take<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip<'a, T>(_1: Chunks<'a, T>[@TraitClause0], _2: usize) -> Skip<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::skip
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::skip<'a, T>(_1: Chunks<'a, T>[TraitClause0], _2: usize) -> Skip<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_while
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> MapWhile<Chunks<'a, T>[@TraitClause0], P>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::map_while
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::map_while<'a, T, B, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> MapWhile<Chunks<'a, T>[TraitClause0], P>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::take_while
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take_while<'a, T, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> TakeWhile<Chunks<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::take_while
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::take_while<'a, T, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> TakeWhile<Chunks<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip_while
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip_while<'a, T, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> SkipWhile<Chunks<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::skip_while
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::skip_while<'a, T, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> SkipWhile<Chunks<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::peekable
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::peekable<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Peekable<Chunks<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::peekable
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::peekable<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Peekable<Chunks<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::enumerate
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::enumerate
 #[lang_item("enumerate_method")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::enumerate<'a, T>(_1: Chunks<'a, T>[@TraitClause0]) -> Enumerate<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::enumerate<'a, T>(_1: Chunks<'a, T>[TraitClause0]) -> Enumerate<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter_map
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> FilterMap<Chunks<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::filter_map
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> FilterMap<Chunks<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::filter
 #[lang_item("iter_filter")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter<'a, T, P>(_1: Chunks<'a, T>[@TraitClause0], _2: P) -> Filter<Chunks<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::filter<'a, T, P>(_1: Chunks<'a, T>[TraitClause0], _2: P) -> Filter<Chunks<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::for_each
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::for_each<'a, T, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F)
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::for_each
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::for_each<'a, T, F>(_1: Chunks<'a, T>[TraitClause0], _2: F)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::map
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::map
 #[lang_item("IteratorMap")]
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map<'a, T, B, F>(_1: Chunks<'a, T>[@TraitClause0], _2: F) -> Map<Chunks<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::map<'a, T, B, F>(_1: Chunks<'a, T>[TraitClause0], _2: F) -> Map<Chunks<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>(_1: Chunks<'a, T>[@TraitClause0], _2: G) -> IntersperseWith<Chunks<'a, T>[@TraitClause0], G>[@TraitClause2, @TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse_with
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>(_1: Chunks<'a, T>[TraitClause0], _2: G) -> IntersperseWith<Chunks<'a, T>[TraitClause0], G>[TraitClause2, TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (G: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (G: FnMut<()>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>(_1: Chunks<'a, T>[@TraitClause0], _2: &'a [T]) -> Intersperse<Chunks<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse<'a, T>(_1: Chunks<'a, T>[TraitClause0], _2: &'a [T]) -> Intersperse<Chunks<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::zip
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::zip<'a, T, U>(_1: Chunks<'a, T>[@TraitClause0], _2: U) -> Zip<Chunks<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::zip
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::zip<'a, T, U>(_1: Chunks<'a, T>[TraitClause0], _2: U) -> Zip<Chunks<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::chain
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::chain<'a, T, U>(_1: Chunks<'a, T>[@TraitClause0], _2: U) -> Chain<Chunks<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::chain
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::chain<'a, T, U>(_1: Chunks<'a, T>[TraitClause0], _2: U) -> Chain<Chunks<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<Chunks<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (Chunks<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
+    TypeConstraint0: TraitClause3::Item = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::step_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::step_by<'a, T>(_1: Chunks<'a, T>[@TraitClause0], _2: usize) -> StepBy<Chunks<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::step_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::step_by<'a, T>(_1: Chunks<'a, T>[TraitClause0], _2: usize) -> StepBy<Chunks<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::advance_by
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::advance_by
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut Chunks<'a, T>[TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut Chunks<'a, T>[@TraitClause0]) -> Result<[&'a [T]; N], IntoIter<&'a [T], N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [&'a [T]; N]}, {built_in impl Sized for IntoIter<&'a [T], N>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}::next_chunk
+pub fn {impl Iterator for Chunks<'a, T>[TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut Chunks<'a, T>[TraitClause0]) -> Result<[&'a [T]; N], IntoIter<&'a [T], N>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>[{built_in impl Sized for [&'a [T]; N]}, {built_in impl Sized for IntoIter<&'a [T], N>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<Chunks<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (Chunks<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[@TraitClause0]}
-impl<'a, T> Iterator for Chunks<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for Chunks<'a, T>[TraitClause0]}
+impl<'a, T> Iterator for Chunks<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Chunks<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ [T]}
+    proof ImpliedClause0: (Chunks<'_, T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Chunks<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ [T]: Sized) = {built_in impl Sized for &'_ [T]}
     type Item = &'a [T]
-    fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next_chunk<'a, '_0_1, T, N>[@TraitClause0, @TraitClause0_1]
-    fn size_hint<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::size_hint<'a, '_0_1, T>[@TraitClause0]
-    fn count = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::count<'a, T>[@TraitClause0]
-    fn last = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::last<'a, T>[@TraitClause0]
-    fn advance_by<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::advance_by<'a, '_0_1, T>[@TraitClause0]
-    fn nth<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::nth<'a, '_0_1, T>[@TraitClause0]
-    fn step_by<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::step_by<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a [T]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a [T]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn enumerate<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::enumerate<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn peekable<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::peekable<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn skip<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::skip<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn take<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::take<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut St, &'a [T])>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a [T],)>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 [&'a [T]; N],)>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn fuse<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a [T]>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a [T]>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a [T]>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a [T]>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T, for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a [T])>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a [T])>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T], &'a [T])>, @TraitClause2_1::parent_clause1::Output = &'a [T]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<T2, (&'a [T], &'a [T])>, @TraitClause3_1::Output = &'a [T], @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<T2, (&'_0_2 &'a [T],)>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a [T],)>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rev<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::rev<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause9_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B)> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
-    fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<Chunks<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cycle<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cycle<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::array_chunks<'a, T, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a [T]>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a [T]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<Chunks<'a, T>[@TraitClause0]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a [T], &'a [T]>> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<Chunks<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[@TraitClause0]
-    vtable: {impl Iterator for Chunks<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    fn next_chunk<'_0_1, const N : usize, TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::next_chunk<'a, '_0_1, T, N>[TraitClause0, TraitClause0_1]
+    fn size_hint<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::size_hint<'a, '_0_1, T>[TraitClause0]
+    fn count = {impl Iterator for Chunks<'a, T>[TraitClause0]}::count<'a, T>[TraitClause0]
+    fn last = {impl Iterator for Chunks<'a, T>[TraitClause0]}::last<'a, T>[TraitClause0]
+    fn advance_by<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::advance_by<'a, '_0_1, T>[TraitClause0]
+    fn nth<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::nth<'a, '_0_1, T>[TraitClause0]
+    fn step_by<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::step_by<'a, T>[TraitClause0, TraitClause0_1]
+    fn chain<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator), TypeConstraint0: TraitClause2_1::Item = &'a [T]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::chain<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::zip<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn intersperse<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Clone)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn intersperse_with<G, TraitClause0_1: (G: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (G: FnMut<()>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a [T]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn for_each<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::for_each<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::filter<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter_map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn enumerate<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::enumerate<'a, T>[TraitClause0, TraitClause0_1]
+    fn peekable<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::peekable<'a, T>[TraitClause0, TraitClause0_1]
+    fn skip_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::skip_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn take_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::take_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map_while<B, P, TraitClause0_1: (B: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::map_while<'a, T, B, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn skip<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::skip<'a, T>[TraitClause0, TraitClause0_1]
+    fn take<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::take<'a, T>[TraitClause0, TraitClause0_1]
+    fn scan<St, B, F, TraitClause0_1: (St: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (F: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 mut St, &'a [T])>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = Option<B>[TraitClause1_1]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flat_map<U, F, TraitClause0_1: (U: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (U: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = U> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flatten<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: IntoIterator)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::flatten<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn map_windows<F, R, const N : usize, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: for<'_0_2> (F: FnMut<(&'_0_2 [&'a [T]; N],)>), TypeConstraint0: for<'_0_2> TraitClause3_1::ImpliedClause1::Output = R> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn fuse<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::fuse<'a, T>[TraitClause0, TraitClause0_1]
+    fn inspect<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::inspect<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn by_ref<'_0_1, TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::by_ref<'a, '_0_1, T>[TraitClause0, TraitClause0_1]
+    fn collect<B, TraitClause0_1: (B: Sized), TraitClause1_1: (B: FromIterator<&'a [T]>), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::collect<'a, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_collect<'_0_1, B, TraitClause0_1: (B: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (&'a [T]: Try), TraitClause3_1: (TraitClause2_1::Residual: Residual<B>), TraitClause4_1: (B: FromIterator<TraitClause2_1::Output>)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_collect<'a, '_0_1, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn collect_into<'_0_1, E, TraitClause0_1: (E: Sized), TraitClause1_1: (E: Extend<&'a [T]>), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::collect_into<'a, '_0_1, T, E>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn partition<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (B: Default), TraitClause4_1: (B: Extend<&'a [T]>), TraitClause5_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::partition<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn partition_in_place<'a, T, P, TraitClause0_1: (T: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator), TraitClause4_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T, TypeConstraint1: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn is_partitioned<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause4_1: (F: FnMut<(B, &'a [T])>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TraitClause4_1: (R: Try), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause4_1::Output = ()> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn fold<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(B, &'a [T])>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::fold<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn reduce<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T], &'a [T])>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a [T]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::reduce<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_reduce<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: (T2: FnMut<(&'a [T], &'a [T])>), TypeConstraint0: TraitClause3_1::Output = &'a [T], TypeConstraint1: TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn all<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::all<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn any<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::any<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::find<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find_map<'_0_1, B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::find_map<'a, '_0_1, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn try_find<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a [T]>[{impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: for<'_0_2> (T2: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: TraitClause3_1::Output = bool, TypeConstraint1: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn position<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::position<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rposition<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: FnMut<(&'a [T],)>), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: ExactSizeIterator), TraitClause4_1: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator), TypeConstraint0: TraitClause1_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::rposition<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Ord)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::max<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Ord)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::min<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn max_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::max_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn min_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn min_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::min_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rev<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: DoubleEndedIterator)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::rev<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn unzip<A, B, FromA, FromB, TraitClause0_1: (A: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (FromA: Sized), TraitClause3_1: (FromB: Sized), TraitClause4_1: (FromA: Default), TraitClause5_1: (FromA: Extend<A>), TraitClause6_1: (FromB: Default), TraitClause7_1: (FromB: Extend<B>), TraitClause8_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause9_1: (Chunks<'a, T>[TraitClause0]: Iterator), TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1, TraitClause6_1, TraitClause7_1, TraitClause8_1, TraitClause9_1]
+    fn copied<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cloned<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for Chunks<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cycle<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Clone)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::cycle<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn array_chunks<const N : usize, TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::array_chunks<'a, T, N>[TraitClause0, TraitClause0_1]
+    fn sum<S, TraitClause0_1: (S: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (S: Sum<&'a [T]>)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::sum<'a, T, S>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn product<P, TraitClause0_1: (P: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: Product<&'a [T]>)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::product<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: Ord), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized), TypeConstraint0: TraitClause1_1::Item = &'a [T]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Ordering> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn partial_cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn partial_cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn eq<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::eq<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn eq_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn ne<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::ne<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn lt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::lt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn le<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::le<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn gt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::gt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn ge<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (Chunks<'a, T>[TraitClause0]: Sized)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::ge<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn is_sorted<TraitClause0_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: PartialOrd<&'a [T]>)> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn is_sorted_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn is_sorted_by_key<F, K, TraitClause0_1: (F: Sized), TraitClause1_1: (K: Sized), TraitClause2_1: (Chunks<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TraitClause4_1: (K: PartialOrd<K>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = K> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for Chunks<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[TraitClause0]
+    vtable: {impl Iterator for Chunks<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 // Full name: core::slice::iter::ChunksExact
 pub opaque type ChunksExact<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked
-pub unsafe fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: usize) -> &'a [T]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::__iterator_get_unchecked
+pub unsafe fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: usize) -> &'a [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::last
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::last<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: usize) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::nth
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::nth<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: usize) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::count
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::count<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> usize
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::count
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::count<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::size_hint
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 ChunksExact<'a, T>[@TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::size_hint
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::size_hint<'a, '_1, T>(_1: &'_1 ChunksExact<'a, T>[TraitClause0]) -> (usize, Option<usize>[{built_in impl Sized for usize}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0]) -> Option<&'a [T]>[{built_in impl Sized for &'a [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by_key
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<K>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    [@TraitClause5]: PartialOrd<K, K>,
-    @TraitClause4::parent_clause1::Output = K,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (K: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TraitClause5: (K: PartialOrd<K>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = K,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: PartialOrd<&'a [T], &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: PartialOrd<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ge
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ge<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ge
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ge<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::gt
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::gt<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::gt
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::gt<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::le
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::le<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::le
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::le<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::lt
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::lt<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::lt
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::lt<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ne
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ne<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ne
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ne<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialEq<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I, _3: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: I, _3: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialEq<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialEq<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: I, _3: F) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: PartialOrd<&'a [T], @TraitClause2::Item>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: PartialOrd<TraitClause2::Item>),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I, _3: F) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: I, _3: F) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<I>,
-    [@TraitClause5]: FnMut<F, (&'a [T], @TraitClause4::Item)>,
-    @TraitClause5::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (I: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T], TraitClause4::Item)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp<'a, T, I>(_1: ChunksExact<'a, T>[@TraitClause0], _2: I) -> Ordering
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp<'a, T, I>(_1: ChunksExact<'a, T>[TraitClause0], _2: I) -> Ordering
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: IntoIterator<I>,
-    [@TraitClause3]: Ord<&'a [T]>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    @TraitClause2::Item = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: IntoIterator),
+    TraitClause3: (&'a [T]: Ord),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TypeConstraint0: TraitClause2::Item = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product<'a, T, P>(_1: ChunksExact<'a, T>[@TraitClause0]) -> P
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::product
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::product<'a, T, P>(_1: ChunksExact<'a, T>[TraitClause0]) -> P
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Product<P, &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: Product<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::sum
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::sum<'a, T, S>(_1: ChunksExact<'a, T>[@TraitClause0]) -> S
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::sum
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::sum<'a, T, S>(_1: ChunksExact<'a, T>[TraitClause0]) -> S
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<S>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Sum<S, &'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (S: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (S: Sum<&'a [T]>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::array_chunks
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: ChunksExact<'a, T>[@TraitClause0]) -> ArrayChunks<ChunksExact<'a, T>[@TraitClause0], N>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::array_chunks
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::array_chunks<'a, T, const N : usize>(_1: ChunksExact<'a, T>[TraitClause0]) -> ArrayChunks<ChunksExact<'a, T>[TraitClause0], N>[TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cycle
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cycle<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Cycle<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cycle
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cycle<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Cycle<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cloned
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cloned
 #[lang_item("iter_cloned")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Cloned<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Cloned<ChunksExact<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Clone<T>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<ChunksExact<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Clone),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::copied
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::copied
 #[lang_item("iter_copied")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Copied<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause3]
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Copied<ChunksExact<'a, T>[TraitClause0]>[TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Iterator<ChunksExact<'a, T>[@TraitClause0]>,
-    T : 'a,
-    {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Iterator),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::unzip
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: ChunksExact<'a, T>[@TraitClause0]) -> (FromA, FromB)
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::unzip
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>(_1: ChunksExact<'a, T>[TraitClause0]) -> (FromA, FromB)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<FromA>,
-    [@TraitClause4]: Sized<FromB>,
-    [@TraitClause5]: Default<FromA>,
-    [@TraitClause6]: Extend<FromA, A>,
-    [@TraitClause7]: Default<FromB>,
-    [@TraitClause8]: Extend<FromB, B>,
-    [@TraitClause9]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause10]: Iterator<ChunksExact<'a, T>[@TraitClause0]>,
-    {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B),
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (FromA: Sized),
+    TraitClause4: (FromB: Sized),
+    TraitClause5: (FromA: Default),
+    TraitClause6: (FromA: Extend<A>),
+    TraitClause7: (FromB: Default),
+    TraitClause8: (FromB: Extend<B>),
+    TraitClause9: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause10: (ChunksExact<'a, T>[TraitClause0]: Iterator),
+    TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rev
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rev<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Rev<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rev
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rev<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Rev<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by_key
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1, '_1_1> FnMut<F, (&'_0_1 &'a [T], &'_1_1 &'a [T])>,
-    for<'_0_1, '_1_1> @TraitClause3::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1, '_1_1> (F: FnMut<(&'_0_1 &'a [T], &'_1_1 &'a [T])>),
+    TypeConstraint0: for<'_0_1, '_1_1> TraitClause3::ImpliedClause1::Output = Ordering,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by_key
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Ord<B>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (B: Ord),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Ord<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Ord),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rposition
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rposition<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: FnMut<P, (&'a [T],)>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: ExactSizeIterator<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>,
-    @TraitClause2::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: FnMut<(&'a [T],)>),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: ExactSizeIterator),
+    TraitClause5: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::position
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::position
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::position<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: P) -> Option<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_find
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_find
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_find<'a, '_1, T, R, T2>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: for<'_0_1> FnMut<T2, (&'_0_1 &'a [T],)>,
-    @TraitClause4::Output = bool,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: for<'_0_1> (T2: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: TraitClause4::Output = bool,
+    TypeConstraint1: for<'_0_1> TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find_map
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<B>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find_map
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find_map<'a, '_1, T, B, F>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<B>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: P) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find<'a, '_1, T, P>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: P) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::any
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::any
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::any<'a, '_1, T, F>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::all
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: F) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::all
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::all<'a, '_1, T, F>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: F) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: T2) -> @TraitClause5::TryType
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_reduce
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_reduce<'a, '_1, T, R, T2>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: T2) -> TraitClause5::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: Sized<T2>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Try<R>,
-    [@TraitClause5]: Residual<@TraitClause4::Residual, Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>,
-    [@TraitClause6]: FnMut<T2, (&'a [T], &'a [T])>,
-    @TraitClause4::Output = &'a [T],
-    @TraitClause6::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (T2: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (R: Try),
+    TraitClause5: (TraitClause4::Residual: Residual<Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>),
+    TraitClause6: (T2: FnMut<(&'a [T], &'a [T])>),
+    TypeConstraint0: TraitClause4::Output = &'a [T],
+    TypeConstraint1: TraitClause6::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::reduce
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::reduce<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T], &'a [T])>,
-    @TraitClause3::parent_clause1::Output = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T], &'a [T])>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fold
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fold<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: B, _3: F) -> B
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fold
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fold<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: B, _3: F) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (B, &'a [T])>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(B, &'a [T])>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_for_each
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: F) -> R
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_for_each
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_for_each<'a, '_1, T, F, R>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    [@TraitClause5]: Try<R>,
-    @TraitClause4::parent_clause1::Output = R,
-    @TraitClause5::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TraitClause5: (R: Try),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause5::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_fold
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: B, _3: F) -> R
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_fold
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_fold<'a, '_1, T, B, F, R>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: B, _3: F) -> R
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<R>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: FnMut<F, (B, &'a [T])>,
-    [@TraitClause6]: Try<R>,
-    @TraitClause5::parent_clause1::Output = R,
-    @TraitClause6::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (R: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause5: (F: FnMut<(B, &'a [T])>),
+    TraitClause6: (R: Try),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = R,
+    TypeConstraint1: TraitClause6::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_partitioned
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> bool
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_partitioned
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<P, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition_in_place
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> usize
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition_in_place
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<P, (&'_0_1 T,)>,
-    T : 'a,
-    {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator),
+    TraitClause5: for<'_0_1> (P: FnMut<(&'_0_1 T,)>),
+    TypeOutlives0: T: 'a,
+    TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T,
+    TypeConstraint1: for<'_0_1> TraitClause5::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> (B, B)
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> (B, B)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: Default<B>,
-    [@TraitClause5]: Extend<B, &'a [T]>,
-    [@TraitClause6]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause6::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (B: Default),
+    TraitClause5: (B: Extend<&'a [T]>),
+    TraitClause6: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause6::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into<'a, '_1, T, E>(_1: ChunksExact<'a, T>[@TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect_into
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect_into<'a, '_1, T, E>(_1: ChunksExact<'a, T>[TraitClause0], _2: &'_1 mut E) -> &'_1 mut E
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Extend<E, &'a [T]>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Extend<&'a [T]>),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_collect
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0]) -> @TraitClause4::TryType
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_collect
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_collect<'a, '_1, T, B>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0]) -> TraitClause4::TryType
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: Try<&'a [T]>,
-    [@TraitClause4]: Residual<@TraitClause3::Residual, B>,
-    [@TraitClause5]: FromIterator<B, @TraitClause3::Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (&'a [T]: Try),
+    TraitClause4: (TraitClause3::Residual: Residual<B>),
+    TraitClause5: (B: FromIterator<TraitClause3::Output>),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect
 #[lang_item("iterator_collect_fn")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect<'a, T, B>(_1: ChunksExact<'a, T>[@TraitClause0]) -> B
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect<'a, T, B>(_1: ChunksExact<'a, T>[TraitClause0]) -> B
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: FromIterator<B, &'a [T]>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (B: FromIterator<&'a [T]>),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::by_ref
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0]) -> &'_1 mut ChunksExact<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::by_ref
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::by_ref<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0]) -> &'_1 mut ChunksExact<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::inspect
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::inspect<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Inspect<ChunksExact<'a, T>[@TraitClause0], F>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::inspect
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::inspect<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Inspect<ChunksExact<'a, T>[TraitClause0], F>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<F, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (F: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fuse
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fuse<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Fuse<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fuse
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fuse<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Fuse<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> MapWindows<ChunksExact<'a, T>[@TraitClause0], F, N>[@TraitClause3, @TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_windows
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, const N : usize>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> MapWindows<ChunksExact<'a, T>[TraitClause0], F, N>[TraitClause3, TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<R>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: for<'_0_1> FnMut<F, (&'_0_1 [&'a [T]; N],)>,
-    for<'_0_1> @TraitClause4::parent_clause1::Output = R,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (R: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: for<'_0_1> (F: FnMut<(&'_0_1 [&'a [T]; N],)>),
+    TypeConstraint0: for<'_0_1> TraitClause4::ImpliedClause1::Output = R,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Flatten<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flatten
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flatten<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Flatten<ChunksExact<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: IntoIterator<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flat_map
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> FlatMap<ChunksExact<'a, T>[@TraitClause0], U, F>[@TraitClause3, @TraitClause1, @TraitClause2, @TraitClause4]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flat_map
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> FlatMap<ChunksExact<'a, T>[TraitClause0], U, F>[TraitClause3, TraitClause1, TraitClause2, TraitClause4]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: IntoIterator<U>,
-    [@TraitClause5]: FnMut<F, (&'a [T],)>,
-    @TraitClause5::parent_clause1::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (U: IntoIterator),
+    TraitClause5: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause5::ImpliedClause1::Output = U,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::scan
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: St, _3: F) -> Scan<ChunksExact<'a, T>[@TraitClause0], St, F>[@TraitClause4, @TraitClause1, @TraitClause3]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::scan
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: St, _3: F) -> Scan<ChunksExact<'a, T>[TraitClause0], St, F>[TraitClause4, TraitClause1, TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<St>,
-    [@TraitClause2]: Sized<B>,
-    [@TraitClause3]: Sized<F>,
-    [@TraitClause4]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause5]: for<'_0_1> FnMut<F, (&'_0_1 mut St, &'a [T])>,
-    for<'_0_1> @TraitClause5::parent_clause1::Output = Option<B>[@TraitClause2],
+    TraitClause0: (T: Sized),
+    TraitClause1: (St: Sized),
+    TraitClause2: (B: Sized),
+    TraitClause3: (F: Sized),
+    TraitClause4: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause5: for<'_0_1> (F: FnMut<(&'_0_1 mut St, &'a [T])>),
+    TypeConstraint0: for<'_0_1> TraitClause5::ImpliedClause1::Output = Option<B>[TraitClause2],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0], _2: usize) -> Take<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take<'a, T>(_1: ChunksExact<'a, T>[TraitClause0], _2: usize) -> Take<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0], _2: usize) -> Skip<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip<'a, T>(_1: ChunksExact<'a, T>[TraitClause0], _2: usize) -> Skip<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_while
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> MapWhile<ChunksExact<'a, T>[@TraitClause0], P>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_while
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_while<'a, T, B, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> MapWhile<ChunksExact<'a, T>[TraitClause0], P>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<P>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<P, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (P: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (P: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take_while
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take_while<'a, T, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> TakeWhile<ChunksExact<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take_while
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take_while<'a, T, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> TakeWhile<ChunksExact<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip_while
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip_while<'a, T, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> SkipWhile<ChunksExact<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip_while
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip_while<'a, T, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> SkipWhile<ChunksExact<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::peekable
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::peekable<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Peekable<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::peekable
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::peekable<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Peekable<ChunksExact<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::enumerate
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::enumerate
 #[lang_item("enumerate_method")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::enumerate<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0]) -> Enumerate<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::enumerate<'a, T>(_1: ChunksExact<'a, T>[TraitClause0]) -> Enumerate<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter_map
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> FilterMap<ChunksExact<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter_map
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> FilterMap<ChunksExact<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = Option<B>[@TraitClause1],
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = Option<B>[TraitClause1],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter
 #[lang_item("iter_filter")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter<'a, T, P>(_1: ChunksExact<'a, T>[@TraitClause0], _2: P) -> Filter<ChunksExact<'a, T>[@TraitClause0], P>[@TraitClause2, @TraitClause1]
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter<'a, T, P>(_1: ChunksExact<'a, T>[TraitClause0], _2: P) -> Filter<ChunksExact<'a, T>[TraitClause0], P>[TraitClause2, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<P>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: for<'_0_1> FnMut<P, (&'_0_1 &'a [T],)>,
-    for<'_0_1> @TraitClause3::parent_clause1::Output = bool,
+    TraitClause0: (T: Sized),
+    TraitClause1: (P: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: for<'_0_1> (P: FnMut<(&'_0_1 &'a [T],)>),
+    TypeConstraint0: for<'_0_1> TraitClause3::ImpliedClause1::Output = bool,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::for_each
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::for_each<'a, T, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F)
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::for_each
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::for_each<'a, T, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<F, (&'a [T],)>,
-    @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = (),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map
 #[lang_item("IteratorMap")]
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map<'a, T, B, F>(_1: ChunksExact<'a, T>[@TraitClause0], _2: F) -> Map<ChunksExact<'a, T>[@TraitClause0], F>[@TraitClause3, @TraitClause2]
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map<'a, T, B, F>(_1: ChunksExact<'a, T>[TraitClause0], _2: F) -> Map<ChunksExact<'a, T>[TraitClause0], F>[TraitClause3, TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause4]: FnMut<F, (&'a [T],)>,
-    @TraitClause4::parent_clause1::Output = B,
+    TraitClause0: (T: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause4: (F: FnMut<(&'a [T],)>),
+    TypeConstraint0: TraitClause4::ImpliedClause1::Output = B,
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>(_1: ChunksExact<'a, T>[@TraitClause0], _2: G) -> IntersperseWith<ChunksExact<'a, T>[@TraitClause0], G>[@TraitClause2, @TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse_with
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>(_1: ChunksExact<'a, T>[TraitClause0], _2: G) -> IntersperseWith<ChunksExact<'a, T>[TraitClause0], G>[TraitClause2, TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<G>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: FnMut<G, ()>,
-    @TraitClause3::parent_clause1::Output = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (G: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (G: FnMut<()>),
+    TypeConstraint0: TraitClause3::ImpliedClause1::Output = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0], _2: &'a [T]) -> Intersperse<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0], @TraitClause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse<'a, T>(_1: ChunksExact<'a, T>[TraitClause0], _2: &'a [T]) -> Intersperse<ChunksExact<'a, T>[TraitClause0]>[TraitClause1, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0], TraitClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause2]: Clone<&'a [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause2: (&'a [T]: Clone),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::zip
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::zip<'a, T, U>(_1: ChunksExact<'a, T>[@TraitClause0], _2: U) -> Zip<ChunksExact<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::zip
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::zip<'a, T, U>(_1: ChunksExact<'a, T>[TraitClause0], _2: U) -> Zip<ChunksExact<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::chain
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::chain<'a, T, U>(_1: ChunksExact<'a, T>[@TraitClause0], _2: U) -> Chain<ChunksExact<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::chain
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::chain<'a, T, U>(_1: ChunksExact<'a, T>[TraitClause0], _2: U) -> Chain<ChunksExact<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: IntoIterator<U>,
-    @TraitClause3::Item = &'a [T],
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (ChunksExact<'a, T>[TraitClause0]: Sized),
+    TraitClause3: (U: IntoIterator),
+    TypeConstraint0: TraitClause3::Item = &'a [T],
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::step_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::step_by<'a, T>(_1: ChunksExact<'a, T>[@TraitClause0], _2: usize) -> StepBy<ChunksExact<'a, T>[@TraitClause0]>[@TraitClause1]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::step_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::step_by<'a, T>(_1: ChunksExact<'a, T>[TraitClause0], _2: usize) -> StepBy<ChunksExact<'a, T>[TraitClause0]>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::advance_by
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::advance_by
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::advance_by<'a, '_1, T>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0], _2: usize) -> Result<(), NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]>[{built_in impl Sized for ()}, {built_in impl Sized for NonZero<usize>[{built_in impl Sized for usize}, {impl ZeroablePrimitive for usize}]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk
-pub fn {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut ChunksExact<'a, T>[@TraitClause0]) -> Result<[&'a [T]; N], IntoIter<&'a [T], N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>[{built_in impl Sized for [&'a [T]; N]}, {built_in impl Sized for IntoIter<&'a [T], N>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]}]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next_chunk
+pub fn {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next_chunk<'a, '_1, T, const N : usize>(_1: &'_1 mut ChunksExact<'a, T>[TraitClause0]) -> Result<[&'a [T]; N], IntoIter<&'a [T], N>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>[{built_in impl Sized for [&'a [T]; N]}, {built_in impl Sized for IntoIter<&'a [T], N>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<ChunksExact<'a, T>[@TraitClause0]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (ChunksExact<'a, T>[TraitClause0]: Sized),
 = <opaque>
 
-// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}
-impl<'a, T> Iterator for ChunksExact<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl Iterator for ChunksExact<'a, T>[TraitClause0]}
+impl<'a, T> Iterator for ChunksExact<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for ChunksExact<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for &'_ [T]}
+    proof ImpliedClause0: (ChunksExact<'_, T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for ChunksExact<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ [T]: Sized) = {built_in impl Sized for &'_ [T]}
     type Item = &'a [T]
-    fn next<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    fn next_chunk<'_0_1, const N : usize, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next_chunk<'a, '_0_1, T, N>[@TraitClause0, @TraitClause0_1]
-    fn size_hint<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::size_hint<'a, '_0_1, T>[@TraitClause0]
-    fn count = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::count<'a, T>[@TraitClause0]
-    fn last = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::last<'a, T>[@TraitClause0]
-    fn advance_by<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::advance_by<'a, '_0_1, T>[@TraitClause0]
-    fn nth<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::nth<'a, '_0_1, T>[@TraitClause0]
-    fn step_by<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::step_by<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn chain<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>, @TraitClause2_1::Item = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::chain<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn zip<U, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: IntoIterator<U>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn intersperse<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<&'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn intersperse_with<G, [@TraitClause0_1]: Sized<G>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<G, ()>, @TraitClause2_1::parent_clause1::Output = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::intersperse_with<'a, T, G>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn for_each<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::for_each<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn filter_map<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::filter_map<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn enumerate<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::enumerate<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn peekable<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::peekable<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn skip_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn take_while<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take_while<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn map_while<B, P, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<P, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_while<'a, T, B, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn skip<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::skip<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn take<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::take<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn scan<St, B, F, [@TraitClause0_1]: Sized<St>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<F>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 mut St, &'a [T])>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = Option<B>[@TraitClause1_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::scan<'a, T, St, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flat_map<U, F, [@TraitClause0_1]: Sized<U>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<U>, [@TraitClause4_1]: FnMut<F, (&'a [T],)>, @TraitClause4_1::parent_clause1::Output = U> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flat_map<'a, T, U, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn flatten<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: IntoIterator<&'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::flatten<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn map_windows<F, R, const N : usize, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: for<'_0_2> FnMut<F, (&'_0_2 [&'a [T]; N],)>, for<'_0_2> @TraitClause3_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::map_windows<'a, T, F, R, N>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn fuse<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fuse<'a, T>[@TraitClause0, @TraitClause0_1]
-    fn inspect<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::inspect<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::by_ref<'a, '_0_1, T>[@TraitClause0, @TraitClause0_1]
-    fn collect<B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: FromIterator<B, &'a [T]>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect<'a, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_collect<'_0_1, B, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Try<&'a [T]>, [@TraitClause3_1]: Residual<@TraitClause2_1::Residual, B>, [@TraitClause4_1]: FromIterator<B, @TraitClause2_1::Output>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_collect<'a, '_0_1, T, B>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn collect_into<'_0_1, E, [@TraitClause0_1]: Sized<E>, [@TraitClause1_1]: Extend<E, &'a [T]>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::collect_into<'a, '_0_1, T, E>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn partition<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Default<B>, [@TraitClause4_1]: Extend<B, &'a [T]>, [@TraitClause5_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause5_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn partition_in_place<'a, T, P, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Sized<P>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<P, (&'_0_2 T,)>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a mut T, for<'_0_2> @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn is_partitioned<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_partitioned<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_fold<'_0_1, B, F, R, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<R>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: FnMut<F, (B, &'a [T])>, [@TraitClause5_1]: Try<R>, @TraitClause4_1::parent_clause1::Output = R, @TraitClause5_1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn try_for_each<'_0_1, F, R, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<R>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, [@TraitClause4_1]: Try<R>, @TraitClause3_1::parent_clause1::Output = R, @TraitClause4_1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn fold<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (B, &'a [T])>, @TraitClause3_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::fold<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn reduce<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T], &'a [T])>, @TraitClause2_1::parent_clause1::Output = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::reduce<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn try_reduce<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: FnMut<T2, (&'a [T], &'a [T])>, @TraitClause3_1::Output = &'a [T], @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn all<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::all<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn any<'_0_1, F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<F, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::any<'a, '_0_1, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2> FnMut<P, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn find_map<'_0_1, B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, @TraitClause3_1::parent_clause1::Output = Option<B>[@TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::find_map<'a, '_0_1, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn try_find<'_0_1, R, T2, [@TraitClause0_1]: Sized<R>, [@TraitClause1_1]: Sized<T2>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Try<R>, [@TraitClause4_1]: Residual<@TraitClause3_1::Residual, Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::parent_clause1]>, [@TraitClause5_1]: for<'_0_2> FnMut<T2, (&'_0_2 &'a [T],)>, @TraitClause3_1::Output = bool, for<'_0_2> @TraitClause5_1::parent_clause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1]
-    fn position<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: FnMut<P, (&'a [T],)>, @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::position<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rposition<'_0_1, P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: FnMut<P, (&'a [T],)>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: ExactSizeIterator<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rposition<'a, '_0_1, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn min<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Ord<&'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn max_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn max_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::max_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn min_by_key<B, F, [@TraitClause0_1]: Sized<B>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Ord<B>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause4_1]: for<'_0_2> FnMut<F, (&'_0_2 &'a [T],)>, for<'_0_2> @TraitClause4_1::parent_clause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by_key<'a, T, B, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn min_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::min_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn rev<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: DoubleEndedIterator<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::rev<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn unzip<A, B, FromA, FromB, [@TraitClause0_1]: Sized<A>, [@TraitClause1_1]: Sized<B>, [@TraitClause2_1]: Sized<FromA>, [@TraitClause3_1]: Sized<FromB>, [@TraitClause4_1]: Default<FromA>, [@TraitClause5_1]: Extend<FromA, A>, [@TraitClause6_1]: Default<FromB>, [@TraitClause7_1]: Extend<FromB, B>, [@TraitClause8_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause9_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = (A, B)> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1, @TraitClause5_1, @TraitClause6_1, @TraitClause7_1, @TraitClause8_1, @TraitClause9_1]
-    fn copied<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::copied<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cloned<'a, T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: Iterator<ChunksExact<'a, T>[@TraitClause0]>, T : 'a, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'a, T>[@TraitClause0]::Item = &'a T> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cloned<'a, 'a, T, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cycle<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: Clone<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cycle<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn array_chunks<const N : usize, [@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::array_chunks<'a, T, N>[@TraitClause0, @TraitClause0_1]
-    fn sum<S, [@TraitClause0_1]: Sized<S>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Sum<S, &'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::sum<'a, T, S>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn product<P, [@TraitClause0_1]: Sized<P>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: Product<P, &'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::product<'a, T, P>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: Ord<&'a [T]>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, @TraitClause1_1::Item = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn partial_cmp<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn partial_cmp_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::partial_cmp_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn eq<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn eq_by<I, F, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: Sized<F>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: IntoIterator<I>, [@TraitClause4_1]: FnMut<F, (&'a [T], @TraitClause3_1::Item)>, @TraitClause4_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::eq_by<'a, T, I, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn ne<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialEq<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ne<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn lt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::lt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn le<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::le<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn gt<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::gt<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn ge<I, [@TraitClause0_1]: Sized<I>, [@TraitClause1_1]: IntoIterator<I>, [@TraitClause2_1]: PartialOrd<&'a [T], @TraitClause1_1::Item>, [@TraitClause3_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::ge<'a, T, I>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1]
-    fn is_sorted<[@TraitClause0_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause1_1]: PartialOrd<&'a [T], &'a [T]>> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted<'a, T>[@TraitClause0, @TraitClause0_1, @TraitClause1_1]
-    fn is_sorted_by<F, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause2_1]: for<'_0_2, '_1_2> FnMut<F, (&'_0_2 &'a [T], &'_1_2 &'a [T])>, for<'_0_2, '_1_2> @TraitClause2_1::parent_clause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by<'a, T, F>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    fn is_sorted_by_key<F, K, [@TraitClause0_1]: Sized<F>, [@TraitClause1_1]: Sized<K>, [@TraitClause2_1]: Sized<ChunksExact<'a, T>[@TraitClause0]>, [@TraitClause3_1]: FnMut<F, (&'a [T],)>, [@TraitClause4_1]: PartialOrd<K, K>, @TraitClause3_1::parent_clause1::Output = K> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::is_sorted_by_key<'a, T, F, K>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1, @TraitClause3_1, @TraitClause4_1]
-    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[@TraitClause0]
-    vtable: {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    fn next_chunk<'_0_1, const N : usize, TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next_chunk<'a, '_0_1, T, N>[TraitClause0, TraitClause0_1]
+    fn size_hint<'_0_1> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::size_hint<'a, '_0_1, T>[TraitClause0]
+    fn count = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::count<'a, T>[TraitClause0]
+    fn last = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::last<'a, T>[TraitClause0]
+    fn advance_by<'_0_1> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::advance_by<'a, '_0_1, T>[TraitClause0]
+    fn nth<'_0_1> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::nth<'a, '_0_1, T>[TraitClause0]
+    fn step_by<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::step_by<'a, T>[TraitClause0, TraitClause0_1]
+    fn chain<U, TraitClause0_1: (U: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator), TypeConstraint0: TraitClause2_1::Item = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::chain<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (U: IntoIterator)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::zip<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn intersperse<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Clone)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn intersperse_with<G, TraitClause0_1: (G: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (G: FnMut<()>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::intersperse_with<'a, T, G>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn for_each<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::for_each<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter<P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn filter_map<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::filter_map<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn enumerate<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::enumerate<'a, T>[TraitClause0, TraitClause0_1]
+    fn peekable<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::peekable<'a, T>[TraitClause0, TraitClause0_1]
+    fn skip_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn take_while<P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take_while<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn map_while<B, P, TraitClause0_1: (B: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_while<'a, T, B, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn skip<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::skip<'a, T>[TraitClause0, TraitClause0_1]
+    fn take<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::take<'a, T>[TraitClause0, TraitClause0_1]
+    fn scan<St, B, F, TraitClause0_1: (St: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (F: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 mut St, &'a [T])>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = Option<B>[TraitClause1_1]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::scan<'a, T, St, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flat_map<U, F, TraitClause0_1: (U: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (U: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = U> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flat_map<'a, T, U, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn flatten<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: IntoIterator)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::flatten<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn map_windows<F, R, const N : usize, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: for<'_0_2> (F: FnMut<(&'_0_2 [&'a [T]; N],)>), TypeConstraint0: for<'_0_2> TraitClause3_1::ImpliedClause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::map_windows<'a, T, F, R, N>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn fuse<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fuse<'a, T>[TraitClause0, TraitClause0_1]
+    fn inspect<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::inspect<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn by_ref<'_0_1, TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::by_ref<'a, '_0_1, T>[TraitClause0, TraitClause0_1]
+    fn collect<B, TraitClause0_1: (B: Sized), TraitClause1_1: (B: FromIterator<&'a [T]>), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect<'a, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_collect<'_0_1, B, TraitClause0_1: (B: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (&'a [T]: Try), TraitClause3_1: (TraitClause2_1::Residual: Residual<B>), TraitClause4_1: (B: FromIterator<TraitClause2_1::Output>)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_collect<'a, '_0_1, T, B>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn collect_into<'_0_1, E, TraitClause0_1: (E: Sized), TraitClause1_1: (E: Extend<&'a [T]>), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::collect_into<'a, '_0_1, T, E>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn partition<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (B: Default), TraitClause4_1: (B: Extend<&'a [T]>), TraitClause5_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn partition_in_place<'a, T, P, TraitClause0_1: (T: Sized), TraitClause1_1: (P: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator), TraitClause4_1: for<'_0_2> (P: FnMut<(&'_0_2 T,)>), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a mut T, TypeConstraint1: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partition_in_place<'a, 'a, T, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn is_partitioned<P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_partitioned<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_fold<'_0_1, B, F, R, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (R: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause4_1: (F: FnMut<(B, &'a [T])>), TraitClause5_1: (R: Try), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause5_1::Output = B> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_fold<'a, '_0_1, T, B, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn try_for_each<'_0_1, F, R, TraitClause0_1: (F: Sized), TraitClause1_1: (R: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TraitClause4_1: (R: Try), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = R, TypeConstraint1: TraitClause4_1::Output = ()> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_for_each<'a, '_0_1, T, F, R>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn fold<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(B, &'a [T])>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::fold<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn reduce<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T], &'a [T])>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::reduce<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn try_reduce<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: (T2: FnMut<(&'a [T], &'a [T])>), TypeConstraint0: TraitClause3_1::Output = &'a [T], TypeConstraint1: TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_reduce<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn all<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::all<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn any<'_0_1, F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::any<'a, '_0_1, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2> (P: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn find_map<'_0_1, B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = Option<B>[TraitClause0_1]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::find_map<'a, '_0_1, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn try_find<'_0_1, R, T2, TraitClause0_1: (R: Sized), TraitClause1_1: (T2: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (R: Try), TraitClause4_1: (TraitClause3_1::Residual: Residual<Option<&'a [T]>[{impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::ImpliedClause1]>), TraitClause5_1: for<'_0_2> (T2: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: TraitClause3_1::Output = bool, TypeConstraint1: for<'_0_2> TraitClause5_1::ImpliedClause1::Output = R> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::try_find<'a, '_0_1, T, R, T2>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1]
+    fn position<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: FnMut<(&'a [T],)>), TypeConstraint0: TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::position<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rposition<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: FnMut<(&'a [T],)>), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: ExactSizeIterator), TraitClause4_1: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator), TypeConstraint0: TraitClause1_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rposition<'a, '_0_1, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Ord)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn min<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: Ord)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn max_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn max_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::max_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn min_by_key<B, F, TraitClause0_1: (B: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (B: Ord), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause4_1: for<'_0_2> (F: FnMut<(&'_0_2 &'a [T],)>), TypeConstraint0: for<'_0_2> TraitClause4_1::ImpliedClause1::Output = B> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by_key<'a, T, B, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn min_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::min_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn rev<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: DoubleEndedIterator)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::rev<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn unzip<A, B, FromA, FromB, TraitClause0_1: (A: Sized), TraitClause1_1: (B: Sized), TraitClause2_1: (FromA: Sized), TraitClause3_1: (FromB: Sized), TraitClause4_1: (FromA: Default), TraitClause5_1: (FromA: Extend<A>), TraitClause6_1: (FromB: Default), TraitClause7_1: (FromB: Extend<B>), TraitClause8_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause9_1: (ChunksExact<'a, T>[TraitClause0]: Iterator), TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = (A, B)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::unzip<'a, T, A, B, FromA, FromB>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1, TraitClause5_1, TraitClause6_1, TraitClause7_1, TraitClause8_1, TraitClause9_1]
+    fn copied<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::copied<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cloned<'a, T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Iterator), TypeOutlives0: T: 'a, TypeConstraint0: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'a, T>[TraitClause0]::Item = &'a T> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cloned<'a, 'a, T, T>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cycle<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Clone)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cycle<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn array_chunks<const N : usize, TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::array_chunks<'a, T, N>[TraitClause0, TraitClause0_1]
+    fn sum<S, TraitClause0_1: (S: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (S: Sum<&'a [T]>)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::sum<'a, T, S>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn product<P, TraitClause0_1: (P: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: (P: Product<&'a [T]>)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::product<'a, T, P>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: Ord), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TypeConstraint0: TraitClause1_1::Item = &'a [T]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Ordering> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn partial_cmp<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn partial_cmp_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = Option<Ordering>[{built_in impl Sized for Ordering}]> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::partial_cmp_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn eq<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn eq_by<I, F, TraitClause0_1: (I: Sized), TraitClause1_1: (F: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (I: IntoIterator), TraitClause4_1: (F: FnMut<(&'a [T], TraitClause3_1::Item)>), TypeConstraint0: TraitClause4_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::eq_by<'a, T, I, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn ne<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialEq<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ne<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn lt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::lt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn le<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::le<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn gt<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::gt<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn ge<I, TraitClause0_1: (I: Sized), TraitClause1_1: (I: IntoIterator), TraitClause2_1: (&'a [T]: PartialOrd<TraitClause1_1::Item>), TraitClause3_1: (ChunksExact<'a, T>[TraitClause0]: Sized)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::ge<'a, T, I>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1]
+    fn is_sorted<TraitClause0_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause1_1: (&'a [T]: PartialOrd<&'a [T]>)> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted<'a, T>[TraitClause0, TraitClause0_1, TraitClause1_1]
+    fn is_sorted_by<F, TraitClause0_1: (F: Sized), TraitClause1_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause2_1: for<'_0_2, '_1_2> (F: FnMut<(&'_0_2 &'a [T], &'_1_2 &'a [T])>), TypeConstraint0: for<'_0_2, '_1_2> TraitClause2_1::ImpliedClause1::Output = bool> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by<'a, T, F>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    fn is_sorted_by_key<F, K, TraitClause0_1: (F: Sized), TraitClause1_1: (K: Sized), TraitClause2_1: (ChunksExact<'a, T>[TraitClause0]: Sized), TraitClause3_1: (F: FnMut<(&'a [T],)>), TraitClause4_1: (K: PartialOrd<K>), TypeConstraint0: TraitClause3_1::ImpliedClause1::Output = K> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::is_sorted_by_key<'a, T, F, K>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1, TraitClause3_1, TraitClause4_1]
+    fn __iterator_get_unchecked<'_0_1> = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::__iterator_get_unchecked<'a, '_0_1, T>[TraitClause0]
+    vtable: {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 // Full name: core::slice::{[T]}::iter
 #[lang_item("slice_iter")]
-pub fn iter<'_0, T>(_1: &'_0 [T]) -> Iter<'_0, T>[@TraitClause0]
+pub fn iter<'_0, T>(_1: &'_0 [T]) -> Iter<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::{[T]}::chunks
-pub fn chunks<'_0, T>(_1: &'_0 [T], _2: usize) -> Chunks<'_0, T>[@TraitClause0]
+pub fn chunks<'_0, T>(_1: &'_0 [T], _2: usize) -> Chunks<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::{[T]}::chunks_exact
-pub fn chunks_exact<'_0, T>(_1: &'_0 [T], _2: usize) -> ChunksExact<'_0, T>[@TraitClause0]
+pub fn chunks_exact<'_0, T>(_1: &'_0 [T], _2: usize) -> ChunksExact<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::main
@@ -5165,7 +5165,7 @@ fn main()
     _5 = copy a_1
     _4 = {impl IntoIterator for [T; N]}::into_iter<i32, 7 : usize>[{built_in impl Sized for i32}](move _5)
     storage_dead(_5)
-    _3 = {impl IntoIterator for I}::into_iter<IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]}, {impl Iterator for IntoIter<T, N>[@TraitClause0]}<i32, 7 : usize>[{built_in impl Sized for i32}]](move _4)
+    _3 = {impl IntoIterator for I}::into_iter<IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7 : usize>[{built_in impl Sized for i32}]}, {impl Iterator for IntoIter<T, N>[TraitClause0]}<i32, 7 : usize>[{built_in impl Sized for i32}]](move _4)
     storage_dead(_4)
     storage_live(iter_6)
     iter_6 = move _3
@@ -5175,7 +5175,7 @@ fn main()
         storage_live(_9)
         _9 = &mut iter_6
         _8 = &two-phase-mut (*_9)
-        _7 = {impl Iterator for IntoIter<T, N>[@TraitClause0]}::next<'87, i32, 7 : usize>[{built_in impl Sized for i32}](move _8)
+        _7 = {impl Iterator for IntoIter<T, N>[TraitClause0]}::next<'87, i32, 7 : usize>[{built_in impl Sized for i32}](move _8)
         storage_dead(_8)
         match _7 {
             Option::None => {
@@ -5198,9 +5198,9 @@ fn main()
     }
     storage_dead(_9)
     storage_dead(_7)
-    conditional_drop[{impl Destruct for IntoIter<T, N>[@TraitClause0]}::drop_in_place<i32, 7 : usize>[{built_in impl Sized for i32}]] iter_6
+    conditional_drop[{impl Destruct for IntoIter<T, N>[TraitClause0]}::drop_in_place<i32, 7 : usize>[{built_in impl Sized for i32}]] iter_6
     storage_dead(iter_6)
-    conditional_drop[{impl Destruct for IntoIter<T, N>[@TraitClause0]}::drop_in_place<i32, 7 : usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[{impl Destruct for IntoIter<T, N>[TraitClause0]}::drop_in_place<i32, 7 : usize>[{built_in impl Sized for i32}]] _3
     storage_dead(_3)
     storage_live(_13)
     storage_live(_14)
@@ -5211,7 +5211,7 @@ fn main()
     storage_dead(_16)
     _14 = iter<'90, i32>[{built_in impl Sized for i32}](move _15)
     storage_dead(_15)
-    _13 = {impl IntoIterator for I}::into_iter<Iter<'91, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'91, i32>[{built_in impl Sized for i32}]}, {impl Iterator for Iter<'a, T>[@TraitClause0]}<'91, i32>[{built_in impl Sized for i32}]](move _14)
+    _13 = {impl IntoIterator for I}::into_iter<Iter<'91, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'91, i32>[{built_in impl Sized for i32}]}, {impl Iterator for Iter<'a, T>[TraitClause0]}<'91, i32>[{built_in impl Sized for i32}]](move _14)
     storage_dead(_14)
     storage_live(iter_17)
     iter_17 = move _13
@@ -5221,7 +5221,7 @@ fn main()
         storage_live(_20)
         _20 = &mut iter_17
         _19 = &two-phase-mut (*_20)
-        _18 = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'100, '102, i32>[{built_in impl Sized for i32}](move _19)
+        _18 = {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'100, '102, i32>[{built_in impl Sized for i32}](move _19)
         storage_dead(_19)
         match _18 {
             Option::None => {
@@ -5259,7 +5259,7 @@ fn main()
     storage_dead(_28)
     _26 = chunks<'112, i32>[{built_in impl Sized for i32}](move _27, const 2 : usize)
     storage_dead(_27)
-    _25 = {impl IntoIterator for I}::into_iter<Chunks<'113, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'113, i32>[{built_in impl Sized for i32}]}, {impl Iterator for Chunks<'a, T>[@TraitClause0]}<'113, i32>[{built_in impl Sized for i32}]](move _26)
+    _25 = {impl IntoIterator for I}::into_iter<Chunks<'113, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'113, i32>[{built_in impl Sized for i32}]}, {impl Iterator for Chunks<'a, T>[TraitClause0]}<'113, i32>[{built_in impl Sized for i32}]](move _26)
     storage_dead(_26)
     storage_live(iter_29)
     iter_29 = move _25
@@ -5269,7 +5269,7 @@ fn main()
         storage_live(_32)
         _32 = &mut iter_29
         _31 = &two-phase-mut (*_32)
-        _30 = {impl Iterator for Chunks<'a, T>[@TraitClause0]}::next<'122, '124, i32>[{built_in impl Sized for i32}](move _31)
+        _30 = {impl Iterator for Chunks<'a, T>[TraitClause0]}::next<'122, '124, i32>[{built_in impl Sized for i32}](move _31)
         storage_dead(_31)
         match _30 {
             Option::None => {
@@ -5297,7 +5297,7 @@ fn main()
     storage_dead(_37)
     _35 = chunks_exact<'127, i32>[{built_in impl Sized for i32}](move _36, const 2 : usize)
     storage_dead(_36)
-    _34 = {impl IntoIterator for I}::into_iter<ChunksExact<'128, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'128, i32>[{built_in impl Sized for i32}]}, {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}<'128, i32>[{built_in impl Sized for i32}]](move _35)
+    _34 = {impl IntoIterator for I}::into_iter<ChunksExact<'128, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'128, i32>[{built_in impl Sized for i32}]}, {impl Iterator for ChunksExact<'a, T>[TraitClause0]}<'128, i32>[{built_in impl Sized for i32}]](move _35)
     storage_dead(_35)
     storage_live(iter_38)
     iter_38 = move _34
@@ -5307,7 +5307,7 @@ fn main()
         storage_live(_41)
         _41 = &mut iter_38
         _40 = &two-phase-mut (*_41)
-        _39 = {impl Iterator for ChunksExact<'a, T>[@TraitClause0]}::next<'137, '139, i32>[{built_in impl Sized for i32}](move _40)
+        _39 = {impl Iterator for ChunksExact<'a, T>[TraitClause0]}::next<'137, '139, i32>[{built_in impl Sized for i32}](move _40)
         storage_dead(_40)
         match _39 {
             Option::None => {

--- a/charon/tests/ui/lifetime-mutability.out
+++ b/charon/tests/ui/lifetime-mutability.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -52,7 +52,7 @@ pub fn test1(x_1: E1) -> bool
 // Full name: test_crate::id
 pub fn id<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,15 +25,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -52,28 +52,28 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn method1 = test_crate::Trait::method1<Self>[Self]
-    fn method2<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>> = test_crate::Trait::method2<Self, T>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn method2<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy)> = test_crate::Trait::method2<Self, T>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::method1<Self>(_1: Self, _2: &'static u32) -> bool
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 = <method_without_default_body>
 
 fn test_crate::Trait::method2<Self, T>(_1: Self, _2: T)
 where
-    [@TraitClause0]: Trait<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
+    TraitClause0: (Self: Trait),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for ()}::method2
 fn {impl Trait for ()}::method2<T>(self_1: (), _other_2: T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let self_1: (); // arg #1
@@ -98,24 +98,24 @@ fn {impl Trait for ()}::method1(self_1: (), _other_2: &'static u32) -> bool
 
 // Full name: test_crate::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl Sized for ()}
+    proof ImpliedClause0: ((): Sized) = {built_in impl Sized for ()}
     fn method1 = {impl Trait for ()}::method1
-    fn method2<T, [@TraitClause0_1]: Sized<T>> = {impl Trait for ()}::method2<T>[@TraitClause0_1]
+    fn method2<T, TraitClause0_1: (T: Sized)> = {impl Trait for ()}::method2<T>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyCompare
 trait MyCompare<Self, Other>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Other>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Other: Sized)
     fn compare = test_crate::MyCompare::compare<Self, Other>[Self]
     non-dyn-compatible
 }
 
 fn test_crate::MyCompare::compare<Self, Other>(_1: Self, _2: Other) -> bool
 where
-    [@TraitClause0]: MyCompare<Self, Other>,
+    TraitClause0: (Self: MyCompare<Other>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl MyCompare<&'a ()> for &'a ()}::compare
@@ -131,8 +131,8 @@ fn {impl MyCompare<&'a ()> for &'a ()}::compare<'a>(self_1: &'a (), _other_2: &'
 
 // Full name: test_crate::{impl MyCompare<&'a ()> for &'a ()}
 impl<'a> MyCompare<&'a ()> for &'a () {
-    parent_clause0 = {built_in impl Sized for &'_ ()}
-    parent_clause1 = {built_in impl Sized for &'_ ()}
+    proof ImpliedClause0: (&'_ (): Sized) = {built_in impl Sized for &'_ ()}
+    proof ImpliedClause1: (&'_ (): Sized) = {built_in impl Sized for &'_ ()}
     fn compare = {impl MyCompare<&'a ()> for &'a ()}::compare<'a>
     non-dyn-compatible
 }
@@ -228,14 +228,14 @@ fn main()
 // Full name: test_crate::Foo
 trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn foo<'a, 'b> = test_crate::Foo::foo<'a, 'b, Self>[Self]
     non-dyn-compatible
 }
 
 fn test_crate::Foo::foo<'a, 'b, Self>(_1: &'a (), _2: &'b ()) -> &'a ()
 where
-    [@TraitClause0]: Foo<Self>,
+    TraitClause0: (Self: Foo),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Foo for ()}::foo
@@ -251,7 +251,7 @@ fn {impl Foo for ()}::foo<'a, 'b>(x_1: &'b (), y_2: &'a ()) -> &'b ()
 
 // Full name: test_crate::{impl Foo for ()}
 impl Foo for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     fn foo<'a, 'b> = {impl Foo for ()}::foo<'a, 'b>
     non-dyn-compatible
 }

--- a/charon/tests/ui/method-ref.out
+++ b/charon/tests/ui/method-ref.out
@@ -16,14 +16,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Ord
 trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn cmp<'_0_1, '_1_1> = cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -31,21 +31,21 @@ trait Ord<Self>
 // Full name: test_crate::Ord::cmp
 fn cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <method_without_default_body>
 
 // Full name: test_crate::min
 fn min<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Ord<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Ord),
 {
     let _0: (); // return
-    let _1: for<'_0_1, '_1_1> @TraitClause1::cmp<'_0_1, '_1_1>; // anonymous local
+    let _1: for<'_0_1, '_1_1> TraitClause1::cmp<'_0_1, '_1_1>; // anonymous local
 
     _0 = ()
     storage_live(_1)
-    _1 = const @TraitClause1::cmp<'4, '5>
+    _1 = const TraitClause1::cmp<'4, '5>
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("RangeFrom")]
 pub struct RangeFrom<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
 }
@@ -37,22 +37,22 @@ where
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::is_some
-pub fn is_some<'_0, T>(_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: core::option::{Option<T>[TraitClause0]}::is_some
+pub fn is_some<'_0, T>(_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::private_slice_index::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
@@ -60,10 +60,10 @@ pub trait Sealed<Self>
 #[lang_item("SliceIndex")]
 pub trait SliceIndex<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sealed<Self>
-    parent_clause2 : [@TraitClause2]: MetaSized<T>
-    parent_clause3 : [@TraitClause3]: MetaSized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Sealed)
+    proof ImpliedClause2: (T: MetaSized)
+    proof ImpliedClause3: (Self::Output: MetaSized)
     type Output
     fn get<'_0_1> = core::slice::index::SliceIndex::get<'_0_1, Self, T>[Self]
     fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut<'_0_1, Self, T>[Self]
@@ -75,102 +75,102 @@ pub trait SliceIndex<Self, T>
 }
 
 // Full name: core::slice::index::{impl Index<I> for [T]}::index
-pub fn {impl Index<I> for [T]}::index<'_0, T, I>(_1: &'_0 [T], _2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(_1: &'_0 [T], _2: I) -> &'_0 TraitClause2::Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T]>),
 = <opaque>
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}
 impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}] {
-    parent_clause0 = {built_in impl MetaSized for RangeFrom<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause0: (RangeFrom<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for RangeFrom<usize>[{built_in impl Sized for usize}]}
     vtable: {impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}::{vtable}
 }
 
-pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 @TraitClause0::Output>[{built_in impl Sized for &'_0 @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 TraitClause0::Output>[{built_in impl Sized for &'_0 TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut @TraitClause0::Output>[{built_in impl Sized for &'_0 mut @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut TraitClause0::Output>[{built_in impl Sized for &'_0 mut TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
-pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut
 pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> &'_0 mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index
 pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
 pub unsafe fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: *mut [T]) -> *mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked
 pub unsafe fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: *const [T]) -> *const [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut
 pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get
 pub fn {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(_1: RangeFrom<usize>[{built_in impl Sized for usize}], _2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}
 impl<T> SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for RangeFrom<usize>[{built_in impl Sized for usize}]}
-    parent_clause1 = {impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for [T]}
-    parent_clause3 = {built_in impl MetaSized for [T]}
+    proof ImpliedClause0: (RangeFrom<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for RangeFrom<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause1: (RangeFrom<usize>[{built_in impl Sized for usize}]: Sealed) = {impl Sealed for RangeFrom<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause2: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause3: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
     type Output = [T]
-    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl SliceIndex<[T]> for RangeFrom<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: alloc::alloc::Global
@@ -190,23 +190,23 @@ fn bar()
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    fn method<U, [@TraitClause0_1]: Sized<U>> = test_crate::Trait::method<Self, T, U>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    fn method<U, TraitClause0_1: (U: Sized)> = test_crate::Trait::method<Self, T, U>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::method<Self, T, U>()
 where
-    [@TraitClause0]: Trait<Self, T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (Self: Trait<T>),
+    TraitClause1: (U: Sized),
 = <method_without_default_body>
 
-// Full name: test_crate::{impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method
-fn {impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method<T, U>()
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
+fn {impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method<T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
     let _0: (); // return
 
@@ -215,23 +215,23 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}
-impl<T> Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+impl<T> Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method<T, U>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    fn method<U, TraitClause0_1: (U: Sized)> = {impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method<T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]> for Option<U>[@TraitClause1]}::method
-fn {impl Trait<alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]> for Option<U>[@TraitClause1]}::method<T, U, V>()
+// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}::method
+fn {impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}::method<T, U, V>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<V>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (V: Sized),
 {
     let _0: (); // return
 
@@ -240,15 +240,15 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]> for Option<U>[@TraitClause1]}
-impl<T, U> Trait<alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]> for Option<U>[@TraitClause1]
+// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}
+impl<T, U> Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<U>[@TraitClause1]}
-    parent_clause1 = {built_in impl Sized for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}
-    fn method<V, [@TraitClause0_1]: Sized<V>> = {impl Trait<alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]> for Option<U>[@TraitClause1]}::method<T, U, V>[@TraitClause0, @TraitClause1, @TraitClause0_1]
+    proof ImpliedClause0: (Option<U>[TraitClause1]: MetaSized) = {built_in impl MetaSized for Option<U>[TraitClause1]}
+    proof ImpliedClause1: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    fn method<V, TraitClause0_1: (V: Sized)> = {impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}::method<T, U, V>[TraitClause0, TraitClause1, TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -359,17 +359,17 @@ fn funs_with_disambiguator(b_1: bool) -> u32
 // Full name: test_crate::MonoContainer
 struct MonoContainer<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   item: T,
 }
 
-// Full name: test_crate::{MonoContainer<T>[@TraitClause0]}::create
-fn create<T>(item_1: T) -> MonoContainer<T>[@TraitClause0]
+// Full name: test_crate::{MonoContainer<T>[TraitClause0]}::create
+fn create<T>(item_1: T) -> MonoContainer<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: MonoContainer<T>[@TraitClause0]; // return
+    let _0: MonoContainer<T>[TraitClause0]; // return
     let item_1: T; // arg #1
     let _2: T; // anonymous local
 
@@ -403,24 +403,24 @@ fn mono_usage()
 // Full name: test_crate::Get
 trait Get<'a, Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn get = test_crate::Get::get<'a, Self, T>[Self]
     vtable: test_crate::Get::{vtable}<'a, T>
 }
 
 fn test_crate::Get::get<'a, Self, T>(_1: Self) -> &'a T
 where
-    [@TraitClause0]: Get<'a, Self, T>,
+    TraitClause0: (Self: Get<'a, T>),
 = <method_without_default_body>
 
-// Full name: test_crate::{impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get
-fn {impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get<'a, T>(self_1: &'a MonoContainer<T>[@TraitClause0]) -> &'a T
+// Full name: test_crate::{impl Get<'a, T> for &'a MonoContainer<T>[TraitClause0]}::get
+fn {impl Get<'a, T> for &'a MonoContainer<T>[TraitClause0]}::get<'a, T>(self_1: &'a MonoContainer<T>[TraitClause0]) -> &'a T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
-    let self_1: &'3 MonoContainer<T>[@TraitClause0]; // arg #1
+    let self_1: &'3 MonoContainer<T>[TraitClause0]; // arg #1
     let _2: &'4 T; // anonymous local
 
     storage_live(_2)
@@ -430,15 +430,15 @@ where
     return
 }
 
-// Full name: test_crate::{impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}
-impl<'a, T> Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]
+// Full name: test_crate::{impl Get<'a, T> for &'a MonoContainer<T>[TraitClause0]}
+impl<'a, T> Get<'a, T> for &'a MonoContainer<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for &'_ MonoContainer<T>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
-    fn get = {impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::get<'a, T>[@TraitClause0]
-    vtable: {impl Get<'a, T> for &'a MonoContainer<T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    proof ImpliedClause0: (&'_ MonoContainer<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for &'_ MonoContainer<T>[TraitClause0]}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn get = {impl Get<'a, T> for &'a MonoContainer<T>[TraitClause0]}::get<'a, T>[TraitClause0]
+    vtable: {impl Get<'a, T> for &'a MonoContainer<T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait core::marker::MetaSized::<&_ mut _><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<&_ mut _><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<&_ mut _><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<&_ mut _><'_0>)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ pub trait core::marker::MetaSized::<Option<&_ mut _>><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<Option<&_ mut _>><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<Option<&_ mut _>><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<Option<&_ mut _>><'_0>)
     non-dyn-compatible
 }
 
@@ -74,7 +74,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<Option<&_ mut _>><'_0, T0>(_1:
 // Full name: test_crate::identity
 fn identity<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -86,7 +86,7 @@ where
 
 fn test_crate::identity::<&_ mut _><'_0, T0>(x_1: &'_0 mut T0) -> &'_0 mut T0
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
     let _0: &'_0 mut T0; // return
     let x_1: &'_0 mut T0; // arg #1
@@ -98,7 +98,7 @@ where
 
 fn test_crate::identity::<Option<&_ mut _>><'_0, T0>(x_1: Option<&'_0 mut T0>) -> Option<&'_0 mut T0>
 where
-    [@TraitClause0]: core::marker::Sized::<Option<&_ mut _>><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<Option<&_ mut _>><'_0>),
 {
     let _0: Option<&'_0 mut T0>; // return
     let x_1: Option<&'_0 mut T0>; // arg #1
@@ -111,7 +111,7 @@ where
 // Full name: test_crate::use_id_mut
 fn use_id_mut<A>(x_1: A)
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 {
     let _0: (); // return
     let x_1: A; // arg #1

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,7 +31,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<closure<'_, '_>>(_1: *mut clos
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -43,9 +43,9 @@ opaque type core::ops::function::FnOnce::{vtable}
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
@@ -55,10 +55,10 @@ opaque type core::ops::function::FnMut::{vtable}
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::FnMut::{vtable}
 }
 
@@ -66,10 +66,10 @@ pub trait FnMut<Self, Args>
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
 }
 
@@ -87,27 +87,27 @@ pub extern "rust-call" fn call_once(_1: closure<'_, '_>, _2: (u8, u8)) -> u8
 
 // Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnOnce<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {built_in impl Sized for (u8, u8)}
-    parent_clause2 = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause2: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnMut<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u8, u8)}
-    parent_clause3 = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> Fn<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnMut<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u8, u8)}
-    parent_clause3 = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = {impl FnMut<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -33,7 +33,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<closure>(_1: *mut closure)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -43,9 +43,9 @@ opaque type core::ops::function::FnOnce::{vtable}
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
@@ -60,9 +60,9 @@ impl Destruct for closure {
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}
 impl FnOnce<(u8,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -46,7 +46,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<test_crate::main::closure#2>(_
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -58,9 +58,9 @@ opaque type core::ops::function::FnOnce::{vtable}
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
@@ -70,10 +70,10 @@ opaque type core::ops::function::FnMut::{vtable}
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::FnMut::{vtable}
 }
 
@@ -81,10 +81,10 @@ pub trait FnMut<Self, Args>
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
 }
 
@@ -107,27 +107,27 @@ impl<'_0> Destruct for test_crate::main::closure<'_0> {
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}
 impl<'_0> FnOnce<(u8,)> for test_crate::main::closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure<'_0>}
 impl<'_0> FnMut<(u8,)> for test_crate::main::closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    parent_clause1 = {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}
 impl<'_0> Fn<(u8,)> for test_crate::main::closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    parent_clause1 = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnMut<(u8,)>) = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 
@@ -157,18 +157,18 @@ impl<'_0> Destruct for test_crate::main::closure#1<'_0> {
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}
 impl<'_0> FnOnce<(u8,)> for test_crate::main::closure#1<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}
 impl<'_0> FnMut<(u8,)> for test_crate::main::closure#1<'_0> {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
-    parent_clause1 = {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure#1<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 
@@ -198,9 +198,9 @@ impl Destruct for test_crate::main::closure#2 {
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}
 impl FnOnce<(u8,)> for test_crate::main::closure#2 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#2}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (test_crate::main::closure#2: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#2}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait Sized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -30,9 +30,9 @@ opaque type core::ops::function::FnOnce::{vtable}
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
@@ -42,10 +42,10 @@ opaque type core::ops::function::FnMut::{vtable}
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::FnMut::{vtable}
 }
 
@@ -53,10 +53,10 @@ pub trait FnMut<Self, Args>
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/generic-method.out
+++ b/charon/tests/ui/monomorphization/generic-method.out
@@ -10,13 +10,13 @@ pub trait MetaSized<Self>
 // Full name: test_crate::Foo
 trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Foo for u64}
 impl Foo for u64 {
-    parent_clause0 = {built_in impl MetaSized for u64}
+    proof ImpliedClause0: (u64: MetaSized) = {built_in impl MetaSized for u64}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
+++ b/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
@@ -11,7 +11,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -23,7 +23,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -38,7 +38,7 @@ pub enum Option::<&'_ [u64]> {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -47,14 +47,14 @@ where
 // Full name: test_crate::MyConfig
 pub trait MyConfig<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyConfig
 pub trait MyConfig<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const SLICE_HOLDER : Option<&'static [u64]>[{built_in impl Sized for &'static [u64]}]
     fn op = test_crate::MyConfig::op<Self>[Self]
     non-dyn-compatible
@@ -62,7 +62,7 @@ pub trait MyConfig<Self>
 
 pub fn test_crate::MyConfig::op<Self>(_1: u64) -> u64
 where
-    [@TraitClause0]: MyConfig<Self>,
+    TraitClause0: (Self: MyConfig),
 = <method_without_default_body>
 
 // Full name: test_crate::Concrete

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<closure::<()>>(_1: *mut closur
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -40,9 +40,9 @@ opaque type core::ops::function::FnOnce::{vtable}
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
@@ -52,10 +52,10 @@ opaque type core::ops::function::FnMut::{vtable}
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::FnMut::{vtable}
 }
 
@@ -63,10 +63,10 @@ pub trait FnMut<Self, Args>
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
 }
 
@@ -81,18 +81,18 @@ impl Destruct for closure::<()> {
 
 // Full name: test_crate::foo::{const}::{impl FnOnce<((),)> for closure::<()>}
 impl FnOnce<((),)> for closure::<()> {
-    parent_clause0 = {built_in impl MetaSized for closure::<()>}
-    parent_clause1 = {built_in impl Sized for ((),)}
-    parent_clause2 = {built_in impl Tuple for ((),)}
+    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
+    proof ImpliedClause1: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause2: (((),): Tuple) = {built_in impl Tuple for ((),)}
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}
 impl FnMut<((),)> for closure::<()> {
-    parent_clause0 = {built_in impl MetaSized for closure::<()>}
-    parent_clause1 = {impl FnOnce<((),)> for closure::<()>}
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
+    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
+    proof ImpliedClause1: (closure::<()>: FnOnce<((),)>) = {impl FnOnce<((),)> for closure::<()>}
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
     non-dyn-compatible
 }
 
@@ -164,10 +164,10 @@ fn foo::<()>(x_1: ())
 
 // Full name: test_crate::foo::{const}::{impl Fn<((),)> for closure::<()>}
 impl Fn<((),)> for closure::<()> {
-    parent_clause0 = {built_in impl MetaSized for closure::<()>}
-    parent_clause1 = {impl FnMut<((),)> for closure::<()>}
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
+    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
+    proof ImpliedClause1: (closure::<()>: FnMut<((),)>) = {impl FnMut<((),)> for closure::<()>}
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/issue-922-assoc-const-with-default.out
+++ b/charon/tests/ui/monomorphization/issue-922-assoc-const-with-default.out
@@ -11,20 +11,20 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl SizedTypeProperties for ()}
 impl SizedTypeProperties for () {
-    parent_clause0 = {built_in impl Sized for ()}
+    proof ImpliedClause0: ((): Sized) = {built_in impl Sized for ()}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
+++ b/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
@@ -17,7 +17,7 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -97,7 +97,7 @@ static {impl Trait for i32}::{vtable}: test_crate::Trait::{vtable} = {impl Trait
 
 // Full name: test_crate::{impl Trait for i32}
 impl Trait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl Trait for i32}::{vtable}
 }
 
@@ -171,7 +171,7 @@ static {impl Trait for usize}::{vtable}: test_crate::Trait::{vtable} = {impl Tra
 
 // Full name: test_crate::{impl Trait for usize}
 impl Trait for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     vtable: {impl Trait for usize}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
@@ -17,7 +17,7 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -94,7 +94,7 @@ static {impl Trait for i32}::{vtable}: test_crate::Trait::{vtable} = {impl Trait
 
 // Full name: test_crate::{impl Trait for i32}
 impl Trait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl Trait for i32}::{vtable}
 }
 
@@ -168,7 +168,7 @@ static {impl Trait for usize}::{vtable}: test_crate::Trait::{vtable} = {impl Tra
 
 // Full name: test_crate::{impl Trait for usize}
 impl Trait for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     vtable: {impl Trait for usize}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
@@ -17,7 +17,7 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -94,7 +94,7 @@ static {impl Trait for i32}::{vtable}: test_crate::Trait::{vtable} = {impl Trait
 
 // Full name: test_crate::{impl Trait for i32}
 impl Trait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl Trait for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-generics-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-2.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -104,8 +104,8 @@ static {impl Trait<bool> for i32}::{vtable}: test_crate::Trait::{vtable} = {impl
 
 // Full name: test_crate::{impl Trait<bool> for i32}
 impl Trait<bool> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     vtable: {impl Trait<bool> for i32}::{vtable}
 }
 
@@ -177,8 +177,8 @@ static {impl Trait<usize> for u32}::{vtable}: test_crate::Trait::{vtable} = {imp
 
 // Full name: test_crate::{impl Trait<usize> for u32}
 impl Trait<usize> for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (usize: Sized) = {built_in impl Sized for usize}
     vtable: {impl Trait<usize> for u32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -106,8 +106,8 @@ static {impl Trait<usize> for i32}::{vtable}: test_crate::Trait::{vtable} = {imp
 
 // Full name: test_crate::{impl Trait<usize> for i32}
 impl Trait<usize> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (usize: Sized) = {built_in impl Sized for usize}
     vtable: {impl Trait<usize> for i32}::{vtable}
 }
 
@@ -181,8 +181,8 @@ static {impl Trait<bool> for bool}::{vtable}: test_crate::Trait::{vtable} = {imp
 
 // Full name: test_crate::{impl Trait<bool> for bool}
 impl Trait<bool> for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     vtable: {impl Trait<bool> for bool}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -103,8 +103,8 @@ static {impl Trait<usize> for i32}::{vtable}: test_crate::Trait::{vtable} = {imp
 
 // Full name: test_crate::{impl Trait<usize> for i32}
 impl Trait<usize> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (usize: Sized) = {built_in impl Sized for usize}
     vtable: {impl Trait<usize> for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-generics.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -101,8 +101,8 @@ static {impl Trait<bool> for i32}::{vtable}: test_crate::Trait::{vtable} = {impl
 
 // Full name: test_crate::{impl Trait<bool> for i32}
 impl Trait<bool> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     vtable: {impl Trait<bool> for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple-trait-two-methods.out
+++ b/charon/tests/ui/monomorphization/simple-trait-two-methods.out
@@ -18,7 +18,7 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -126,7 +126,7 @@ static {impl Trait for i32}::{vtable}: test_crate::Trait::{vtable} = {impl Trait
 
 // Full name: test_crate::{impl Trait for i32}
 impl Trait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl Trait for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple_trait.out
+++ b/charon/tests/ui/monomorphization/simple_trait.out
@@ -17,7 +17,7 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
@@ -94,7 +94,7 @@ static {impl Trait for i32}::{vtable}: test_crate::Trait::{vtable} = {impl Trait
 
 // Full name: test_crate::{impl Trait for i32}
 impl Trait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl Trait for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple_trait_with_trait_alias.out
+++ b/charon/tests/ui/monomorphization/simple_trait_with_trait_alias.out
@@ -16,7 +16,7 @@ struct test_crate::A::{vtable} {
 // Full name: test_crate::A
 trait A<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::A::{vtable}
 }
 
@@ -31,25 +31,25 @@ struct test_crate::B::{vtable} {
 // Full name: test_crate::B
 trait B<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: A<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: A)
     vtable: test_crate::B::{vtable}
 }
 
 // Full name: test_crate::B::{impl B for i32}
 impl B for i32
 where
-    [@TraitClause0]: MetaSized<i32>,
-    [@TraitClause1]: A<i32>,
+    TraitClause0: (i32: MetaSized),
+    TraitClause1: (i32: A),
 {
-    parent_clause0 = @TraitClause0
-    parent_clause1 = @TraitClause1
+    proof ImpliedClause0: (i32: MetaSized) = TraitClause0
+    proof ImpliedClause1: (i32: A) = TraitClause1
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl A for i32}
 impl A for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     vtable: {impl A for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/simple_trait_with_trait_alias_generics.out
+++ b/charon/tests/ui/monomorphization/simple_trait_with_trait_alias_generics.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,8 +24,8 @@ struct test_crate::A::{vtable} {
 // Full name: test_crate::A
 trait A<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::A::{vtable}
 }
 
@@ -40,26 +40,26 @@ struct test_crate::B::{vtable} {
 // Full name: test_crate::B
 trait B<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: A<Self, i32>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: A<i32>)
     vtable: test_crate::B::{vtable}
 }
 
 // Full name: test_crate::B::{impl B for i32}
 impl B for i32
 where
-    [@TraitClause0]: MetaSized<i32>,
-    [@TraitClause1]: A<i32, i32>,
+    TraitClause0: (i32: MetaSized),
+    TraitClause1: (i32: A<i32>),
 {
-    parent_clause0 = @TraitClause0
-    parent_clause1 = @TraitClause1
+    proof ImpliedClause0: (i32: MetaSized) = TraitClause0
+    proof ImpliedClause1: (i32: A<i32>) = TraitClause1
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl A<i32> for i32}
 impl A<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     vtable: {impl A<i32> for i32}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -17,7 +17,7 @@ struct test_crate::MyIterator::{vtable} {
 // Full name: test_crate::MyIterator
 trait MyIterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::MyIterator::{vtable}
 }
 
@@ -51,13 +51,13 @@ fn method<'_0>(self_1: &'_0 B)
 
 // Full name: test_crate::{impl MyIterator for A}
 impl MyIterator for A {
-    parent_clause0 = {built_in impl MetaSized for A}
+    proof ImpliedClause0: (A: MetaSized) = {built_in impl MetaSized for A}
     vtable: {impl MyIterator for A}::{vtable}
 }
 
 // Full name: test_crate::{impl MyIterator for B}
 impl MyIterator for B {
-    parent_clause0 = {built_in impl MetaSized for B}
+    proof ImpliedClause0: (B: MetaSized) = {built_in impl MetaSized for B}
     vtable: {impl MyIterator for B}::{vtable}
 }
 

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait core::marker::MetaSized::<&_ mut _><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<&_ mut _><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<&_ mut _><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<&_ mut _><'_0>)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ pub trait core::marker::MetaSized::<Option<&_ mut _>><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<Option<&_ mut _>><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<Option<&_ mut _>><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<Option<&_ mut _>><'_0>)
     non-dyn-compatible
 }
 
@@ -38,7 +38,7 @@ pub trait core::marker::MetaSized::<Option<Option<&_ mut _>>><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<Option<Option<&_ mut _>>><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<Option<Option<&_ mut _>>><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<Option<Option<&_ mut _>>><'_0>)
     non-dyn-compatible
 }
 
@@ -94,7 +94,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<Option<Option<&_ mut _>>><'_0,
 // Full name: test_crate::identity
 fn identity<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -106,7 +106,7 @@ where
 
 fn test_crate::identity::<&_ mut _><'_0, T0>(x_1: &'_0 mut T0) -> &'_0 mut T0
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
     let _0: &'_0 mut T0; // return
     let x_1: &'_0 mut T0; // arg #1
@@ -118,7 +118,7 @@ where
 
 fn test_crate::identity::<Option<&_ mut _>><'_0, T0>(x_1: Option<&'_0 mut T0>) -> Option<&'_0 mut T0>
 where
-    [@TraitClause0]: core::marker::Sized::<Option<&_ mut _>><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<Option<&_ mut _>><'_0>),
 {
     let _0: Option<&'_0 mut T0>; // return
     let x_1: Option<&'_0 mut T0>; // arg #1
@@ -130,7 +130,7 @@ where
 
 fn test_crate::identity::<Option<Option<&_ mut _>>><'_0, T0>(x_1: Option<Option<&'_0 mut T0>>) -> Option<Option<&'_0 mut T0>>
 where
-    [@TraitClause0]: core::marker::Sized::<Option<Option<&_ mut _>>><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<Option<Option<&_ mut _>>><'_0>),
 {
     let _0: Option<Option<&'_0 mut T0>>; // return
     let x_1: Option<Option<&'_0 mut T0>>; // arg #1
@@ -143,8 +143,8 @@ where
 // Full name: test_crate::use_id_mut
 fn use_id_mut<X, A>(x_1: A)
 where
-    [@TraitClause0]: Sized<X>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (X: Sized),
+    TraitClause1: (A: Sized),
 {
     let _0: (); // return
     let x_1: A; // arg #1

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait core::marker::MetaSized::<&_ mut _><'_0, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<&_ mut _><'_0, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<&_ mut _><'_0, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<&_ mut _><'_0>)
     non-dyn-compatible
 }
 
@@ -28,94 +28,94 @@ pub trait core::marker::MetaSized::<&_ mut &_ mut _><'_0, '_1, T0>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<&_ mut &_ mut _><'_0, '_1, T0>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<&_ mut &_ mut _><'_0, '_1, T0>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<&_ mut &_ mut _><'_0, '_1>)
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::MetaSized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause0])
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>
+pub trait core::marker::MetaSized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>
+pub trait core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0>[TraitClause0, TraitClause1])
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<Iter<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::MetaSized::<Iter<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::<Iter<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Sized::<Iter<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<Iter<_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<Iter<_, _>[TraitClause0]><'_0>[TraitClause0])
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<IterWrapper<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::MetaSized::<IterWrapper<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::<IterWrapper<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<IterWrapper<_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<IterWrapper<_, _>[TraitClause0]><'_0>[TraitClause0])
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<IterMut<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::MetaSized::<IterMut<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
+    TypeOutlives1: T0: '_0,
 
 #[lang_item("sized")]
-pub trait core::marker::Sized::<IterMut<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Sized::<IterMut<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
+    TypeOutlives1: T0: '_0,
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<IterMut<_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<IterMut<_, _>[TraitClause0]><'_0>[TraitClause0])
     non-dyn-compatible
 }
 
 #[lang_item("meta_sized")]
-pub trait core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 
 // Full name: core::marker::Destruct
 #[lang_item("destruct")]
@@ -135,56 +135,56 @@ pub trait core::marker::Destruct::<&_ mut _><'_0, T0>
 #[lang_item("Option")]
 pub enum core::option::Option::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   None,
   Some(&'_0 mut T0),
 }
 
 #[lang_item("destruct")]
-pub trait core::marker::Destruct::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Destruct::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0, T0>[TraitClause0]
     non-dyn-compatible
 }
 
 #[lang_item("Option")]
-pub enum core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>
+pub enum core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   None,
-  Some(core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]),
+  Some(core::option::Option::<&_ mut _><'_0, T0>[TraitClause1]),
 }
 
 #[lang_item("destruct")]
-pub trait core::marker::Destruct::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>
+pub trait core::marker::Destruct::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0, T0>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: core::slice::iter::IterMut
 pub opaque type IterMut<mut 'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
 #[lang_item("destruct")]
-pub trait core::marker::Destruct::<IterMut<_, _>[@TraitClause0]><'_0, T0>
+pub trait core::marker::Destruct::<IterMut<_, _>[TraitClause0]><'_0, T0>
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
+    TypeOutlives1: T0: '_0,
 {
-    fn drop_in_place = core::marker::Destruct::drop_in_place::<IterMut<_, _>[@TraitClause0]><'_0, T0>[@TraitClause0]
+    fn drop_in_place = core::marker::Destruct::drop_in_place::<IterMut<_, _>[TraitClause0]><'_0, T0>[TraitClause0]
     non-dyn-compatible
 }
 
@@ -195,29 +195,29 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 unsafe fn core::marker::Destruct::drop_in_place::<&_ mut _><'_0, T0>(_1: *mut &'_0 mut T0)
 = <opaque>
 
-unsafe fn core::marker::Destruct::drop_in_place::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>(_1: *mut core::option::Option::<&_ mut _><'_0, T0>[@TraitClause0])
+unsafe fn core::marker::Destruct::drop_in_place::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0, T0>(_1: *mut core::option::Option::<&_ mut _><'_0, T0>[TraitClause0])
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 = <opaque>
 
-unsafe fn core::marker::Destruct::drop_in_place::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>(_1: *mut core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause0, @TraitClause1])
+unsafe fn core::marker::Destruct::drop_in_place::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0, T0>(_1: *mut core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 = <opaque>
 
-unsafe fn core::marker::Destruct::drop_in_place::<IterMut<_, _>[@TraitClause0]><'_0, T0>(_1: *mut IterMut<'_0, T0>[@TraitClause0])
+unsafe fn core::marker::Destruct::drop_in_place::<IterMut<_, _>[TraitClause0]><'_0, T0>(_1: *mut IterMut<'_0, T0>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T0>,
-    T0 : '_0,
-    T0 : '_0,
+    TraitClause0: (T0: Sized),
+    TypeOutlives0: T0: '_0,
+    TypeOutlives1: T0: '_0,
 = <opaque>
 
 // Full name: core::marker::Tuple
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -225,26 +225,26 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
 // Full name: core::ops::function::FnOnce::call_once
-pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -253,7 +253,7 @@ where
 #[lang_item("Option")]
 pub enum core::option::Option::<&_ mut &_ mut _><'_0, '_1, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut &_ mut _><'_0, '_1, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut &_ mut _><'_0, '_1>),
 {
   None,
   Some(&'_0 mut &'_1 mut T0),
@@ -262,53 +262,53 @@ where
 // Full name: test_crate::Iter
 struct Iter<mut 'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
   head: &'a mut T,
   tail: core::option::Option::<&_ mut _><'a, T>[{built_in impl core::marker::Sized::<&_ mut _><'a> for T}],
 }
 
 #[lang_item("Option")]
-pub enum core::option::Option::<Iter<_, _>[@TraitClause1]><'_0, T0>
+pub enum core::option::Option::<Iter<_, _>[TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<Iter<_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: core::marker::Sized::<Iter<_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 {
   None,
-  Some(Iter<'_0, T0>[@TraitClause1]),
+  Some(Iter<'_0, T0>[TraitClause1]),
 }
 
 // Full name: test_crate::IterWrapper
 struct IterWrapper<mut 'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
-  Iter<'a, T>[@TraitClause0],
+  Iter<'a, T>[TraitClause0],
 }
 
 #[lang_item("Option")]
-pub enum core::option::Option::<IterWrapper<_, _>[@TraitClause1]><'_0, T0>
+pub enum core::option::Option::<IterWrapper<_, _>[TraitClause1]><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<IterWrapper<_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: Sized<T0>,
-    T0 : '_0,
+    TraitClause0: (T0: core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: Sized),
+    TypeOutlives0: T0: '_0,
 {
   None,
-  Some(IterWrapper<'_0, T0>[@TraitClause1]),
+  Some(IterWrapper<'_0, T0>[TraitClause1]),
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::map
-pub fn map<T, U, F>(_1: Option<T>[@TraitClause0], _2: F) -> Option<U>[@TraitClause1]
+// Full name: core::option::{Option<T>[TraitClause0]}::map
+pub fn map<T, U, F>(_1: Option<T>[TraitClause0], _2: F) -> Option<U>[TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<F>,
-    [@TraitClause3]: FnOnce<F, (T,)>,
-    [@TraitClause4]: Destruct<F>,
-    @TraitClause3::Output = U,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (F: Sized),
+    TraitClause3: (F: FnOnce<(T,)>),
+    TraitClause4: (F: Destruct),
+    TypeConstraint0: TraitClause3::Output = U,
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -318,8 +318,8 @@ pub struct Global {}
 // Full name: test_crate::option_mut
 fn option_mut<X, A>(x_1: A)
 where
-    [@TraitClause0]: Sized<X>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (X: Sized),
+    TraitClause1: (A: Sized),
 {
     let _0: (); // return
     let x_1: A; // arg #1
@@ -328,7 +328,7 @@ where
     let _4: u32; // anonymous local
     let _5: core::option::Option::<&_ mut _><'16, A>[{built_in impl core::marker::Sized::<&_ mut _><'16> for A}]; // anonymous local
     let _6: &'19 mut A; // anonymous local
-    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'41, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'41>[{built_in impl core::marker::Sized::<&_ mut _><'41> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'41> for A}]; // anonymous local
+    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'41, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'41>[{built_in impl core::marker::Sized::<&_ mut _><'41> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'41> for A}]; // anonymous local
     let _8: core::option::Option::<&_ mut _><'50, A>[{built_in impl core::marker::Sized::<&_ mut _><'50> for A}]; // anonymous local
     let _9: &'53 mut A; // anonymous local
     let _10: core::option::Option::<&_ mut &_ mut _><'68, '69, u32>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'68, '69> for u32}]; // anonymous local
@@ -357,7 +357,7 @@ where
     _9 = &mut x_1
     _8 = core::option::Option::<&_ mut _>::Some { 0: move _9 }
     storage_dead(_9)
-    _7 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]>::Some { 0: move _8 }
+    _7 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]>::Some { 0: move _8 }
     storage_dead(_8)
     storage_dead(_7)
     storage_live(_10)
@@ -381,7 +381,7 @@ where
 // Full name: test_crate::identity
 fn identity<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -393,7 +393,7 @@ where
 
 fn test_crate::identity::<&_ mut _><'_0, T0>(x_1: &'_0 mut T0) -> &'_0 mut T0
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
     let _0: &'_0 mut T0; // return
     let x_1: &'_0 mut T0; // arg #1
@@ -403,52 +403,52 @@ where
     return
 }
 
-fn test_crate::identity::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>(x_1: core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]) -> core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]
+fn test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>(x_1: core::option::Option::<&_ mut _><'_0, T0>[TraitClause1]) -> core::option::Option::<&_ mut _><'_0, T0>[TraitClause1]
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    let _0: core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]; // return
-    let x_1: core::option::Option::<&_ mut _><'_0, T0>[@TraitClause1]; // arg #1
+    let _0: core::option::Option::<&_ mut _><'_0, T0>[TraitClause1]; // return
+    let x_1: core::option::Option::<&_ mut _><'_0, T0>[TraitClause1]; // arg #1
 
     _0 = move x_1
-    conditional_drop[{built_in impl core::marker::Destruct::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0>[@TraitClause1] for T0}::drop_in_place] x_1
+    conditional_drop[{built_in impl core::marker::Destruct::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause1] for T0}::drop_in_place] x_1
     return
 }
 
-fn test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause1, @TraitClause2]><'_0, T0>(x_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]) -> core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]
+fn test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'_0, T0>(x_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>[TraitClause1, TraitClause2]) -> core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>[TraitClause1, TraitClause2]
 where
-    [@TraitClause0]: core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2],
-    [@TraitClause1]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_0, T0>[@TraitClause2],
-    [@TraitClause2]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0>[TraitClause1, TraitClause2]),
+    TraitClause1: (T0: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause2]),
+    TraitClause2: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-    let _0: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]; // return
-    let x_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'_0, T0>[@TraitClause1, @TraitClause2]; // arg #1
+    let _0: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>[TraitClause1, TraitClause2]; // return
+    let x_1: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'_0, T0>[TraitClause1, TraitClause2]; // arg #1
 
     _0 = move x_1
-    conditional_drop[{built_in impl core::marker::Destruct::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'_0>[@TraitClause1, @TraitClause2] for T0}::drop_in_place] x_1
+    conditional_drop[{built_in impl core::marker::Destruct::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'_0>[TraitClause1, TraitClause2] for T0}::drop_in_place] x_1
     return
 }
 
-fn test_crate::identity::<IterMut<_, _>[@TraitClause1]><'_0, T0>(x_1: IterMut<'_0, T0>[@TraitClause1]) -> IterMut<'_0, T0>[@TraitClause1]
+fn test_crate::identity::<IterMut<_, _>[TraitClause1]><'_0, T0>(x_1: IterMut<'_0, T0>[TraitClause1]) -> IterMut<'_0, T0>[TraitClause1]
 where
-    [@TraitClause0]: core::marker::Sized::<IterMut<_, _>[@TraitClause0]><'_0, T0>[@TraitClause1],
-    [@TraitClause1]: Sized<T0>,
-    T0 : '_0,
-    T0 : '_0,
+    TraitClause0: (T0: core::marker::Sized::<IterMut<_, _>[TraitClause0]><'_0>[TraitClause1]),
+    TraitClause1: (T0: Sized),
+    TypeOutlives0: T0: '_0,
+    TypeOutlives1: T0: '_0,
 {
-    let _0: IterMut<'_0, T0>[@TraitClause1]; // return
-    let x_1: IterMut<'_0, T0>[@TraitClause1]; // arg #1
+    let _0: IterMut<'_0, T0>[TraitClause1]; // return
+    let x_1: IterMut<'_0, T0>[TraitClause1]; // arg #1
 
     _0 = move x_1
-    conditional_drop[{built_in impl core::marker::Destruct::<IterMut<_, _>[@TraitClause0]><'_0>[@TraitClause1] for T0}::drop_in_place] x_1
+    conditional_drop[{built_in impl core::marker::Destruct::<IterMut<_, _>[TraitClause0]><'_0>[TraitClause1] for T0}::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::mutable_identity
 fn mutable_identity<'_0, T>(x_1: &'_0 mut T) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
     let x_1: &'2 mut T; // arg #1
@@ -472,8 +472,8 @@ where
 // Full name: test_crate::use_id_mut
 fn use_id_mut<X, A>(x_1: A)
 where
-    [@TraitClause0]: Sized<X>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (X: Sized),
+    TraitClause1: (A: Sized),
 {
     let _0: (); // return
     let x_1: A; // arg #1
@@ -486,8 +486,8 @@ where
     let _8: core::option::Option::<&_ mut _><'14, u32>[{built_in impl core::marker::Sized::<&_ mut _><'14> for u32}]; // anonymous local
     let _9: &'17 mut u32; // anonymous local
     let _10: u32; // anonymous local
-    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'45, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'45>[{built_in impl core::marker::Sized::<&_ mut _><'45> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'45> for A}]; // anonymous local
-    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'54, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'54>[{built_in impl core::marker::Sized::<&_ mut _><'54> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'54> for A}]; // anonymous local
+    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'45, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'45>[{built_in impl core::marker::Sized::<&_ mut _><'45> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'45> for A}]; // anonymous local
+    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'54, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'54>[{built_in impl core::marker::Sized::<&_ mut _><'54> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'54> for A}]; // anonymous local
     let _13: core::option::Option::<&_ mut _><'63, A>[{built_in impl core::marker::Sized::<&_ mut _><'63> for A}]; // anonymous local
     let _14: &'66 mut A; // anonymous local
     let _15: Option<&'72 u32>[{built_in impl Sized for &'72 u32}]; // anonymous local
@@ -535,7 +535,7 @@ where
     _9 = &mut _10
     _8 = core::option::Option::<&_ mut _>::Some { 0: move _9 }
     storage_dead(_9)
-    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><'97, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'97>[{built_in impl core::marker::Sized::<&_ mut _><'97> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'97> for u32}](move _8)
+    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'97, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'97>[{built_in impl core::marker::Sized::<&_ mut _><'97> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'97> for u32}](move _8)
     storage_dead(_8)
     storage_dead(_10)
     storage_dead(_7)
@@ -547,9 +547,9 @@ where
     _14 = &mut x_1
     _13 = core::option::Option::<&_ mut _>::Some { 0: move _14 }
     storage_dead(_14)
-    _12 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]>::Some { 0: move _13 }
+    _12 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]>::Some { 0: move _13 }
     storage_dead(_13)
-    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause1, @TraitClause2]><'144, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[@TraitClause1]><_, _>[@TraitClause0, @TraitClause1]><'144>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'144>[{built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'144>[{built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'144> for A}](move _12)
+    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'144, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'144>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'144>[{built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'144>[{built_in impl core::marker::Sized::<&_ mut _><'144> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'144> for A}](move _12)
     storage_live(_21)
     storage_live(_24)
     storage_live(_25)
@@ -580,14 +580,14 @@ where
 // Full name: test_crate::Foo1
 struct Foo1<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
 struct test_crate::Foo1::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   &'_0 mut T0,
 }
@@ -595,31 +595,31 @@ where
 // Full name: test_crate::Foo2
 struct Foo2<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  Foo1<T>[@TraitClause0],
+  Foo1<T>[TraitClause0],
 }
 
 struct test_crate::Foo2::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-  test_crate::Foo1::<&_ mut _><'_0, T0>[@TraitClause0],
+  test_crate::Foo1::<&_ mut _><'_0, T0>[TraitClause0],
 }
 
 // Full name: test_crate::Foo3
 struct Foo3<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  Foo2<T>[@TraitClause0],
+  Foo2<T>[TraitClause0],
 }
 
 struct test_crate::Foo3::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
-  test_crate::Foo2::<&_ mut _><'_0, T0>[@TraitClause0],
+  test_crate::Foo2::<&_ mut _><'_0, T0>[TraitClause0],
 }
 
 // Full name: test_crate::use_foo
@@ -636,39 +636,39 @@ fn use_foo<'_0>(_1: test_crate::Foo3::<&_ mut _><'_0, u32>[{built_in impl core::
 // Full name: test_crate::Triple
 struct Triple<A, B, C>
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Sized<C>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (C: Sized),
 {
   A,
   B,
   C,
 }
 
-struct test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[@TraitClause3]><'_0, '_1, '_2, T0, T1, T2>
+struct test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'_0, '_1, '_2, T0, T1, T2>
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: core::marker::Sized::<&_ mut &_ mut _><'_0, '_1, T1>,
-    [@TraitClause2]: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'_2, T2>[@TraitClause3],
-    [@TraitClause3]: core::marker::Sized::<&_ mut _><'_2, T2>,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T1: core::marker::Sized::<&_ mut &_ mut _><'_0, '_1>),
+    TraitClause2: (T2: core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'_2>[TraitClause3]),
+    TraitClause3: (T2: core::marker::Sized::<&_ mut _><'_2>),
 {
   T0,
   &'_0 mut &'_1 mut T1,
-  core::option::Option::<&_ mut _><'_2, T2>[@TraitClause3],
+  core::option::Option::<&_ mut _><'_2, T2>[TraitClause3],
 }
 
 // Full name: test_crate::Example
 type Example<'a, 'b, T>
 where
-    [@TraitClause0]: Sized<T>, = test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[@TraitClause3]><'a, 'b, 'a, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'a, 'b> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'a>[{built_in impl core::marker::Sized::<&_ mut _><'a> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'a> for bool}]
+    TraitClause0: (T: Sized), = test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'a, 'b, 'a, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'a, 'b> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'a>[{built_in impl core::marker::Sized::<&_ mut _><'a> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'a> for bool}]
 
 // Full name: test_crate::use_example
-fn use_example<'a, 'b, T>(_1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[@TraitClause3]><'a, 'b, 'a, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'a, 'b> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'a>[{built_in impl core::marker::Sized::<&_ mut _><'a> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'a> for bool}])
+fn use_example<'a, 'b, T>(_1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'a, 'b, 'a, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'a, 'b> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'a>[{built_in impl core::marker::Sized::<&_ mut _><'a> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'a> for bool}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[@TraitClause3]><'42, '43, '44, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'42, '43> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[@TraitClause0]><'44>[{built_in impl core::marker::Sized::<&_ mut _><'44> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'44> for bool}]; // arg #1
+    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'42, '43, '44, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'42, '43> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'44>[{built_in impl core::marker::Sized::<&_ mut _><'44> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'44> for bool}]; // arg #1
 
     _0 = ()
     _0 = ()
@@ -678,35 +678,35 @@ where
 // Full name: test_crate::List
 enum List<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   Nil,
-  Cons(ListNode<T>[@TraitClause0]),
+  Cons(ListNode<T>[TraitClause0]),
 }
 
 // Full name: test_crate::ListNode
 struct ListNode<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   val: T,
-  next: alloc::boxed::Box<List<T>[@TraitClause0]>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}],
+  next: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}],
 }
 
 enum test_crate::List::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   Nil,
-  Cons(test_crate::ListNode::<&_ mut _><'_0, T0>[@TraitClause0]),
+  Cons(test_crate::ListNode::<&_ mut _><'_0, T0>[TraitClause0]),
 }
 
 struct test_crate::ListNode::<&_ mut _><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   val: &'_0 mut T0,
-  next: alloc::boxed::Box<test_crate::List::<&_ mut _><'_0, T0>[@TraitClause0]>[{built_in impl core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[@TraitClause0]><'_0>[@TraitClause0] for T0}, {built_in impl Sized for Global}],
+  next: alloc::boxed::Box<test_crate::List::<&_ mut _><'_0, T0>[TraitClause0]>[{built_in impl core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause0] for T0}, {built_in impl Sized for Global}],
 }
 
 // Full name: test_crate::use_list_mut
@@ -722,20 +722,20 @@ fn use_list_mut<'_0, '_1>(_1: &'_0 test_crate::List::<&_ mut _><'_1, u32>[{built
 
 struct test_crate::Iter::<_, &_ mut _><'_0, '_1, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_1, T0>,
-    &'_1 mut T0 : '_0,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_1>),
+    TypeOutlives0: &'_1 mut T0: '_0,
 {
   head: &'_0 mut &'_1 mut T0,
   tail: core::option::Option::<&_ mut &_ mut _><'_0, '_1, T0>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'_0, '_1> for T0}],
 }
 
 // Full name: test_crate::use_iter
-fn use_iter<'a, 'b, T>(_1: core::option::Option::<Iter<_, _>[@TraitClause1]><'a, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[@TraitClause0]><'a>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}])
+fn use_iter<'a, 'b, T>(_1: core::option::Option::<Iter<_, _>[TraitClause1]><'a, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'a>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let _1: core::option::Option::<Iter<_, _>[@TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[@TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<Iter<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     _0 = ()
     _0 = ()
@@ -745,7 +745,7 @@ where
 // Full name: test_crate::use_iter_mut
 fn use_iter_mut<'a, 'b, T>(_1: test_crate::Iter::<_, &_ mut _><'a, 'b, T>[{built_in impl core::marker::Sized::<&_ mut _><'b> for T}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: test_crate::Iter::<_, &_ mut _><'7, '8, T>[{built_in impl core::marker::Sized::<&_ mut _><'8> for T}]; // arg #1
@@ -756,12 +756,12 @@ where
 }
 
 // Full name: test_crate::use_iter_wrapper
-fn use_iter_wrapper<'a, 'b, T>(_1: core::option::Option::<IterWrapper<_, _>[@TraitClause1]><'a, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[@TraitClause0]><'a>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}])
+fn use_iter_wrapper<'a, 'b, T>(_1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'a, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'a>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let _1: core::option::Option::<IterWrapper<_, _>[@TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[@TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     _0 = ()
     _0 = ()
@@ -771,21 +771,21 @@ where
 // Full name: test_crate::ArrayWrapper
 struct ArrayWrapper<T, const N : usize>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   [T; N],
 }
 
 struct test_crate::ArrayWrapper::<&_ mut _, 1 : usize><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   [&'_0 mut T0; 1 : usize],
 }
 
 struct test_crate::ArrayWrapper::<&_ mut _, 2 : usize><'_0, T0>
 where
-    [@TraitClause0]: core::marker::Sized::<&_ mut _><'_0, T0>,
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   [&'_0 mut T0; 2 : usize],
 }
@@ -805,7 +805,7 @@ fn use_const_generic<'_0, '_1>(_1: test_crate::ArrayWrapper::<&_ mut _, 1 : usiz
 // Full name: test_crate::use_opaque_iter
 fn use_opaque_iter<'a, 'b, T>(x_1: IterMut<'a, bool>[{built_in impl Sized for bool}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let x_1: IterMut<'1, bool>[{built_in impl Sized for bool}]; // arg #1
@@ -816,7 +816,7 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = move x_1
-    _2 = test_crate::identity::<IterMut<_, _>[@TraitClause1]><'4, bool>[{built_in impl core::marker::Sized::<IterMut<_, _>[@TraitClause0]><'4>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}](move _3)
+    _2 = test_crate::identity::<IterMut<_, _>[TraitClause1]><'4, bool>[{built_in impl core::marker::Sized::<IterMut<_, _>[TraitClause0]><'4>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}](move _3)
     storage_dead(_3)
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/multi-target/default-trait-assoc-const.out
+++ b/charon/tests/ui/multi-target/default-trait-assoc-const.out
@@ -3,14 +3,14 @@ pub trait core::marker::MetaSized<Self>
 
 trait test_crate::Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     const VALUE : usize
     non-dyn-compatible
 }
 
 fn test_crate::Trait::VALUE<Self>() -> usize
 where
-    [@TraitClause0]: test_crate::Trait<Self>,
+    TraitClause0: (Self: test_crate::Trait),
 {
     let _0: usize; // return
 
@@ -20,12 +20,12 @@ where
 
 const test_crate::Trait::VALUE<Self>: usize
 where
-    [@TraitClause0]: test_crate::Trait<Self>,
+    TraitClause0: (Self: test_crate::Trait),
  = test_crate::Trait::VALUE()
 
 // Full name: test_crate::{impl test_crate::Trait for ()}
 impl test_crate::Trait for () {
-    parent_clause0 = {built_in impl core::marker::MetaSized for ()}
+    proof ImpliedClause0: ((): core::marker::MetaSized) = {built_in impl core::marker::MetaSized for ()}
     const VALUE = test_crate::Trait::VALUE<()>[test_crate::{impl test_crate::Trait for ()}]
     non-dyn-compatible
 }

--- a/charon/tests/ui/multi-target/issue-1182-dedup-impls.out
+++ b/charon/tests/ui/multi-target/issue-1182-dedup-impls.out
@@ -3,14 +3,14 @@ pub trait core::marker::MetaSized<Self>
 
 pub trait test_crate::Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     fn method = test_crate::Foo::method<Self>[Self]
     non-dyn-compatible
 }
 
 pub fn test_crate::Foo::method<Self>() -> u32
 where
-    [@TraitClause0]: test_crate::Foo<Self>,
+    TraitClause0: (Self: test_crate::Foo),
 = <method_without_default_body>
 
 pub struct test_crate::Struct {}
@@ -39,7 +39,7 @@ pub fn test_crate::{impl test_crate::Foo for test_crate::Struct}::method() -> u3
 
 // Full name: test_crate::{impl test_crate::Foo for test_crate::Struct}
 impl test_crate::Foo for test_crate::Struct {
-    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::Struct}
+    proof ImpliedClause0: (test_crate::Struct: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for test_crate::Struct}
     fn method = test_crate::{impl test_crate::Foo for test_crate::Struct}::method
     non-dyn-compatible
 }

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing-simple.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing-simple.out
@@ -4,13 +4,13 @@ pub trait core::marker::MetaSized<Self>
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     non-dyn-compatible
 }
 
 trait test_crate::Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     fn method1<'_0_1> = test_crate::Trait::method1<'_0_1, Self>[Self]
     fn method2<'_0_1> = test_crate::Trait::method2<'_0_1, Self>[Self]
     vtable: test_crate::Trait::{vtable}
@@ -18,7 +18,7 @@ trait test_crate::Trait<Self>
 
 fn test_crate::Trait::method1<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: test_crate::Trait<Self>,
+    TraitClause0: (Self: test_crate::Trait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -30,7 +30,7 @@ where
 
 fn test_crate::Trait::method2<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: test_crate::Trait<Self>,
+    TraitClause0: (Self: test_crate::Trait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -42,8 +42,8 @@ where
 
 fn test_crate::f<'_0, T0>(x_1: &'_0 T0)
 where
-    [@TraitClause0]: core::marker::Sized<T0>,
-    [@TraitClause1]: test_crate::Trait<T0>,
+    TraitClause0: (T0: core::marker::Sized),
+    TraitClause1: (T0: test_crate::Trait),
 {
     let _0: (); // return
     let x_1: &'1 T0; // arg #1
@@ -52,15 +52,15 @@ where
     _0 = ()
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = @TraitClause1::method1<'4>(move _2)
+    _0 = TraitClause1::method1<'4>(move _2)
     storage_dead(_2)
     return
 }
 
 fn test_crate::g<'_0, T0>(x_1: &'_0 T0)
 where
-    [@TraitClause0]: core::marker::Sized<T0>,
-    [@TraitClause1]: test_crate::Trait<T0>,
+    TraitClause0: (T0: core::marker::Sized),
+    TraitClause1: (T0: test_crate::Trait),
 {
     let _0: (); // return
     let x_1: &'1 T0; // arg #1
@@ -69,7 +69,7 @@ where
     _0 = ()
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = @TraitClause1::method2<'4>(move _2)
+    _0 = TraitClause1::method2<'4>(move _2)
     storage_dead(_2)
     return
 }

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
@@ -4,19 +4,19 @@ pub trait core::marker::MetaSized<Self>
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     non-dyn-compatible
 }
 
 pub opaque type core::iter::adapters::zip::Zip<A, B>
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::marker::Sized<B>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (B: core::marker::Sized),
 
 #[lang_item("Option")]
 pub enum core::option::Option<T>
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 {
   None,
   Some(T),
@@ -25,12 +25,12 @@ where
 #[lang_item("IntoIterator")]
 pub trait core::iter::traits::collect::IntoIterator<Self>
 where
-    Self::parent_clause3::Item = Self::Item,
+    TypeConstraint0: Self::ImpliedClause3::Item = Self::Item,
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: core::marker::Sized<Self::IntoIter>
-    parent_clause3 : [@TraitClause3]: core::iter::traits::iterator::Iterator<Self::IntoIter>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::Item: core::marker::Sized)
+    proof ImpliedClause2: (Self::IntoIter: core::marker::Sized)
+    proof ImpliedClause3: (Self::IntoIter: core::iter::traits::iterator::Iterator)
     type Item
     type IntoIter
     fn into_iter = core::iter::traits::collect::IntoIterator::into_iter<Self>[Self]
@@ -40,165 +40,165 @@ where
 #[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::Item: core::marker::Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
-    fn zip<U, [@TraitClause0_1]: core::marker::Sized<U>, [@TraitClause1_1]: core::marker::Sized<Self>, [@TraitClause2_1]: core::iter::traits::collect::IntoIterator<U>> = core::iter::traits::iterator::Iterator::zip<Self, U>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    fn zip<U, TraitClause0_1: (U: core::marker::Sized), TraitClause1_1: (Self: core::marker::Sized), TraitClause2_1: (U: core::iter::traits::collect::IntoIterator)> = core::iter::traits::iterator::Iterator::zip<Self, U>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-pub fn core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::next<'_0, A, B>(_1: &'_0 mut core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]) -> core::option::Option<(@TraitClause2::Item, @TraitClause3::Item)>[{built_in impl core::marker::Sized for (@TraitClause2::Item, @TraitClause3::Item)}]
+pub fn core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'_0, A, B>(_1: &'_0 mut core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]) -> core::option::Option<(TraitClause2::Item, TraitClause3::Item)>[{built_in impl core::marker::Sized for (TraitClause2::Item, TraitClause3::Item)}]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::marker::Sized<B>,
-    [@TraitClause2]: core::iter::traits::iterator::Iterator<A>,
-    [@TraitClause3]: core::iter::traits::iterator::Iterator<B>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (B: core::marker::Sized),
+    TraitClause2: (A: core::iter::traits::iterator::Iterator),
+    TraitClause3: (B: core::iter::traits::iterator::Iterator),
 = <opaque>
 
-pub fn core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::zip<A, B, U>(_1: core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1], _2: U) -> core::iter::adapters::zip::Zip<core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1], @TraitClause6::IntoIter>[@TraitClause5, @TraitClause6::parent_clause2]
+pub fn core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::zip<A, B, U>(_1: core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1], _2: U) -> core::iter::adapters::zip::Zip<core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1], TraitClause6::IntoIter>[TraitClause5, TraitClause6::ImpliedClause2]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::marker::Sized<B>,
-    [@TraitClause2]: core::iter::traits::iterator::Iterator<A>,
-    [@TraitClause3]: core::iter::traits::iterator::Iterator<B>,
-    [@TraitClause4]: core::marker::Sized<U>,
-    [@TraitClause5]: core::marker::Sized<core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]>,
-    [@TraitClause6]: core::iter::traits::collect::IntoIterator<U>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (B: core::marker::Sized),
+    TraitClause2: (A: core::iter::traits::iterator::Iterator),
+    TraitClause3: (B: core::iter::traits::iterator::Iterator),
+    TraitClause4: (U: core::marker::Sized),
+    TraitClause5: (core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]: core::marker::Sized),
+    TraitClause6: (U: core::iter::traits::collect::IntoIterator),
 = <opaque>
 
-// Full name: core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}
-impl<A, B> core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]
+// Full name: core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}
+impl<A, B> core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::marker::Sized<B>,
-    [@TraitClause2]: core::iter::traits::iterator::Iterator<A>,
-    [@TraitClause3]: core::iter::traits::iterator::Iterator<B>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (B: core::marker::Sized),
+    TraitClause2: (A: core::iter::traits::iterator::Iterator),
+    TraitClause3: (B: core::iter::traits::iterator::Iterator),
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl core::marker::Sized for (@TraitClause2::Item, @TraitClause3::Item)}
-    type Item = (@TraitClause2::Item, @TraitClause3::Item)
-    fn next<'_0_1> = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::next<'_0_1, A, B>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
-    fn zip<U, [@TraitClause0_1]: core::marker::Sized<U>, [@TraitClause1_1]: core::marker::Sized<core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]>, [@TraitClause2_1]: core::iter::traits::collect::IntoIterator<U>> = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::zip<A, B, U>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    vtable: core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::{vtable}<A, B>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+    proof ImpliedClause0: (core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((TraitClause2::Item, TraitClause3::Item): core::marker::Sized) = {built_in impl core::marker::Sized for (TraitClause2::Item, TraitClause3::Item)}
+    type Item = (TraitClause2::Item, TraitClause3::Item)
+    fn next<'_0_1> = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'_0_1, A, B>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
+    fn zip<U, TraitClause0_1: (U: core::marker::Sized), TraitClause1_1: (core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]: core::marker::Sized), TraitClause2_1: (U: core::iter::traits::collect::IntoIterator)> = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::zip<A, B, U>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    vtable: core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::{vtable}<A, B>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 }
 
 #[lang_item("into_iter")]
-pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(_1: Self) -> @TraitClause0::IntoIter
+pub fn core::iter::traits::collect::IntoIterator::into_iter<Self>(_1: Self) -> TraitClause0::IntoIter
 where
-    [@TraitClause0]: core::iter::traits::collect::IntoIterator<Self>,
+    TraitClause0: (Self: core::iter::traits::collect::IntoIterator),
 = <opaque>
 
 pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    TraitClause0: (I: core::marker::Sized),
+    TraitClause1: (I: core::iter::traits::iterator::Iterator),
 = <opaque>
 
 // Full name: core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}
 impl<I> core::iter::traits::collect::IntoIterator for I
 where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    TraitClause0: (I: core::marker::Sized),
+    TraitClause1: (I: core::iter::traits::iterator::Iterator),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1::parent_clause1
-    parent_clause2 = @TraitClause0
-    parent_clause3 = @TraitClause1
-    type Item = @TraitClause1::Item
+    proof ImpliedClause0: (I: core::marker::MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (TraitClause1::Item: core::marker::Sized) = TraitClause1::ImpliedClause1
+    proof ImpliedClause2: (I: core::marker::Sized) = TraitClause0
+    proof ImpliedClause3: (I: core::iter::traits::iterator::Iterator) = TraitClause1
+    type Item = TraitClause1::Item
     type IntoIter = I
-    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>[@TraitClause0, @TraitClause1]
-    vtable: core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::{vtable}<I>[@TraitClause0, @TraitClause1]
+    fn into_iter = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>[TraitClause0, TraitClause1]
+    vtable: core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::{vtable}<I>[TraitClause0, TraitClause1]
 }
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    TraitClause0: (Self: core::iter::traits::iterator::Iterator),
 = <opaque>
 
-pub fn core::iter::traits::iterator::Iterator::zip<Self, U>(_1: Self, _2: U) -> core::iter::adapters::zip::Zip<Self, @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+pub fn core::iter::traits::iterator::Iterator::zip<Self, U>(_1: Self, _2: U) -> core::iter::adapters::zip::Zip<Self, TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
-    [@TraitClause1]: core::marker::Sized<U>,
-    [@TraitClause2]: core::marker::Sized<Self>,
-    [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>,
+    TraitClause0: (Self: core::iter::traits::iterator::Iterator),
+    TraitClause1: (U: core::marker::Sized),
+    TraitClause2: (Self: core::marker::Sized),
+    TraitClause3: (U: core::iter::traits::collect::IntoIterator),
 = <opaque>
 
 pub opaque type core::slice::iter::IterMut<mut 'a, T>
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: core::marker::Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut core::slice::iter::IterMut<'a, T>[@TraitClause0]) -> core::option::Option<&'a mut T>[{built_in impl core::marker::Sized for &'a mut T}]
+pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut core::slice::iter::IterMut<'a, T>[TraitClause0]) -> core::option::Option<&'a mut T>[{built_in impl core::marker::Sized for &'a mut T}]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
-pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::zip<'a, T, U>(_1: core::slice::iter::IterMut<'a, T>[@TraitClause0], _2: U) -> core::iter::adapters::zip::Zip<core::slice::iter::IterMut<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::zip<'a, T, U>(_1: core::slice::iter::IterMut<'a, T>[TraitClause0], _2: U) -> core::iter::adapters::zip::Zip<core::slice::iter::IterMut<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::marker::Sized<U>,
-    [@TraitClause2]: core::marker::Sized<core::slice::iter::IterMut<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>,
+    TraitClause0: (T: core::marker::Sized),
+    TraitClause1: (U: core::marker::Sized),
+    TraitClause2: (core::slice::iter::IterMut<'a, T>[TraitClause0]: core::marker::Sized),
+    TraitClause3: (U: core::iter::traits::collect::IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}
-impl<'a, T> core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}
+impl<'a, T> core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::slice::iter::IterMut<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl core::marker::Sized for &'_ mut T}
+    proof ImpliedClause0: (core::slice::iter::IterMut<'_, T>[TraitClause0]: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::slice::iter::IterMut<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ mut T: core::marker::Sized) = {built_in impl core::marker::Sized for &'_ mut T}
     type Item = &'a mut T
-    fn next<'_0_1> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    fn zip<U, [@TraitClause0_1]: core::marker::Sized<U>, [@TraitClause1_1]: core::marker::Sized<core::slice::iter::IterMut<'a, T>[@TraitClause0]>, [@TraitClause2_1]: core::iter::traits::collect::IntoIterator<U>> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    vtable: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    fn zip<U, TraitClause0_1: (U: core::marker::Sized), TraitClause1_1: (core::slice::iter::IterMut<'a, T>[TraitClause0]: core::marker::Sized), TraitClause2_1: (U: core::iter::traits::collect::IntoIterator)> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::zip<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    vtable: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 #[lang_item("SliceIter")]
 pub opaque type core::slice::iter::Iter<'a, T>
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: core::marker::Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut core::slice::iter::Iter<'a, T>[@TraitClause0]) -> core::option::Option<&'a T>[{built_in impl core::marker::Sized for &'a T}]
+pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut core::slice::iter::Iter<'a, T>[TraitClause0]) -> core::option::Option<&'a T>[{built_in impl core::marker::Sized for &'a T}]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
-pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::zip<'a, T, U>(_1: core::slice::iter::Iter<'a, T>[@TraitClause0], _2: U) -> core::iter::adapters::zip::Zip<core::slice::iter::Iter<'a, T>[@TraitClause0], @TraitClause3::IntoIter>[@TraitClause2, @TraitClause3::parent_clause2]
+pub fn core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'a, T, U>(_1: core::slice::iter::Iter<'a, T>[TraitClause0], _2: U) -> core::iter::adapters::zip::Zip<core::slice::iter::Iter<'a, T>[TraitClause0], TraitClause3::IntoIter>[TraitClause2, TraitClause3::ImpliedClause2]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: core::marker::Sized<U>,
-    [@TraitClause2]: core::marker::Sized<core::slice::iter::Iter<'a, T>[@TraitClause0]>,
-    [@TraitClause3]: core::iter::traits::collect::IntoIterator<U>,
+    TraitClause0: (T: core::marker::Sized),
+    TraitClause1: (U: core::marker::Sized),
+    TraitClause2: (core::slice::iter::Iter<'a, T>[TraitClause0]: core::marker::Sized),
+    TraitClause3: (U: core::iter::traits::collect::IntoIterator),
 = <opaque>
 
-// Full name: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}
-impl<'a, T> core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]
+// Full name: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}
+impl<'a, T> core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::slice::iter::Iter<'_, T>[@TraitClause0]}
-    parent_clause1 = {built_in impl core::marker::Sized for &'_ T}
+    proof ImpliedClause0: (core::slice::iter::Iter<'_, T>[TraitClause0]: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::slice::iter::Iter<'_, T>[TraitClause0]}
+    proof ImpliedClause1: (&'_ T: core::marker::Sized) = {built_in impl core::marker::Sized for &'_ T}
     type Item = &'a T
-    fn next<'_0_1> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::next<'a, '_0_1, T>[@TraitClause0]
-    fn zip<U, [@TraitClause0_1]: core::marker::Sized<U>, [@TraitClause1_1]: core::marker::Sized<core::slice::iter::Iter<'a, T>[@TraitClause0]>, [@TraitClause2_1]: core::iter::traits::collect::IntoIterator<U>> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::zip<'a, T, U>[@TraitClause0, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
-    vtable: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::{vtable}<'a, T>[@TraitClause0]
+    fn next<'_0_1> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::next<'a, '_0_1, T>[TraitClause0]
+    fn zip<U, TraitClause0_1: (U: core::marker::Sized), TraitClause1_1: (core::slice::iter::Iter<'a, T>[TraitClause0]: core::marker::Sized), TraitClause2_1: (U: core::iter::traits::collect::IntoIterator)> = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'a, T, U>[TraitClause0, TraitClause0_1, TraitClause1_1, TraitClause2_1]
+    vtable: core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::{vtable}<'a, T>[TraitClause0]
 }
 
 #[lang_item("slice_iter")]
-pub fn core::slice::{[T]}::iter<'_0, T>(_1: &'_0 [T]) -> core::slice::iter::Iter<'_0, T>[@TraitClause0]
+pub fn core::slice::{[T]}::iter<'_0, T>(_1: &'_0 [T]) -> core::slice::iter::Iter<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
-pub fn core::slice::{[T]}::iter_mut<'_0, T>(_1: &'_0 mut [T]) -> core::slice::iter::IterMut<'_0, T>[@TraitClause0]
+pub fn core::slice::{[T]}::iter_mut<'_0, T>(_1: &'_0 mut [T]) -> core::slice::iter::IterMut<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
 fn test_crate::f<'_0>(blocks_1: &'_0 mut [u8])
@@ -220,7 +220,7 @@ fn test_crate::f<'_0>(blocks_1: &'_0 mut [u8])
     _4 = &two-phase-mut (*blocks_1) with_metadata(copy blocks_1.metadata)
     _3 = core::slice::{[T]}::iter_mut<'23, u8>[{built_in impl core::marker::Sized for u8}](move _4)
     storage_dead(_4)
-    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}<'24, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
+    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}<'24, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
     storage_dead(_3)
     storage_live(iter_5)
     iter_5 = move _2
@@ -230,7 +230,7 @@ fn test_crate::f<'_0>(blocks_1: &'_0 mut [u8])
         storage_live(_8)
         _8 = &mut iter_5
         _7 = &two-phase-mut (*_8)
-        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[@TraitClause0]}::next<'33, '35, u8>[{built_in impl core::marker::Sized for u8}](move _7)
+        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'33, '35, u8>[{built_in impl core::marker::Sized for u8}](move _7)
         storage_dead(_7)
         match _6 {
             core::option::Option::None => {
@@ -280,10 +280,10 @@ fn test_crate::g<'_0, '_1>(s0_1: &'_0 [u8], s1_2: &'_1 [u8])
     _8 = &(*s1_2) with_metadata(copy s1_2.metadata)
     _7 = core::slice::{[T]}::iter<'81, u8>[{built_in impl core::marker::Sized for u8}](move _8)
     storage_dead(_8)
-    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}::zip<'103, u8, core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'103, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}<'82, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
+    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'103, u8, core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'103, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'82, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'82, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
     storage_dead(_7)
     storage_dead(_5)
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}<'109, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'107, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'109, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'107, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'109, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
     storage_dead(_4)
     storage_live(iter_9)
     iter_9 = move _3
@@ -293,7 +293,7 @@ fn test_crate::g<'_0, '_1>(s0_1: &'_0 [u8], s1_2: &'_1 [u8])
         storage_live(_12)
         _12 = &mut iter_9
         _11 = &two-phase-mut (*_12)
-        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[@TraitClause0, @TraitClause1]}::next<'200, core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'184, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'184, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[@TraitClause0]}<'184, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
+        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'200, core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'184, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'184, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'184, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
         storage_dead(_11)
         match _10 {
             core::option::Option::None => {

--- a/charon/tests/ui/multi-target/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target/multi-target-from-symcrypt.out
@@ -15,14 +15,14 @@ pub trait core::marker::MetaSized<Self>
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     non-dyn-compatible
 }
 
 #[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
+    proof ImpliedClause0: (Self: core::marker::Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -30,8 +30,8 @@ pub trait core::clone::Clone<Self>
 #[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self: core::clone::Clone)
     non-dyn-compatible
 }
 
@@ -42,15 +42,15 @@ pub fn core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::
 
 // Full name: core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
 impl core::clone::Clone for core::core_arch::x86::__m128i {
-    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (core::core_arch::x86::__m128i: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
     fn clone<'_0_1> = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
 impl core::marker::Copy for core::core_arch::x86::__m128i {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::x86::__m128i}
-    parent_clause1 = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (core::core_arch::x86::__m128i: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::core_arch::x86::__m128i}
+    proof ImpliedClause1: (core::core_arch::x86::__m128i: core::clone::Clone) = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
     non-dyn-compatible
 }
 
@@ -59,15 +59,15 @@ pub fn core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::cor
 
 // Full name: core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
 impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t {
-    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
     fn clone<'_0_1> = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
 impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::arm_shared::neon::uint16x8_t}
-    parent_clause1 = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause1: (core::core_arch::arm_shared::neon::uint16x8_t: core::clone::Clone) = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
     non-dyn-compatible
 }
 
@@ -83,7 +83,7 @@ pub unsafe fn core::core_arch::x86::sse2::_mm_storeu_si128(_1: *mut core::core_a
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: core::clone::Clone<Self>,
+    TraitClause0: (Self: core::clone::Clone),
 = <opaque>
 
 pub fn core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
@@ -91,7 +91,7 @@ pub fn core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0>(_1: &
 
 // Full name: core::clone::impls::{impl core::clone::Clone for usize}
 impl core::clone::Clone for usize {
-    parent_clause0 = {built_in impl core::marker::Sized for usize}
+    proof ImpliedClause0: (usize: core::marker::Sized) = {built_in impl core::marker::Sized for usize}
     fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -106,7 +106,7 @@ pub trait core::cmp::PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>,
+    TraitClause0: (Self: core::cmp::PartialEq<Rhs>),
 = <opaque>
 
 #[lang_item("Ordering")]
@@ -119,7 +119,7 @@ pub enum core::cmp::Ordering {
 #[lang_item("Option")]
 pub enum core::option::Option<T>
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 {
   None,
   Some(T),
@@ -128,7 +128,7 @@ where
 #[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: core::cmp::PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -136,7 +136,7 @@ pub trait core::cmp::PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option<core::cmp::Ordering>[{built_in impl core::marker::Sized for core::cmp::Ordering}]
 where
-    [@TraitClause0]: core::cmp::PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: core::cmp::PartialOrd<Rhs>),
 = <opaque>
 
 pub fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}::eq<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
@@ -153,7 +153,7 @@ pub fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_
 
 // Full name: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
 impl core::cmp::PartialOrd<usize> for usize {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
+    proof ImpliedClause0: (usize: core::cmp::PartialEq<usize>) = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
     vtable: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::{vtable}
 }
@@ -161,9 +161,9 @@ impl core::cmp::PartialOrd<usize> for usize {
 #[lang_item("range_step")]
 pub trait core::iter::range::Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
-    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: core::marker::Sized)
+    proof ImpliedClause1: (Self: core::clone::Clone)
+    proof ImpliedClause2: (Self: core::cmp::PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -172,17 +172,17 @@ pub trait core::iter::range::Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option<usize>[{built_in impl core::marker::Sized for usize}])
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
 pub fn core::iter::range::{impl core::iter::range::Step for usize}::backward_checked(_1: usize, _2: usize) -> core::option::Option<usize>[{built_in impl core::marker::Sized for usize}]
@@ -196,9 +196,9 @@ pub fn core::iter::range::{impl core::iter::range::Step for usize}::steps_betwee
 
 // Full name: core::iter::range::{impl core::iter::range::Step for usize}
 impl core::iter::range::Step for usize {
-    parent_clause0 = {built_in impl core::marker::Sized for usize}
-    parent_clause1 = core::clone::impls::{impl core::clone::Clone for usize}
-    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
+    proof ImpliedClause0: (usize: core::marker::Sized) = {built_in impl core::marker::Sized for usize}
+    proof ImpliedClause1: (usize: core::clone::Clone) = core::clone::impls::{impl core::clone::Clone for usize}
+    proof ImpliedClause2: (usize: core::cmp::PartialOrd<usize>) = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
     fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step for usize}::steps_between<'_0_1, '_1_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}::backward_checked
@@ -208,7 +208,7 @@ impl core::iter::range::Step for usize {
 #[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
 where
-    [@TraitClause0]: core::marker::Sized<Idx>,
+    TraitClause0: (Idx: core::marker::Sized),
 {
   start: Idx,
   end: Idx,
@@ -217,42 +217,42 @@ where
 #[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::Item: core::marker::Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut core::ops::range::Range<A>[@TraitClause0]) -> core::option::Option<A>[@TraitClause0]
+pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'_0, A>(_1: &'_0 mut core::ops::range::Range<A>[TraitClause0]) -> core::option::Option<A>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::iter::range::Step<A>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (A: core::iter::range::Step),
 = <opaque>
 
-// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}
-impl<A> core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]
+// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}
+impl<A> core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::iter::range::Step<A>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (A: core::iter::range::Step),
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::ops::range::Range<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (core::ops::range::Range<A>[TraitClause0]: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::ops::range::Range<A>[TraitClause0]}
+    proof ImpliedClause1: (A: core::marker::Sized) = TraitClause0
     type Item = A
-    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'_0_1, A>[TraitClause0, TraitClause1]
+    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    TraitClause0: (I: core::marker::Sized),
+    TraitClause1: (I: core::iter::traits::iterator::Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    TraitClause0: (Self: core::iter::traits::iterator::Iterator),
 = <opaque>
 
 pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
@@ -260,19 +260,19 @@ pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
 
 pub fn core::slice::{[T]}::as_ptr<'_0, T>(_1: &'_0 [T]) -> *const T
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
 pub fn core::slice::{[T]}::as_mut_ptr<'_0, T>(_1: &'_0 mut [T]) -> *mut T
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
 trait test_crate::NttIntrinsicsInterface<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Vec128>
-    parent_clause2 : [@TraitClause2]: core::marker::Copy<Self::Vec128>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::Vec128: core::marker::Sized)
+    proof ImpliedClause2: (Self::Vec128: core::marker::Copy)
     type Vec128
     fn vec128_load<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_load<'_0_1, Self>[Self]
     fn vec128_store<'_0_1> = test_crate::NttIntrinsicsInterface::vec128_store<'_0_1, Self>[Self]
@@ -280,19 +280,19 @@ trait test_crate::NttIntrinsicsInterface<Self>
     non-dyn-compatible
 }
 
-fn test_crate::NttIntrinsicsInterface::vec128_load<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::Vec128
+fn test_crate::NttIntrinsicsInterface::vec128_load<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> TraitClause0::Vec128
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
+    TraitClause0: (Self: test_crate::NttIntrinsicsInterface),
 = <method_without_default_body>
 
-fn test_crate::NttIntrinsicsInterface::vec128_store<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::Vec128)
+fn test_crate::NttIntrinsicsInterface::vec128_store<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: TraitClause0::Vec128)
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
+    TraitClause0: (Self: test_crate::NttIntrinsicsInterface),
 = <method_without_default_body>
 
-fn test_crate::NttIntrinsicsInterface::vec128_add<Self>(_1: @TraitClause0::Vec128, _2: @TraitClause0::Vec128) -> @TraitClause0::Vec128
+fn test_crate::NttIntrinsicsInterface::vec128_add<Self>(_1: TraitClause0::Vec128, _2: TraitClause0::Vec128) -> TraitClause0::Vec128
 where
-    [@TraitClause0]: test_crate::NttIntrinsicsInterface<Self>,
+    TraitClause0: (Self: test_crate::NttIntrinsicsInterface),
 = <method_without_default_body>
 
 pub struct test_crate::ntt_xmm::NttIntrinsicsXmm {}
@@ -373,9 +373,9 @@ fn test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate:
 
 // Full name: test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm}
 impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm {
-    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::ntt_xmm::NttIntrinsicsXmm}
-    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
-    parent_clause2 = core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (test_crate::ntt_xmm::NttIntrinsicsXmm: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for test_crate::ntt_xmm::NttIntrinsicsXmm}
+    proof ImpliedClause1: (core::core_arch::x86::__m128i: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
+    proof ImpliedClause2: (core::core_arch::x86::__m128i: core::marker::Copy) = core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
     type Vec128 = core::core_arch::x86::__m128i
     fn vec128_load<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm}::vec128_load<'_0_1>
     fn vec128_store<'_0_1> = test_crate::ntt_xmm::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_xmm::NttIntrinsicsXmm}::vec128_store<'_0_1>
@@ -453,9 +453,9 @@ fn test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate
 
 // Full name: test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon}
 impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon {
-    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::ntt_neon::NttIntrinsicsNeon}
-    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
-    parent_clause2 = core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (test_crate::ntt_neon::NttIntrinsicsNeon: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for test_crate::ntt_neon::NttIntrinsicsNeon}
+    proof ImpliedClause1: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause2: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Copy) = core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
     type Vec128 = core::core_arch::arm_shared::neon::uint16x8_t
     fn vec128_load<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon}::vec128_load<'_0_1>
     fn vec128_store<'_0_1> = test_crate::ntt_neon::{impl test_crate::NttIntrinsicsInterface for test_crate::ntt_neon::NttIntrinsicsNeon}::vec128_store<'_0_1>
@@ -492,7 +492,7 @@ fn test_crate::ntt_layer_generic<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: 
     storage_live(_3)
     storage_live(_4)
     _4 = core::ops::range::Range { start: const 0 : usize, end: const 8 : usize }
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]>[{built_in impl core::marker::Sized for core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}<usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]>[{built_in impl core::marker::Sized for core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}<usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}]](move _4)
     storage_dead(_4)
     storage_live(iter_5)
     iter_5 = move _3
@@ -502,7 +502,7 @@ fn test_crate::ntt_layer_generic<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: 
         storage_live(_8)
         _8 = &mut iter_5
         _7 = &two-phase-mut (*_8)
-        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'8, usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}](move _7)
+        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'8, usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}](move _7)
         storage_dead(_7)
         match _6 {
             core::option::Option::None => {
@@ -559,40 +559,40 @@ fn test_crate::ntt_layer_generic<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: 
 
 fn test_crate::ntt_layer_vec128<'_0, '_1, T>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::NttIntrinsicsInterface<T>,
+    TraitClause0: (T: core::marker::Sized),
+    TraitClause1: (T: test_crate::NttIntrinsicsInterface),
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1
     let b_2: &'3 [u16; 8 : usize]; // arg #2
-    let va_3: @TraitClause1::Vec128; // local
+    let va_3: TraitClause1::Vec128; // local
     let _4: &'4 [u16; 8 : usize]; // anonymous local
-    let vb_5: @TraitClause1::Vec128; // local
+    let vb_5: TraitClause1::Vec128; // local
     let _6: &'5 [u16; 8 : usize]; // anonymous local
-    let vr_7: @TraitClause1::Vec128; // local
-    let _8: @TraitClause1::Vec128; // anonymous local
-    let _9: @TraitClause1::Vec128; // anonymous local
+    let vr_7: TraitClause1::Vec128; // local
+    let _8: TraitClause1::Vec128; // anonymous local
+    let _9: TraitClause1::Vec128; // anonymous local
     let _10: (); // anonymous local
     let _11: &'6 mut [u16; 8 : usize]; // anonymous local
-    let _12: @TraitClause1::Vec128; // anonymous local
+    let _12: TraitClause1::Vec128; // anonymous local
 
     _0 = ()
     storage_live(va_3)
     storage_live(_4)
     _4 = &(*a_1)
-    va_3 = @TraitClause1::vec128_load<'8>(move _4)
+    va_3 = TraitClause1::vec128_load<'8>(move _4)
     storage_dead(_4)
     storage_live(vb_5)
     storage_live(_6)
     _6 = &(*b_2)
-    vb_5 = @TraitClause1::vec128_load<'10>(move _6)
+    vb_5 = TraitClause1::vec128_load<'10>(move _6)
     storage_dead(_6)
     storage_live(vr_7)
     storage_live(_8)
     _8 = copy va_3
     storage_live(_9)
     _9 = copy vb_5
-    vr_7 = @TraitClause1::vec128_add(move _8, move _9)
+    vr_7 = TraitClause1::vec128_add(move _8, move _9)
     storage_dead(_9)
     storage_dead(_8)
     storage_live(_10)
@@ -600,7 +600,7 @@ where
     _11 = &two-phase-mut (*a_1)
     storage_live(_12)
     _12 = copy vr_7
-    _10 = @TraitClause1::vec128_store<'12>(move _11, move _12)
+    _10 = TraitClause1::vec128_store<'12>(move _11, move _12)
     storage_dead(_12)
     storage_dead(_11)
     storage_dead(_10)

--- a/charon/tests/ui/multi-target/multi-targets-file-ids.out
+++ b/charon/tests/ui/multi-target/multi-targets-file-ids.out
@@ -15,14 +15,14 @@ pub trait core::marker::MetaSized<Self>
 #[lang_item("sized")]
 pub trait core::marker::Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
     non-dyn-compatible
 }
 
 #[lang_item("clone")]
 pub trait core::clone::Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
+    proof ImpliedClause0: (Self: core::marker::Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -30,8 +30,8 @@ pub trait core::clone::Clone<Self>
 #[lang_item("copy")]
 pub trait core::marker::Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self: core::clone::Clone)
     non-dyn-compatible
 }
 
@@ -42,15 +42,15 @@ pub fn core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::
 
 // Full name: core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
 impl core::clone::Clone for core::core_arch::x86::__m128i {
-    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (core::core_arch::x86::__m128i: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
     fn clone<'_0_1> = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
 impl core::marker::Copy for core::core_arch::x86::__m128i {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::x86::__m128i}
-    parent_clause1 = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (core::core_arch::x86::__m128i: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::core_arch::x86::__m128i}
+    proof ImpliedClause1: (core::core_arch::x86::__m128i: core::clone::Clone) = core::core_arch::x86::{impl core::clone::Clone for core::core_arch::x86::__m128i}
     non-dyn-compatible
 }
 
@@ -59,15 +59,15 @@ pub fn core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::cor
 
 // Full name: core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
 impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t {
-    parent_clause0 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
     fn clone<'_0_1> = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}::clone<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
 impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::core_arch::arm_shared::neon::uint16x8_t}
-    parent_clause1 = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause1: (core::core_arch::arm_shared::neon::uint16x8_t: core::clone::Clone) = core::core_arch::arm_shared::neon::{impl core::clone::Clone for core::core_arch::arm_shared::neon::uint16x8_t}
     non-dyn-compatible
 }
 
@@ -83,7 +83,7 @@ pub unsafe fn core::core_arch::x86::sse2::_mm_storeu_si128(_1: *mut core::core_a
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: core::clone::Clone<Self>,
+    TraitClause0: (Self: core::clone::Clone),
 = <opaque>
 
 pub fn core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0>(_1: &'_0 usize) -> usize
@@ -91,7 +91,7 @@ pub fn core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0>(_1: &
 
 // Full name: core::clone::impls::{impl core::clone::Clone for usize}
 impl core::clone::Clone for usize {
-    parent_clause0 = {built_in impl core::marker::Sized for usize}
+    proof ImpliedClause0: (usize: core::marker::Sized) = {built_in impl core::marker::Sized for usize}
     fn clone<'_0_1> = core::clone::impls::{impl core::clone::Clone for usize}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -106,7 +106,7 @@ pub trait core::cmp::PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>,
+    TraitClause0: (Self: core::cmp::PartialEq<Rhs>),
 = <opaque>
 
 #[lang_item("Ordering")]
@@ -119,7 +119,7 @@ pub enum core::cmp::Ordering {
 #[lang_item("Option")]
 pub enum core::option::Option<T>
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 {
   None,
   Some(T),
@@ -128,7 +128,7 @@ where
 #[lang_item("partial_ord")]
 pub trait core::cmp::PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: core::cmp::PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: core::cmp::PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -136,7 +136,7 @@ pub trait core::cmp::PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> core::option::Option<core::cmp::Ordering>[{built_in impl core::marker::Sized for core::cmp::Ordering}]
 where
-    [@TraitClause0]: core::cmp::PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: core::cmp::PartialOrd<Rhs>),
 = <opaque>
 
 pub fn core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}::eq<'_0, '_1>(_1: &'_0 usize, _2: &'_1 usize) -> bool
@@ -153,7 +153,7 @@ pub fn core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_
 
 // Full name: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
 impl core::cmp::PartialOrd<usize> for usize {
-    parent_clause0 = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
+    proof ImpliedClause0: (usize: core::cmp::PartialEq<usize>) = core::cmp::impls::{impl core::cmp::PartialEq<usize> for usize}
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
     vtable: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::{vtable}
 }
@@ -161,9 +161,9 @@ impl core::cmp::PartialOrd<usize> for usize {
 #[lang_item("range_step")]
 pub trait core::iter::range::Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::Sized<Self>
-    parent_clause1 : [@TraitClause1]: core::clone::Clone<Self>
-    parent_clause2 : [@TraitClause2]: core::cmp::PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: core::marker::Sized)
+    proof ImpliedClause1: (Self: core::clone::Clone)
+    proof ImpliedClause2: (Self: core::cmp::PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -172,17 +172,17 @@ pub trait core::iter::range::Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, core::option::Option<usize>[{built_in impl core::marker::Sized for usize}])
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
-pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
-pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[@TraitClause0::parent_clause0]
+pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> core::option::Option<Self>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: core::iter::range::Step<Self>,
+    TraitClause0: (Self: core::iter::range::Step),
 = <opaque>
 
 pub fn core::iter::range::{impl core::iter::range::Step for usize}::backward_checked(_1: usize, _2: usize) -> core::option::Option<usize>[{built_in impl core::marker::Sized for usize}]
@@ -196,9 +196,9 @@ pub fn core::iter::range::{impl core::iter::range::Step for usize}::steps_betwee
 
 // Full name: core::iter::range::{impl core::iter::range::Step for usize}
 impl core::iter::range::Step for usize {
-    parent_clause0 = {built_in impl core::marker::Sized for usize}
-    parent_clause1 = core::clone::impls::{impl core::clone::Clone for usize}
-    parent_clause2 = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
+    proof ImpliedClause0: (usize: core::marker::Sized) = {built_in impl core::marker::Sized for usize}
+    proof ImpliedClause1: (usize: core::clone::Clone) = core::clone::impls::{impl core::clone::Clone for usize}
+    proof ImpliedClause2: (usize: core::cmp::PartialOrd<usize>) = core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}
     fn steps_between<'_0_1, '_1_1> = core::iter::range::{impl core::iter::range::Step for usize}::steps_between<'_0_1, '_1_1>
     fn forward_checked = core::iter::range::{impl core::iter::range::Step for usize}::forward_checked
     fn backward_checked = core::iter::range::{impl core::iter::range::Step for usize}::backward_checked
@@ -208,7 +208,7 @@ impl core::iter::range::Step for usize {
 #[lang_item("Range")]
 pub struct core::ops::range::Range<Idx>
 where
-    [@TraitClause0]: core::marker::Sized<Idx>,
+    TraitClause0: (Idx: core::marker::Sized),
 {
   start: Idx,
   end: Idx,
@@ -217,42 +217,42 @@ where
 #[lang_item("iterator")]
 pub trait core::iter::traits::iterator::Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::Item>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::Item: core::marker::Sized)
     type Item
     fn next<'_0_1> = core::iter::traits::iterator::Iterator::next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
-pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0, A>(_1: &'_0 mut core::ops::range::Range<A>[@TraitClause0]) -> core::option::Option<A>[@TraitClause0]
+pub fn core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'_0, A>(_1: &'_0 mut core::ops::range::Range<A>[TraitClause0]) -> core::option::Option<A>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::iter::range::Step<A>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (A: core::iter::range::Step),
 = <opaque>
 
-// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}
-impl<A> core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]
+// Full name: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}
+impl<A> core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]
 where
-    [@TraitClause0]: core::marker::Sized<A>,
-    [@TraitClause1]: core::iter::range::Step<A>,
+    TraitClause0: (A: core::marker::Sized),
+    TraitClause1: (A: core::iter::range::Step),
 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for core::ops::range::Range<A>[@TraitClause0]}
-    parent_clause1 = @TraitClause0
+    proof ImpliedClause0: (core::ops::range::Range<A>[TraitClause0]: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for core::ops::range::Range<A>[TraitClause0]}
+    proof ImpliedClause1: (A: core::marker::Sized) = TraitClause0
     type Item = A
-    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'_0_1, A>[@TraitClause0, @TraitClause1]
-    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    fn next<'_0_1> = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'_0_1, A>[TraitClause0, TraitClause1]
+    vtable: core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 pub fn core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<I>(_1: I) -> I
 where
-    [@TraitClause0]: core::marker::Sized<I>,
-    [@TraitClause1]: core::iter::traits::iterator::Iterator<I>,
+    TraitClause0: (I: core::marker::Sized),
+    TraitClause1: (I: core::iter::traits::iterator::Iterator),
 = <opaque>
 
 #[lang_item("next")]
-pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn core::iter::traits::iterator::Iterator::next<'_0, Self>(_1: &'_0 mut Self) -> core::option::Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: core::iter::traits::iterator::Iterator<Self>,
+    TraitClause0: (Self: core::iter::traits::iterator::Iterator),
 = <opaque>
 
 pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
@@ -260,19 +260,19 @@ pub fn core::num::{u16}::wrapping_add(_1: u16, _2: u16) -> u16
 
 pub fn core::slice::{[T]}::as_ptr<'_0, T>(_1: &'_0 [T]) -> *const T
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
 pub fn core::slice::{[T]}::as_mut_ptr<'_0, T>(_1: &'_0 mut [T]) -> *mut T
 where
-    [@TraitClause0]: core::marker::Sized<T>,
+    TraitClause0: (T: core::marker::Sized),
 = <opaque>
 
 trait test_crate::SimdOps<Self>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: core::marker::Sized<Self::V128>
-    parent_clause2 : [@TraitClause2]: core::marker::Copy<Self::V128>
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    proof ImpliedClause1: (Self::V128: core::marker::Sized)
+    proof ImpliedClause2: (Self::V128: core::marker::Copy)
     type V128
     fn load<'_0_1> = test_crate::SimdOps::load<'_0_1, Self>[Self]
     fn store<'_0_1> = test_crate::SimdOps::store<'_0_1, Self>[Self]
@@ -280,19 +280,19 @@ trait test_crate::SimdOps<Self>
     non-dyn-compatible
 }
 
-fn test_crate::SimdOps::load<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> @TraitClause0::V128
+fn test_crate::SimdOps::load<'_0, Self>(_1: &'_0 [u16; 8 : usize]) -> TraitClause0::V128
 where
-    [@TraitClause0]: test_crate::SimdOps<Self>,
+    TraitClause0: (Self: test_crate::SimdOps),
 = <method_without_default_body>
 
-fn test_crate::SimdOps::store<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: @TraitClause0::V128)
+fn test_crate::SimdOps::store<'_0, Self>(_1: &'_0 mut [u16; 8 : usize], _2: TraitClause0::V128)
 where
-    [@TraitClause0]: test_crate::SimdOps<Self>,
+    TraitClause0: (Self: test_crate::SimdOps),
 = <method_without_default_body>
 
-fn test_crate::SimdOps::add<Self>(_1: @TraitClause0::V128, _2: @TraitClause0::V128) -> @TraitClause0::V128
+fn test_crate::SimdOps::add<Self>(_1: TraitClause0::V128, _2: TraitClause0::V128) -> TraitClause0::V128
 where
-    [@TraitClause0]: test_crate::SimdOps<Self>,
+    TraitClause0: (Self: test_crate::SimdOps),
 = <method_without_default_body>
 
 pub struct test_crate::x86::Sse2 {}
@@ -373,9 +373,9 @@ fn test_crate::x86::{impl test_crate::SimdOps for test_crate::x86::Sse2}::load<'
 
 // Full name: test_crate::x86::{impl test_crate::SimdOps for test_crate::x86::Sse2}
 impl test_crate::SimdOps for test_crate::x86::Sse2 {
-    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::x86::Sse2}
-    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
-    parent_clause2 = core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
+    proof ImpliedClause0: (test_crate::x86::Sse2: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for test_crate::x86::Sse2}
+    proof ImpliedClause1: (core::core_arch::x86::__m128i: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::x86::__m128i}
+    proof ImpliedClause2: (core::core_arch::x86::__m128i: core::marker::Copy) = core::core_arch::x86::{impl core::marker::Copy for core::core_arch::x86::__m128i}
     type V128 = core::core_arch::x86::__m128i
     fn load<'_0_1> = test_crate::x86::{impl test_crate::SimdOps for test_crate::x86::Sse2}::load<'_0_1>
     fn store<'_0_1> = test_crate::x86::{impl test_crate::SimdOps for test_crate::x86::Sse2}::store<'_0_1>
@@ -453,9 +453,9 @@ fn test_crate::arm::{impl test_crate::SimdOps for test_crate::arm::Neon}::load<'
 
 // Full name: test_crate::arm::{impl test_crate::SimdOps for test_crate::arm::Neon}
 impl test_crate::SimdOps for test_crate::arm::Neon {
-    parent_clause0 = {built_in impl core::marker::MetaSized for test_crate::arm::Neon}
-    parent_clause1 = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
-    parent_clause2 = core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause0: (test_crate::arm::Neon: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for test_crate::arm::Neon}
+    proof ImpliedClause1: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Sized) = {built_in impl core::marker::Sized for core::core_arch::arm_shared::neon::uint16x8_t}
+    proof ImpliedClause2: (core::core_arch::arm_shared::neon::uint16x8_t: core::marker::Copy) = core::core_arch::arm_shared::neon::{impl core::marker::Copy for core::core_arch::arm_shared::neon::uint16x8_t}
     type V128 = core::core_arch::arm_shared::neon::uint16x8_t
     fn load<'_0_1> = test_crate::arm::{impl test_crate::SimdOps for test_crate::arm::Neon}::load<'_0_1>
     fn store<'_0_1> = test_crate::arm::{impl test_crate::SimdOps for test_crate::arm::Neon}::store<'_0_1>
@@ -465,32 +465,32 @@ impl test_crate::SimdOps for test_crate::arm::Neon {
 
 fn test_crate::add_generic<'_0, '_1, T>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u16; 8 : usize])
 where
-    [@TraitClause0]: core::marker::Sized<T>,
-    [@TraitClause1]: test_crate::SimdOps<T>,
+    TraitClause0: (T: core::marker::Sized),
+    TraitClause1: (T: test_crate::SimdOps),
 {
     let _0: (); // return
     let a_1: &'1 mut [u16; 8 : usize]; // arg #1
     let b_2: &'3 [u16; 8 : usize]; // arg #2
-    let va_3: @TraitClause1::V128; // local
+    let va_3: TraitClause1::V128; // local
     let _4: &'4 [u16; 8 : usize]; // anonymous local
-    let vb_5: @TraitClause1::V128; // local
+    let vb_5: TraitClause1::V128; // local
     let _6: &'5 [u16; 8 : usize]; // anonymous local
     let _7: (); // anonymous local
     let _8: &'6 mut [u16; 8 : usize]; // anonymous local
-    let _9: @TraitClause1::V128; // anonymous local
-    let _10: @TraitClause1::V128; // anonymous local
-    let _11: @TraitClause1::V128; // anonymous local
+    let _9: TraitClause1::V128; // anonymous local
+    let _10: TraitClause1::V128; // anonymous local
+    let _11: TraitClause1::V128; // anonymous local
 
     _0 = ()
     storage_live(va_3)
     storage_live(_4)
     _4 = &(*a_1)
-    va_3 = @TraitClause1::load<'8>(move _4)
+    va_3 = TraitClause1::load<'8>(move _4)
     storage_dead(_4)
     storage_live(vb_5)
     storage_live(_6)
     _6 = &(*b_2)
-    vb_5 = @TraitClause1::load<'10>(move _6)
+    vb_5 = TraitClause1::load<'10>(move _6)
     storage_dead(_6)
     storage_live(_7)
     storage_live(_8)
@@ -500,10 +500,10 @@ where
     _10 = copy va_3
     storage_live(_11)
     _11 = copy vb_5
-    _9 = @TraitClause1::add(move _10, move _11)
+    _9 = TraitClause1::add(move _10, move _11)
     storage_dead(_11)
     storage_dead(_10)
-    _7 = @TraitClause1::store<'12>(move _8, move _9)
+    _7 = TraitClause1::store<'12>(move _8, move _9)
     storage_dead(_9)
     storage_dead(_8)
     storage_dead(_7)
@@ -542,7 +542,7 @@ fn test_crate::add_scalar<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u
     storage_live(_3)
     storage_live(_4)
     _4 = core::ops::range::Range { start: const 0 : usize, end: const 8 : usize }
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]>[{built_in impl core::marker::Sized for core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}<usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]>[{built_in impl core::marker::Sized for core::ops::range::Range<usize>[{built_in impl core::marker::Sized for usize}]}, core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}<usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}]](move _4)
     storage_dead(_4)
     storage_live(iter_5)
     iter_5 = move _3
@@ -552,7 +552,7 @@ fn test_crate::add_scalar<'_0, '_1>(a_1: &'_0 mut [u16; 8 : usize], b_2: &'_1 [u
         storage_live(_8)
         _8 = &mut iter_5
         _7 = &two-phase-mut (*_8)
-        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[@TraitClause0]}::next<'8, usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}](move _7)
+        _6 = core::iter::range::{impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>[TraitClause0]}::next<'8, usize>[{built_in impl core::marker::Sized for usize}, core::iter::range::{impl core::iter::range::Step for usize}](move _7)
         storage_dead(_7)
         match _6 {
             core::option::Option::None => {

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,32 +27,32 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref
-pub fn {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]) -> &'_0 T
+// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref
+pub fn {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref_mut
-pub fn {impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref_mut<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]) -> &'_0 mut T
+// Full name: alloc::boxed::{impl DerefMut for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref_mut
+pub fn {impl DerefMut for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref_mut<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 mut T
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
   x: T1,
   y: T2,
@@ -61,31 +61,31 @@ where
 // Full name: test_crate::List
 pub enum List<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  Cons(T, alloc::boxed::Box<List<T>[@TraitClause0]>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}]),
+  Cons(T, alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]),
   Nil,
 }
 
-// Full name: test_crate::List::{impl Destruct for List<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for List<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut List<T>[@TraitClause0])
+// Full name: test_crate::List::{impl Destruct for List<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for List<T>[TraitClause0]}::drop_in_place<T>(_1: *mut List<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::List::{impl Destruct for List<T>[@TraitClause0]}
-impl<T> Destruct for List<T>[@TraitClause0]
+// Full name: test_crate::List::{impl Destruct for List<T>[TraitClause0]}
+impl<T> Destruct for List<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for List<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for List<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 
 // Full name: test_crate::One
 pub enum One<T1>
 where
-    [@TraitClause0]: Sized<T1>,
+    TraitClause0: (T1: Sized),
 {
   One(T1),
 }
@@ -107,8 +107,8 @@ pub struct EmptyStruct {}
 // Full name: test_crate::Sum
 pub enum Sum<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
   Left(T1),
   Right(T2),
@@ -117,8 +117,8 @@ where
 // Full name: test_crate::Tuple
 pub struct Tuple<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
   T1,
   T2,
@@ -177,45 +177,45 @@ pub fn create_pair(x_1: u32, y_2: u64) -> Pair<u32, u64>[{built_in impl Sized fo
 // Full name: test_crate::IdType
 pub struct IdType<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::IdType::{impl Destruct for IdType<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for IdType<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut IdType<T>[@TraitClause0])
+// Full name: test_crate::IdType::{impl Destruct for IdType<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for IdType<T>[TraitClause0]}::drop_in_place<T>(_1: *mut IdType<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::IdType::{impl Destruct for IdType<T>[@TraitClause0]}
-impl<T> Destruct for IdType<T>[@TraitClause0]
+// Full name: test_crate::IdType::{impl Destruct for IdType<T>[TraitClause0]}
+impl<T> Destruct for IdType<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for IdType<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for IdType<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 
 // Full name: test_crate::use_id_type
-pub fn use_id_type<T>(x_1: IdType<T>[@TraitClause0]) -> T
+pub fn use_id_type<T>(x_1: IdType<T>[TraitClause0]) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
-    let x_1: IdType<T>[@TraitClause0]; // arg #1
+    let x_1: IdType<T>[TraitClause0]; // arg #1
 
     _0 = move (x_1).0
-    conditional_drop[{impl Destruct for IdType<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for IdType<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] x_1
     return
 }
 
 // Full name: test_crate::create_id_type
-pub fn create_id_type<T>(x_1: T) -> IdType<T>[@TraitClause0]
+pub fn create_id_type<T>(x_1: T) -> IdType<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: IdType<T>[@TraitClause0]; // return
+    let _0: IdType<T>[TraitClause0]; // return
     let x_1: T; // arg #1
     let _2: T; // anonymous local
 
@@ -376,10 +376,10 @@ pub fn test_list1()
     _2 = @BoxNew<List<i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for List<i32>[{built_in impl Sized for i32}]}](move _3)
     storage_dead(_3)
     l_1 = List::Cons { 0: const 0 : i32, 1: move _2 }
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<List<i32>[{built_in impl Sized for i32}], Global>[{built_in impl MetaSized for List<i32>[{built_in impl Sized for i32}]}, {built_in impl Sized for Global}]] _2
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<List<i32>[{built_in impl Sized for i32}], Global>[{built_in impl MetaSized for List<i32>[{built_in impl Sized for i32}]}, {built_in impl Sized for Global}]] _2
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{impl Destruct for List<T>[@TraitClause0]}::drop_in_place<i32>[{built_in impl Sized for i32}]] l_1
+    conditional_drop[{impl Destruct for List<T>[TraitClause0]}::drop_in_place<i32>[{built_in impl Sized for i32}]] l_1
     storage_dead(l_1)
     return
 }
@@ -402,13 +402,13 @@ pub fn test_box1()
     storage_live(x_2)
     storage_live(_3)
     _3 = &two-phase-mut b_1
-    x_2 = {impl DerefMut for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref_mut<'9, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}](move _3)
+    x_2 = {impl DerefMut for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref_mut<'9, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}](move _3)
     storage_dead(_3)
     (*x_2) = const 1 : i32
     storage_live(x_4)
     storage_live(_5)
     _5 = &b_1
-    x_4 = {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref<'11, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}](move _5)
+    x_4 = {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref<'11, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}](move _5)
     storage_dead(_5)
     storage_live(_6)
     storage_live(_7)
@@ -424,7 +424,7 @@ pub fn test_box1()
     _0 = ()
     storage_dead(x_4)
     storage_dead(x_2)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]] b_1
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]] b_1
     storage_dead(b_1)
     return
 }
@@ -456,12 +456,12 @@ pub fn test_unreachable(b_1: bool)
 }
 
 // Full name: test_crate::is_cons
-pub fn is_cons<'_0, T>(l_1: &'_0 List<T>[@TraitClause0]) -> bool
+pub fn is_cons<'_0, T>(l_1: &'_0 List<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let l_1: &'1 List<T>[@TraitClause0]; // arg #1
+    let l_1: &'1 List<T>[TraitClause0]; // arg #1
 
     match (*l_1) {
         List::Cons => {
@@ -476,16 +476,16 @@ where
 }
 
 // Full name: test_crate::split_list
-pub fn split_list<T>(l_1: List<T>[@TraitClause0]) -> (T, List<T>[@TraitClause0])
+pub fn split_list<T>(l_1: List<T>[TraitClause0]) -> (T, List<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: (T, List<T>[@TraitClause0]); // return
-    let l_1: List<T>[@TraitClause0]; // arg #1
+    let _0: (T, List<T>[TraitClause0]); // return
+    let l_1: List<T>[TraitClause0]; // arg #1
     let hd_2: T; // local
-    let tl_3: alloc::boxed::Box<List<T>[@TraitClause0]>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl_3: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _4: T; // anonymous local
-    let _5: List<T>[@TraitClause0]; // anonymous local
+    let _5: List<T>[TraitClause0]; // anonymous local
 
     match l_1 {
         List::Cons => {
@@ -503,15 +503,15 @@ where
     storage_live(_5)
     _5 = move (*tl_3)
     _0 = (move _4, move _5)
-    conditional_drop[{impl Destruct for List<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] _5
+    conditional_drop[{impl Destruct for List<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] _5
     storage_dead(_5)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] _4
     storage_dead(_4)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<List<T>[@TraitClause0], Global>[{built_in impl MetaSized for List<T>[@TraitClause0]}, {built_in impl Sized for Global}]] tl_3
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<List<T>[TraitClause0], Global>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]] tl_3
     storage_dead(tl_3)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] hd_2
     storage_dead(hd_2)
-    conditional_drop[{impl Destruct for List<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] l_1
+    conditional_drop[{impl Destruct for List<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] l_1
     return
 }
 
@@ -527,18 +527,18 @@ pub fn test_char() -> char
 // Full name: test_crate::Tree
 pub enum Tree<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   Leaf(T),
-  Node(T, NodeElem<T>[@TraitClause0], alloc::boxed::Box<Tree<T>[@TraitClause0]>[{built_in impl MetaSized for Tree<T>[@TraitClause0]}, {built_in impl Sized for Global}]),
+  Node(T, NodeElem<T>[TraitClause0], alloc::boxed::Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}]),
 }
 
 // Full name: test_crate::NodeElem
 pub enum NodeElem<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  Cons(alloc::boxed::Box<Tree<T>[@TraitClause0]>[{built_in impl MetaSized for Tree<T>[@TraitClause0]}, {built_in impl Sized for Global}], alloc::boxed::Box<NodeElem<T>[@TraitClause0]>[{built_in impl MetaSized for NodeElem<T>[@TraitClause0]}, {built_in impl Sized for Global}]),
+  Cons(alloc::boxed::Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}], alloc::boxed::Box<NodeElem<T>[TraitClause0]>[{built_in impl MetaSized for NodeElem<T>[TraitClause0]}, {built_in impl Sized for Global}]),
   Nil,
 }
 
@@ -643,8 +643,8 @@ pub fn test_even_odd()
 // Full name: test_crate::StructWithTuple
 pub struct StructWithTuple<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
   p: (T1, T2),
 }
@@ -691,10 +691,10 @@ pub fn new_tuple3() -> StructWithTuple<u64, i64>[{built_in impl Sized for u64}, 
 // Full name: test_crate::StructWithPair
 pub struct StructWithPair<T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
 {
-  p: Pair<T1, T2>[@TraitClause0, @TraitClause1],
+  p: Pair<T1, T2>[TraitClause0, TraitClause1],
 }
 
 // Full name: test_crate::new_pair1

--- a/charon/tests/ui/params.out
+++ b/charon/tests/ui/params.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -34,10 +34,10 @@ struct SStatic {
 // Full name: test_crate::E0
 enum E0<mut 'a, mut 'b, T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    T1 : 'a,
-    T2 : 'b,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
 {
   V1(&'a mut T1, &'b mut T2),
 }
@@ -45,102 +45,102 @@ where
 // Full name: test_crate::E1
 enum E1<mut 'a, mut 'b, T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    T1 : 'a,
-    T2 : 'b,
-    T2 : 'a,
-    T1 : 'b,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
+    TypeOutlives2: T2: 'a,
+    TypeOutlives3: T1: 'b,
 {
   V1(&'a mut T1, &'b mut T2),
-  V2(alloc::boxed::Box<E1<'a, 'b, T2, T1>[@TraitClause1, @TraitClause0]>[{built_in impl MetaSized for E1<'a, 'b, T2, T1>[@TraitClause1, @TraitClause0]}, {built_in impl Sized for Global}]),
+  V2(alloc::boxed::Box<E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}]),
 }
 
 // Full name: test_crate::E2
 enum E2<mut 'a, mut 'b, T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    T1 : 'a,
-    T2 : 'b,
-    T1 : 'b,
-    T2 : 'a,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
+    TypeOutlives2: T1: 'b,
+    TypeOutlives3: T2: 'a,
 {
   V1(&'a mut T1, &'b mut T2),
-  V3(alloc::boxed::Box<E2<'b, 'a, T1, T2>[@TraitClause0, @TraitClause1]>[{built_in impl MetaSized for E2<'b, 'a, T1, T2>[@TraitClause0, @TraitClause1]}, {built_in impl Sized for Global}]),
+  V3(alloc::boxed::Box<E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}]),
 }
 
 // Full name: test_crate::E3
 enum E3<mut 'a, mut 'b, 'c, T1, T2>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    T1 : 'a,
-    T2 : 'b,
-    T2 : 'a,
-    T1 : 'b,
-    T2 : 'c,
-    T1 : 'c,
-    'a : 'c,
-    'b : 'c,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
+    TypeOutlives2: T2: 'a,
+    TypeOutlives3: T1: 'b,
+    TypeOutlives4: T2: 'c,
+    TypeOutlives5: T1: 'c,
+    RegionOutlives0: 'a: 'c,
+    RegionOutlives1: 'b: 'c,
 {
   V1(&'a mut T1, &'b mut T2),
-  V2(alloc::boxed::Box<E3<'a, 'b, 'c, T2, T1>[@TraitClause1, @TraitClause0]>[{built_in impl MetaSized for E3<'a, 'b, 'c, T2, T1>[@TraitClause1, @TraitClause0]}, {built_in impl Sized for Global}]),
-  V3(alloc::boxed::Box<E3<'b, 'a, 'c, T1, T2>[@TraitClause0, @TraitClause1]>[{built_in impl MetaSized for E3<'b, 'a, 'c, T1, T2>[@TraitClause0, @TraitClause1]}, {built_in impl Sized for Global}]),
+  V2(alloc::boxed::Box<E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}]),
+  V3(alloc::boxed::Box<E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}]),
   V4(&'c &'a T1),
 }
 
 // Full name: test_crate::E4
 enum E4<mut 'a, mut 'b, 'c, T1, T2, T3>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    [@TraitClause2]: Sized<T3>,
-    T1 : 'a,
-    T2 : 'b,
-    T2 : 'a,
-    T1 : 'b,
-    T3 : 'c,
-    T3 : 'a,
-    T3 : 'b,
-    'a : 'c,
-    'b : 'c,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TraitClause2: (T3: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
+    TypeOutlives2: T2: 'a,
+    TypeOutlives3: T1: 'b,
+    TypeOutlives4: T3: 'c,
+    TypeOutlives5: T3: 'a,
+    TypeOutlives6: T3: 'b,
+    RegionOutlives0: 'a: 'c,
+    RegionOutlives1: 'b: 'c,
 {
   V1(&'a mut T1, &'b mut T2),
-  V2(alloc::boxed::Box<E4<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]>[{built_in impl MetaSized for E4<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]}, {built_in impl Sized for Global}]),
-  V3(alloc::boxed::Box<E4<'b, 'a, 'c, T1, T2, T3>[@TraitClause0, @TraitClause1, @TraitClause2]>[{built_in impl MetaSized for E4<'b, 'a, 'c, T1, T2, T3>[@TraitClause0, @TraitClause1, @TraitClause2]}, {built_in impl Sized for Global}]),
+  V2(alloc::boxed::Box<E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}]),
+  V3(alloc::boxed::Box<E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}]),
   V4(&'c &'a T3),
 }
 
 // Full name: test_crate::E5
 enum E5<mut 'a, mut 'b, 'c, T1, T2, T3>
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    [@TraitClause2]: Sized<T3>,
-    T1 : 'a,
-    T2 : 'b,
-    T2 : 'a,
-    T1 : 'b,
-    T3 : 'a,
-    T3 : 'c,
-    T3 : 'b,
-    'c : 'a,
-    'c : 'b,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TraitClause2: (T3: Sized),
+    TypeOutlives0: T1: 'a,
+    TypeOutlives1: T2: 'b,
+    TypeOutlives2: T2: 'a,
+    TypeOutlives3: T1: 'b,
+    TypeOutlives4: T3: 'a,
+    TypeOutlives5: T3: 'c,
+    TypeOutlives6: T3: 'b,
+    RegionOutlives0: 'c: 'a,
+    RegionOutlives1: 'c: 'b,
 {
   V1(&'a mut T1, &'b mut T2),
-  V2(alloc::boxed::Box<E5<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]>[{built_in impl MetaSized for E5<'a, 'b, 'c, T2, T1, T3>[@TraitClause1, @TraitClause0, @TraitClause2]}, {built_in impl Sized for Global}]),
-  V3(alloc::boxed::Box<E5<'b, 'a, 'c, T1, T2, T3>[@TraitClause0, @TraitClause1, @TraitClause2]>[{built_in impl MetaSized for E5<'b, 'a, 'c, T1, T2, T3>[@TraitClause0, @TraitClause1, @TraitClause2]}, {built_in impl Sized for Global}]),
+  V2(alloc::boxed::Box<E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}]),
+  V3(alloc::boxed::Box<E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}]),
   V4(&'a &'c T3),
 }
 
 // Full name: test_crate::S1
 struct S1<mut 'a, mut 'b, mut 'c, 'd>
 where
-    'c : 'a,
-    'd : 'b,
-    'd : 'a,
-    'c : 'b,
+    RegionOutlives0: 'c: 'a,
+    RegionOutlives1: 'd: 'b,
+    RegionOutlives2: 'd: 'a,
+    RegionOutlives3: 'c: 'b,
 {
   x: E1<'a, 'b, &'c mut u32, &'d u32>[{built_in impl Sized for &'c mut u32}, {built_in impl Sized for &'d u32}],
 }

--- a/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
+++ b/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait core::marker::MetaSized::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>
 #[lang_item("sized")]
 pub trait core::marker::Sized::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>
 {
-    parent_clause0 : [@TraitClause0]: core::marker::MetaSized::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<(&_ mut _, &_ mut _)><'_0, '_1, T1>)
     non-dyn-compatible
 }
 
@@ -47,7 +47,7 @@ unsafe fn core::marker::Destruct::drop_in_place::<(&_ mut _, &_ mut _)><'_0, '_1
 // Full name: test_crate::id
 fn id<T>(x_1: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: T; // return
     let x_1: T; // arg #1
@@ -59,7 +59,7 @@ where
 
 fn test_crate::id::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>(x_1: (&'_0 mut T0, &'_1 mut T1)) -> (&'_0 mut T0, &'_1 mut T1)
 where
-    [@TraitClause0]: core::marker::Sized::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>,
+    TraitClause0: (T0: core::marker::Sized::<(&_ mut _, &_ mut _)><'_0, '_1, T1>),
 {
     let _0: (&'_0 mut T0, &'_1 mut T1); // return
     let x_1: (&'_0 mut T0, &'_1 mut T1); // arg #1
@@ -72,8 +72,8 @@ where
 // Full name: test_crate::call_id_pair_mut
 fn call_id_pair_mut<'a, T, U>(x_1: (&'a mut T, &'a mut U)) -> (&'a mut T, &'a mut U)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
     let _0: (&'4 mut T, &'5 mut U); // return
     let x_1: (&'6 mut T, &'7 mut U); // arg #1

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -8,33 +8,33 @@ pub trait MetaSized<Self>
 #[lang_item("Borrow")]
 pub trait Borrow<Self, Borrowed>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Borrowed>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Borrowed: MetaSized)
     fn borrow<'_0_1> = core::borrow::Borrow::borrow<'_0_1, Self, Borrowed>[Self]
     vtable: core::borrow::Borrow::{vtable}<Borrowed>
 }
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(_1: &'_0 Self) -> &'_0 Borrowed
 where
-    [@TraitClause0]: Borrow<Self, Borrowed>,
+    TraitClause0: (Self: Borrow<Borrowed>),
 = <opaque>
 
 // Full name: core::borrow::{impl Borrow<T> for T}::borrow
 #[lang_item("noop_method_borrow")]
 pub fn {impl Borrow<T> for T}::borrow<'_0, T>(_1: &'_0 T) -> &'_0 T
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <opaque>
 
 // Full name: core::borrow::{impl Borrow<T> for T}
 impl<T> Borrow<T> for T
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 {
-    parent_clause0 = @TraitClause0
-    parent_clause1 = @TraitClause0
-    fn borrow<'_0_1> = {impl Borrow<T> for T}::borrow<'_0_1, T>[@TraitClause0]
-    vtable: {impl Borrow<T> for T}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0
+    proof ImpliedClause1: (T: MetaSized) = TraitClause0
+    fn borrow<'_0_1> = {impl Borrow<T> for T}::borrow<'_0_1, T>[TraitClause0]
+    vtable: {impl Borrow<T> for T}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: core::cmp::PartialEq
@@ -48,14 +48,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -71,7 +71,7 @@ impl PartialEq<u32> for u32 {
 
 // Full name: core::cmp::impls::{impl Eq for u32}
 impl Eq for u32 {
-    parent_clause0 = {impl PartialEq<u32> for u32}
+    proof ImpliedClause0: (u32: PartialEq<u32>) = {impl PartialEq<u32> for u32}
     non-dyn-compatible
 }
 
@@ -79,14 +79,14 @@ impl Eq for u32 {
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = core::hash::Hasher::finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = core::hash::Hasher::write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -96,54 +96,54 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 pub fn core::hash::Hasher::finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 pub fn core::hash::Hasher::write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::BuildHasher
 #[lang_item("BuildHasher")]
 pub trait BuildHasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Hasher>
-    parent_clause2 : [@TraitClause2]: Hasher<Self::Hasher>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Hasher: Sized)
+    proof ImpliedClause2: (Self::Hasher: Hasher)
     type Hasher
     fn build_hasher<'_0_1> = core::hash::BuildHasher::build_hasher<'_0_1, Self>[Self]
     vtable: core::hash::BuildHasher::{vtable}<Self::Hasher>
 }
 
-pub fn core::hash::BuildHasher::build_hasher<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Hasher
+pub fn core::hash::BuildHasher::build_hasher<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Hasher
 where
-    [@TraitClause0]: BuildHasher<Self>,
+    TraitClause0: (Self: BuildHasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for u32}::hash
 pub fn {impl Hash for u32}::hash<'_0, '_1, H>(_1: &'_0 u32, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for u32}
 impl Hash for u32 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for u32}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for u32}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -151,7 +151,7 @@ impl Hash for u32 {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -161,54 +161,54 @@ where
 #[lang_item("HashMap")]
 pub opaque type HashMap<K, V, S, A>
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: Sized<V>,
-    [@TraitClause2]: Sized<S>,
-    [@TraitClause3]: Sized<A>,
+    TraitClause0: (K: Sized),
+    TraitClause1: (V: Sized),
+    TraitClause2: (S: Sized),
+    TraitClause3: (A: Sized),
 
-// Full name: std::collections::hash::map::{HashMap<K, V, S, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::get
-pub fn get<'_0, '_1, K, V, S, A, Q>(_1: &'_0 HashMap<K, V, S, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3], _2: &'_1 Q) -> Option<&'_0 V>[{built_in impl Sized for &'_0 V}]
+// Full name: std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::get
+pub fn get<'_0, '_1, K, V, S, A, Q>(_1: &'_0 HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3], _2: &'_1 Q) -> Option<&'_0 V>[{built_in impl Sized for &'_0 V}]
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: Sized<V>,
-    [@TraitClause2]: Sized<S>,
-    [@TraitClause3]: Sized<A>,
-    [@TraitClause4]: Eq<K>,
-    [@TraitClause5]: Hash<K>,
-    [@TraitClause6]: BuildHasher<S>,
-    [@TraitClause7]: MetaSized<Q>,
-    [@TraitClause8]: Borrow<K, Q>,
-    [@TraitClause9]: Hash<Q>,
-    [@TraitClause10]: Eq<Q>,
+    TraitClause0: (K: Sized),
+    TraitClause1: (V: Sized),
+    TraitClause2: (S: Sized),
+    TraitClause3: (A: Sized),
+    TraitClause4: (K: Eq),
+    TraitClause5: (K: Hash),
+    TraitClause6: (S: BuildHasher),
+    TraitClause7: (Q: MetaSized),
+    TraitClause8: (K: Borrow<Q>),
+    TraitClause9: (Q: Hash),
+    TraitClause10: (Q: Eq),
 = <opaque>
 
-// Full name: std::collections::hash::map::{HashMap<K, V, S, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::insert
+// Full name: std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::insert
 #[lang_item("hashmap_insert")]
-pub fn insert<'_0, K, V, S, A>(_1: &'_0 mut HashMap<K, V, S, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3], _2: K, _3: V) -> Option<V>[@TraitClause1]
+pub fn insert<'_0, K, V, S, A>(_1: &'_0 mut HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3], _2: K, _3: V) -> Option<V>[TraitClause1]
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: Sized<V>,
-    [@TraitClause2]: Sized<S>,
-    [@TraitClause3]: Sized<A>,
-    [@TraitClause4]: Eq<K>,
-    [@TraitClause5]: Hash<K>,
-    [@TraitClause6]: BuildHasher<S>,
+    TraitClause0: (K: Sized),
+    TraitClause1: (V: Sized),
+    TraitClause2: (S: Sized),
+    TraitClause3: (A: Sized),
+    TraitClause4: (K: Eq),
+    TraitClause5: (K: Hash),
+    TraitClause6: (S: BuildHasher),
 = <opaque>
 
-// Full name: std::collections::hash::map::{impl Index<&'_0 Q> for HashMap<K, V, S, A>[@TraitClause0, @TraitClause2, @TraitClause3, @TraitClause4]}::index
-pub fn {impl Index<&'_0 Q> for HashMap<K, V, S, A>[@TraitClause0, @TraitClause2, @TraitClause3, @TraitClause4]}::index<'_0, '_1, K, Q, V, S, A>(_1: &'_1 HashMap<K, V, S, A>[@TraitClause0, @TraitClause2, @TraitClause3, @TraitClause4], _2: &'_0 Q) -> &'_1 V
+// Full name: std::collections::hash::map::{impl Index<&'_0 Q> for HashMap<K, V, S, A>[TraitClause0, TraitClause2, TraitClause3, TraitClause4]}::index
+pub fn {impl Index<&'_0 Q> for HashMap<K, V, S, A>[TraitClause0, TraitClause2, TraitClause3, TraitClause4]}::index<'_0, '_1, K, Q, V, S, A>(_1: &'_1 HashMap<K, V, S, A>[TraitClause0, TraitClause2, TraitClause3, TraitClause4], _2: &'_0 Q) -> &'_1 V
 where
-    [@TraitClause0]: Sized<K>,
-    [@TraitClause1]: MetaSized<Q>,
-    [@TraitClause2]: Sized<V>,
-    [@TraitClause3]: Sized<S>,
-    [@TraitClause4]: Sized<A>,
-    [@TraitClause5]: Eq<K>,
-    [@TraitClause6]: Hash<K>,
-    [@TraitClause7]: Borrow<K, Q>,
-    [@TraitClause8]: Eq<Q>,
-    [@TraitClause9]: Hash<Q>,
-    [@TraitClause10]: BuildHasher<S>,
+    TraitClause0: (K: Sized),
+    TraitClause1: (Q: MetaSized),
+    TraitClause2: (V: Sized),
+    TraitClause3: (S: Sized),
+    TraitClause4: (A: Sized),
+    TraitClause5: (K: Eq),
+    TraitClause6: (K: Hash),
+    TraitClause7: (K: Borrow<Q>),
+    TraitClause8: (Q: Eq),
+    TraitClause9: (Q: Hash),
+    TraitClause10: (S: BuildHasher),
 = <opaque>
 
 // Full name: std::hash::random::RandomState
@@ -227,7 +227,7 @@ pub fn {impl Hasher for DefaultHasher}::write<'_0, '_1>(_1: &'_0 mut DefaultHash
 
 // Full name: std::hash::random::{impl Hasher for DefaultHasher}
 impl Hasher for DefaultHasher {
-    parent_clause0 = {built_in impl MetaSized for DefaultHasher}
+    proof ImpliedClause0: (DefaultHasher: MetaSized) = {built_in impl MetaSized for DefaultHasher}
     fn finish<'_0_1> = {impl Hasher for DefaultHasher}::finish<'_0_1>
     fn write<'_0_1, '_1_1> = {impl Hasher for DefaultHasher}::write<'_0_1, '_1_1>
     vtable: {impl Hasher for DefaultHasher}::{vtable}
@@ -239,9 +239,9 @@ pub fn {impl BuildHasher for RandomState}::build_hasher<'_0>(_1: &'_0 RandomStat
 
 // Full name: std::hash::random::{impl BuildHasher for RandomState}
 impl BuildHasher for RandomState {
-    parent_clause0 = {built_in impl MetaSized for RandomState}
-    parent_clause1 = {built_in impl Sized for DefaultHasher}
-    parent_clause2 = {impl Hasher for DefaultHasher}
+    proof ImpliedClause0: (RandomState: MetaSized) = {built_in impl MetaSized for RandomState}
+    proof ImpliedClause1: (DefaultHasher: Sized) = {built_in impl Sized for DefaultHasher}
+    proof ImpliedClause2: (DefaultHasher: Hasher) = {impl Hasher for DefaultHasher}
     type Hasher = DefaultHasher
     fn build_hasher<'_0_1> = {impl BuildHasher for RandomState}::build_hasher<'_0_1>
     vtable: {impl BuildHasher for RandomState}::{vtable}
@@ -319,7 +319,7 @@ pub fn get_or_insert<'_0>(map_1: &'_0 mut HashMap<u32, u32, RandomState, Global>
             _14 = move _17
             _13 = &(*_14)
             _12 = &(*_13)
-            _10 = {impl Index<&'_0 Q> for HashMap<K, V, S, A>[@TraitClause0, @TraitClause2, @TraitClause3, @TraitClause4]}::index<'33, '35, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, {impl Eq for u32}, {impl Hash for u32}, {impl Borrow<T> for T}<u32>[{built_in impl MetaSized for u32}], {impl Eq for u32}, {impl Hash for u32}, {impl BuildHasher for RandomState}](move _11, move _12)
+            _10 = {impl Index<&'_0 Q> for HashMap<K, V, S, A>[TraitClause0, TraitClause2, TraitClause3, TraitClause4]}::index<'33, '35, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, {impl Eq for u32}, {impl Hash for u32}, {impl Borrow<T> for T}<u32>[{built_in impl MetaSized for u32}], {impl Eq for u32}, {impl Hash for u32}, {impl BuildHasher for RandomState}](move _11, move _12)
             storage_dead(_12)
             storage_dead(_11)
             _9 = &(*_10)

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("RefCell")]
 pub opaque type RefCell<T>
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 
 // Full name: core::cell::BorrowError
 pub struct BorrowError {}
@@ -17,22 +17,22 @@ pub struct BorrowError {}
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
-// Full name: core::cell::{RefCell<T>[@TraitClause0::parent_clause0]}::new
-pub fn new<T>(_1: T) -> RefCell<T>[@TraitClause0::parent_clause0]
+// Full name: core::cell::{RefCell<T>[TraitClause0::ImpliedClause0]}::new
+pub fn new<T>(_1: T) -> RefCell<T>[TraitClause0::ImpliedClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -42,20 +42,20 @@ where
 #[lang_item("RefCellRef")]
 pub opaque type Ref<'b, T>
 where
-    [@TraitClause0]: MetaSized<T>,
-    T : 'b,
+    TraitClause0: (T: MetaSized),
+    TypeOutlives0: T: 'b,
 
-// Full name: core::cell::{RefCell<T>[@TraitClause0]}::try_borrow
-pub fn try_borrow<'_0, T>(_1: &'_0 RefCell<T>[@TraitClause0]) -> Result<Ref<'_0, T>[@TraitClause0], BorrowError>[{built_in impl Sized for Ref<'_0, T>[@TraitClause0]}, {built_in impl Sized for BorrowError}]
+// Full name: core::cell::{RefCell<T>[TraitClause0]}::try_borrow
+pub fn try_borrow<'_0, T>(_1: &'_0 RefCell<T>[TraitClause0]) -> Result<Ref<'_0, T>[TraitClause0], BorrowError>[{built_in impl Sized for Ref<'_0, T>[TraitClause0]}, {built_in impl Sized for BorrowError}]
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <opaque>
 
 // Full name: core::clone::Clone
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -64,24 +64,24 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::result::Result::{impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place<T, E>(_1: *mut Result<T, E>[@TraitClause0, @TraitClause1])
+// Full name: core::result::Result::{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place<T, E>(_1: *mut Result<T, E>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 = <opaque>
 
 // Full name: test_crate::wrap
@@ -101,7 +101,7 @@ fn wrap<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 // Full name: test_crate::wrap2
 fn wrap2<'a>(x_1: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 where
-    [@TraitClause0]: Clone<&'a ()>,
+    TraitClause0: (&'a (): Clone),
 {
     let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
     let x_1: &'9 u32; // arg #1
@@ -131,7 +131,7 @@ fn foo()
     _3 = &ref_b_1
     _2 = try_borrow<'12, bool>[{built_in impl MetaSized for bool}](move _3)
     storage_dead(_3)
-    conditional_drop[{impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place<Ref<'22, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'22, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
+    conditional_drop[{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place<Ref<'22, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'22, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
     storage_dead(_2)
     _0 = ()
     storage_dead(ref_b_1)
@@ -141,22 +141,22 @@ fn foo()
 // Full name: test_crate::Foo
 trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::S>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::S: Sized)
     type S
     vtable: test_crate::Foo::{vtable}<Self::S>
 }
 
 // Full name: test_crate::f
-fn f<T, U>() -> Option<@TraitClause3::S>[@TraitClause3::parent_clause1]
+fn f<T, U>() -> Option<TraitClause3::S>[TraitClause3::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Foo<T>,
-    [@TraitClause3]: Foo<U>,
-    @TraitClause2::S = @TraitClause3::S,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Foo),
+    TraitClause3: (U: Foo),
+    TypeConstraint0: TraitClause2::S = TraitClause3::S,
 {
-    let _0: Option<@TraitClause3::S>[@TraitClause3::parent_clause1]; // return
+    let _0: Option<TraitClause3::S>[TraitClause3::ImpliedClause1]; // return
 
     panic(core::panicking::panic)
 }

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -24,7 +24,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -34,7 +34,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -48,90 +48,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -274,7 +274,7 @@ fn precondition_check(this_1: *const (), count_2: isize, size_3: usize)
 // Full name: core::ptr::const_ptr::{*const T}::offset
 pub unsafe fn offset<T>(self_1: *const T, count_2: isize) -> *const T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: *const T; // return
     let self_1: *const T; // arg #1
@@ -289,7 +289,7 @@ where
     if move _5 {
         storage_live(_4)
         _4 = cast<*const T, *const ()>(copy self_1)
-        _3 = precondition_check(move _4, copy count_2, const {impl SizedTypeProperties for T}<T>[@TraitClause0]::SIZE)
+        _3 = precondition_check(move _4, copy count_2, const {impl SizedTypeProperties for T}<T>[TraitClause0]::SIZE)
         storage_dead(_4)
     } else {
     }
@@ -300,7 +300,7 @@ where
 // Full name: core::slice::{[T]}::as_ptr
 pub fn as_ptr<'_0, T>(_1: &'_0 [T]) -> *const T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::main

--- a/charon/tests/ui/ptr_no_provenance.out
+++ b/charon/tests/ui/ptr_no_provenance.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -39,14 +39,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -62,7 +62,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -72,7 +72,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -81,8 +81,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = core::cmp::Ord::cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -90,13 +90,13 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
@@ -111,7 +111,7 @@ impl PartialEq<()> for () {
 
 // Full name: core::cmp::impls::{impl Eq for ()}
 impl Eq for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     non-dyn-compatible
 }
 
@@ -121,7 +121,7 @@ pub fn {impl PartialOrd<()> for ()}::partial_cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1
 
 // Full name: core::cmp::impls::{impl PartialOrd<()> for ()}
 impl PartialOrd<()> for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<()> for ()}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<()> for ()}::{vtable}
 }
@@ -132,8 +132,8 @@ pub fn {impl Ord for ()}::cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> Ordering
 
 // Full name: core::cmp::impls::{impl Ord for ()}
 impl Ord for () {
-    parent_clause0 = {impl Eq for ()}
-    parent_clause1 = {impl PartialOrd<()> for ()}
+    proof ImpliedClause0: ((): Eq) = {impl Eq for ()}
+    proof ImpliedClause1: ((): PartialOrd<()>) = {impl PartialOrd<()> for ()}
     fn cmp<'_0_1, '_1_1> = {impl Ord for ()}::cmp<'_0_1, '_1_1>
     non-dyn-compatible
 }
@@ -145,8 +145,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -162,7 +162,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for ()}::fmt
@@ -178,7 +178,7 @@ impl Debug for () {
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -188,39 +188,39 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}::hash
 pub fn {impl Hash for ()}::hash<'_0, '_1, H>(_1: &'_0 (), _2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}
 impl Hash for () {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -232,8 +232,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -253,15 +253,15 @@ pub trait Unpin<Self>
 #[lang_item("pointee_trait")]
 pub trait Pointee<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self::Metadata>
-    parent_clause1 : [@TraitClause1]: Debug<Self::Metadata>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Metadata>
-    parent_clause3 : [@TraitClause3]: Send<Self::Metadata>
-    parent_clause4 : [@TraitClause4]: Sync<Self::Metadata>
-    parent_clause5 : [@TraitClause5]: Ord<Self::Metadata>
-    parent_clause6 : [@TraitClause6]: Hash<Self::Metadata>
-    parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
-    parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
+    proof ImpliedClause0: (Self::Metadata: Sized)
+    proof ImpliedClause1: (Self::Metadata: Debug)
+    proof ImpliedClause2: (Self::Metadata: Copy)
+    proof ImpliedClause3: (Self::Metadata: Send)
+    proof ImpliedClause4: (Self::Metadata: Sync)
+    proof ImpliedClause5: (Self::Metadata: Ord)
+    proof ImpliedClause6: (Self::Metadata: Hash)
+    proof ImpliedClause7: (Self::Metadata: Unpin)
+    proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
 }
@@ -269,19 +269,19 @@ pub trait Pointee<Self>
 // Full name: core::ptr::metadata::Thin
 pub trait Thin<Self>
 where
-    Self::parent_clause0::Metadata = (),
+    TypeConstraint0: Self::ImpliedClause0::Metadata = (),
 {
-    parent_clause0 : [@TraitClause0]: Pointee<Self>
+    proof ImpliedClause0: (Self: Pointee)
     non-dyn-compatible
 }
 
 // Full name: core::ptr::metadata::Thin::{impl Thin for Self}
 impl<Self> Thin for Self
 where
-    [@TraitClause0]: Pointee<Self>,
-    @TraitClause0::Metadata = (),
+    TraitClause0: (Self: Pointee),
+    TypeConstraint0: TraitClause0::Metadata = (),
 {
-    parent_clause0 = @TraitClause0
+    proof ImpliedClause0: (Self: Pointee) = TraitClause0
     non-dyn-compatible
 }
 
@@ -289,7 +289,7 @@ where
 #[lang_item("ptr_null")]
 pub fn null<T>() -> *const T
 where
-    [@TraitClause0]: Thin<T>,
+    TraitClause0: (T: Thin),
 {
     let _0: *const T; // return
     let _1: *const T; // anonymous local

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,14 +24,14 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -41,8 +41,8 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
@@ -52,12 +52,12 @@ pub trait Iterator<Self>
 #[lang_item("IntoIterator")]
 pub trait IntoIterator<Self>
 where
-    Self::parent_clause3::Item = Self::Item,
+    TypeConstraint0: Self::ImpliedClause3::Item = Self::Item,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: Sized<Self::IntoIter>
-    parent_clause3 : [@TraitClause3]: Iterator<Self::IntoIter>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    proof ImpliedClause2: (Self::IntoIter: Sized)
+    proof ImpliedClause3: (Self::IntoIter: Iterator)
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
@@ -66,24 +66,24 @@ where
 
 // Full name: core::iter::traits::collect::IntoIterator::into_iter
 #[lang_item("into_iter")]
-pub fn into_iter<Self>(_1: Self) -> @TraitClause0::IntoIter
+pub fn into_iter<Self>(_1: Self) -> TraitClause0::IntoIter
 where
-    [@TraitClause0]: IntoIterator<Self>,
+    TraitClause0: (Self: IntoIterator),
 = <opaque>
 
 // Full name: core::iter::traits::iterator::Iterator::next
 #[lang_item("next")]
-pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -103,7 +103,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -111,10 +111,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -124,32 +124,32 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::FnMut::call_mut
-pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
-pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -158,9 +158,9 @@ where
 // Full name: test_crate::foo
 fn foo<F>(_f_1: F)
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: for<'a> FnMut<F, (&'a (),)>,
-    for<'a> @TraitClause1::parent_clause1::Output = (),
+    TraitClause0: (F: Sized),
+    TraitClause1: for<'a> (F: FnMut<(&'a (),)>),
+    TypeConstraint0: for<'a> TraitClause1::ImpliedClause1::Output = (),
 {
     let _0: (); // return
     let _f_1: F; // arg #1
@@ -174,9 +174,9 @@ where
 // Full name: test_crate::bar
 fn bar<'b, T>()
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'b,
-    for<'a> &'b T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'b,
+    TypeOutlives1: for<'a> &'b T: 'a,
 {
     let _0: (); // return
 
@@ -198,20 +198,20 @@ pub fn f<'a>(_1: &'a ()) -> Option<(&'a u8,)>[{built_in impl Sized for (&'a u8,)
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
-// Full name: test_crate::{impl Trait for Result<T, U>[@TraitClause0, @TraitClause1]}
-impl<T, U> Trait for Result<T, U>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{impl Trait for Result<T, U>[TraitClause0, TraitClause1]}
+impl<T, U> Trait for Result<T, U>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: for<'a> IntoIterator<&'a Result<T, U>[@TraitClause0, @TraitClause1]>,
-    [@TraitClause3]: for<'a> Copy<@TraitClause2::Item>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: for<'a> (&'a Result<T, U>[TraitClause0, TraitClause1]: IntoIterator),
+    TraitClause3: for<'a> (TraitClause2::Item: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for Result<T, U>[@TraitClause0, @TraitClause1]}
-    vtable: {impl Trait for Result<T, U>[@TraitClause0, @TraitClause1]}::{vtable}<T, U>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+    proof ImpliedClause0: (Result<T, U>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for Result<T, U>[TraitClause0, TraitClause1]}
+    vtable: {impl Trait for Result<T, U>[TraitClause0, TraitClause1]}::{vtable}<T, U>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 }
 
 

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -94,7 +94,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -102,8 +102,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -178,9 +178,9 @@ pub trait Destruct<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<Self>> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, @TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (Self: Destruct)> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -188,8 +188,8 @@ pub trait Clone<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -209,7 +209,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 // Full name: core::clone::impls::{impl Clone for usize}::clone_from
 pub fn {impl Clone for usize}::clone_from<'_0, '_1>(self_1: &'_0 mut usize, source_2: &'_1 usize)
 where
-    [@TraitClause0]: Destruct<usize>,
+    TraitClause0: (usize: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut usize; // arg #1
@@ -219,7 +219,7 @@ where
     _0 = ()
     storage_live(_3)
     _3 = {impl Clone for usize}::clone<'5>(move source_2)
-    drop[@TraitClause0::drop_in_place] (*self_1)
+    drop[TraitClause0::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -227,24 +227,24 @@ where
 
 // Full name: core::clone::impls::{impl Clone for usize}
 impl Clone for usize {
-    parent_clause0 = {built_in impl Sized for usize}
+    proof ImpliedClause0: (usize: Sized) = {built_in impl Sized for usize}
     fn clone<'_0_1> = {impl Clone for usize}::clone<'_0_1>
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<usize>> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[@TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (usize: Destruct)> = {impl Clone for usize}::clone_from<'_0_1, '_1_1>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: core::marker::{impl Copy for usize}
 impl Copy for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl Clone for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause1: (usize: Clone) = {impl Clone for usize}
     non-dyn-compatible
 }
 
 // Full name: core::intrinsics::ctpop
 pub fn ctpop<T>(x_1: T) -> u32
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <intrinsic:ctpop>
 
 fn core::ptr::alignment::{Alignment}::new_unchecked::precondition_check(align_1: usize)
@@ -427,20 +427,20 @@ pub struct AllocError {}
 // Full name: core::alloc::Allocator
 pub trait Allocator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn allocate<'_0_1> = core::alloc::Allocator::allocate<'_0_1, Self>[Self]
     fn allocate_zeroed<'_0_1> = core::alloc::Allocator::allocate_zeroed<'_0_1, Self>[Self]
     fn deallocate<'_0_1> = core::alloc::Allocator::deallocate<'_0_1, Self>[Self]
     fn grow<'_0_1> = core::alloc::Allocator::grow<'_0_1, Self>[Self]
     fn grow_zeroed<'_0_1> = core::alloc::Allocator::grow_zeroed<'_0_1, Self>[Self]
     fn shrink<'_0_1> = core::alloc::Allocator::shrink<'_0_1, Self>[Self]
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Self>> = core::alloc::Allocator::by_ref<'_0_1, Self>[Self, @TraitClause0_1]
+    fn by_ref<'_0_1, TraitClause0_1: (Self: Sized)> = core::alloc::Allocator::by_ref<'_0_1, Self>[Self, TraitClause0_1]
     vtable: core::alloc::Allocator::{vtable}
 }
 
 pub fn core::alloc::Allocator::allocate<'_0, Self>(_1: &'_0 Self, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <method_without_default_body>
 
 // Full name: core::ptr::const_ptr::{*const T}::is_aligned_to
@@ -606,8 +606,8 @@ fn core::ptr::write_bytes::precondition_check(addr_1: *const (), align_2: usize,
 #[lang_item("ControlFlow")]
 pub enum ControlFlow<B, C>
 where
-    [@TraitClause0]: Sized<B>,
-    [@TraitClause1]: Sized<C>,
+    TraitClause0: (B: Sized),
+    TraitClause1: (C: Sized),
 {
   Continue(C),
   Break(B),
@@ -647,7 +647,7 @@ pub const core::num::{isize}::MAX: isize = core::num::{isize}::MAX()
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -660,7 +660,7 @@ pub trait SizedTypeProperties<Self>
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local
@@ -671,7 +671,7 @@ where
 
     storage_live(_5)
     storage_live(_1)
-    _1 = const @TraitClause0::SIZE
+    _1 = const TraitClause0::SIZE
     switch copy _1 {
         0 : usize => {
             _0 = copy core::num::{usize}::MAX
@@ -698,48 +698,48 @@ where
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: Layout; // return
 
-    _0 = from_size_align_unchecked(const @TraitClause0::SIZE, const @TraitClause0::ALIGN)
+    _0 = from_size_align_unchecked(const TraitClause0::SIZE, const TraitClause0::ALIGN)
     return
 }
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: bool; // return
 
-    _0 = const @TraitClause0::SIZE == const 0 : usize
+    _0 = const TraitClause0::SIZE == const 0 : usize
     return
 }
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -791,14 +791,14 @@ fn unwrap_failed() -> !
     panic(core::panicking::panic)
 }
 
-// Full name: core::option::{Option<T>[@TraitClause0]}::unwrap
+// Full name: core::option::{Option<T>[TraitClause0]}::unwrap
 #[lang_item("option_unwrap")]
-pub fn unwrap<T>(self_1: Option<T>[@TraitClause0]) -> T
+pub fn unwrap<T>(self_1: Option<T>[TraitClause0]) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let val_0: T; // return
-    let self_1: Option<T>[@TraitClause0]; // arg #1
+    let self_1: Option<T>[TraitClause0]; // arg #1
     let _2: !; // anonymous local
 
     storage_live(_2)
@@ -816,13 +816,13 @@ where
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: Alignment; // return
     let _1: Option<Alignment>[{built_in impl Sized for Alignment}]; // anonymous local
 
     storage_live(_1)
-    _1 = core::ptr::alignment::{Alignment}::new(const @TraitClause0::ALIGN)
+    _1 = core::ptr::alignment::{Alignment}::new(const TraitClause0::ALIGN)
     _0 = unwrap<Alignment>[{built_in impl Sized for Alignment}](move _1)
     storage_dead(_1)
     return
@@ -831,24 +831,24 @@ where
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::intrinsics::align_of
 pub fn align_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <intrinsic:align_of>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
 
-    _0 = align_of<Self>[@TraitClause0::parent_clause0]()
+    _0 = align_of<Self>[TraitClause0::ImpliedClause0]()
     return
 }
 
@@ -856,24 +856,24 @@ where
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::intrinsics::size_of
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <intrinsic:size_of>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 {
     let _0: usize; // return
 
-    _0 = size_of<Self>[@TraitClause0::parent_clause0]()
+    _0 = size_of<Self>[TraitClause0::ImpliedClause0]()
     return
 }
 
@@ -881,28 +881,28 @@ where
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
 // Full name: core::intrinsics::write_bytes
 pub unsafe fn write_bytes<T>(dst_1: *mut T, val_2: u8, count_3: usize)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <intrinsic:write_bytes>
 
 // Full name: core::convert::Infallible
@@ -911,7 +911,7 @@ pub enum Infallible {
 
 pub fn core::alloc::Allocator::allocate_zeroed<'_0, Self>(self_1: &'_0 Self, layout_2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Self; // arg #1
@@ -943,7 +943,7 @@ where
     storage_live(_16)
     storage_live(_3)
     storage_live(self_4)
-    self_4 = @TraitClause0::allocate<'3>(move self_1, move layout_2)
+    self_4 = TraitClause0::allocate<'3>(move self_1, move layout_2)
     storage_live(v_11)
     match self_4 {
         Result::Ok => {
@@ -1005,7 +1005,7 @@ where
 
 pub unsafe fn core::alloc::Allocator::deallocate<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout)
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <method_without_default_body>
 
 // Full name: core::fmt::{Arguments<'a>}::from_str
@@ -1342,7 +1342,7 @@ fn core::ptr::copy_nonoverlapping::precondition_check(src_1: *const (), dst_2: *
 
 pub unsafe fn core::alloc::Allocator::grow<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Self; // arg #1
@@ -1375,7 +1375,7 @@ where
     storage_live(_17)
     storage_live(_5)
     storage_live(self_6)
-    self_6 = @TraitClause0::allocate<'9>(copy self_1, move new_layout_4)
+    self_6 = TraitClause0::allocate<'9>(copy self_1, move new_layout_4)
     storage_live(v_13)
     match self_6 {
         Result::Ok => {
@@ -1428,14 +1428,14 @@ where
     storage_dead(count_11)
     storage_dead(dst_10)
     storage_dead(src_9)
-    _12 = @TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
+    _12 = TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
     _0 = Result::Ok { 0: copy new_ptr_8 }
     return
 }
 
 pub unsafe fn core::alloc::Allocator::grow_zeroed<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Self; // arg #1
@@ -1468,7 +1468,7 @@ where
     storage_live(_17)
     storage_live(_5)
     storage_live(self_6)
-    self_6 = @TraitClause0::allocate_zeroed<'9>(copy self_1, move new_layout_4)
+    self_6 = TraitClause0::allocate_zeroed<'9>(copy self_1, move new_layout_4)
     storage_live(v_13)
     match self_6 {
         Result::Ok => {
@@ -1521,14 +1521,14 @@ where
     storage_dead(count_11)
     storage_dead(dst_10)
     storage_dead(src_9)
-    _12 = @TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
+    _12 = TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
     _0 = Result::Ok { 0: copy new_ptr_8 }
     return
 }
 
 pub unsafe fn core::alloc::Allocator::shrink<'_0, Self>(self_1: &'_0 Self, ptr_2: NonNull<u8>, old_layout_3: Layout, new_layout_4: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 {
     let _0: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // return
     let self_1: &'1 Self; // arg #1
@@ -1561,7 +1561,7 @@ where
     storage_live(_17)
     storage_live(_5)
     storage_live(self_6)
-    self_6 = @TraitClause0::allocate<'9>(copy self_1, copy new_layout_4)
+    self_6 = TraitClause0::allocate<'9>(copy self_1, copy new_layout_4)
     storage_live(v_13)
     match self_6 {
         Result::Ok => {
@@ -1614,15 +1614,15 @@ where
     storage_dead(count_11)
     storage_dead(dst_10)
     storage_dead(src_9)
-    _12 = @TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
+    _12 = TraitClause0::deallocate<'11>(move self_1, move ptr_2, move old_layout_3)
     _0 = Result::Ok { 0: copy new_ptr_8 }
     return
 }
 
 pub fn core::alloc::Allocator::by_ref<'_0, Self>(self_1: &'_0 Self) -> &'_0 Self
 where
-    [@TraitClause0]: Allocator<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Allocator),
+    TraitClause1: (Self: Sized),
 {
     let _0: &'1 Self; // return
     let self_1: &'2 Self; // arg #1
@@ -1634,13 +1634,13 @@ where
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <method_without_default_body>
 
 pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
-    [@TraitClause0]: Clone<Self>,
-    [@TraitClause1]: Destruct<Self>,
+    TraitClause0: (Self: Clone),
+    TraitClause1: (Self: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut Self; // arg #1
@@ -1649,8 +1649,8 @@ where
 
     _0 = ()
     storage_live(_3)
-    _3 = @TraitClause0::clone<'5>(move source_2)
-    drop[@TraitClause1::drop_in_place] (*self_1)
+    _3 = TraitClause0::clone<'5>(move source_2)
+    drop[TraitClause1::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -2748,7 +2748,7 @@ pub fn {impl Allocator for Global}::allocate<'_0>(self_1: &'_0 Global, layout_2:
 // Full name: alloc::alloc::{impl Allocator for Global}::by_ref
 pub fn {impl Allocator for Global}::by_ref<'_0>(self_1: &'_0 Global) -> &'_0 Global
 where
-    [@TraitClause0]: Sized<Global>,
+    TraitClause0: (Global: Sized),
 {
     let _0: &'1 Global; // return
     let self_1: &'2 Global; // arg #1
@@ -2759,14 +2759,14 @@ where
 
 // Full name: alloc::alloc::{impl Allocator for Global}
 impl Allocator for Global {
-    parent_clause0 = {built_in impl MetaSized for Global}
+    proof ImpliedClause0: (Global: MetaSized) = {built_in impl MetaSized for Global}
     fn allocate<'_0_1> = {impl Allocator for Global}::allocate<'_0_1>
     fn allocate_zeroed<'_0_1> = {impl Allocator for Global}::allocate_zeroed<'_0_1>
     fn deallocate<'_0_1> = {impl Allocator for Global}::deallocate<'_0_1>
     fn grow<'_0_1> = {impl Allocator for Global}::grow<'_0_1>
     fn grow_zeroed<'_0_1> = {impl Allocator for Global}::grow_zeroed<'_0_1>
     fn shrink<'_0_1> = {impl Allocator for Global}::shrink<'_0_1>
-    fn by_ref<'_0_1, [@TraitClause0_1]: Sized<Global>> = {impl Allocator for Global}::by_ref<'_0_1>[@TraitClause0_1]
+    fn by_ref<'_0_1, TraitClause0_1: (Global: Sized)> = {impl Allocator for Global}::by_ref<'_0_1>[TraitClause0_1]
     vtable: {impl Allocator for Global}::{vtable}
 }
 
@@ -2802,28 +2802,28 @@ pub fn handle_alloc_error(layout_1: Layout) -> !
 #[lang_item("owned_box")]
 pub struct Box<T, A>
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 {
   Unique<T>,
   A,
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place
-unsafe fn {impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2])
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place
+unsafe fn {impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 = <missing>
 
 #[lang_item("box_new")]
-pub fn alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<T>(x_1: T) -> Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+pub fn alloc::boxed::{Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<T>(x_1: T) -> Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
+    let _0: Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
     let x_1: T; // arg #1
     let ptr_2: *mut T; // local
     let size_3: usize; // local
@@ -2842,9 +2842,9 @@ where
     storage_live(_9)
     storage_live(_11)
     storage_live(size_3)
-    size_3 = const {impl SizedTypeProperties for T}<T>[@TraitClause0]::SIZE
+    size_3 = const {impl SizedTypeProperties for T}<T>[TraitClause0]::SIZE
     storage_live(align_4)
-    align_4 = const {impl SizedTypeProperties for T}<T>[@TraitClause0]::ALIGN
+    align_4 = const {impl SizedTypeProperties for T}<T>[TraitClause0]::ALIGN
     storage_live(layout_5)
     storage_live(ptr_7)
     storage_live(_12)
@@ -2875,16 +2875,16 @@ where
     storage_dead(size_3)
     ptr_2 = cast<*mut [u8], *mut T>(copy _11)
     (*ptr_2) = move x_1
-    _0 = transmute<*mut T, Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]>(copy ptr_2)
+    _0 = transmute<*mut T, Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]>(copy ptr_2)
     return
 }
 
-// Full name: alloc::boxed::{Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::from_raw
-pub unsafe fn from_raw<T>(raw_1: *mut T) -> Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+// Full name: alloc::boxed::{Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::from_raw
+pub unsafe fn from_raw<T>(raw_1: *mut T) -> Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 {
-    let _0: Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
+    let _0: Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
     let raw_1: *mut T; // arg #1
     let _2: Unique<T>; // anonymous local
     let _3: NonNull<T>; // anonymous local
@@ -2922,13 +2922,13 @@ where
     return
 }
 
-// Full name: alloc::boxed::{Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::into_raw
-pub fn into_raw<T>(b_1: Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]) -> *mut T
+// Full name: alloc::boxed::{Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::into_raw
+pub fn into_raw<T>(b_1: Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]) -> *mut T
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 {
     let _0: *mut T; // return
-    let b_1: Box<T, Global>[@TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // arg #1
+    let b_1: Box<T, Global>[TraitClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // arg #1
     let _2: *const T; // anonymous local
     let _3: NonNull<T>; // anonymous local
 
@@ -2940,16 +2940,16 @@ where
     return
 }
 
-// Full name: alloc::boxed::{Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::leak
-pub fn leak<'a, T, A>(b_1: Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]) -> &'a mut T
+// Full name: alloc::boxed::{Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::leak
+pub fn leak<'a, T, A>(b_1: Box<T, A>[TraitClause0, TraitClause1, TraitClause2]) -> &'a mut T
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
-    A : 'a,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
+    TypeOutlives0: A: 'a,
 {
     let _0: &'1 mut T; // return
-    let b_1: Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]; // arg #1
+    let b_1: Box<T, A>[TraitClause0, TraitClause1, TraitClause2]; // arg #1
     let _2: *mut T; // anonymous local
     let _3: *const T; // anonymous local
     let _4: NonNull<T>; // anonymous local
@@ -2982,7 +2982,7 @@ unsafe fn foo()
     storage_live(_9)
     _0 = ()
     storage_live(b_1)
-    b_1 = alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<i32>[{built_in impl Sized for i32}](const 42 : i32)
+    b_1 = alloc::boxed::{Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<i32>[{built_in impl Sized for i32}](const 42 : i32)
     storage_live(p_2)
     storage_live(_3)
     _3 = move b_1
@@ -2990,7 +2990,7 @@ unsafe fn foo()
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
-    _5 = alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<i32>[{built_in impl Sized for i32}](const 42 : i32)
+    _5 = alloc::boxed::{Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new<i32>[{built_in impl Sized for i32}](const 42 : i32)
     _4 = leak<'2, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {impl Allocator for Global}](move _5)
     storage_dead(_5)
     storage_dead(_4)
@@ -3004,7 +3004,7 @@ unsafe fn foo()
     i_8 = copy (*_9)
     _0 = ()
     storage_dead(i_8)
-    drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {impl Allocator for Global}]] b_6
+    drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {impl Allocator for Global}]] b_6
     storage_dead(b_6)
     storage_dead(p_2)
     storage_dead(b_1)

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,8 +16,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -26,18 +26,18 @@ where
 // Full name: test_crate::MyTryFrom
 pub trait MyTryFrom<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Error>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self::Error: Sized)
     type Error
-    fn from<[@TraitClause0_1]: Sized<Self>> = test_crate::MyTryFrom::from<Self, T>[Self, @TraitClause0_1]
+    fn from<TraitClause0_1: (Self: Sized)> = test_crate::MyTryFrom::from<Self, T>[Self, TraitClause0_1]
     vtable: test_crate::MyTryFrom::{vtable}<T, Self::Error>
 }
 
-pub fn test_crate::MyTryFrom::from<Self, T>(_1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause1, @TraitClause0::parent_clause2]
+pub fn test_crate::MyTryFrom::from<Self, T>(_1: T) -> Result<Self, TraitClause0::Error>[TraitClause1, TraitClause0::ImpliedClause2]
 where
-    [@TraitClause0]: MyTryFrom<Self, T>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: MyTryFrom<T>),
+    TraitClause1: (Self: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl MyTryFrom<&'_0 bool> for bool}::from
@@ -56,9 +56,9 @@ pub fn {impl MyTryFrom<&'_0 bool> for bool}::from<'_0>(v_1: &'_0 bool) -> Result
 
 // Full name: test_crate::{impl MyTryFrom<&'_0 bool> for bool}
 impl<'_0> MyTryFrom<&'_0 bool> for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
-    parent_clause1 = {built_in impl Sized for &'_ bool}
-    parent_clause2 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
+    proof ImpliedClause1: (&'_ bool: Sized) = {built_in impl Sized for &'_ bool}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
     type Error = ()
     fn from = {impl MyTryFrom<&'_0 bool> for bool}::from<'_0>
     vtable: {impl MyTryFrom<&'_0 bool> for bool}::{vtable}<'_0>

--- a/charon/tests/ui/regressions/invalid-reconstruct-assert.out
+++ b/charon/tests/ui/regressions/invalid-reconstruct-assert.out
@@ -28,15 +28,15 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: core::hint::select_unpredictable
 pub fn select_unpredictable<T>(_1: bool, _2: T, _3: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 = <opaque>
 
 unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
@@ -46,7 +46,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -54,10 +54,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -67,30 +67,30 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -106,10 +106,10 @@ fn {impl SliceIndex<[T]> for usize}::get_unchecked::precondition_check(_1: usize
 // Full name: core::slice::{[T]}::binary_search_by
 pub fn binary_search_by<'a, T, F>(self_1: &'a [T], f_2: F) -> Result<usize, usize>[{built_in impl Sized for usize}, {built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<F>,
-    [@TraitClause2]: FnMut<F, (&'a T,)>,
-    @TraitClause2::parent_clause1::Output = Ordering,
+    TraitClause0: (T: Sized),
+    TraitClause1: (F: Sized),
+    TraitClause2: (F: FnMut<(&'a T,)>),
+    TypeConstraint0: TraitClause2::ImpliedClause1::Output = Ordering,
 {
     let _0: Result<usize, usize>[{built_in impl Sized for usize}, {built_in impl Sized for usize}]; // return
     let self_1: &'1 [T]; // arg #1
@@ -259,7 +259,7 @@ where
         _15 = &(*_29);
         storage_dead(_29);
         _14 = (copy _15,);
-        cmp_12 = @TraitClause2::call_mut<'19>(move _13, move _14) -> bb14 (unwind: bb13);
+        cmp_12 = TraitClause2::call_mut<'19>(move _13, move _14) -> bb14 (unwind: bb13);
     }
 
     bb9: {
@@ -275,7 +275,7 @@ where
         storage_dead(_35);
         storage_dead(index_22);
         _20 = (copy _21,);
-        cmp_18 = @TraitClause2::call_mut<'24>(move _19, move _20) -> bb17 (unwind: bb13);
+        cmp_18 = TraitClause2::call_mut<'24>(move _19, move _20) -> bb17 (unwind: bb13);
     }
 
     bb11: {
@@ -507,10 +507,10 @@ fn {impl FnOnce<(&'_ u32,)> for closure}::call_once<'_0>(_1: closure, _2: (&'_0 
 
 // Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for closure}
 impl<'_0> FnOnce<(&'_ u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u32,)}
-    parent_clause3 = {built_in impl Sized for Ordering}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause3: (Ordering: Sized) = {built_in impl Sized for Ordering}
     type Output = Ordering
     fn call_once = {impl FnOnce<(&'_ u32,)> for closure}::call_once<'_0>
     non-dyn-compatible
@@ -518,10 +518,10 @@ impl<'_0> FnOnce<(&'_ u32,)> for closure {
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for closure}
 impl<'_0> FnMut<(&'_ u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(&'_ u32,)> for closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for closure}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for closure}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,45 +48,45 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::make_early
 fn make_early<'a, T>(_1: fn(&'a T))
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: fn(&'2 T); // arg #1
@@ -245,10 +245,10 @@ fn {impl FnOnce<(&'_ u8,)> for test_crate::main::closure}::call_once<'_0>(_1: te
 
 // Full name: test_crate::main::{impl FnOnce<(&'_ u8,)> for test_crate::main::closure}
 impl<'_0> FnOnce<(&'_ u8,)> for test_crate::main::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure}
-    parent_clause1 = {built_in impl Sized for (&'_ u8,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u8,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
+    proof ImpliedClause2: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<(&'_ u8,)> for test_crate::main::closure}::call_once<'_0>
     non-dyn-compatible
@@ -256,20 +256,20 @@ impl<'_0> FnOnce<(&'_ u8,)> for test_crate::main::closure {
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u8,)> for test_crate::main::closure}
 impl<'_0> FnMut<(&'_ u8,)> for test_crate::main::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure}
-    parent_clause1 = {impl FnOnce<(&'_ u8,)> for test_crate::main::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u8,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u8,)}
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: (test_crate::main::closure: FnOnce<(&'_ u8,)>) = {impl FnOnce<(&'_ u8,)> for test_crate::main::closure}<'_0>
+    proof ImpliedClause2: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
+    proof ImpliedClause3: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ u8,)> for test_crate::main::closure}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<(&'_ u8,)> for test_crate::main::closure}
 impl<'_0> Fn<(&'_ u8,)> for test_crate::main::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure}
-    parent_clause1 = {impl FnMut<(&'_ u8,)> for test_crate::main::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u8,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u8,)}
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: (test_crate::main::closure: FnMut<(&'_ u8,)>) = {impl FnMut<(&'_ u8,)> for test_crate::main::closure}<'_0>
+    proof ImpliedClause2: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
+    proof ImpliedClause3: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
     fn call<'_0_1> = {impl Fn<(&'_ u8,)> for test_crate::main::closure}::call<'_0, '_0_1>
     non-dyn-compatible
 }
@@ -282,10 +282,10 @@ impl Destruct for test_crate::main::closure {
 
 // Full name: test_crate::main::{impl FnOnce<(&'_ u16,)> for test_crate::main::closure#1}
 impl<'_0> FnOnce<(&'_ u16,)> for test_crate::main::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#1}
-    parent_clause1 = {built_in impl Sized for (&'_ u16,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u16,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (test_crate::main::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1}
+    proof ImpliedClause1: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
+    proof ImpliedClause2: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<(&'_ u16,)> for test_crate::main::closure#1}::call_once<'_0>
     non-dyn-compatible
@@ -293,20 +293,20 @@ impl<'_0> FnOnce<(&'_ u16,)> for test_crate::main::closure#1 {
 
 // Full name: test_crate::main::{impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}
 impl<'_0> FnMut<(&'_ u16,)> for test_crate::main::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#1}
-    parent_clause1 = {impl FnOnce<(&'_ u16,)> for test_crate::main::closure#1}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u16,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u16,)}
+    proof ImpliedClause0: (test_crate::main::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1}
+    proof ImpliedClause1: (test_crate::main::closure#1: FnOnce<(&'_ u16,)>) = {impl FnOnce<(&'_ u16,)> for test_crate::main::closure#1}<'_0>
+    proof ImpliedClause2: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
+    proof ImpliedClause3: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<(&'_ u16,)> for test_crate::main::closure#1}
 impl<'_0> Fn<(&'_ u16,)> for test_crate::main::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::main::closure#1}
-    parent_clause1 = {impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ u16,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u16,)}
+    proof ImpliedClause0: (test_crate::main::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1}
+    proof ImpliedClause1: (test_crate::main::closure#1: FnMut<(&'_ u16,)>) = {impl FnMut<(&'_ u16,)> for test_crate::main::closure#1}<'_0>
+    proof ImpliedClause2: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
+    proof ImpliedClause3: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
     fn call<'_0_1> = {impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/regressions/issue-1067-filename-ice.out
+++ b/charon/tests/ui/regressions/issue-1067-filename-ice.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,8 +18,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -35,15 +35,15 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), core::fmt::Error>[{built_in impl Sized for ()}, {built_in impl Sized for core::fmt::Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
-// Full name: core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap
-pub fn unwrap<T, E>(_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
+// Full name: core::result::{Result<T, E>[TraitClause0, TraitClause1]}::unwrap
+pub fn unwrap<T, E>(_1: Result<T, E>[TraitClause0, TraitClause1]) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Debug<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Debug),
 = <opaque>
 
 pub opaque type std::io::error::Error
@@ -62,31 +62,31 @@ impl Debug for std::io::error::Error {
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-// Full name: std::io::impls::{impl Write for Vec<u8>[{built_in impl Sized for u8}, @TraitClause0]}::write_all
-pub fn {impl Write for Vec<u8>[{built_in impl Sized for u8}, @TraitClause0]}::write_all<'_0, '_1, A>(_1: &'_0 mut Vec<u8>[{built_in impl Sized for u8}, @TraitClause0], _2: &'_1 [u8]) -> Result<(), std::io::error::Error>[{built_in impl Sized for ()}, {built_in impl Sized for std::io::error::Error}]
+// Full name: std::io::impls::{impl Write for Vec<u8>[{built_in impl Sized for u8}, TraitClause0]}::write_all
+pub fn {impl Write for Vec<u8>[{built_in impl Sized for u8}, TraitClause0]}::write_all<'_0, '_1, A>(_1: &'_0 mut Vec<u8>[{built_in impl Sized for u8}, TraitClause0], _2: &'_1 [u8]) -> Result<(), std::io::error::Error>[{built_in impl Sized for ()}, {built_in impl Sized for std::io::error::Error}]
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 = <opaque>
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::{Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::vec::{Vec<T>[TraitClause0, {built_in impl Sized for Global}]}::new
 #[lang_item("vec_new")]
-pub fn new<T>() -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn new<T>() -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::main
@@ -121,7 +121,7 @@ fn main()
     _6 = &(*_7)
     _5 = @ArrayToSliceShared<'_, u8, 5 : usize>(move _6)
     storage_dead(_6)
-    _3 = {impl Write for Vec<u8>[{built_in impl Sized for u8}, @TraitClause0]}::write_all<'11, '12, Global>[{built_in impl Sized for Global}](move _4, move _5)
+    _3 = {impl Write for Vec<u8>[{built_in impl Sized for u8}, TraitClause0]}::write_all<'11, '12, Global>[{built_in impl Sized for Global}](move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
     _2 = unwrap<(), std::io::error::Error>[{built_in impl Sized for ()}, {built_in impl Sized for std::io::error::Error}, {impl Debug for std::io::error::Error}](move _3)
@@ -129,7 +129,7 @@ fn main()
     storage_dead(_7)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] buf_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] buf_1
     storage_dead(buf_1)
     return
 }

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -27,7 +27,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -41,7 +41,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -55,90 +55,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -146,7 +146,7 @@ where
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -164,9 +164,9 @@ fn slice_index_fail(_1: usize, _2: usize, _3: usize) -> !
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
 // Full name: core::slice::raw::from_raw_parts::precondition_check
 fn precondition_check(_1: *mut (), _2: usize, _3: usize, _4: usize)

--- a/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
+++ b/charon/tests/ui/regressions/issue-1074-vtable-supertrait.out
@@ -35,17 +35,17 @@ struct test_crate::MyTrait::{vtable} {
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 where
-    Self : 'static,
+    TypeOutlives0: Self: 'static,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Send<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Send)
     fn foo<'_0_1> = test_crate::MyTrait::foo<'_0_1, Self>[Self]
     vtable: test_crate::MyTrait::{vtable}
 }
 
 pub fn test_crate::MyTrait::foo<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: MyTrait<Self>,
+    TraitClause0: (Self: MyTrait),
 = <method_without_default_body>
 
 // Full name: test_crate::MyStruct
@@ -129,8 +129,8 @@ static {impl MyTrait for MyStruct}::{vtable}: test_crate::MyTrait::{vtable} = {i
 
 // Full name: test_crate::{impl MyTrait for MyStruct}
 impl MyTrait for MyStruct {
-    parent_clause0 = {built_in impl MetaSized for MyStruct}
-    parent_clause1 = {built_in impl Send for MyStruct}
+    proof ImpliedClause0: (MyStruct: MetaSized) = {built_in impl MetaSized for MyStruct}
+    proof ImpliedClause1: (MyStruct: Send) = {built_in impl Send for MyStruct}
     fn foo<'_0_1> = {impl MyTrait for MyStruct}::foo<'_0_1>
     vtable: {impl MyTrait for MyStruct}::{vtable}
 }

--- a/charon/tests/ui/regressions/issue-1089-inline-const-precise-drops.out
+++ b/charon/tests/ui/regressions/issue-1089-inline-const-precise-drops.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,8 +27,8 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::foo
 fn foo<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local

--- a/charon/tests/ui/regressions/issue-393-vec-with-control-flow.out
+++ b/charon/tests/ui/regressions/issue-393-vec-with-control-flow.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,13 +16,13 @@ pub trait Sized<Self>
 #[lang_item("maybe_uninit")]
 pub opaque type MaybeUninit<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -32,45 +32,45 @@ where
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new_uninit
-pub fn new_uninit<T>() -> alloc::boxed::Box<MaybeUninit<T>[@TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[@TraitClause0]}, {built_in impl Sized for Global}]
+// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new_uninit
+pub fn new_uninit<T>() -> alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<MaybeUninit<T>[@TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[@TraitClause0]}, @TraitClause1]}::write
-pub fn write<T, A>(_1: alloc::boxed::Box<MaybeUninit<T>[@TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[@TraitClause0]}, @TraitClause1], _2: T) -> alloc::boxed::Box<T>[@TraitClause0::parent_clause0, @TraitClause1]
+// Full name: alloc::boxed::{alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1]}::write
+pub fn write<T, A>(_1: alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1], _2: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: test_crate::next
@@ -100,7 +100,7 @@ pub fn next(b_1: bool) -> Option<Vec<u8>[{built_in impl Sized for u8}, {built_in
         _0 = Option::None {  }
         storage_dead(_5)
         storage_dead(_4)
-        conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<MaybeUninit<[u8; 1 : usize]>[{built_in impl Sized for [u8; 1 : usize]}], Global>[{built_in impl MetaSized for MaybeUninit<[u8; 1 : usize]>[{built_in impl Sized for [u8; 1 : usize]}]}, {built_in impl Sized for Global}]] _3
+        conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<MaybeUninit<[u8; 1 : usize]>[{built_in impl Sized for [u8; 1 : usize]}], Global>[{built_in impl MetaSized for MaybeUninit<[u8; 1 : usize]>[{built_in impl Sized for [u8; 1 : usize]}]}, {built_in impl Sized for Global}]] _3
         storage_dead(_3)
         storage_dead(vec_2)
         return
@@ -125,9 +125,9 @@ pub fn next(b_1: bool) -> Option<Vec<u8>[{built_in impl Sized for u8}, {built_in
     storage_live(_6)
     _6 = move vec_2
     _0 = Option::Some { 0: move _6 }
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _6
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _6
     storage_dead(_6)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] vec_2
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] vec_2
     storage_dead(vec_2)
     return
 }

--- a/charon/tests/ui/regressions/issue-792-trait-ref-panic-when-tracing.out
+++ b/charon/tests/ui/regressions/issue-792-trait-ref-panic-when-tracing.out
@@ -8,23 +8,23 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Internal
 trait Internal<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::IntAssoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::IntAssoc: Sized)
     type IntAssoc
     fn internal_method<'_0_1> = test_crate::Internal::internal_method<'_0_1, Self>[Self]
     vtable: test_crate::Internal::{vtable}<Self::IntAssoc>
 }
 
-fn test_crate::Internal::internal_method<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::IntAssoc
+fn test_crate::Internal::internal_method<'_0, Self>(_1: &'_0 Self) -> TraitClause0::IntAssoc
 where
-    [@TraitClause0]: Internal<Self>,
+    TraitClause0: (Self: Internal),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Internal for i32}::internal_method
@@ -46,8 +46,8 @@ fn {impl Internal for i32}::internal_method<'_0>(self_1: &'_0 i32) -> i32
 
 // Full name: test_crate::{impl Internal for i32}
 impl Internal for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     type IntAssoc = i32
     fn internal_method<'_0_1> = {impl Internal for i32}::internal_method<'_0_1>
     vtable: {impl Internal for i32}::{vtable}

--- a/charon/tests/ui/regressions/issue-967-assoc-type-coherence.out
+++ b/charon/tests/ui/regressions/issue-967-assoc-type-coherence.out
@@ -8,62 +8,62 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasOutput
 pub trait HasOutput<Self, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Output: Sized)
     vtable: test_crate::HasOutput::{vtable}<Self_Output>
 }
 
 // Full name: test_crate::Bound
 pub trait Bound<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Bound::{vtable}
 }
 
 // Full name: test_crate::HasBlockSize
 pub trait HasBlockSize<Self, Self_BlockSize, Self_Clause2_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_BlockSize>
-    parent_clause2 : [@TraitClause2]: HasOutput<Self_BlockSize, Self_Clause2_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_BlockSize: Sized)
+    proof ImpliedClause2: (Self_BlockSize: HasOutput<Self_Clause2_Output>)
     vtable: test_crate::HasBlockSize::{vtable}<Self_BlockSize>
 }
 
 // Full name: test_crate::HasReaderCore
 pub trait HasReaderCore<Self, Self_ReaderCore, Self_Clause2_BlockSize, Self_Clause2_Clause2_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_ReaderCore>
-    parent_clause2 : [@TraitClause2]: HasBlockSize<Self_ReaderCore, Self_Clause2_BlockSize, Self_Clause2_Clause2_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_ReaderCore: Sized)
+    proof ImpliedClause2: (Self_ReaderCore: HasBlockSize<Self_Clause2_BlockSize, Self_Clause2_Clause2_Output>)
     vtable: test_crate::HasReaderCore::{vtable}<Self_ReaderCore>
 }
 
 // Full name: test_crate::Wrapper
 pub struct Wrapper<T, Clause1_BlockSize, Clause1_Clause2_Output>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasBlockSize<T, Clause1_BlockSize, Clause1_Clause2_Output>,
-    [@TraitClause2]: Bound<Clause1_Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasBlockSize<Clause1_BlockSize, Clause1_Clause2_Output>),
+    TraitClause2: (Clause1_Clause2_Output: Bound),
 {
   T,
 }
 
 // Full name: test_crate::foo
-pub fn foo<T, Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output, Clause2_Output>() -> Wrapper<Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>[@TraitClause1::parent_clause1, @TraitClause1::parent_clause2, @TraitClause3]
+pub fn foo<T, Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output, Clause2_Output>() -> Wrapper<Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>[TraitClause1::ImpliedClause1, TraitClause1::ImpliedClause2, TraitClause3]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasReaderCore<T, Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>,
-    [@TraitClause2]: HasOutput<Clause1_Clause2_BlockSize, Clause2_Output>,
-    [@TraitClause3]: Bound<Clause2_Output>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasReaderCore<Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>),
+    TraitClause2: (Clause1_Clause2_BlockSize: HasOutput<Clause2_Output>),
+    TraitClause3: (Clause2_Output: Bound),
 {
-    let _0: Wrapper<Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>[@TraitClause1::parent_clause1, @TraitClause1::parent_clause2, @TraitClause3]; // return
+    let _0: Wrapper<Clause1_ReaderCore, Clause1_Clause2_BlockSize, Clause1_Clause2_Clause2_Output>[TraitClause1::ImpliedClause1, TraitClause1::ImpliedClause2, TraitClause3]; // return
 
     panic(core::panicking::panic)
 }

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn get_bool<'_0_1> = test_crate::BoolTrait::get_bool<'_0_1, Self>[Self]
     fn ret_true<'_0_1> = test_crate::BoolTrait::ret_true<'_0_1, Self>[Self]
     vtable: test_crate::BoolTrait::{vtable}
@@ -23,12 +23,12 @@ pub trait BoolTrait<Self>
 
 pub fn test_crate::BoolTrait::get_bool<'_0, Self>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 = <method_without_default_body>
 
 pub fn test_crate::BoolTrait::ret_true<'_0, Self>(self_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 {
     let _0: bool; // return
     let self_1: &'1 Self; // arg #1
@@ -59,7 +59,7 @@ pub fn {impl BoolTrait for bool}::ret_true<'_0>(self_1: &'_0 bool) -> bool
 
 // Full name: test_crate::{impl BoolTrait for bool}
 impl BoolTrait for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
     fn get_bool<'_0_1> = {impl BoolTrait for bool}::get_bool<'_0_1>
     fn ret_true<'_0_1> = {impl BoolTrait for bool}::ret_true<'_0_1>
     vtable: {impl BoolTrait for bool}::{vtable}
@@ -68,7 +68,7 @@ impl BoolTrait for bool {
 // Full name: test_crate::test_bool_trait
 pub fn test_bool_trait<T>(x_1: bool) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
     let x_1: bool; // arg #1

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -42,7 +42,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -50,8 +50,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -74,7 +74,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <method_without_default_body>
 
 // Full name: core::fmt::num::{impl LowerHex for u32}::fmt
@@ -144,14 +144,14 @@ impl Debug for u32 {
 fn unwrap_failed<'_0, '_1>(_1: &'_0 str, _2: &'_1 (dyn Debug + '_1)) -> !
 = <missing>
 
-pub fn core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<T, E>(self_1: Result<T, E>[@TraitClause0, @TraitClause1]) -> T
+pub fn core::result::{Result<T, E>[TraitClause0, TraitClause1]}::unwrap<T, E>(self_1: Result<T, E>[TraitClause0, TraitClause1]) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
-    [@TraitClause2]: Debug<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (E: Debug),
 {
     let t_0: T; // return
-    let self_1: Result<T, E>[@TraitClause0, @TraitClause1]; // arg #1
+    let self_1: Result<T, E>[TraitClause0, TraitClause1]; // arg #1
     let e_2: E; // local
     let _3: !; // anonymous local
     let _4: &'3 (dyn Debug + '4); // anonymous local
@@ -167,7 +167,7 @@ where
             e_2 = move (self_1 as variant Result::Err).0
             storage_live(_4)
             _5 = &e_2
-            _4 = unsize_cast<&'6 E, &'7 (dyn Debug + '8), &vtable_of(@TraitClause2)>(copy _5)
+            _4 = unsize_cast<&'6 E, &'7 (dyn Debug + '8), &vtable_of(TraitClause2)>(copy _5)
             _3 = unwrap_failed<'11, '12>(const "called `Result::unwrap()` on an `Err` value", move _4)
         },
     }
@@ -183,7 +183,7 @@ fn test_crate::unwrap(res_1: Result<u32, u32>[{built_in impl Sized for u32}, {bu
 
     storage_live(_2)
     _2 = copy res_1
-    _0 = core::result::{Result<T, E>[@TraitClause0, @TraitClause1]}::unwrap<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {impl Debug for u32}](move _2)
+    _0 = core::result::{Result<T, E>[TraitClause0, TraitClause1]}::unwrap<u32, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {impl Debug for u32}](move _2)
     storage_dead(_2)
     return
 }

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -51,23 +51,23 @@ fn bar()
 // Full name: test_crate::Trait
 trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    fn method<U, [@TraitClause0_1]: Sized<U>> = test_crate::Trait::method<Self, T, U>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    fn method<U, TraitClause0_1: (U: Sized)> = test_crate::Trait::method<Self, T, U>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::method<Self, T, U>()
 where
-    [@TraitClause0]: Trait<Self, T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (Self: Trait<T>),
+    TraitClause1: (U: Sized),
 = <method_without_default_body>
 
-// Full name: test_crate::{impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method
-fn {impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method<T, U>()
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
+fn {impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method<T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
     let _0: (); // return
 
@@ -76,22 +76,22 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}
-impl<T> Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+impl<T> Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<Option<T>[@TraitClause0]> for alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::method<T, U>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    fn method<U, TraitClause0_1: (U: Sized)> = {impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method<T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Trait<T> for [T]}::method
 fn {impl Trait<T> for [T]}::method<T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
     let _0: (); // return
 
@@ -103,19 +103,19 @@ where
 // Full name: test_crate::{impl Trait<T> for [T]}
 impl<T> Trait<T> for [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = @TraitClause0
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for [T]}::method<T, U>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn method<U, TraitClause0_1: (U: Sized)> = {impl Trait<T> for [T]}::method<T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Trait<T> for &'_0 [T]}::method
 fn {impl Trait<T> for &'_0 [T]}::method<'_0, T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
     let _0: (); // return
 
@@ -127,28 +127,28 @@ where
 // Full name: test_crate::{impl Trait<T> for &'_0 [T]}
 impl<'_0, T> Trait<T> for &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for &'_ [T]}
-    parent_clause1 = @TraitClause0
-    fn method<U, [@TraitClause0_1]: Sized<U>> = {impl Trait<T> for &'_0 [T]}::method<'_0, T, U>[@TraitClause0, @TraitClause0_1]
+    proof ImpliedClause0: (&'_ [T]: MetaSized) = {built_in impl MetaSized for &'_ [T]}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn method<U, TraitClause0_1: (U: Sized)> = {impl Trait<T> for &'_0 [T]}::method<'_0, T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Generic
 struct Generic<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   value: T,
 }
 
-// Full name: test_crate::{Generic<T>[@TraitClause0]}::new
-fn new<T>(value_1: T) -> Generic<T>[@TraitClause0]
+// Full name: test_crate::{Generic<T>[TraitClause0]}::new
+fn new<T>(value_1: T) -> Generic<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Generic<T>[@TraitClause0]; // return
+    let _0: Generic<T>[TraitClause0]; // return
     let value_1: T; // arg #1
     let _2: T; // anonymous local
 
@@ -161,13 +161,13 @@ where
     return
 }
 
-// Full name: test_crate::{Generic<T>[@TraitClause0]}::get
-fn get<'_0, T>(self_1: &'_0 Generic<T>[@TraitClause0]) -> &'_0 T
+// Full name: test_crate::{Generic<T>[TraitClause0]}::get
+fn get<'_0, T>(self_1: &'_0 Generic<T>[TraitClause0]) -> &'_0 T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 T; // return
-    let self_1: &'3 Generic<T>[@TraitClause0]; // arg #1
+    let self_1: &'3 Generic<T>[TraitClause0]; // arg #1
     let _2: &'4 T; // anonymous local
 
     storage_live(_2)

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,14 +35,14 @@ pub trait Tuple<Self>
 #[lang_item("mem_size_of")]
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::mem::align_of
 #[lang_item("mem_align_of")]
 pub fn align_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::f32::{f32}::MAX
@@ -63,10 +63,10 @@ pub const MIN: f64 = MIN()
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -76,39 +76,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::addr_of
@@ -395,10 +395,10 @@ fn fn_casts()
 
 // Full name: test_crate::fn_casts::{impl FnOnce<(u8,)> for closure}
 impl FnOnce<(u8,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<(u8,)> for closure}::call_once
     non-dyn-compatible
@@ -406,20 +406,20 @@ impl FnOnce<(u8,)> for closure {
 
 // Full name: test_crate::fn_casts::{impl FnMut<(u8,)> for closure}
 impl FnMut<(u8,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(u8,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for closure}
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     fn call_mut<'_0_1> = {impl FnMut<(u8,)> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::fn_casts::{impl Fn<(u8,)> for closure}
 impl Fn<(u8,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<(u8,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<(u8,)>) = {impl FnMut<(u8,)> for closure}
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     fn call<'_0_1> = {impl Fn<(u8,)> for closure}::call<'_0_1>
     non-dyn-compatible
 }
@@ -480,7 +480,7 @@ static STEAL2: [(); 13 : usize] = STEAL2()
 // Full name: test_crate::nullary_ops::Struct
 struct Struct<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   a: u8,
   b: T,
@@ -489,7 +489,7 @@ where
 // Full name: test_crate::nullary_ops
 fn nullary_ops<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let size_1: usize; // local
@@ -514,13 +514,13 @@ where
     storage_live(_12)
     storage_live(_14)
     storage_live(size_1)
-    size_1 = size_of<T>[@TraitClause0]()
+    size_1 = size_of<T>[TraitClause0]()
     storage_live(align_2)
-    align_2 = align_of<T>[@TraitClause0]()
+    align_2 = align_of<T>[TraitClause0]()
     storage_live(_16)
     storage_live(_17)
     // This is `const (false)` in the MIR we get, but `true` in const evaluation.
-    _17 = offset_of(Struct<T>[@TraitClause0].b)<usize>
+    _17 = offset_of(Struct<T>[TraitClause0].b)<usize>
     _16 = move _17
     storage_live(ub_3)
     storage_live(_15)

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -7,14 +7,14 @@ pub trait MetaSized<Self>
 // Full name: test_crate::Trait
 trait Trait<'a, Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn method<'b> = test_crate::Trait::method<'a, 'b, Self>[Self]
     vtable: test_crate::Trait::{vtable}<'a>
 }
 
 fn test_crate::Trait::method<'a, 'b, Self>(_1: &'b Self) -> &'b ()
 where
-    [@TraitClause0]: Trait<'a, Self>,
+    TraitClause0: (Self: Trait<'a>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait<'a> for &'a ()}::method
@@ -23,7 +23,7 @@ fn {impl Trait<'a> for &'a ()}::method<'a, 'b>(_1: &'b &'a ()) -> &'b ()
 
 // Full name: test_crate::{impl Trait<'a> for &'a ()}
 impl<'a> Trait<'a> for &'a () {
-    parent_clause0 = {built_in impl MetaSized for &'_ ()}
+    proof ImpliedClause0: (&'_ (): MetaSized) = {built_in impl MetaSized for &'_ ()}
     fn method<'b> = {impl Trait<'a> for &'a ()}::method<'a, 'b>
     vtable: {impl Trait<'a> for &'a ()}::{vtable}<'a>
 }

--- a/charon/tests/ui/send_bound.out
+++ b/charon/tests/ui/send_bound.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,8 +31,8 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::foo
 fn foo<M>(_msg_1: M)
 where
-    [@TraitClause0]: Sized<M>,
-    [@TraitClause1]: Send<M>,
+    TraitClause0: (M: Sized),
+    TraitClause1: (M: Send),
 {
     let _0: (); // return
     let _msg_1: M; // arg #1

--- a/charon/tests/ui/simple/additions.out
+++ b/charon/tests/ui/simple/additions.out
@@ -16,7 +16,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,16 +24,16 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<Self>> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, @TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (Self: Destruct)> = core::clone::Clone::clone_from<'_0_1, '_1_1, Self>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <method_without_default_body>
 
 // Full name: core::marker::Destruct::drop_in_place
@@ -42,8 +42,8 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 
 pub fn core::clone::Clone::clone_from<'_0, '_1, Self>(self_1: &'_0 mut Self, source_2: &'_1 Self)
 where
-    [@TraitClause0]: Clone<Self>,
-    [@TraitClause1]: Destruct<Self>,
+    TraitClause0: (Self: Clone),
+    TraitClause1: (Self: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut Self; // arg #1
@@ -52,8 +52,8 @@ where
 
     _0 = ()
     storage_live(_3)
-    _3 = @TraitClause0::clone<'5>(move source_2)
-    drop[@TraitClause1::drop_in_place] (*self_1)
+    _3 = TraitClause0::clone<'5>(move source_2)
+    drop[TraitClause1::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -72,7 +72,7 @@ pub fn {impl Clone for u8}::clone<'_0>(self_1: &'_0 u8) -> u8
 // Full name: core::clone::impls::{impl Clone for u8}::clone_from
 pub fn {impl Clone for u8}::clone_from<'_0, '_1>(self_1: &'_0 mut u8, source_2: &'_1 u8)
 where
-    [@TraitClause0]: Destruct<u8>,
+    TraitClause0: (u8: Destruct),
 {
     let _0: (); // return
     let self_1: &'1 mut u8; // arg #1
@@ -82,7 +82,7 @@ where
     _0 = ()
     storage_live(_3)
     _3 = {impl Clone for u8}::clone<'5>(move source_2)
-    drop[@TraitClause0::drop_in_place] (*self_1)
+    drop[TraitClause0::drop_in_place] (*self_1)
     (*self_1) = move _3
     storage_dead(_3)
     return
@@ -90,9 +90,9 @@ where
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
-    fn clone_from<'_0_1, '_1_1, [@TraitClause0_1]: Destruct<u8>> = {impl Clone for u8}::clone_from<'_0_1, '_1_1>[@TraitClause0_1]
+    fn clone_from<'_0_1, '_1_1, TraitClause0_1: (u8: Destruct)> = {impl Clone for u8}::clone_from<'_0_1, '_1_1>[TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -100,21 +100,21 @@ impl Clone for u8 {
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 pub fn core::intrinsics::saturating_add<T>(a_1: T, b_2: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <intrinsic:saturating_add>
 
 // Full name: core::marker::{impl Copy for u8}
 impl Copy for u8 {
-    parent_clause0 = {built_in impl MetaSized for u8}
-    parent_clause1 = {impl Clone for u8}
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
+    proof ImpliedClause1: (u8: Clone) = {impl Clone for u8}
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/alias-ty-missing-hrtb.out
+++ b/charon/tests/ui/simple/alias-ty-missing-hrtb.out
@@ -8,15 +8,15 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasLifetimeAssoc
 pub trait HasLifetimeAssoc<'a, Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Assoc: Sized)
     type Assoc
     vtable: test_crate::HasLifetimeAssoc::{vtable}<'a, Self::Assoc>
 }
@@ -24,8 +24,8 @@ pub trait HasLifetimeAssoc<'a, Self>
 // Full name: test_crate::FnAlias
 pub type FnAlias<B>
 where
-    [@TraitClause0]: Sized<B>,
-    [@TraitClause1]: HasLifetimeAssoc<'_, B>, = fn<'a>(@TraitClause1::Assoc)
+    TraitClause0: (B: Sized),
+    TraitClause1: (B: HasLifetimeAssoc<'_>), = fn<'a>(TraitClause1::Assoc)
 
 
 

--- a/charon/tests/ui/simple/assoc-const-with-self-clause.out
+++ b/charon/tests/ui/simple/assoc-const-with-self-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,8 +25,8 @@ where
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    const GEN : Option<Self>[Self::parent_clause0]
+    proof ImpliedClause0: (Self: Sized)
+    const GEN : Option<Self>[Self::ImpliedClause0]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/simple/box-dyn-fnonce-raw.out
@@ -17,7 +17,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -39,7 +39,7 @@ pub opaque type NonNull<T>
 // Full name: core::alloc::Allocator
 pub trait Allocator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn allocate<'_0_1> = core::alloc::Allocator::allocate<'_0_1, Self>[Self]
     fn deallocate<'_0_1> = core::alloc::Allocator::deallocate<'_0_1, Self>[Self]
     vtable: core::alloc::Allocator::{vtable}
@@ -47,24 +47,24 @@ pub trait Allocator<Self>
 
 pub fn core::alloc::Allocator::allocate<'_0, Self>(_1: &'_0 Self, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <opaque>
 
 pub unsafe fn core::alloc::Allocator::deallocate<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout)
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <opaque>
 
 // Full name: core::intrinsics::size_of_val
 pub unsafe fn size_of_val<T>(ptr_1: *const T) -> usize
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <intrinsic:size_of_val>
 
 // Full name: core::intrinsics::align_of_val
 pub unsafe fn align_of_val<T>(ptr_1: *const T) -> usize
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <intrinsic:align_of_val>
 
 // Full name: core::marker::PhantomData
@@ -86,7 +86,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -96,7 +96,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -110,90 +110,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -209,18 +209,18 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <method_without_default_body>
 
 // Full name: core::ptr::unique::Unique
@@ -253,7 +253,7 @@ pub fn {impl Allocator for Global}::allocate<'_0>(_1: &'_0 Global, _2: Layout) -
 
 // Full name: alloc::alloc::{impl Allocator for Global}
 impl Allocator for Global {
-    parent_clause0 = {built_in impl MetaSized for Global}
+    proof ImpliedClause0: (Global: MetaSized) = {built_in impl MetaSized for Global}
     fn allocate<'_0_1> = {impl Allocator for Global}::allocate<'_0_1>
     fn deallocate<'_0_1> = {impl Allocator for Global}::deallocate<'_0_1>
     vtable: {impl Allocator for Global}::{vtable}
@@ -267,29 +267,29 @@ pub fn handle_alloc_error(_1: Layout) -> !
 #[lang_item("owned_box")]
 pub struct Box<T, A>
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 {
   Unique<T>,
   A,
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place
-unsafe fn {impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2])
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place
+unsafe fn {impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 = <missing>
 
-// Full name: alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new
+// Full name: alloc::boxed::{Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new
 #[lang_item("box_new")]
-pub fn new<T>(x_1: T) -> Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+pub fn new<T>(x_1: T) -> Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
+    let _0: Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]; // return
     let x_1: T; // arg #1
     let ptr_2: *mut T; // local
     let size_3: usize; // local
@@ -308,9 +308,9 @@ where
     storage_live(_9)
     storage_live(_11)
     storage_live(size_3)
-    size_3 = const {impl SizedTypeProperties for T}<T>[@TraitClause0]::SIZE
+    size_3 = const {impl SizedTypeProperties for T}<T>[TraitClause0]::SIZE
     storage_live(align_4)
-    align_4 = const {impl SizedTypeProperties for T}<T>[@TraitClause0]::ALIGN
+    align_4 = const {impl SizedTypeProperties for T}<T>[TraitClause0]::ALIGN
     storage_live(layout_5)
     storage_live(ptr_7)
     storage_live(_12)
@@ -341,19 +341,19 @@ where
     storage_dead(size_3)
     ptr_2 = cast<*mut [u8], *mut T>(copy _11)
     (*ptr_2) = move x_1
-    _0 = transmute<*mut T, Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]>(copy ptr_2)
+    _0 = transmute<*mut T, Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]>(copy ptr_2)
     return
 }
 
-// Full name: alloc::boxed::{impl Drop for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop
-pub fn {impl Drop for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop<'_0, T, A>(self_1: &'_0 mut Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2])
+// Full name: alloc::boxed::{impl Drop for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop
+pub fn {impl Drop for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop<'_0, T, A>(self_1: &'_0 mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 {
     let _0: (); // return
-    let self_1: &'1 mut Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]; // arg #1
+    let self_1: &'1 mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2]; // arg #1
     let layout_2: Layout; // local
     let t_3: *const T; // local
     let _4: *mut T; // anonymous local
@@ -387,9 +387,9 @@ where
     _4 = transmute<NonNull<T>, *mut T>(copy ptr_14)
     t_3 = transmute<NonNull<T>, *const T>(copy ptr_14)
     storage_live(alignment_8)
-    size_7 = size_of_val<T>[@TraitClause0](copy t_3)
+    size_7 = size_of_val<T>[TraitClause0](copy t_3)
     storage_live(align_9)
-    align_9 = align_of_val<T>[@TraitClause0](move t_3)
+    align_9 = align_of_val<T>[TraitClause0](move t_3)
     storage_live(_16)
     _16 = ub_checks<bool>
     if move _16 {
@@ -417,7 +417,7 @@ where
             _13 = cast<*mut T, *const u8>(copy _4)
             unique_12 = NonNull { 0: copy _13 }
             storage_dead(_13)
-            _5 = @TraitClause2::deallocate<'7>(move _6, move unique_12, move layout_2)
+            _5 = TraitClause2::deallocate<'7>(move _6, move unique_12, move layout_2)
             storage_dead(_6)
             return
         },
@@ -425,21 +425,21 @@ where
     return
 }
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::call_once
-pub extern "rust-call" fn {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::call_once<Args, F, A>(self_1: Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5], args_2: Args) -> @TraitClause4::Output
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once
+pub extern "rust-call" fn {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once<Args, F, A>(self_1: Box<F, A>[TraitClause1, TraitClause2, TraitClause5], args_2: Args) -> TraitClause4::Output
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
 {
-    let _0: @TraitClause4::Output; // return
-    let self_1: Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]; // arg #1
+    let _0: TraitClause4::Output; // return
+    let self_1: Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // arg #1
     let args_2: Args; // arg #2
-    let _3: Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]; // anonymous local
-    let _4: &'1 mut Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]; // anonymous local
+    let _3: Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
+    let _4: &'1 mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
     let _5: (); // anonymous local
     let _6: *const F; // anonymous local
 
@@ -449,106 +449,106 @@ where
     storage_live(_3)
     _3 = move self_1
     _6 = transmute<NonNull<F>, *const F>(copy ((_3).0).0)
-    _0 = @TraitClause4::call_once(move (*_6), move args_2)
+    _0 = TraitClause4::call_once(move (*_6), move args_2)
     _4 = &mut _3
-    _5 = {impl Drop for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop<'6, F, A>[@TraitClause1, @TraitClause2, @TraitClause5](move _4)
+    _5 = {impl Drop for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop<'6, F, A>[TraitClause1, TraitClause2, TraitClause5](move _4)
     drop[{built_in impl Destruct for A}::drop_in_place] (_3).1
     storage_dead(_3)
     return
 }
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::call_once::{vtable_method}
-extern "rust-call" fn {vtable_method}<Args, F, A>(_1: (dyn FnOnce<Args, Output = @TraitClause4::Output>), _2: Args) -> @TraitClause4::Output
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once::{vtable_method}
+extern "rust-call" fn {vtable_method}<Args, F, A>(_1: (dyn FnOnce<Args, Output = TraitClause4::Output>), _2: Args) -> TraitClause4::Output
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
 {
-    let _0: @TraitClause4::Output; // return
-    let _1: (dyn FnOnce<Args, Output = @TraitClause4::Output> + '0); // arg #1
+    let _0: TraitClause4::Output; // return
+    let _1: (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
     let _2: Args; // arg #2
-    let _3: Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]; // anonymous local
+    let _3: Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
 
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<Args, Output = @TraitClause4::Output> + '1), Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]>(move _1)
-    _0 = {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::call_once<Args, F, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5](move _3, move _2)
+    _3 = concretize<(dyn FnOnce<Args, Output = TraitClause4::Output> + '1), Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move _1)
+    _0 = {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5](move _3, move _2)
     return
 }
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}<Args, F, A>(dyn_self_1: *mut (dyn FnOnce<Args, Output = @TraitClause4::Output>))
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<Args, F, A>(dyn_self_1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output>))
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
 {
     let ret_0: (); // return
-    let dyn_self_1: *mut (dyn FnOnce<Args, Output = @TraitClause4::Output> + '0); // arg #1
-    let target_self_2: *mut Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]; // local
+    let dyn_self_1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
+    let target_self_2: *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // local
 
     ret_0 = ()
     storage_live(target_self_2)
-    target_self_2 = concretize<*mut (dyn FnOnce<Args, Output = @TraitClause4::Output> + '1), *mut Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]>(move dyn_self_1)
-    drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]] (*target_self_2)
+    target_self_2 = concretize<*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1), *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move dyn_self_1)
+    drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<F, A>[TraitClause1, TraitClause2, TraitClause5]] (*target_self_2)
     return
 }
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}
-fn {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}<Args, F, A>() -> core::ops::function::FnOnce::{vtable}<Args, @TraitClause4::Output>
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}
+fn {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}<Args, F, A>() -> core::ops::function::FnOnce::{vtable}<Args, TraitClause4::Output>
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
 {
-    let ret_0: core::ops::function::FnOnce::{vtable}<Args, @TraitClause4::Output>; // return
+    let ret_0: core::ops::function::FnOnce::{vtable}<Args, TraitClause4::Output>; // return
     let size_1: usize; // local
     let align_2: usize; // local
 
     storage_live(size_1)
-    size_1 = size_of<Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]>
+    size_1 = size_of<Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>
     storage_live(align_2)
-    align_2 = align_of<Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]>
-    ret_0 = core::ops::function::FnOnce::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<Args, F, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5], method_call_once: const {vtable_method}<Args, F, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5], super_trait_0: const &vtable_of({built_in impl MetaSized for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}) }
+    align_2 = align_of<Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>
+    ret_0 = core::ops::function::FnOnce::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], method_call_once: const {vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], super_trait_0: const &vtable_of({built_in impl MetaSized for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}) }
     return
 }
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}
-static {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}<Args, F, A>: core::ops::function::FnOnce::{vtable}<Args, @TraitClause4::Output>
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}
+static {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}<Args, F, A>: core::ops::function::FnOnce::{vtable}<Args, TraitClause4::Output>
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
- = {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}()
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
+ = {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}()
 
-// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}
-impl<Args, F, A> FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]
+// Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}
+impl<Args, F, A> FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]
 where
-    [@TraitClause0]: Sized<Args>,
-    [@TraitClause1]: MetaSized<F>,
-    [@TraitClause2]: Sized<A>,
-    [@TraitClause3]: Tuple<Args>,
-    [@TraitClause4]: FnOnce<F, Args>,
-    [@TraitClause5]: Allocator<A>,
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: FnOnce<Args>),
+    TraitClause5: (A: Allocator),
 {
-    parent_clause0 = {built_in impl MetaSized for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}
-    parent_clause1 = @TraitClause0
-    parent_clause2 = @TraitClause3
-    parent_clause3 = @TraitClause4::parent_clause3
-    type Output = @TraitClause4::Output
-    fn call_once = {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::call_once<Args, F, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5]
-    vtable: {impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}<Args, F, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5]
+    proof ImpliedClause0: (Box<F, A>[TraitClause1, TraitClause2, TraitClause5]: MetaSized) = {built_in impl MetaSized for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}
+    proof ImpliedClause1: (Args: Sized) = TraitClause0
+    proof ImpliedClause2: (Args: Tuple) = TraitClause3
+    proof ImpliedClause3: (TraitClause4::Output: Sized) = TraitClause4::ImpliedClause3
+    type Output = TraitClause4::Output
+    fn call_once = {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5]
+    vtable: {impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5]
 }
 
 // Full name: test_crate::box_box
@@ -565,14 +565,14 @@ pub fn box_box(f_1: Box<(dyn FnOnce<(), Output = ()> + 'static), Global>[{built_
     storage_live(_4)
     _4 = move f_1
     _3 = new<Box<(dyn FnOnce<(), Output = ()> + '24), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '25)}, {built_in impl Sized for Global}, {impl Allocator for Global}]>[{built_in impl Sized for Box<(dyn FnOnce<(), Output = ()> + '30), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '31)}, {built_in impl Sized for Global}, {impl Allocator for Global}]}](move _4)
-    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '18), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '19)}, {built_in impl Sized for Global}, {impl Allocator for Global}], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '20), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '21)}, {built_in impl Sized for Global}, {impl Allocator for Global}]}, {built_in impl Sized for Global}, {impl Allocator for Global}], Box<(dyn FnOnce<(), Output = ()> + '47), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '48)}, {built_in impl Sized for Global}, {impl Allocator for Global}], &{impl FnOnce<Args> for Box<F, A>[@TraitClause1, @TraitClause2, @TraitClause5]}::{vtable}<(), (dyn FnOnce<(), Output = ()> + '67), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '69)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '71), ()>, {impl Allocator for Global}]>(move _3)
-    conditional_drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<Box<(dyn FnOnce<(), Output = ()> + '88), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '89)}, {built_in impl Sized for Global}, {impl Allocator for Global}], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '88), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '89)}, {built_in impl Sized for Global}, {impl Allocator for Global}]}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _3
+    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '18), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '19)}, {built_in impl Sized for Global}, {impl Allocator for Global}], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '20), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '21)}, {built_in impl Sized for Global}, {impl Allocator for Global}]}, {built_in impl Sized for Global}, {impl Allocator for Global}], Box<(dyn FnOnce<(), Output = ()> + '47), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '48)}, {built_in impl Sized for Global}, {impl Allocator for Global}], &{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::{vtable}<(), (dyn FnOnce<(), Output = ()> + '67), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '69)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '71), ()>, {impl Allocator for Global}]>(move _3)
+    conditional_drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<Box<(dyn FnOnce<(), Output = ()> + '88), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '89)}, {built_in impl Sized for Global}, {impl Allocator for Global}], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '88), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '89)}, {built_in impl Sized for Global}, {impl Allocator for Global}]}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _3
     storage_dead(_4)
     storage_dead(_3)
     _0 = unsize_cast<Box<(dyn FnOnce<(), Output = ()> + '8), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '9)}, {built_in impl Sized for Global}, {impl Allocator for Global}], Box<(dyn FnOnce<(), Output = ()> + '105), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '106)}, {built_in impl Sized for Global}, {impl Allocator for Global}],  at []>(move _2)
-    conditional_drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<(dyn FnOnce<(), Output = ()> + '113), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '113)}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _2
+    conditional_drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<(dyn FnOnce<(), Output = ()> + '113), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '113)}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _2
     storage_dead(_2)
-    conditional_drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<(dyn FnOnce<(), Output = ()> + '122), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '122)}, {built_in impl Sized for Global}, {impl Allocator for Global}]] f_1
+    conditional_drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<(dyn FnOnce<(), Output = ()> + '122), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '122)}, {built_in impl Sized for Global}, {impl Allocator for Global}]] f_1
     return
 }
 

--- a/charon/tests/ui/simple/box-dyn-fnonce.out
+++ b/charon/tests/ui/simple/box-dyn-fnonce.out
@@ -1,7 +1,7 @@
 error: trying to access the allocator field from Box, but it is being treated as a builtin (without allocator)
  --> /rustc/library/alloc/src/boxed.rs:2250:51
 
-note: the error occurred when translating `alloc::boxed::{impl core::ops::function::FnOnce<Args> for alloc::boxed::Box<F, A>[@TraitClause1, @TraitClause2]}::call_once`, which is (transitively) used at the following location(s):
+note: the error occurred when translating `alloc::boxed::{impl core::ops::function::FnOnce<Args> for alloc::boxed::Box<F, A>[TraitClause1, TraitClause2]}::call_once`, which is (transitively) used at the following location(s):
  --> tests/ui/simple/box-dyn-fnonce.rs:4:5
   |
 4 |     f();
@@ -9,7 +9,7 @@ note: the error occurred when translating `alloc::boxed::{impl core::ops::functi
 error: trying to access the allocator field from Box, but it is being treated as a builtin (without allocator)
  --> /rustc/library/alloc/src/boxed.rs:1931:17
 
-note: the error occurred when translating `alloc::boxed::{impl core::ops::drop::Drop for alloc::boxed::Box<T, A>[@TraitClause0, @TraitClause1]}::drop`, which is (transitively) used at the following location(s):
+note: the error occurred when translating `alloc::boxed::{impl core::ops::drop::Drop for alloc::boxed::Box<T, A>[TraitClause0, TraitClause1]}::drop`, which is (transitively) used at the following location(s):
  --> tests/ui/simple/box-dyn-fnonce.rs:4:5
   |
 4 |     f();

--- a/charon/tests/ui/simple/box-into-inner.out
+++ b/charon/tests/ui/simple/box-into-inner.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -22,7 +22,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -36,90 +36,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -134,11 +134,11 @@ pub opaque type Unique<T>
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::{impl Drop for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop
-pub fn {impl Drop for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::{impl Drop for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop
+pub fn {impl Drop for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: alloc::string::String
@@ -192,7 +192,7 @@ fn into_inner(b_1: alloc::boxed::Box<String>[{built_in impl MetaSized for String
     storage_dead(_x_2)
     _5 = transmute<NonNull<String>, *const String>(copy ((*b_1)).0)
     _3 = &mut b_1
-    _4 = {impl Drop for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop<'5, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}](move _3)
+    _4 = {impl Drop for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop<'5, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}](move _3)
     return
 }
 

--- a/charon/tests/ui/simple/box-new.out
+++ b/charon/tests/ui/simple/box-new.out
@@ -15,7 +15,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -23,8 +23,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -37,7 +37,7 @@ pub opaque type NonNull<T>
 // Full name: core::alloc::Allocator
 pub trait Allocator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn allocate<'_0_1> = core::alloc::Allocator::allocate<'_0_1, Self>[Self]
     fn deallocate<'_0_1> = core::alloc::Allocator::deallocate<'_0_1, Self>[Self]
     vtable: core::alloc::Allocator::{vtable}
@@ -45,12 +45,12 @@ pub trait Allocator<Self>
 
 pub fn core::alloc::Allocator::allocate<'_0, Self>(_1: &'_0 Self, _2: Layout) -> Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <opaque>
 
 pub unsafe fn core::alloc::Allocator::deallocate<'_0, Self>(_1: &'_0 Self, _2: NonNull<u8>, _3: Layout)
 where
-    [@TraitClause0]: Allocator<Self>,
+    TraitClause0: (Self: Allocator),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -67,7 +67,7 @@ pub fn {impl Allocator for Global}::allocate<'_0>(_1: &'_0 Global, _2: Layout) -
 
 // Full name: alloc::alloc::{impl Allocator for Global}
 impl Allocator for Global {
-    parent_clause0 = {built_in impl MetaSized for Global}
+    proof ImpliedClause0: (Global: MetaSized) = {built_in impl MetaSized for Global}
     fn allocate<'_0_1> = {impl Allocator for Global}::allocate<'_0_1>
     fn deallocate<'_0_1> = {impl Allocator for Global}::deallocate<'_0_1>
     vtable: {impl Allocator for Global}::{vtable}
@@ -77,23 +77,23 @@ impl Allocator for Global {
 #[lang_item("owned_box")]
 pub opaque type Box<T, A>
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 
-// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place
-unsafe fn {impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2])
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place
+unsafe fn {impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<T, A>(_1: *mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Allocator<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
 = <opaque>
 
-// Full name: alloc::boxed::{Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new
+// Full name: alloc::boxed::{Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]}::new
 #[lang_item("box_new")]
-pub fn new<T>(_1: T) -> Box<T, Global>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
+pub fn new<T>(_1: T) -> Box<T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, {impl Allocator for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::main
@@ -105,7 +105,7 @@ fn main()
     _0 = ()
     storage_live(_1)
     _1 = new<i32>[{built_in impl Sized for i32}](const 42 : i32)
-    drop[{impl Destruct for Box<T, A>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _1
+    drop[{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {impl Allocator for Global}]] _1
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/builtin-drop-mono.out
+++ b/charon/tests/ui/simple/builtin-drop-mono.out
@@ -11,7 +11,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/builtin-drop.out
+++ b/charon/tests/ui/simple/builtin-drop.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -37,13 +37,13 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::string::String
@@ -63,8 +63,8 @@ impl Destruct for String {
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_in_place
 unsafe fn {impl Destruct for [T; N]}::drop_in_place<T, const N : usize>(_1: *mut [T; N])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
     let _1: *mut [T; N]; // arg #1
@@ -102,7 +102,7 @@ where
             _10 = @SliceIndexMut<'_, T>(move _9, copy _6)
             _7 = &raw mut (*_10)
             _6 = move _6 wrap.+ const 1 : usize
-            drop[@TraitClause1::drop_in_place] (*_7)
+            drop[TraitClause1::drop_in_place] (*_7)
             continue 0
         }
     }
@@ -112,18 +112,18 @@ where
 // Full name: test_crate::<array>::{impl Destruct for [T; N]}
 impl<T, const N : usize> Destruct for [T; N]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
-    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for [T; N]}::drop_in_place<T, N>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_in_place
 unsafe fn {impl Destruct for [T]}::drop_in_place<T>(_1: *mut [T])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
     let _1: *mut [T]; // arg #1
@@ -155,7 +155,7 @@ where
             _8 = @SliceIndexMut<'_, T>(move _7, copy _4)
             _5 = &raw mut (*_8)
             _4 = move _4 wrap.+ const 1 : usize
-            drop[@TraitClause1::drop_in_place] (*_5)
+            drop[TraitClause1::drop_in_place] (*_5)
             continue 0
         }
     }
@@ -165,19 +165,19 @@ where
 // Full name: test_crate::<slice>::{impl Destruct for [T]}
 impl<T> Destruct for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
-    fn drop_in_place = {impl Destruct for [T]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for [T]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_in_place
 unsafe fn {impl Destruct for (A, B)}::drop_in_place<A, B>(_1: *mut (A, B))
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Destruct<A>,
-    [@TraitClause2]: Destruct<B>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Destruct),
+    TraitClause2: (B: Destruct),
 {
     let _0: (); // return
     let _1: *mut (A, B); // arg #1
@@ -186,19 +186,19 @@ where
     storage_live(_2)
     _0 = ()
     _2 = &mut (*_1) with_metadata(copy _1.metadata)
-    drop[@TraitClause1::drop_in_place] (*_2).0
-    drop[@TraitClause2::drop_in_place] (*_2).1
+    drop[TraitClause1::drop_in_place] (*_2).0
+    drop[TraitClause2::drop_in_place] (*_2).1
     return
 }
 
 // Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}
 impl<A, B> Destruct for (A, B)
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Destruct<A>,
-    [@TraitClause2]: Destruct<B>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Destruct),
+    TraitClause2: (B: Destruct),
 {
-    fn drop_in_place = {impl Destruct for (A, B)}::drop_in_place<A, B>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn drop_in_place = {impl Destruct for (A, B)}::drop_in_place<A, B>[TraitClause0, TraitClause1, TraitClause2]
     non-dyn-compatible
 }
 
@@ -222,24 +222,24 @@ fn drop_slice(_1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [Stri
 
     _0 = ()
     _0 = ()
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<[String], Global>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, {impl Destruct for [T]}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]] _1
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<[String], Global>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, {impl Destruct for [T]}<String>[{built_in impl Sized for String}, {impl Destruct for String}], {impl Destruct for Global}]] _1
     return
 }
 
 // Full name: test_crate::drop_tuple
 fn drop_tuple<A, B>(_1: (A, B))
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Sized<B>,
-    [@TraitClause2]: Destruct<A>,
-    [@TraitClause3]: Destruct<B>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+    TraitClause2: (A: Destruct),
+    TraitClause3: (B: Destruct),
 {
     let _0: (); // return
     let _1: (A, B); // arg #1
 
     _0 = ()
     _0 = ()
-    drop[{impl Destruct for (A, B)}::drop_in_place<A, B>[@TraitClause0, @TraitClause2, @TraitClause3]] _1
+    drop[{impl Destruct for (A, B)}::drop_in_place<A, B>[TraitClause0, TraitClause2, TraitClause3]] _1
     return
 }
 

--- a/charon/tests/ui/simple/call-foreign-defaulted-method.out
+++ b/charon/tests/ui/simple/call-foreign-defaulted-method.out
@@ -48,14 +48,14 @@ fn main()
 // Full name: test_crate::foo::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn defaulted<'_0_1> = test_crate::foo::Trait::defaulted<'_0_1, Self>[Self]
     vtable: test_crate::foo::Trait::{vtable}
 }
 
 pub fn test_crate::foo::Trait::defaulted<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -67,7 +67,7 @@ where
 
 // Full name: test_crate::foo::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     fn defaulted<'_0_1> = {impl Trait for ()}::defaulted<'_0_1>
     vtable: {impl Trait for ()}::{vtable}
 }

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -26,74 +26,74 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Trait
 pub trait Trait<Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type: Sized)
     vtable: test_crate::Trait::{vtable}<Self_Type>
 }
 
 // Full name: test_crate::{impl Trait<()> for ()}
 impl Trait<()> for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
     vtable: {impl Trait<()> for ()}::{vtable}
 }
 
 // Full name: test_crate::HashMap
 pub struct HashMap<S>
 where
-    [@TraitClause0]: Sized<S>,
+    TraitClause0: (S: Sized),
 {
   S,
 }
 
-// Full name: test_crate::HashMap::{impl Destruct for HashMap<S>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for HashMap<S>[@TraitClause0]}::drop_in_place<S>(_1: *mut HashMap<S>[@TraitClause0])
+// Full name: test_crate::HashMap::{impl Destruct for HashMap<S>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for HashMap<S>[TraitClause0]}::drop_in_place<S>(_1: *mut HashMap<S>[TraitClause0])
 where
-    [@TraitClause0]: Sized<S>,
+    TraitClause0: (S: Sized),
 = <missing>
 
-// Full name: test_crate::HashMap::{impl Destruct for HashMap<S>[@TraitClause0]}
-impl<S> Destruct for HashMap<S>[@TraitClause0]
+// Full name: test_crate::HashMap::{impl Destruct for HashMap<S>[TraitClause0]}
+impl<S> Destruct for HashMap<S>[TraitClause0]
 where
-    [@TraitClause0]: Sized<S>,
+    TraitClause0: (S: Sized),
 {
-    fn drop_in_place = {impl Destruct for HashMap<S>[@TraitClause0]}::drop_in_place<S>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for HashMap<S>[TraitClause0]}::drop_in_place<S>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{HashMap<S>[@TraitClause0]}::get
-pub fn get<S, Q, Clause2_Type>(_x_1: HashMap<S>[@TraitClause0], _k_2: Q)
+// Full name: test_crate::{HashMap<S>[TraitClause0]}::get
+pub fn get<S, Q, Clause2_Type>(_x_1: HashMap<S>[TraitClause0], _k_2: Q)
 where
-    [@TraitClause0]: Sized<S>,
-    [@TraitClause1]: Sized<Q>,
-    [@TraitClause2]: Trait<Q, Clause2_Type>,
+    TraitClause0: (S: Sized),
+    TraitClause1: (Q: Sized),
+    TraitClause2: (Q: Trait<Clause2_Type>),
 {
     let _0: (); // return
-    let _x_1: HashMap<S>[@TraitClause0]; // arg #1
+    let _x_1: HashMap<S>[TraitClause0]; // arg #1
     let _k_2: Q; // arg #2
 
     _0 = ()
     _0 = ()
     conditional_drop[{built_in impl Destruct for Q}::drop_in_place] _k_2
-    conditional_drop[{impl Destruct for HashMap<S>[@TraitClause0]}::drop_in_place<S>[@TraitClause0]] _x_1
+    conditional_drop[{impl Destruct for HashMap<S>[TraitClause0]}::drop_in_place<S>[TraitClause0]] _x_1
     return
 }
 
 // Full name: test_crate::top_level_get
-pub fn top_level_get<S, Q, Clause2_Type>(_x_1: HashMap<S>[@TraitClause0], _k_2: Q)
+pub fn top_level_get<S, Q, Clause2_Type>(_x_1: HashMap<S>[TraitClause0], _k_2: Q)
 where
-    [@TraitClause0]: Sized<S>,
-    [@TraitClause1]: Sized<Q>,
-    [@TraitClause2]: Trait<Q, Clause2_Type>,
+    TraitClause0: (S: Sized),
+    TraitClause1: (Q: Sized),
+    TraitClause2: (Q: Trait<Clause2_Type>),
 {
     let _0: (); // return
-    let _x_1: HashMap<S>[@TraitClause0]; // arg #1
+    let _x_1: HashMap<S>[TraitClause0]; // arg #1
     let _k_2: Q; // arg #2
 
     _0 = ()
     _0 = ()
     conditional_drop[{built_in impl Destruct for Q}::drop_in_place] _k_2
-    conditional_drop[{impl Destruct for HashMap<S>[@TraitClause0]}::drop_in_place<S>[@TraitClause0]] _x_1
+    conditional_drop[{impl Destruct for HashMap<S>[TraitClause0]}::drop_in_place<S>[TraitClause0]] _x_1
     return
 }
 

--- a/charon/tests/ui/simple/call-method-via-supertrait-bound.out
+++ b/charon/tests/ui/simple/call-method-via-supertrait-bound.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,36 +27,36 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::OtherTrait
 trait OtherTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::OtherTrait::{vtable}
 }
 
 // Full name: test_crate::ImpliesOtherTrait
 trait ImpliesOtherTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: OtherTrait<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: OtherTrait)
     vtable: test_crate::ImpliesOtherTrait::{vtable}
 }
 
 // Full name: test_crate::HasMethod
 trait HasMethod<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn method<'_0_1> = test_crate::HasMethod::method<'_0_1, Self>[Self]
     vtable: test_crate::HasMethod::{vtable}
 }
 
 fn test_crate::HasMethod::method<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: HasMethod<Self>,
+    TraitClause0: (Self: HasMethod),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl HasMethod for T}::method
 fn {impl HasMethod for T}::method<'_0, T>(self_1: &'_0 T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: OtherTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: OtherTrait),
 {
     let _0: (); // return
     let self_1: &'1 T; // arg #1
@@ -69,19 +69,19 @@ where
 // Full name: test_crate::{impl HasMethod for T}
 impl<T> HasMethod for T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: OtherTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: OtherTrait),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    fn method<'_0_1> = {impl HasMethod for T}::method<'_0_1, T>[@TraitClause0, @TraitClause1]
-    vtable: {impl HasMethod for T}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    fn method<'_0_1> = {impl HasMethod for T}::method<'_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl HasMethod for T}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::call_method
 fn call_method<T>(x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ImpliesOtherTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ImpliesOtherTrait),
 {
     let _0: (); // return
     let x_1: T; // arg #1
@@ -92,7 +92,7 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = {impl HasMethod for T}::method<'3, T>[@TraitClause0, @TraitClause1::parent_clause1](move _3)
+    _2 = {impl HasMethod for T}::method<'3, T>[TraitClause0, TraitClause1::ImpliedClause1](move _3)
     storage_dead(_3)
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/simple/catch-unwind.out
+++ b/charon/tests/ui/simple/catch-unwind.out
@@ -14,9 +14,9 @@ pub opaque type TypeId
 #[lang_item("Any")]
 pub trait Any<Self>
 where
-    Self : 'static,
+    TypeOutlives0: Self: 'static,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn type_id<'_0_1> = type_id<'_0_1, Self>[Self]
     vtable: core::any::Any::{vtable}
 }
@@ -24,7 +24,7 @@ where
 // Full name: core::any::Any::type_id
 pub fn type_id<'_0, Self>(_1: &'_0 Self) -> TypeId
 where
-    [@TraitClause0]: Any<Self>,
+    TraitClause0: (Self: Any),
 = <opaque>
 
 // Full name: core::marker::Send
@@ -35,7 +35,7 @@ pub trait Send<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -43,7 +43,7 @@ pub trait Sized<Self>
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -51,18 +51,18 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::panic::unwind_safe::UnwindSafe
@@ -73,18 +73,18 @@ pub trait UnwindSafe<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
 }
 
-// Full name: core::result::Result::{impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place<T, E>(_1: *mut Result<T, E>[@TraitClause0, @TraitClause1])
+// Full name: core::result::Result::{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place<T, E>(_1: *mut Result<T, E>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -92,13 +92,13 @@ where
 pub struct Global {}
 
 // Full name: std::panic::catch_unwind
-pub fn catch_unwind<F, R>(_1: F) -> Result<R, alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]>[@TraitClause1, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]}]
+pub fn catch_unwind<F, R>(_1: F) -> Result<R, alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]>[TraitClause1, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]}]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<R>,
-    [@TraitClause2]: FnOnce<F, ()>,
-    [@TraitClause3]: UnwindSafe<F>,
-    @TraitClause2::Output = R,
+    TraitClause0: (F: Sized),
+    TraitClause1: (R: Sized),
+    TraitClause2: (F: FnOnce<()>),
+    TraitClause3: (F: UnwindSafe),
+    TypeConstraint0: TraitClause2::Output = R,
 = <opaque>
 
 // Full name: test_crate::main::closure
@@ -118,10 +118,10 @@ fn {impl FnOnce<()> for closure}::call_once(_1: closure, tupled_args_2: ())
 
 // Full name: test_crate::main::{impl FnOnce<()> for closure}
 impl FnOnce<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for closure}::call_once
     non-dyn-compatible
@@ -140,7 +140,7 @@ fn main()
     _2 = closure {  }
     _1 = catch_unwind<closure, ()>[{built_in impl Sized for closure}, {built_in impl Sized for ()}, {impl FnOnce<()> for closure}, {built_in impl UnwindSafe for closure}](move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for Result<T, E>[@TraitClause0, @TraitClause1]}::drop_in_place<(), alloc::boxed::Box<(dyn Any + Send + '48)>[{built_in impl MetaSized for (dyn Any + Send + '49)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + '48)>[{built_in impl MetaSized for (dyn Any + Send + '49)}, {built_in impl Sized for Global}]}]] _1
+    conditional_drop[{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_in_place<(), alloc::boxed::Box<(dyn Any + Send + '48)>[{built_in impl MetaSized for (dyn Any + Send + '49)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + '48)>[{built_in impl MetaSized for (dyn Any + Send + '49)}, {built_in impl Sized for Global}]}]] _1
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/closure-capture-ref-by-move.out
+++ b/charon/tests/ui/simple/closure-capture-ref-by-move.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,22 +48,22 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::foo::closure
@@ -143,10 +143,10 @@ fn {impl FnOnce<()> for closure<'_0>}::call_once<'_0>(_1: closure<'_0>, _2: ())
 
 // Full name: test_crate::foo::{impl FnOnce<()> for closure<'_0>}
 impl<'_0> FnOnce<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for closure<'_0>}::call_once<'_0>
     non-dyn-compatible
@@ -154,10 +154,10 @@ impl<'_0> FnOnce<()> for closure<'_0> {
 
 // Full name: test_crate::foo::{impl FnMut<()> for closure<'_0>}
 impl<'_0> FnMut<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<()> for closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<()>) = {impl FnOnce<()> for closure<'_0>}<'_0>
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,47 +48,47 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::apply_to
 fn apply_to<'_0, T0>(f_1: &'_0 T0) -> u8
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: Fn<T0, (u8, u8)>,
-    @TraitClause1::parent_clause1::parent_clause1::Output = u8,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: Fn<(u8, u8)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::ImpliedClause1::Output = u8,
 {
     let _0: u8; // return
     let f_1: &'1 T0; // arg #1
@@ -99,7 +99,7 @@ where
     _2 = &(*f_1)
     storage_live(_3)
     _3 = (const 10 : u8, const 20 : u8)
-    _0 = @TraitClause1::call<'4>(move _2, move _3)
+    _0 = TraitClause1::call<'4>(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     return
@@ -108,9 +108,9 @@ where
 // Full name: test_crate::apply_to_mut
 fn apply_to_mut<'_0, T0>(f_1: &'_0 mut T0) -> u8
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: FnMut<T0, (u8, u8)>,
-    @TraitClause1::parent_clause1::Output = u8,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: FnMut<(u8, u8)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::Output = u8,
 {
     let _0: u8; // return
     let f_1: &'1 mut T0; // arg #1
@@ -121,7 +121,7 @@ where
     _2 = &mut (*f_1)
     storage_live(_3)
     _3 = (const 10 : u8, const 20 : u8)
-    _0 = @TraitClause1::call_mut<'4>(move _2, move _3)
+    _0 = TraitClause1::call_mut<'4>(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     return
@@ -130,9 +130,9 @@ where
 // Full name: test_crate::apply_to_once
 fn apply_to_once<T0>(f_1: T0) -> u8
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: FnOnce<T0, (u8, u8)>,
-    @TraitClause1::Output = u8,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: FnOnce<(u8, u8)>),
+    TypeConstraint0: TraitClause1::Output = u8,
 {
     let _0: u8; // return
     let f_1: T0; // arg #1
@@ -143,7 +143,7 @@ where
     _2 = move f_1
     storage_live(_3)
     _3 = (const 10 : u8, const 20 : u8)
-    _0 = @TraitClause1::call_once(move _2, move _3)
+    _0 = TraitClause1::call_once(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T0}::drop_in_place] f_1
@@ -241,10 +241,10 @@ fn {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}::call_once<'_0, '_1>(_1: closur
 
 // Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnOnce<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {built_in impl Sized for (u8, u8)}
-    parent_clause2 = {built_in impl Tuple for (u8, u8)}
-    parent_clause3 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause2: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause3: (u8: Sized) = {built_in impl Sized for u8}
     type Output = u8
     fn call_once = {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}::call_once<'_0, '_1>
     non-dyn-compatible
@@ -252,20 +252,20 @@ impl<'_0, '_1> FnOnce<(u8, u8)> for closure<'_0, '_1> {
 
 // Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnMut<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u8, u8)}
-    parent_clause3 = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = {impl FnOnce<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
     fn call_mut<'_0_1> = {impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}
 impl<'_0, '_1> Fn<(u8, u8)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnMut<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (u8, u8)}
-    parent_clause3 = {built_in impl Tuple for (u8, u8)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = {impl FnMut<(u8, u8)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
     fn call<'_0_1> = {impl Fn<(u8, u8)> for closure<'_0, '_1>}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/closure-fnmut.out
+++ b/charon/tests/ui/simple/closure-fnmut.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,30 +48,30 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::apply_to_zero_mut
 fn apply_to_zero_mut<T0>(f_1: T0) -> u8
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: FnMut<T0, (u8,)>,
-    @TraitClause1::parent_clause1::Output = u8,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: FnMut<(u8,)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::Output = u8,
 {
     let _0: u8; // return
     let f_1: T0; // arg #1
@@ -82,7 +82,7 @@ where
     _2 = &mut f_1
     storage_live(_3)
     _3 = (const 0 : u8,)
-    _0 = @TraitClause1::call_mut<'3>(move _2, move _3)
+    _0 = TraitClause1::call_mut<'3>(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T0}::drop_in_place] f_1
@@ -144,10 +144,10 @@ fn {impl FnOnce<(u8,)> for closure<'_0>}::call_once<'_0>(_1: closure<'_0>, _2: (
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for closure<'_0>}
 impl<'_0> FnOnce<(u8,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
-    parent_clause3 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause3: (u8: Sized) = {built_in impl Sized for u8}
     type Output = u8
     fn call_once = {impl FnOnce<(u8,)> for closure<'_0>}::call_once<'_0>
     non-dyn-compatible
@@ -155,10 +155,10 @@ impl<'_0> FnOnce<(u8,)> for closure<'_0> {
 
 // Full name: test_crate::main::{impl FnMut<(u8,)> for closure<'_0>}
 impl<'_0> FnMut<(u8,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<(u8,)> for closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (u8,)}
-    parent_clause3 = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for closure<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
     fn call_mut<'_0_1> = {impl FnMut<(u8,)> for closure<'_0>}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/closure-fnonce.out
+++ b/charon/tests/ui/simple/closure-fnonce.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,34 +35,34 @@ pub trait Tuple<Self>
 #[lang_item("mem_drop")]
 pub fn drop<T>(_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::apply_to_zero_once
 fn apply_to_zero_once<T0>(f_1: T0) -> u8
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: FnOnce<T0, (u8,)>,
-    @TraitClause1::Output = u8,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: FnOnce<(u8,)>),
+    TypeConstraint0: TraitClause1::Output = u8,
 {
     let _0: u8; // return
     let f_1: T0; // arg #1
@@ -73,7 +73,7 @@ where
     _2 = move f_1
     storage_live(_3)
     _3 = (const 0 : u8,)
-    _0 = @TraitClause1::call_once(move _2, move _3)
+    _0 = TraitClause1::call_once(move _2, move _3)
     storage_dead(_3)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T0}::drop_in_place] f_1
@@ -138,10 +138,10 @@ fn {impl FnOnce<(u8,)> for closure}::call_once(_1: closure, tupled_args_2: (u8,)
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}
 impl FnOnce<(u8,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u8,)}
-    parent_clause2 = {built_in impl Tuple for (u8,)}
-    parent_clause3 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    proof ImpliedClause3: (u8: Sized) = {built_in impl Sized for u8}
     type Output = u8
     fn call_once = {impl FnOnce<(u8,)> for closure}::call_once
     non-dyn-compatible

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,64 +48,64 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Foo
 pub struct Foo<F>
 where
-    [@TraitClause0]: Sized<F>,
+    TraitClause0: (F: Sized),
 {
   F,
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::closure
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::closure
 struct closure<F, T>
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {}
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method
 pub fn method<F, T>()
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
     let _0: (); // return
-    let _closure_1: closure<F, T>[@TraitClause0, @TraitClause1]; // local
+    let _closure_1: closure<F, T>[TraitClause0, TraitClause1]; // local
 
     _0 = ()
     storage_live(_closure_1)
@@ -115,21 +115,21 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::closure::{impl Destruct for closure<F, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for closure<F, T>[@TraitClause0, @TraitClause1]}::drop_in_place<F, T>(_1: *mut closure<F, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::closure::{impl Destruct for closure<F, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for closure<F, T>[TraitClause0, TraitClause1]}::drop_in_place<F, T>(_1: *mut closure<F, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 = <missing>
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call<'_0, F, T>(_1: &'_0 closure<F, T>[@TraitClause0, @TraitClause1], tupled_args_2: ((),))
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call<'_0, F, T>(_1: &'_0 closure<F, T>[TraitClause0, TraitClause1], tupled_args_2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
     let _0: (); // return
-    let _1: &'1 closure<F, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 closure<F, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: ((),); // arg #2
     let _x_3: (); // local
 
@@ -140,93 +140,93 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, F, T>(state_1: &'_0 mut closure<F, T>[@TraitClause0, @TraitClause1], args_2: ((),))
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_mut<'_0, F, T>(state_1: &'_0 mut closure<F, T>[TraitClause0, TraitClause1], args_2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
     let _0: (); // return
-    let state_1: &'_0 mut closure<F, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_0 mut closure<F, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: ((),); // arg #2
-    let _3: &'0 closure<F, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 closure<F, T>[TraitClause0, TraitClause1]; // anonymous local
 
     _0 = ()
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call<'2, F, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call<'2, F, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_once<F, T>(_1: closure<F, T>[@TraitClause0, @TraitClause1], _2: ((),))
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_once<F, T>(_1: closure<F, T>[TraitClause0, TraitClause1], _2: ((),))
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
     let _0: (); // return
-    let _1: closure<F, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: closure<F, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: ((),); // arg #2
-    let _3: &'1 mut closure<F, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 mut closure<F, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut<'3, F, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for closure<F, T>[@TraitClause0, @TraitClause1]}::drop_in_place<F, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_mut<'3, F, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for closure<F, T>[TraitClause0, TraitClause1]}::drop_in_place<F, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}
-impl<F, T> FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]}
+impl<F, T> FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ((),)}
-    parent_clause2 = {built_in impl Tuple for ((),)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<F, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause2: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_once<F, T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_once<F, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}
-impl<F, T> FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}
+impl<F, T> FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}<F, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
-    fn call_mut<'_0_1> = {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0_1, F, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<F, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (closure<F, T>[TraitClause0, TraitClause1]: FnOnce<((),)>) = {impl FnOnce<((),)> for closure<F, T>[TraitClause0, TraitClause1]}<F, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    fn call_mut<'_0_1> = {impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call_mut<'_0_1, F, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::{impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}
-impl<F, T> Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::{impl Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]}
+impl<F, T> Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<F, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}<F, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ((),)}
-    parent_clause3 = {built_in impl Tuple for ((),)}
-    fn call<'_0_1> = {impl Fn<((),)> for closure<F, T>[@TraitClause0, @TraitClause1]}::call<'_0_1, F, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<F, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<F, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (closure<F, T>[TraitClause0, TraitClause1]: FnMut<((),)>) = {impl FnMut<((),)> for closure<F, T>[TraitClause0, TraitClause1]}<F, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    fn call<'_0_1> = {impl Fn<((),)> for closure<F, T>[TraitClause0, TraitClause1]}::call<'_0_1, F, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method::closure::{impl Destruct for closure<F, T>[@TraitClause0, @TraitClause1]}
-impl<F, T> Destruct for closure<F, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method::closure::{impl Destruct for closure<F, T>[TraitClause0, TraitClause1]}
+impl<F, T> Destruct for closure<F, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for closure<F, T>[@TraitClause0, @TraitClause1]}::drop_in_place<F, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for closure<F, T>[TraitClause0, TraitClause1]}::drop_in_place<F, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/closure-inside-inline-const.out
+++ b/charon/tests/ui/simple/closure-inside-inline-const.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,17 +35,17 @@ pub trait Tuple<Self>
 #[lang_item("mem_size_of")]
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -55,166 +55,166 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::foo::{const}::closure
 struct closure<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {}
 
 // Full name: test_crate::foo
 pub fn foo<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local
     let _2: usize; // anonymous local
-    let _f_3: closure<T>[@TraitClause0]; // local
+    let _f_3: closure<T>[TraitClause0]; // local
 
     storage_live(_1)
     storage_live(_2)
     storage_live(_f_3)
     _f_3 = closure {  }
-    _2 = size_of<T>[@TraitClause0]()
+    _2 = size_of<T>[TraitClause0]()
     storage_dead(_f_3)
     _1 = move _2
     _0 = move _1
     return
 }
 
-// Full name: test_crate::foo::{const}::closure::{impl Destruct for closure<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for closure<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut closure<T>[@TraitClause0])
+// Full name: test_crate::foo::{const}::closure::{impl Destruct for closure<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for closure<T>[TraitClause0]}::drop_in_place<T>(_1: *mut closure<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::foo::{const}::{impl Fn<()> for closure<T>[@TraitClause0]}::call
-fn {impl Fn<()> for closure<T>[@TraitClause0]}::call<'_0, T>(_1: &'_0 closure<T>[@TraitClause0], tupled_args_2: ()) -> i32
+// Full name: test_crate::foo::{const}::{impl Fn<()> for closure<T>[TraitClause0]}::call
+fn {impl Fn<()> for closure<T>[TraitClause0]}::call<'_0, T>(_1: &'_0 closure<T>[TraitClause0], tupled_args_2: ()) -> i32
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: i32; // return
-    let _1: &'1 closure<T>[@TraitClause0]; // arg #1
+    let _1: &'1 closure<T>[TraitClause0]; // arg #1
     let tupled_args_2: (); // arg #2
 
     _0 = const 42 : i32
     return
 }
 
-// Full name: test_crate::foo::{const}::{impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut
-fn {impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut<'_0, T>(state_1: &'_0 mut closure<T>[@TraitClause0], args_2: ()) -> i32
+// Full name: test_crate::foo::{const}::{impl FnMut<()> for closure<T>[TraitClause0]}::call_mut
+fn {impl FnMut<()> for closure<T>[TraitClause0]}::call_mut<'_0, T>(state_1: &'_0 mut closure<T>[TraitClause0], args_2: ()) -> i32
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: i32; // return
-    let state_1: &'_0 mut closure<T>[@TraitClause0]; // arg #1
+    let state_1: &'_0 mut closure<T>[TraitClause0]; // arg #1
     let args_2: (); // arg #2
-    let _3: &'0 closure<T>[@TraitClause0]; // anonymous local
+    let _3: &'0 closure<T>[TraitClause0]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<()> for closure<T>[@TraitClause0]}::call<'2, T>[@TraitClause0](move _3, move args_2)
+    _0 = {impl Fn<()> for closure<T>[TraitClause0]}::call<'2, T>[TraitClause0](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::foo::{const}::{impl FnOnce<()> for closure<T>[@TraitClause0]}::call_once
-fn {impl FnOnce<()> for closure<T>[@TraitClause0]}::call_once<T>(_1: closure<T>[@TraitClause0], _2: ()) -> i32
+// Full name: test_crate::foo::{const}::{impl FnOnce<()> for closure<T>[TraitClause0]}::call_once
+fn {impl FnOnce<()> for closure<T>[TraitClause0]}::call_once<T>(_1: closure<T>[TraitClause0], _2: ()) -> i32
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: i32; // return
-    let _1: closure<T>[@TraitClause0]; // arg #1
+    let _1: closure<T>[TraitClause0]; // arg #1
     let _2: (); // arg #2
-    let _3: &'1 mut closure<T>[@TraitClause0]; // anonymous local
+    let _3: &'1 mut closure<T>[TraitClause0]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut<'3, T>[@TraitClause0](move _3, move _2)
-    drop[{impl Destruct for closure<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] _1
+    _0 = {impl FnMut<()> for closure<T>[TraitClause0]}::call_mut<'3, T>[TraitClause0](move _3, move _2)
+    drop[{impl Destruct for closure<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] _1
     return
 }
 
-// Full name: test_crate::foo::{const}::{impl FnOnce<()> for closure<T>[@TraitClause0]}
-impl<T> FnOnce<()> for closure<T>[@TraitClause0]
+// Full name: test_crate::foo::{const}::{impl FnOnce<()> for closure<T>[TraitClause0]}
+impl<T> FnOnce<()> for closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<T>[TraitClause0]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (i32: Sized) = {built_in impl Sized for i32}
     type Output = i32
-    fn call_once = {impl FnOnce<()> for closure<T>[@TraitClause0]}::call_once<T>[@TraitClause0]
+    fn call_once = {impl FnOnce<()> for closure<T>[TraitClause0]}::call_once<T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{const}::{impl FnMut<()> for closure<T>[@TraitClause0]}
-impl<T> FnMut<()> for closure<T>[@TraitClause0]
+// Full name: test_crate::foo::{const}::{impl FnMut<()> for closure<T>[TraitClause0]}
+impl<T> FnMut<()> for closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T>[@TraitClause0]}
-    parent_clause1 = {impl FnOnce<()> for closure<T>[@TraitClause0]}<T>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<()> for closure<T>[@TraitClause0]}::call_mut<'_0_1, T>[@TraitClause0]
+    proof ImpliedClause0: (closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<T>[TraitClause0]}
+    proof ImpliedClause1: (closure<T>[TraitClause0]: FnOnce<()>) = {impl FnOnce<()> for closure<T>[TraitClause0]}<T>[TraitClause0]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<()> for closure<T>[TraitClause0]}::call_mut<'_0_1, T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{const}::{impl Fn<()> for closure<T>[@TraitClause0]}
-impl<T> Fn<()> for closure<T>[@TraitClause0]
+// Full name: test_crate::foo::{const}::{impl Fn<()> for closure<T>[TraitClause0]}
+impl<T> Fn<()> for closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T>[@TraitClause0]}
-    parent_clause1 = {impl FnMut<()> for closure<T>[@TraitClause0]}<T>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<()> for closure<T>[@TraitClause0]}::call<'_0_1, T>[@TraitClause0]
+    proof ImpliedClause0: (closure<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<T>[TraitClause0]}
+    proof ImpliedClause1: (closure<T>[TraitClause0]: FnMut<()>) = {impl FnMut<()> for closure<T>[TraitClause0]}<T>[TraitClause0]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<()> for closure<T>[TraitClause0]}::call<'_0_1, T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{const}::closure::{impl Destruct for closure<T>[@TraitClause0]}
-impl<T> Destruct for closure<T>[@TraitClause0]
+// Full name: test_crate::foo::{const}::closure::{impl Destruct for closure<T>[TraitClause0]}
+impl<T> Destruct for closure<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for closure<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for closure<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,46 +48,46 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Thing
 trait Thing<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn foo = foo<Self>[Self]
     non-dyn-compatible
@@ -116,41 +116,41 @@ impl<A> Destruct for (A,) {
 // Full name: test_crate::Thing::foo::closure
 struct closure<Self>
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {}
 
-// Full name: test_crate::Thing::foo::{impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call
-fn {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'_0, Self>(_1: &'_0 closure<Self>[@TraitClause0], tupled_args_2: (@TraitClause0::Item,))
+// Full name: test_crate::Thing::foo::{impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call
+fn {impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call<'_0, Self>(_1: &'_0 closure<Self>[TraitClause0], tupled_args_2: (TraitClause0::Item,))
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
     let _0: (); // return
-    let _1: &'1 closure<Self>[@TraitClause0]; // arg #1
-    let tupled_args_2: (@TraitClause0::Item,); // arg #2
-    let _3: @TraitClause0::Item; // anonymous local
+    let _1: &'1 closure<Self>[TraitClause0]; // arg #1
+    let tupled_args_2: (TraitClause0::Item,); // arg #2
+    let _3: TraitClause0::Item; // anonymous local
 
     storage_live(_3)
     _0 = ()
     _3 = move tupled_args_2.0
     _0 = ()
-    conditional_drop[{built_in impl Destruct for @TraitClause0::Item}::drop_in_place] _3
+    conditional_drop[{built_in impl Destruct for TraitClause0::Item}::drop_in_place] _3
     return
 }
 
 // Full name: test_crate::Thing::foo
-fn foo<Self>(i_1: @TraitClause0::Item)
+fn foo<Self>(i_1: TraitClause0::Item)
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
     let _0: (); // return
-    let i_1: @TraitClause0::Item; // arg #1
-    let _2: &'1 closure<Self>[@TraitClause0]; // anonymous local
-    let _3: (@TraitClause0::Item,); // anonymous local
-    let _4: @TraitClause0::Item; // anonymous local
-    let _5: &'2 closure<Self>[@TraitClause0]; // anonymous local
-    let _6: &'3 closure<Self>[@TraitClause0]; // anonymous local
-    let _7: &'6 closure<Self>[@TraitClause0]; // anonymous local
-    let _8: closure<Self>[@TraitClause0]; // anonymous local
+    let i_1: TraitClause0::Item; // arg #1
+    let _2: &'1 closure<Self>[TraitClause0]; // anonymous local
+    let _3: (TraitClause0::Item,); // anonymous local
+    let _4: TraitClause0::Item; // anonymous local
+    let _5: &'2 closure<Self>[TraitClause0]; // anonymous local
+    let _6: &'3 closure<Self>[TraitClause0]; // anonymous local
+    let _7: &'6 closure<Self>[TraitClause0]; // anonymous local
+    let _8: closure<Self>[TraitClause0]; // anonymous local
 
     storage_live(_6)
     storage_live(_7)
@@ -167,102 +167,102 @@ where
     storage_live(_4)
     _4 = move i_1
     _3 = (move _4,)
-    _0 = {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'5, Self>[@TraitClause0](move _2, move _3)
-    conditional_drop[{built_in impl Destruct for @TraitClause0::Item}::drop_in_place] _4
+    _0 = {impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call<'5, Self>[TraitClause0](move _2, move _3)
+    conditional_drop[{built_in impl Destruct for TraitClause0::Item}::drop_in_place] _4
     storage_dead(_4)
     storage_dead(_3)
     storage_dead(_2)
-    conditional_drop[{built_in impl Destruct for @TraitClause0::Item}::drop_in_place] i_1
+    conditional_drop[{built_in impl Destruct for TraitClause0::Item}::drop_in_place] i_1
     return
 }
 
-// Full name: test_crate::Thing::foo::closure::{impl Destruct for closure<Self>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for closure<Self>[@TraitClause0]}::drop_in_place<Self>(_1: *mut closure<Self>[@TraitClause0])
+// Full name: test_crate::Thing::foo::closure::{impl Destruct for closure<Self>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for closure<Self>[TraitClause0]}::drop_in_place<Self>(_1: *mut closure<Self>[TraitClause0])
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 = <missing>
 
-// Full name: test_crate::Thing::foo::{impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut
-fn {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut<'_0, Self>(state_1: &'_0 mut closure<Self>[@TraitClause0], args_2: (@TraitClause0::Item,))
+// Full name: test_crate::Thing::foo::{impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_mut
+fn {impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_mut<'_0, Self>(state_1: &'_0 mut closure<Self>[TraitClause0], args_2: (TraitClause0::Item,))
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
     let _0: (); // return
-    let state_1: &'_0 mut closure<Self>[@TraitClause0]; // arg #1
-    let args_2: (@TraitClause0::Item,); // arg #2
-    let _3: &'0 closure<Self>[@TraitClause0]; // anonymous local
+    let state_1: &'_0 mut closure<Self>[TraitClause0]; // arg #1
+    let args_2: (TraitClause0::Item,); // arg #2
+    let _3: &'0 closure<Self>[TraitClause0]; // anonymous local
 
     _0 = ()
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'2, Self>[@TraitClause0](move _3, move args_2)
+    _0 = {impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call<'2, Self>[TraitClause0](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::Thing::foo::{impl FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_once
-fn {impl FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_once<Self>(_1: closure<Self>[@TraitClause0], _2: (@TraitClause0::Item,))
+// Full name: test_crate::Thing::foo::{impl FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_once
+fn {impl FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_once<Self>(_1: closure<Self>[TraitClause0], _2: (TraitClause0::Item,))
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
     let _0: (); // return
-    let _1: closure<Self>[@TraitClause0]; // arg #1
-    let _2: (@TraitClause0::Item,); // arg #2
-    let _3: &'1 mut closure<Self>[@TraitClause0]; // anonymous local
+    let _1: closure<Self>[TraitClause0]; // arg #1
+    let _2: (TraitClause0::Item,); // arg #2
+    let _3: &'1 mut closure<Self>[TraitClause0]; // anonymous local
 
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut<'3, Self>[@TraitClause0](move _3, move _2)
-    drop[{impl Destruct for closure<Self>[@TraitClause0]}::drop_in_place<Self>[@TraitClause0]] _1
+    _0 = {impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_mut<'3, Self>[TraitClause0](move _3, move _2)
+    drop[{impl Destruct for closure<Self>[TraitClause0]}::drop_in_place<Self>[TraitClause0]] _1
     return
 }
 
-// Full name: test_crate::Thing::foo::{impl FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}
-impl<Self> FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]
+// Full name: test_crate::Thing::foo::{impl FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}
+impl<Self> FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<Self>[@TraitClause0]}
-    parent_clause1 = {built_in impl Sized for (@TraitClause0::Item,)}
-    parent_clause2 = {built_in impl Tuple for (@TraitClause0::Item,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<Self>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<Self>[TraitClause0]}
+    proof ImpliedClause1: ((TraitClause0::Item,): Sized) = {built_in impl Sized for (TraitClause0::Item,)}
+    proof ImpliedClause2: ((TraitClause0::Item,): Tuple) = {built_in impl Tuple for (TraitClause0::Item,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_once<Self>[@TraitClause0]
+    fn call_once = {impl FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_once<Self>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::Thing::foo::{impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}
-impl<Self> FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]
+// Full name: test_crate::Thing::foo::{impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}
+impl<Self> FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<Self>[@TraitClause0]}
-    parent_clause1 = {impl FnOnce<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}<Self>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for (@TraitClause0::Item,)}
-    parent_clause3 = {built_in impl Tuple for (@TraitClause0::Item,)}
-    fn call_mut<'_0_1> = {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call_mut<'_0_1, Self>[@TraitClause0]
+    proof ImpliedClause0: (closure<Self>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<Self>[TraitClause0]}
+    proof ImpliedClause1: (closure<Self>[TraitClause0]: FnOnce<(TraitClause0::Item,)>) = {impl FnOnce<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}<Self>[TraitClause0]
+    proof ImpliedClause2: ((TraitClause0::Item,): Sized) = {built_in impl Sized for (TraitClause0::Item,)}
+    proof ImpliedClause3: ((TraitClause0::Item,): Tuple) = {built_in impl Tuple for (TraitClause0::Item,)}
+    fn call_mut<'_0_1> = {impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call_mut<'_0_1, Self>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::Thing::foo::{impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}
-impl<Self> Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]
+// Full name: test_crate::Thing::foo::{impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}
+impl<Self> Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<Self>[@TraitClause0]}
-    parent_clause1 = {impl FnMut<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}<Self>[@TraitClause0]
-    parent_clause2 = {built_in impl Sized for (@TraitClause0::Item,)}
-    parent_clause3 = {built_in impl Tuple for (@TraitClause0::Item,)}
-    fn call<'_0_1> = {impl Fn<(@TraitClause0::Item,)> for closure<Self>[@TraitClause0]}::call<'_0_1, Self>[@TraitClause0]
+    proof ImpliedClause0: (closure<Self>[TraitClause0]: MetaSized) = {built_in impl MetaSized for closure<Self>[TraitClause0]}
+    proof ImpliedClause1: (closure<Self>[TraitClause0]: FnMut<(TraitClause0::Item,)>) = {impl FnMut<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}<Self>[TraitClause0]
+    proof ImpliedClause2: ((TraitClause0::Item,): Sized) = {built_in impl Sized for (TraitClause0::Item,)}
+    proof ImpliedClause3: ((TraitClause0::Item,): Tuple) = {built_in impl Tuple for (TraitClause0::Item,)}
+    fn call<'_0_1> = {impl Fn<(TraitClause0::Item,)> for closure<Self>[TraitClause0]}::call<'_0_1, Self>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::Thing::foo::closure::{impl Destruct for closure<Self>[@TraitClause0]}
-impl<Self> Destruct for closure<Self>[@TraitClause0]
+// Full name: test_crate::Thing::foo::closure::{impl Destruct for closure<Self>[TraitClause0]}
+impl<Self> Destruct for closure<Self>[TraitClause0]
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
-    fn drop_in_place = {impl Destruct for closure<Self>[@TraitClause0]}::drop_in_place<Self>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for closure<Self>[TraitClause0]}::drop_in_place<Self>[TraitClause0]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/closure-with-drops.out
+++ b/charon/tests/ui/simple/closure-with-drops.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,22 +35,22 @@ pub trait Tuple<Self>
 #[lang_item("mem_drop")]
 pub fn drop<T>(_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
+    TraitClause2: (T: Destruct),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Destruct<Self>
-    parent_clause4 : [@TraitClause4]: Destruct<Args>
-    parent_clause5 : [@TraitClause5]: Sized<Self::Output>
-    parent_clause6 : [@TraitClause6]: Destruct<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self: Destruct)
+    proof ImpliedClause4: (Args: Destruct)
+    proof ImpliedClause5: (Self::Output: Sized)
+    proof ImpliedClause6: (Self::Output: Destruct)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -60,133 +60,133 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
-    parent_clause4 : [@TraitClause4]: Destruct<Self>
-    parent_clause5 : [@TraitClause5]: Destruct<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    proof ImpliedClause4: (Self: Destruct)
+    proof ImpliedClause5: (Args: Destruct)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
-    parent_clause4 : [@TraitClause4]: Destruct<Self>
-    parent_clause5 : [@TraitClause5]: Destruct<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    proof ImpliedClause4: (Self: Destruct)
+    proof ImpliedClause5: (Args: Destruct)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 struct test_crate::foo::closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
   T,
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
-    let _1: *mut test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
-    let _2: &'1 mut test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _1: *mut test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // arg #1
+    let _2: &'1 mut test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_2)
     _0 = ()
     _2 = &mut (*_1)
-    drop[@TraitClause1::drop_in_place] ((*_2)).0
+    drop[TraitClause1::drop_in_place] ((*_2)).0
     return
 }
 
 // Full name: test_crate::foo
 fn foo<T>(x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
     let x_1: T; // arg #1
-    let _2: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _2: test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     _0 = ()
     storage_live(_2)
     _2 = test_crate::foo::closure { 0: move x_1 }
-    drop[{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]] _2
+    drop[{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]] _2
     storage_dead(_2)
     _0 = ()
     return
 }
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ())
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[TraitClause0, TraitClause1], tupled_args_2: ())
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
     let _0: (); // return
-    let _1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
     let _3: T; // anonymous local
 
     _0 = ()
     storage_live(_3)
     _3 = move (_1).0
-    _0 = drop<T>[@TraitClause0, @TraitClause1, @TraitClause1](move _3)
+    _0 = drop<T>[TraitClause0, TraitClause1, TraitClause1](move _3)
     storage_dead(_3)
     return
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
-    fn drop_in_place = {impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause4 = {built_in impl Destruct for ()}
-    parent_clause5 = {built_in impl Sized for ()}
-    parent_clause6 = {built_in impl Destruct for ()}
+    proof ImpliedClause0: (test_crate::foo::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (test_crate::foo::closure<T>[TraitClause0, TraitClause1]: Destruct) = {impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause4: ((): Destruct) = {built_in impl Destruct for ()}
+    proof ImpliedClause5: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause6: ((): Destruct) = {built_in impl Destruct for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -270,13 +270,13 @@ impl Destruct for test_crate::bar::closure {
 
 // Full name: test_crate::bar::{impl FnOnce<()> for test_crate::bar::closure}
 impl FnOnce<()> for test_crate::bar::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::bar::closure}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {impl Destruct for test_crate::bar::closure}
-    parent_clause4 = {built_in impl Destruct for ()}
-    parent_clause5 = {built_in impl Sized for ()}
-    parent_clause6 = {built_in impl Destruct for ()}
+    proof ImpliedClause0: (test_crate::bar::closure: MetaSized) = {built_in impl MetaSized for test_crate::bar::closure}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (test_crate::bar::closure: Destruct) = {impl Destruct for test_crate::bar::closure}
+    proof ImpliedClause4: ((): Destruct) = {built_in impl Destruct for ()}
+    proof ImpliedClause5: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause6: ((): Destruct) = {built_in impl Destruct for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for test_crate::bar::closure}::call_once
     non-dyn-compatible
@@ -284,24 +284,24 @@ impl FnOnce<()> for test_crate::bar::closure {
 
 // Full name: test_crate::bar::{impl FnMut<()> for test_crate::bar::closure}
 impl FnMut<()> for test_crate::bar::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::bar::closure}
-    parent_clause1 = {impl FnOnce<()> for test_crate::bar::closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    parent_clause4 = {impl Destruct for test_crate::bar::closure}
-    parent_clause5 = {built_in impl Destruct for ()}
+    proof ImpliedClause0: (test_crate::bar::closure: MetaSized) = {built_in impl MetaSized for test_crate::bar::closure}
+    proof ImpliedClause1: (test_crate::bar::closure: FnOnce<()>) = {impl FnOnce<()> for test_crate::bar::closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause4: (test_crate::bar::closure: Destruct) = {impl Destruct for test_crate::bar::closure}
+    proof ImpliedClause5: ((): Destruct) = {built_in impl Destruct for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::bar::closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::bar::{impl Fn<()> for test_crate::bar::closure}
 impl Fn<()> for test_crate::bar::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::bar::closure}
-    parent_clause1 = {impl FnMut<()> for test_crate::bar::closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    parent_clause4 = {impl Destruct for test_crate::bar::closure}
-    parent_clause5 = {built_in impl Destruct for ()}
+    proof ImpliedClause0: (test_crate::bar::closure: MetaSized) = {built_in impl MetaSized for test_crate::bar::closure}
+    proof ImpliedClause1: (test_crate::bar::closure: FnMut<()>) = {impl FnMut<()> for test_crate::bar::closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause4: (test_crate::bar::closure: Destruct) = {impl Destruct for test_crate::bar::closure}
+    proof ImpliedClause5: ((): Destruct) = {built_in impl Destruct for ()}
     fn call<'_0_1> = {impl Fn<()> for test_crate::bar::closure}::call<'_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
+++ b/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::call_fn::closure
@@ -182,10 +182,10 @@ fn {impl FnOnce<(usize,)> for closure<'_0, '_1>}::call_once<'_0, '_1>(_1: closur
 
 // Full name: test_crate::call_fn::{impl FnOnce<(usize,)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnOnce<(usize,)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {built_in impl Sized for (usize,)}
-    parent_clause2 = {built_in impl Tuple for (usize,)}
-    parent_clause3 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause2: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause3: (u8: Sized) = {built_in impl Sized for u8}
     type Output = u8
     fn call_once = {impl FnOnce<(usize,)> for closure<'_0, '_1>}::call_once<'_0, '_1>
     non-dyn-compatible
@@ -193,20 +193,20 @@ impl<'_0, '_1> FnOnce<(usize,)> for closure<'_0, '_1> {
 
 // Full name: test_crate::call_fn::{impl FnMut<(usize,)> for closure<'_0, '_1>}
 impl<'_0, '_1> FnMut<(usize,)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnOnce<(usize,)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (usize,)}
-    parent_clause3 = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(usize,)>) = {impl FnOnce<(usize,)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause3: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
     fn call_mut<'_0_1> = {impl FnMut<(usize,)> for closure<'_0, '_1>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::call_fn::{impl Fn<(usize,)> for closure<'_0, '_1>}
 impl<'_0, '_1> Fn<(usize,)> for closure<'_0, '_1> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0, '_1>}
-    parent_clause1 = {impl FnMut<(usize,)> for closure<'_0, '_1>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (usize,)}
-    parent_clause3 = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(usize,)>) = {impl FnMut<(usize,)> for closure<'_0, '_1>}<'_0, '_1>
+    proof ImpliedClause2: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause3: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
     fn call<'_0_1> = {impl Fn<(usize,)> for closure<'_0, '_1>}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
+++ b/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,15 +25,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -52,7 +52,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -60,10 +60,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
@@ -72,10 +72,10 @@ pub trait FnOnce<Self, Args, Self_Output>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args, Self_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
@@ -84,27 +84,27 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
 #[lang_item("fn")]
 pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args, Self_Clause1_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
 where
-    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+    TraitClause0: (Self: Fn<Args, Clause0_Clause1_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
 where
-    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+    TraitClause0: (Self: FnMut<Args, Clause0_Clause1_Output>),
 = <opaque>
 
 pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 struct test_crate::f::closure<'_0, T> {
@@ -114,8 +114,8 @@ struct test_crate::f::closure<'_0, T> {
 // Full name: test_crate::f
 fn f<'_0, T>(x_1: &'_0 T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
     let x_1: &'1 T; // arg #1
@@ -136,15 +136,15 @@ where
 // Full name: test_crate::f::closure::{impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place
 unsafe fn {impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>(_1: *mut test_crate::f::closure<'_0, T>)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <missing>
 
 // Full name: test_crate::f::{impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call
 fn {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '_1, T>(_1: &'_1 test_crate::f::closure<'_0, T>, tupled_args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let _1: &'1 test_crate::f::closure<'_0, T>; // arg #1
@@ -157,8 +157,8 @@ where
 // Full name: test_crate::f::{impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut
 fn {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::f::closure<'_0, T>, args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let state_1: &'_1 mut test_crate::f::closure<'_0, T>; // arg #1
@@ -167,15 +167,15 @@ where
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
 // Full name: test_crate::f::{impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once
 fn {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once<'_0, T>(_1: test_crate::f::closure<'_0, T>, _2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let _1: test_crate::f::closure<'_0, T>; // arg #1
@@ -184,60 +184,60 @@ where
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '5, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '5, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
 // Full name: test_crate::f::{impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}
 impl<'_0, T> FnOnce<(), T> for test_crate::f::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = @TraitClause0
-    fn call_once = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once<'_0, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::f::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
+    fn call_once = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}::call_once<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::f::{impl FnMut<(), T> for test_crate::f::closure<'_0, T>}
 impl<'_0, T> FnMut<(), T> for test_crate::f::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
-    parent_clause1 = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::f::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    proof ImpliedClause1: (test_crate::f::closure<'_0, T>: FnOnce<(), T>) = {impl FnOnce<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::f::{impl Fn<(), T> for test_crate::f::closure<'_0, T>}
 impl<'_0, T> Fn<(), T> for test_crate::f::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
-    parent_clause1 = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::f::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::f::closure<'_0, T>}
+    proof ImpliedClause1: (test_crate::f::closure<'_0, T>: FnMut<(), T>) = {impl FnMut<(), T> for test_crate::f::closure<'_0, T>}<'_0, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<(), T> for test_crate::f::closure<'_0, T>}::call<'_0, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::f::closure::{impl Destruct for test_crate::f::closure<'_0, T>}
 impl<'_0, T> Destruct for test_crate::f::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    fn drop_in_place = {impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::f::closure<'_0, T>}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -248,8 +248,8 @@ struct test_crate::g::closure<'_0, T> {
 // Full name: test_crate::g
 fn g<T>(x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
     let x_1: T; // arg #1
@@ -270,15 +270,15 @@ where
 // Full name: test_crate::g::closure::{impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place
 unsafe fn {impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>(_1: *mut test_crate::g::closure<'_0, T>)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <missing>
 
 // Full name: test_crate::g::{impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call
 fn {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '_1, T>(_1: &'_1 test_crate::g::closure<'_0, T>, tupled_args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let _1: &'1 test_crate::g::closure<'_0, T>; // arg #1
@@ -291,8 +291,8 @@ where
 // Full name: test_crate::g::{impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut
 fn {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '_1, T>(state_1: &'_1 mut test_crate::g::closure<'_0, T>, args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let state_1: &'_1 mut test_crate::g::closure<'_0, T>; // arg #1
@@ -301,15 +301,15 @@ where
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
 // Full name: test_crate::g::{impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once
 fn {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once<'_0, T>(_1: test_crate::g::closure<'_0, T>, _2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: T; // return
     let _1: test_crate::g::closure<'_0, T>; // arg #1
@@ -318,60 +318,60 @@ where
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '5, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '5, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
 // Full name: test_crate::g::{impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}
 impl<'_0, T> FnOnce<(), T> for test_crate::g::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = @TraitClause0
-    fn call_once = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once<'_0, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::g::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
+    fn call_once = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}::call_once<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::g::{impl FnMut<(), T> for test_crate::g::closure<'_0, T>}
 impl<'_0, T> FnMut<(), T> for test_crate::g::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
-    parent_clause1 = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::g::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    proof ImpliedClause1: (test_crate::g::closure<'_0, T>: FnOnce<(), T>) = {impl FnOnce<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}::call_mut<'_0, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::g::{impl Fn<(), T> for test_crate::g::closure<'_0, T>}
 impl<'_0, T> Fn<(), T> for test_crate::g::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
-    parent_clause1 = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::g::closure<'_0, T>: MetaSized) = {built_in impl MetaSized for test_crate::g::closure<'_0, T>}
+    proof ImpliedClause1: (test_crate::g::closure<'_0, T>: FnMut<(), T>) = {impl FnMut<(), T> for test_crate::g::closure<'_0, T>}<'_0, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<(), T> for test_crate::g::closure<'_0, T>}::call<'_0, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::g::closure::{impl Destruct for test_crate::g::closure<'_0, T>}
 impl<'_0, T> Destruct for test_crate::g::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
-    fn drop_in_place = {impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::g::closure<'_0, T>}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/conditional-drop.out
+++ b/charon/tests/ui/simple/conditional-drop.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -37,13 +37,13 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: test_crate::use_box
@@ -54,7 +54,7 @@ fn use_box(_1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_
 
     _0 = ()
     _0 = ()
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] _1
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] _1
     return
 }
 
@@ -91,7 +91,7 @@ fn main()
     storage_dead(_2)
     // `b` is dropped implicitly here
     if copy _5 {
-        drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] b_1
+        drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] b_1
     } else {
     }
     _5 = const false

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
@@ -10,33 +10,33 @@ trait HasAssoc<Self>
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    fn default_method<T, [@TraitClause0_1]: HasAssoc<T>> = test_crate::Trait::default_method<Self, T>[Self, @TraitClause0_1]
+    fn default_method<T, TraitClause0_1: (T: HasAssoc)> = test_crate::Trait::default_method<Self, T>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
-fn test_crate::Trait::default_method<Self, T>() -> @TraitClause1::Assoc
+fn test_crate::Trait::default_method<Self, T>() -> TraitClause1::Assoc
 where
-    [@TraitClause0]: Trait<Self>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (Self: Trait),
+    TraitClause1: (T: HasAssoc),
 {
-    let _0: @TraitClause1::Assoc; // return
+    let _0: TraitClause1::Assoc; // return
 
     panic(core::panicking::panic)
 }
 
 // Full name: test_crate::{impl Trait for T}::default_method
-fn {impl Trait for T}::default_method<T, T>() -> @TraitClause0::Assoc
+fn {impl Trait for T}::default_method<T, T>() -> TraitClause0::Assoc
 where
-    [@TraitClause0]: HasAssoc<T>,
+    TraitClause0: (T: HasAssoc),
 {
-    let _0: @TraitClause0::Assoc; // return
+    let _0: TraitClause0::Assoc; // return
 
     panic(core::panicking::panic)
 }
 
 // Full name: test_crate::{impl Trait for T}
 impl<T> Trait for T {
-    fn default_method<T, [@TraitClause0_1]: HasAssoc<T>> = {impl Trait for T}::default_method<T, T>[@TraitClause0_1]
+    fn default_method<T, TraitClause0_1: (T: HasAssoc)> = {impl Trait for T}::default_method<T, T>[TraitClause0_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/defaulted-rpitit.2.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.2.out
@@ -8,24 +8,26 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::foo_ty>
-    type foo_ty<[@TraitClause0_1]: Sized<Self>>
-    fn foo<[@TraitClause0_1]: Sized<Self>> = test_crate::MyTrait::foo<Self>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::foo_ty: Sized)
+    type foo_ty = ()
+    where
+        TraitClause0_1: (Self: Sized);
+    fn foo<TraitClause0_1: (Self: Sized)> = test_crate::MyTrait::foo<Self>[Self, TraitClause0_1]
     vtable: test_crate::MyTrait::{vtable}<Self::foo_ty>
 }
 
 pub fn test_crate::MyTrait::foo<Self>()
 where
-    [@TraitClause0]: MyTrait<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: MyTrait),
+    TraitClause1: (Self: Sized),
 {
     let _0: (); // return
 
@@ -40,7 +42,7 @@ pub struct S {}
 // Full name: test_crate::{impl MyTrait for S}::foo
 pub fn {impl MyTrait for S}::foo()
 where
-    [@TraitClause0]: Sized<S>,
+    TraitClause0: (S: Sized),
 {
     let _0: (); // return
 
@@ -51,10 +53,12 @@ where
 
 // Full name: test_crate::{impl MyTrait for S}
 impl MyTrait for S {
-    parent_clause0 = {built_in impl MetaSized for S}
-    parent_clause1 = {impl MyTrait for S}::parent_clause1
-    type foo_ty<[@TraitClause0_1]: Sized<S>> = ()
-    fn foo<[@TraitClause0_1]: Sized<S>> = {impl MyTrait for S}::foo[@TraitClause0_1]
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    proof ImpliedClause1: ({impl MyTrait for S}::foo_ty: Sized) = {impl MyTrait for S}::ImpliedClause1
+    type foo_ty = ()
+    where
+        TraitClause0_1: (S: Sized);
+    fn foo<TraitClause0_1: (S: Sized)> = {impl MyTrait for S}::foo[TraitClause0_1]
     vtable: {impl MyTrait for S}::{vtable}
 }
 

--- a/charon/tests/ui/simple/defaulted-rpitit.3.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.3.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,19 +16,19 @@ pub trait Sized<Self>
 #[lang_item("IterEmpty")]
 pub opaque type Empty<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 
 // Full name: core::iter::sources::empty::empty
-pub fn empty<T>() -> Empty<T>[@TraitClause0]
+pub fn empty<T>() -> Empty<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -38,8 +38,8 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
@@ -47,57 +47,61 @@ pub trait Iterator<Self>
 
 // Full name: core::iter::traits::iterator::Iterator::next
 #[lang_item("next")]
-pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    type rows_ty<'_0_1, (Self::rows_ty::[@TraitClause1])::Item = T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    type rows_ty<'_0_1> = Empty<T>[Self::ImpliedClause1]
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::rows_ty>
-        implied_clause_1 : [@TraitClause1_1]: Iterator<Self::rows_ty>
-
+        TypeConstraint0: Self::rows_ty::ImpliedClause1::Item = T,
+        proof ImpliedClause0: (Self::rows_ty: Sized),
+        proof ImpliedClause1: (Self::rows_ty: Iterator);
     fn rows<'_0_1> = test_crate::MyTrait::rows<'_0_1, Self, T>[Self]
     non-dyn-compatible
 }
 
-pub fn test_crate::MyTrait::rows<'_0, Self, T>(self_1: &'_0 Self) -> Empty<T>[@TraitClause0::parent_clause1]
+pub fn test_crate::MyTrait::rows<'_0, Self, T>(self_1: &'_0 Self) -> Empty<T>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: MyTrait<Self, T>,
+    TraitClause0: (Self: MyTrait<T>),
 {
-    let _0: Empty<T>[@TraitClause0::parent_clause1]; // return
+    let _0: Empty<T>[TraitClause0::ImpliedClause1]; // return
     let self_1: &'1 Self; // arg #1
 
-    _0 = empty<T>[@TraitClause0::parent_clause1]()
+    _0 = empty<T>[TraitClause0::ImpliedClause1]()
     return
 }
 
 // Full name: test_crate::{impl MyTrait<T> for ()}::rows
-pub fn {impl MyTrait<T> for ()}::rows<'_0, T>(self_1: &'_0 ()) -> Empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]
+pub fn {impl MyTrait<T> for ()}::rows<'_0, T>(self_1: &'_0 ()) -> Empty<T>[{impl MyTrait<T> for ()}<T>[TraitClause0]::ImpliedClause1]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]; // return
+    let _0: Empty<T>[{impl MyTrait<T> for ()}<T>[TraitClause0]::ImpliedClause1]; // return
     let self_1: &'1 (); // arg #1
 
-    _0 = empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]()
+    _0 = empty<T>[{impl MyTrait<T> for ()}<T>[TraitClause0]::ImpliedClause1]()
     return
 }
 
 // Full name: test_crate::{impl MyTrait<T> for ()}
 impl<T> MyTrait<T> for ()
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = @TraitClause0
-    type rows_ty<'_0_1, ({impl MyTrait<T> for ()}<T>[@TraitClause0]::rows_ty::[@TraitClause1])::Item = T> = Empty<T>[{impl MyTrait<T> for ()}<T>[@TraitClause0]::parent_clause1]
-    fn rows<'_0_1> = {impl MyTrait<T> for ()}::rows<'_0_1, T>[@TraitClause0]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    type rows_ty<'_0_1> = Empty<T>[{impl MyTrait<T> for ()}<T>[TraitClause0]::ImpliedClause1]
+    where
+        TypeConstraint0: {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause1::Item = T,
+        proof ImpliedClause0: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty: Sized) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause0,
+        proof ImpliedClause1: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty: Iterator) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause1;
+    fn rows<'_0_1> = {impl MyTrait<T> for ()}::rows<'_0_1, T>[TraitClause0]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/defaulted-rpitit.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.out
@@ -8,25 +8,24 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type bar_ty<const N : usize>
+    proof ImpliedClause0: (Self: MetaSized)
+    type bar_ty<const N : usize> = [u8; N]
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::bar_ty>
-
+        proof ImpliedClause0: (Self::bar_ty: Sized);
     fn bar<const N : usize> = test_crate::Foo::bar<Self, N>[Self]
     non-dyn-compatible
 }
 
 pub fn test_crate::Foo::bar<Self, const N : usize>() -> [u8; N]
 where
-    [@TraitClause0]: Foo<Self>,
+    TraitClause0: (Self: Foo),
 {
     let _0: [u8; N]; // return
 
@@ -48,8 +47,10 @@ pub fn {impl Foo for S}::bar<const N : usize>() -> [u8; N]
 
 // Full name: test_crate::{impl Foo for S}
 impl Foo for S {
-    parent_clause0 = {built_in impl MetaSized for S}
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
     type bar_ty<const N : usize> = [u8; N]
+    where
+        proof ImpliedClause0: ({impl Foo for S}::bar_ty: Sized) = {impl Foo for S}::bar_ty::ImpliedClause0;
     fn bar<const N : usize> = {impl Foo for S}::bar<N>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/double-promotion.out
+++ b/charon/tests/ui/simple/double-promotion.out
@@ -8,15 +8,15 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Ref
 pub struct Ref<'a, B>
 where
-    [@TraitClause0]: Sized<B>,
-    B : 'a,
+    TraitClause0: (B: Sized),
+    TypeOutlives0: B: 'a,
 {
   &'a B,
 }

--- a/charon/tests/ui/simple/drop-cow.out
+++ b/charon/tests/ui/simple/drop-cow.out
@@ -16,10 +16,10 @@ pub trait MetaSized<Self>
 #[lang_item("Borrow")]
 pub trait Borrow<Self, Borrowed>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Borrowed>
-    parent_clause2 : [@TraitClause2]: Destruct<Self>
-    parent_clause3 : [@TraitClause3]: Destruct<Borrowed>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Borrowed: MetaSized)
+    proof ImpliedClause2: (Self: Destruct)
+    proof ImpliedClause3: (Borrowed: Destruct)
     fn borrow<'_0_1> = borrow<'_0_1, Self, Borrowed>[Self]
     vtable: core::borrow::Borrow::{vtable}<Borrowed>
 }
@@ -27,14 +27,14 @@ pub trait Borrow<Self, Borrowed>
 // Full name: core::borrow::Borrow::borrow
 pub fn borrow<'_0, Self, Borrowed>(_1: &'_0 Self) -> &'_0 Borrowed
 where
-    [@TraitClause0]: Borrow<Self, Borrowed>,
+    TraitClause0: (Self: Borrow<Borrowed>),
 = <opaque>
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -45,11 +45,11 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("ToOwned")]
 pub trait ToOwned<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Destruct<Self>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Owned>
-    parent_clause3 : [@TraitClause3]: Borrow<Self::Owned, Self>
-    parent_clause4 : [@TraitClause4]: Destruct<Self::Owned>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
+    proof ImpliedClause2: (Self::Owned: Sized)
+    proof ImpliedClause3: (Self::Owned: Borrow<Self>)
+    proof ImpliedClause4: (Self::Owned: Destruct)
     type Owned
     fn to_owned<'_0_1> = to_owned<'_0_1, Self>[Self]
     non-dyn-compatible
@@ -57,36 +57,36 @@ pub trait ToOwned<Self>
 
 // Full name: alloc::borrow::ToOwned::to_owned
 #[lang_item("to_owned_method")]
-pub fn to_owned<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Owned
+pub fn to_owned<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Owned
 where
-    [@TraitClause0]: ToOwned<Self>,
+    TraitClause0: (Self: ToOwned),
 = <opaque>
 
 // Full name: test_crate::Cow
 enum Cow<'a, B>
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    [@TraitClause2]: Destruct<B>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TraitClause2: (B: Destruct),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
   Borrowed(&'a B),
-  Owned(@TraitClause1::Owned),
+  Owned(TraitClause1::Owned),
 }
 
-// Full name: test_crate::Cow::{impl Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place
-unsafe fn {impl Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<'a, B>(_1: *mut Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2])
+// Full name: test_crate::Cow::{impl Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place
+unsafe fn {impl Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<'a, B>(_1: *mut Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    [@TraitClause2]: Destruct<B>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TraitClause2: (B: Destruct),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
     let _0: (); // return
-    let _1: *mut Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]; // arg #1
-    let _2: &'1 mut Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]; // anonymous local
+    let _1: *mut Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]; // arg #1
+    let _2: &'1 mut Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]; // anonymous local
 
     storage_live(_2)
     _0 = ()
@@ -95,40 +95,40 @@ where
         Cow::Borrowed => {
         },
         _ => {
-            drop[@TraitClause1::parent_clause4::drop_in_place] ((*_2) as variant Cow::Owned).0
+            drop[TraitClause1::ImpliedClause4::drop_in_place] ((*_2) as variant Cow::Owned).0
             return
         },
     }
     return
 }
 
-// Full name: test_crate::Cow::{impl Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]}
-impl<'a, B> Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]
+// Full name: test_crate::Cow::{impl Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]}
+impl<'a, B> Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    [@TraitClause2]: Destruct<B>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TraitClause2: (B: Destruct),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
-    fn drop_in_place = {impl Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]
+    fn drop_in_place = {impl Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<'a, B>[TraitClause0, TraitClause1, TraitClause2]
     non-dyn-compatible
 }
 
 // Full name: test_crate::drop_cow
-fn drop_cow<'a, B>(_1: Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2])
+fn drop_cow<'a, B>(_1: Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2])
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    [@TraitClause2]: Destruct<B>,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TraitClause2: (B: Destruct),
+    TypeOutlives0: B: 'a,
 {
     let _0: (); // return
-    let _1: Cow<'1, B>[@TraitClause0, @TraitClause1, @TraitClause2]; // arg #1
+    let _1: Cow<'1, B>[TraitClause0, TraitClause1, TraitClause2]; // arg #1
 
     _0 = ()
     _0 = ()
-    drop[{impl Destruct for Cow<'a, B>[@TraitClause0, @TraitClause1, @TraitClause2]}::drop_in_place<'4, B>[@TraitClause0, @TraitClause1, @TraitClause2]] _1
+    drop[{impl Destruct for Cow<'a, B>[TraitClause0, TraitClause1, TraitClause2]}::drop_in_place<'4, B>[TraitClause0, TraitClause1, TraitClause2]] _1
     return
 }
 

--- a/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
+++ b/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/drop-string-desugar.out
+++ b/charon/tests/ui/simple/drop-string-desugar.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -41,10 +41,10 @@ impl Destruct for Global {
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
 
 // Full name: alloc::string::String
 #[lang_item("String")]
@@ -52,13 +52,13 @@ pub struct String {
   vec: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}],
 }
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::string::String::{impl Destruct for String}::drop_in_place
@@ -76,7 +76,7 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
     storage_live(drop_arg_3)
     drop_arg_3 = &raw mut ((*_2)).vec
     storage_live(drop_ret_4)
-    drop_ret_4 = {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}](move drop_arg_3)
+    drop_ret_4 = {impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}](move drop_arg_3)
     return
 }
 

--- a/charon/tests/ui/simple/drop-string.out
+++ b/charon/tests/ui/simple/drop-string.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -41,10 +41,10 @@ impl Destruct for Global {
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
 
 // Full name: alloc::string::String
 #[lang_item("String")]
@@ -52,13 +52,13 @@ pub struct String {
   vec: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}],
 }
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::string::String::{impl Destruct for String}::drop_in_place
@@ -71,7 +71,7 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
     storage_live(_2)
     _0 = ()
     _2 = &mut (*_1)
-    drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}]] ((*_2)).vec
+    drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}, {built_in impl Destruct for u8}, {impl Destruct for Global}]] ((*_2)).vec
     return
 }
 

--- a/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -29,13 +29,13 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Foo::{vtable}
 }
 
 // Full name: test_crate::{impl Foo for ()}
 impl Foo for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     vtable: {impl Foo for ()}::{vtable}
 }
 
@@ -50,8 +50,8 @@ struct test_crate::Broken::{vtable}<Ty0> {
 // Full name: test_crate::Broken
 pub trait Broken<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Assoc: Sized)
     type Assoc
     fn broken<'_0_1> = test_crate::Broken::broken<'_0_1, Self>[Self]
     vtable: test_crate::Broken::{vtable}<Self::Assoc>
@@ -59,14 +59,14 @@ pub trait Broken<Self>
 
 pub fn test_crate::Broken::broken<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Broken<Self>,
+    TraitClause0: (Self: Broken),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Broken for T}::broken
 pub fn {impl Broken for T}::broken<'_0, T>(self_1: &'_0 T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Foo<()>,
+    TraitClause0: (T: Sized),
+    TraitClause1: ((): Foo),
 {
     let _0: (); // return
     let self_1: &'1 T; // arg #1
@@ -79,8 +79,8 @@ where
 // Full name: test_crate::{impl Broken for T}::broken::{vtable_method}
 fn {vtable_method}<'_0, T>(_1: &'_0 (dyn Broken<Assoc = ()>))
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Foo<()>,
+    TraitClause0: (T: Sized),
+    TraitClause1: ((): Foo),
 {
     let _0: (); // return
     let _1: &'_0 (dyn Broken<Assoc = ()> + '0); // arg #1
@@ -89,14 +89,14 @@ where
     _0 = ()
     storage_live(_2)
     _2 = concretize<&'_0 (dyn Broken<Assoc = ()> + '1), &'_0 T>(move _1)
-    _0 = {impl Broken for T}::broken<'_0, T>[@TraitClause0, @TraitClause1](move _2)
+    _0 = {impl Broken for T}::broken<'_0, T>[TraitClause0, TraitClause1](move _2)
     return
 }
 
 // Full name: test_crate::{impl Broken for T}::{vtable_drop_shim}
 unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Broken<Assoc = ()>))
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Broken<Assoc = ()> + '0); // arg #1
@@ -112,7 +112,7 @@ where
 // Full name: test_crate::{impl Broken for T}::{vtable}
 fn {impl Broken for T}::{vtable}<T>() -> test_crate::Broken::{vtable}<()>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let ret_0: test_crate::Broken::{vtable}<()>; // return
     let size_1: usize; // local
@@ -122,26 +122,26 @@ where
     size_1 = size_of<T>
     storage_live(align_2)
     align_2 = align_of<T>
-    ret_0 = test_crate::Broken::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[@TraitClause0], method_broken: const {vtable_method}<'1, T>[@TraitClause0], super_trait_0: const &vtable_of(@TraitClause0::parent_clause0) }
+    ret_0 = test_crate::Broken::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[TraitClause0], method_broken: const {vtable_method}<'1, T>[TraitClause0], super_trait_0: const &vtable_of(TraitClause0::ImpliedClause0) }
     return
 }
 
 // Full name: test_crate::{impl Broken for T}::{vtable}
 static {impl Broken for T}::{vtable}<T>: test_crate::Broken::{vtable}<()>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
  = {impl Broken for T}::{vtable}()
 
 // Full name: test_crate::{impl Broken for T}
 impl<T> Broken for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
     type Assoc = ()
-    fn broken<'_0_1, [@TraitClause0_1]: Foo<()>> = {impl Broken for T}::broken<'_0_1, T>[@TraitClause0, @TraitClause0_1]
-    vtable: {impl Broken for T}::{vtable}<T>[@TraitClause0]
+    fn broken<'_0_1, TraitClause0_1: ((): Foo)> = {impl Broken for T}::broken<'_0_1, T>[TraitClause0, TraitClause0_1]
+    vtable: {impl Broken for T}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/simple/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/simple/dyn-cast-to-supertrait.out
@@ -28,14 +28,14 @@ struct test_crate::Feline::{vtable} {
 // Full name: test_crate::Feline
 trait Feline<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn hunt<'_0_1> = test_crate::Feline::hunt<'_0_1, Self>[Self]
     vtable: test_crate::Feline::{vtable}
 }
 
 fn test_crate::Feline::hunt<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Feline<Self>,
+    TraitClause0: (Self: Feline),
 = <method_without_default_body>
 
 struct test_crate::Pettable::{vtable} {
@@ -49,14 +49,14 @@ struct test_crate::Pettable::{vtable} {
 // Full name: test_crate::Pettable
 trait Pettable<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn pet<'_0_1> = test_crate::Pettable::pet<'_0_1, Self>[Self]
     vtable: test_crate::Pettable::{vtable}
 }
 
 fn test_crate::Pettable::pet<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Pettable<Self>,
+    TraitClause0: (Self: Pettable),
 = <method_without_default_body>
 
 struct test_crate::Cat::{vtable} {
@@ -72,16 +72,16 @@ struct test_crate::Cat::{vtable} {
 // Full name: test_crate::Cat
 trait Cat<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Feline<Self>
-    parent_clause2 : [@TraitClause2]: Pettable<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Feline)
+    proof ImpliedClause2: (Self: Pettable)
     fn meow<'_0_1> = test_crate::Cat::meow<'_0_1, Self>[Self]
     vtable: test_crate::Cat::{vtable}
 }
 
 fn test_crate::Cat::meow<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Cat<Self>,
+    TraitClause0: (Self: Cat),
 = <method_without_default_body>
 
 // Full name: test_crate::HouseCat
@@ -165,7 +165,7 @@ static {impl Feline for HouseCat}::{vtable}: test_crate::Feline::{vtable} = {imp
 
 // Full name: test_crate::{impl Feline for HouseCat}
 impl Feline for HouseCat {
-    parent_clause0 = {built_in impl MetaSized for HouseCat}
+    proof ImpliedClause0: (HouseCat: MetaSized) = {built_in impl MetaSized for HouseCat}
     fn hunt<'_0_1> = {impl Feline for HouseCat}::hunt<'_0_1>
     vtable: {impl Feline for HouseCat}::{vtable}
 }
@@ -229,7 +229,7 @@ static {impl Pettable for HouseCat}::{vtable}: test_crate::Pettable::{vtable} = 
 
 // Full name: test_crate::{impl Pettable for HouseCat}
 impl Pettable for HouseCat {
-    parent_clause0 = {built_in impl MetaSized for HouseCat}
+    proof ImpliedClause0: (HouseCat: MetaSized) = {built_in impl MetaSized for HouseCat}
     fn pet<'_0_1> = {impl Pettable for HouseCat}::pet<'_0_1>
     vtable: {impl Pettable for HouseCat}::{vtable}
 }
@@ -299,9 +299,9 @@ static {impl Cat for HouseCat}::{vtable}: test_crate::Cat::{vtable} = {impl Cat 
 
 // Full name: test_crate::{impl Cat for HouseCat}
 impl Cat for HouseCat {
-    parent_clause0 = {built_in impl MetaSized for HouseCat}
-    parent_clause1 = {impl Feline for HouseCat}
-    parent_clause2 = {impl Pettable for HouseCat}
+    proof ImpliedClause0: (HouseCat: MetaSized) = {built_in impl MetaSized for HouseCat}
+    proof ImpliedClause1: (HouseCat: Feline) = {impl Feline for HouseCat}
+    proof ImpliedClause2: (HouseCat: Pettable) = {impl Pettable for HouseCat}
     fn meow<'_0_1> = {impl Cat for HouseCat}::meow<'_0_1>
     vtable: {impl Cat for HouseCat}::{vtable}
 }

--- a/charon/tests/ui/simple/dyn-field.out
+++ b/charon/tests/ui/simple/dyn-field.out
@@ -13,7 +13,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -21,8 +21,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -39,7 +39,7 @@ pub trait Debug<Self>
 // Full name: core::fmt::Debug::fmt
 pub fn fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: test_crate::UnsizedStruct

--- a/charon/tests/ui/simple/dyn-fn.out
+++ b/charon/tests/ui/simple/dyn-fn.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -29,7 +29,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -37,10 +37,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -52,19 +52,19 @@ opaque type core::ops::function::FnMut::{vtable}<Args, Ty0>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 struct core::ops::function::Fn::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
-  drop: unsafe fn(*mut (dyn Fn<Args, parent_clause1::parent_clause1::Output = Ty0>)),
-  method_call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, parent_clause1::parent_clause1::Output = Ty0>), Args) -> Ty0,
+  drop: unsafe fn(*mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>)),
+  method_call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
   super_trait_1: &'static core::ops::function::FnMut::{vtable}<Args, Ty0>,
 }
@@ -73,37 +73,37 @@ struct core::ops::function::Fn::{vtable}<Args, Ty0> {
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <method_without_default_body>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::takes_fn
-fn takes_fn<'_0>(f_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '_0))
+fn takes_fn<'_0>(f_1: &'_0 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '_0))
 {
     let _0: (); // return
-    let f_1: &'7 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '8); // arg #1
+    let f_1: &'7 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '8); // arg #1
     let counter_2: u32; // local
     let _3: bool; // anonymous local
-    let _4: &'10 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '11); // anonymous local
+    let _4: &'10 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '11); // anonymous local
     let _5: (&'15 mut u32,); // anonymous local
     let _6: &'16 mut u32; // anonymous local
     let _7: &'17 mut u32; // anonymous local
@@ -195,10 +195,10 @@ fn {impl FnOnce<(&'_ mut u32,)> for closure}::call_once<'_0>(_1: closure, _2: (&
 
 // Full name: test_crate::gives_fn::{impl FnOnce<(&'_ mut u32,)> for closure}
 impl<'_0> FnOnce<(&'_ mut u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (&'_ mut u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ mut u32,)}
-    parent_clause3 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
+    proof ImpliedClause2: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause3: (bool: Sized) = {built_in impl Sized for bool}
     type Output = bool
     fn call_once = {impl FnOnce<(&'_ mut u32,)> for closure}::call_once<'_0>
     non-dyn-compatible
@@ -206,20 +206,20 @@ impl<'_0> FnOnce<(&'_ mut u32,)> for closure {
 
 // Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for closure}
 impl<'_0> FnMut<(&'_ mut u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(&'_ mut u32,)> for closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ mut u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(&'_ mut u32,)>) = {impl FnOnce<(&'_ mut u32,)> for closure}<'_0>
+    proof ImpliedClause2: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
+    proof ImpliedClause3: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ mut u32,)> for closure}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}
 impl<'_0> Fn<(&'_ mut u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<(&'_ mut u32,)> for closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (&'_ mut u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<(&'_ mut u32,)>) = {impl FnMut<(&'_ mut u32,)> for closure}<'_0>
+    proof ImpliedClause2: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
+    proof ImpliedClause3: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
     fn call<'_0_1> = {impl Fn<(&'_ mut u32,)> for closure}::call<'_0, '_0_1>
     non-dyn-compatible
 }
@@ -228,7 +228,7 @@ impl<'_0> Fn<(&'_ mut u32,)> for closure {
 fn gives_fn()
 {
     let _0: (); // return
-    let _1: &'7 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '8); // anonymous local
+    let _1: &'7 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '8); // anonymous local
     let _2: &'11 closure; // anonymous local
     let _3: &'12 closure; // anonymous local
     let _4: &'13 closure; // anonymous local
@@ -250,7 +250,7 @@ fn gives_fn()
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'11 closure, &'15 (dyn for<'a> Fn<(&'a mut u32,), parent_clause1::parent_clause1::Output = bool> + '16), &vtable_of({impl Fn<(&'_ mut u32,)> for closure}<'21>)>(move _2)
+    _1 = unsize_cast<&'11 closure, &'15 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '16), &vtable_of({impl Fn<(&'_ mut u32,)> for closure}<'21>)>(move _2)
     storage_dead(_2)
     _0 = takes_fn<'24>(move _1)
     storage_dead(_1)

--- a/charon/tests/ui/simple/dyn-method-with-early-bound-lifetimes.out
+++ b/charon/tests/ui/simple/dyn-method-with-early-bound-lifetimes.out
@@ -17,15 +17,15 @@ struct test_crate::Trait::{vtable} {
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn foo<'a, '_1_1, Self : 'a> = test_crate::Trait::foo<'a, '_1_1, Self>[Self]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn foo<'a, '_1_1, TypeOutlives0: Self: 'a> = test_crate::Trait::foo<'a, '_1_1, Self>[Self]
     vtable: test_crate::Trait::{vtable}
 }
 
 fn test_crate::Trait::foo<'a, '_1, Self>(_1: &'_1 Self)
 where
-    [@TraitClause0]: Trait<Self>,
-    Self : 'a,
+    TraitClause0: (Self: Trait),
+    TypeOutlives0: Self: 'a,
 = <method_without_default_body>
 
 fn test_crate::foo<'_0>(x_1: &'_0 (dyn Trait + '_0))

--- a/charon/tests/ui/simple/explicit_destruct_bound.out
+++ b/charon/tests/ui/simple/explicit_destruct_bound.out
@@ -15,14 +15,14 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::drop
 fn drop<T>(_1: T)
 where
-    [@TraitClause0]: Destruct<T>,
+    TraitClause0: (T: Destruct),
 {
     let _0: (); // return
     let _1: T; // arg #1
 
     _0 = ()
     _0 = ()
-    conditional_drop[@TraitClause0::drop_in_place] _1
+    conditional_drop[TraitClause0::drop_in_place] _1
     return
 }
 

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
@@ -8,22 +8,22 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn method<[@TraitClause0_1]: Sized<Self>> = test_crate::Trait::method<Self>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn method<TraitClause0_1: (Self: Sized)> = test_crate::Trait::method<Self>[Self, TraitClause0_1]
     vtable: test_crate::Trait::{vtable}
 }
 
 fn test_crate::Trait::method<Self>()
 where
-    [@TraitClause0]: Trait<Self>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: Trait),
+    TraitClause1: (Self: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for ()}::method
@@ -38,7 +38,7 @@ fn {impl Trait for ()}::method()
 
 // Full name: test_crate::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     fn method = {impl Trait for ()}::method
     vtable: {impl Trait for ()}::{vtable}
 }

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,38 +25,38 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn method<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Copy<T>> = test_crate::Trait::method<Self, T>[Self, @TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn method<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Copy)> = test_crate::Trait::method<Self, T>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 fn test_crate::Trait::method<Self, T>()
 where
-    [@TraitClause0]: Trait<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: Copy<T>,
+    TraitClause0: (Self: Trait),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: Copy),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for ()}::method
 fn {impl Trait for ()}::method<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: (); // return
 
@@ -67,8 +67,8 @@ where
 
 // Full name: test_crate::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    fn method<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: Clone<T>> = {impl Trait for ()}::method<T>[@TraitClause0_1, @TraitClause1_1]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    fn method<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: Clone)> = {impl Trait for ()}::method<T>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/fn_ptr_trait.out
+++ b/charon/tests/ui/simple/fn_ptr_trait.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,15 +25,15 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Copy
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -41,9 +41,9 @@ pub trait Copy<Self>
 #[lang_item("fn_ptr_trait")]
 pub trait FnPtr<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Copy<Self>
-    parent_clause2 : [@TraitClause2]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Copy)
+    proof ImpliedClause2: (Self: Clone)
     fn addr = addr<Self>[Self]
     non-dyn-compatible
 }
@@ -52,14 +52,14 @@ pub trait FnPtr<Self>
 #[lang_item("fn_ptr_addr")]
 pub fn addr<Self>(_1: Self) -> *const ()
 where
-    [@TraitClause0]: FnPtr<Self>,
+    TraitClause0: (Self: FnPtr),
 = <opaque>
 
 // Full name: test_crate::requires_fn_ptr
 fn requires_fn_ptr<F>()
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: FnPtr<F>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: FnPtr),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/simple/foreign-inline-const.out
+++ b/charon/tests/ui/simple/foreign-inline-const.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,30 +16,30 @@ pub trait Sized<Self>
 #[lang_item("mem_size_of")]
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: closure_inside_inline_const::foo::{const}::closure
 struct closure<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {}
 
 // Full name: closure_inside_inline_const::foo
 pub fn foo<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
     let _1: usize; // anonymous local
     let _2: usize; // anonymous local
-    let _f_3: closure<T>[@TraitClause0]; // local
+    let _f_3: closure<T>[TraitClause0]; // local
 
     storage_live(_1)
     storage_live(_2)
     storage_live(_f_3)
     _f_3 = closure {  }
-    _2 = size_of<T>[@TraitClause0]()
+    _2 = size_of<T>[TraitClause0]()
     storage_dead(_f_3)
     _1 = move _2
     _0 = move _1
@@ -49,14 +49,14 @@ where
 // Full name: test_crate::bar
 fn bar<T>()
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: usize; // anonymous local
 
     _0 = ()
     storage_live(_1)
-    _1 = foo<T>[@TraitClause0]()
+    _1 = foo<T>[TraitClause0]()
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/gat-check-binder-levels.out
+++ b/charon/tests/ui/simple/gat-check-binder-levels.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,46 +25,50 @@ where
 // Full name: test_crate::Link
 pub trait Link<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Link::{vtable}<T>
 }
 
 // Full name: test_crate::{impl Link<T> for U}
 impl<T, U> Link<T> for U
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
-    parent_clause0 = @TraitClause1::parent_clause0
-    parent_clause1 = @TraitClause0
-    vtable: {impl Link<T> for U}::{vtable}<T, U>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (U: MetaSized) = TraitClause1::ImpliedClause0
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    vtable: {impl Link<T> for U}::{vtable}<T, U>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::Trait
 pub trait Trait<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    type Type<U, [@TraitClause0_1]: Sized<U>>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    type Type<U>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::Type>
-        implied_clause_1 : [@TraitClause1_1]: Link<Self::Type, T>
-
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: (Self::Type: Sized),
+        proof ImpliedClause1: (Self::Type: Link<T>);
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo
 pub struct Foo {}
 
-// Full name: test_crate::{impl Trait<Option<T>[@TraitClause0]> for Foo}
-impl<T> Trait<Option<T>[@TraitClause0]> for Foo
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for Foo}
+impl<T> Trait<Option<T>[TraitClause0]> for Foo
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Foo}
-    parent_clause1 = {built_in impl Sized for Option<T>[@TraitClause0]}
-    type Type<U, [@TraitClause0_1]: Sized<U>> = (T, U)
+    proof ImpliedClause0: (Foo: MetaSized) = {built_in impl MetaSized for Foo}
+    proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
+    type Type<U> = (T, U)
+    where
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: ((T, U): Sized) = {built_in impl Sized for (T, U)},
+        proof ImpliedClause1: ((T, U): Link<Option<T>[TraitClause0]>) = {impl Link<T> for U}<Option<T>[TraitClause0], (T, U)>[{built_in impl Sized for Option<T>[TraitClause0]}, {built_in impl Sized for (T, U)}];
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/gat-complex-lifetimes.out
+++ b/charon/tests/ui/simple/gat-complex-lifetimes.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,8 +27,8 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Foo
 pub trait Foo<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn foo = foo<Self, T>[Self]
     vtable: test_crate::Foo::{vtable}<T>
 }
@@ -36,40 +36,39 @@ pub trait Foo<Self, T>
 // Full name: test_crate::Foo::foo
 pub fn foo<Self, T>(_1: Self) -> T
 where
-    [@TraitClause0]: Foo<Self, T>,
+    TraitClause0: (Self: Foo<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::Bar
 pub trait Bar<'a, Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     type Type<'b>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::Type>
-        implied_clause_1 : [@TraitClause1_1]: for<'c> Foo<Self::Type, &'a &'b &'c ()>
-
+        proof ImpliedClause0: (Self::Type: Sized),
+        proof ImpliedClause1: for<'c> (Self::Type: Foo<&'a &'b &'c ()>);
     non-dyn-compatible
 }
 
 // Full name: test_crate::bar
-pub fn bar<'x, 'y, 'z, T>(x_1: @TraitClause1::Type) -> &'x &'y &'z ()
+pub fn bar<'x, 'y, 'z, T>(x_1: TraitClause1::Type) -> &'x &'y &'z ()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Bar<'x, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Bar<'x>),
 {
     let _0: &'6 &'7 &'8 (); // return
-    let x_1: @TraitClause1::Type; // arg #1
+    let x_1: TraitClause1::Type; // arg #1
     let _2: &'11 &'12 &'13 (); // anonymous local
-    let _3: @TraitClause1::Type; // anonymous local
+    let _3: TraitClause1::Type; // anonymous local
 
     storage_live(_2)
     storage_live(_3)
     _3 = move x_1
-    _2 = (@TraitClause1::Type::[@TraitClause1])::foo(move _3)
+    _2 = TraitClause1::Type::ImpliedClause1::foo(move _3)
     _0 = &(*_2)
     storage_dead(_3)
     storage_dead(_2)
-    conditional_drop[{built_in impl Destruct for @TraitClause1::Type}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::Type}::drop_in_place] x_1
     return
 }
 

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -20,24 +20,27 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: test_crate::Collection
 trait Collection<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type Sibling<U, [@TraitClause0_1]: Sized<U>>
+    proof ImpliedClause0: (Self: MetaSized)
+    type Sibling<U> = Vec<U>[TraitClause0_1, {built_in impl Sized for Global}]
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::Sibling>
-
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: (Self::Sibling: Sized);
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Collection for ()}
 impl Collection for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    type Sibling<U, [@TraitClause0_1]: Sized<U>> = Vec<U>[@TraitClause0_1, {built_in impl Sized for Global}]
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    type Sibling<U> = Vec<U>[TraitClause0_1, {built_in impl Sized for Global}]
+    where
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: ({impl Collection for ()}::Sibling: Sized) = {impl Collection for ()}::Sibling::ImpliedClause0;
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/gat-implied-clause.out
+++ b/charon/tests/ui/simple/gat-implied-clause.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -43,65 +43,64 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     type LifetimeGat<'a>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::LifetimeGat>
-        implied_clause_1 : [@TraitClause1_1]: Clone<Self::LifetimeGat>
-
-    type NonLifetimeGat<T, [@TraitClause0_1]: Sized<T>>
+        proof ImpliedClause0: (Self::LifetimeGat: Sized),
+        proof ImpliedClause1: (Self::LifetimeGat: Clone);
+    type NonLifetimeGat<T>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::NonLifetimeGat>
-        implied_clause_1 : [@TraitClause1_1]: Clone<Self::NonLifetimeGat>
-
+        TraitClause0_1: (T: Sized),
+        proof ImpliedClause0: (Self::NonLifetimeGat: Sized),
+        proof ImpliedClause1: (Self::NonLifetimeGat: Clone);
     non-dyn-compatible
 }
 
 // Full name: test_crate::lifetime_gat_bound
-fn lifetime_gat_bound<'_0, X>(x_1: @TraitClause1::LifetimeGat)
+fn lifetime_gat_bound<'_0, X>(x_1: TraitClause1::LifetimeGat)
 where
-    [@TraitClause0]: Sized<X>,
-    [@TraitClause1]: Trait<X>,
+    TraitClause0: (X: Sized),
+    TraitClause1: (X: Trait),
 {
     let _0: (); // return
-    let x_1: @TraitClause1::LifetimeGat; // arg #1
-    let _2: @TraitClause1::LifetimeGat; // anonymous local
-    let _3: &'1 @TraitClause1::LifetimeGat; // anonymous local
+    let x_1: TraitClause1::LifetimeGat; // arg #1
+    let _2: TraitClause1::LifetimeGat; // anonymous local
+    let _3: &'1 TraitClause1::LifetimeGat; // anonymous local
 
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = (@TraitClause1::LifetimeGat::[@TraitClause1])::clone<'3>(move _3)
+    _2 = TraitClause1::LifetimeGat::ImpliedClause1::clone<'3>(move _3)
     storage_dead(_3)
-    conditional_drop[{built_in impl Destruct for @TraitClause1::LifetimeGat}::drop_in_place] _2
+    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat}::drop_in_place] _2
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for @TraitClause1::LifetimeGat}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat}::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::non_lifetime_gat_bound
-fn non_lifetime_gat_bound<X>(x_1: @TraitClause1::NonLifetimeGat)
+fn non_lifetime_gat_bound<X>(x_1: TraitClause1::NonLifetimeGat)
 where
-    [@TraitClause0]: Sized<X>,
-    [@TraitClause1]: Trait<X>,
+    TraitClause0: (X: Sized),
+    TraitClause1: (X: Trait),
 {
     let _0: (); // return
-    let x_1: @TraitClause1::NonLifetimeGat; // arg #1
-    let _2: @TraitClause1::NonLifetimeGat; // anonymous local
-    let _3: &'1 @TraitClause1::NonLifetimeGat; // anonymous local
+    let x_1: TraitClause1::NonLifetimeGat; // arg #1
+    let _2: TraitClause1::NonLifetimeGat; // anonymous local
+    let _3: &'1 TraitClause1::NonLifetimeGat; // anonymous local
 
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = (@TraitClause1::NonLifetimeGat::[@TraitClause1])::clone<'3>(move _3)
+    _2 = TraitClause1::NonLifetimeGat::ImpliedClause1::clone<'3>(move _3)
     storage_dead(_3)
-    conditional_drop[{built_in impl Destruct for @TraitClause1::NonLifetimeGat}::drop_in_place] _2
+    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat}::drop_in_place] _2
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for @TraitClause1::NonLifetimeGat}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat}::drop_in_place] x_1
     return
 }
 

--- a/charon/tests/ui/simple/generic-cast-to-dyn.out
+++ b/charon/tests/ui/simple/generic-cast-to-dyn.out
@@ -14,9 +14,9 @@ pub opaque type TypeId
 #[lang_item("Any")]
 pub trait Any<Self>
 where
-    Self : 'static,
+    TypeOutlives0: Self: 'static,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn type_id<'_0_1> = type_id<'_0_1, Self>[Self]
     vtable: core::any::Any::{vtable}
 }
@@ -24,22 +24,22 @@ where
 // Full name: core::any::Any::type_id
 pub fn type_id<'_0, Self>(_1: &'_0 Self) -> TypeId
 where
-    [@TraitClause0]: Any<Self>,
+    TraitClause0: (Self: Any),
 = <opaque>
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo
 fn foo<'_0, T>(x_1: &'_0 T) -> &'_0 (dyn Any + 'static)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Any<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Any),
 {
     let _0: &'3 (dyn Any + '4); // return
     let x_1: &'6 T; // arg #1
@@ -51,7 +51,7 @@ where
     storage_live(_3)
     storage_live(_4)
     _4 = &(*x_1)
-    _3 = unsize_cast<&'11 T, &'12 (dyn Any + '13), &vtable_of(@TraitClause1)>(move _4)
+    _3 = unsize_cast<&'11 T, &'12 (dyn Any + '13), &vtable_of(TraitClause1)>(move _4)
     storage_dead(_4)
     _2 = &(*_3) with_metadata(copy _3.metadata)
     _0 = unsize_cast<&'7 (dyn Any + '8), &'15 (dyn Any + '16),  at []>(move _2)

--- a/charon/tests/ui/simple/generic-discriminant.out
+++ b/charon/tests/ui/simple/generic-discriminant.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -40,14 +40,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -58,8 +58,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -76,13 +76,13 @@ pub trait Debug<Self>
 // Full name: core::fmt::Debug::fmt
 pub fn fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -92,28 +92,28 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: core::hash::Hash::hash
 pub fn hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::marker::Send
@@ -124,8 +124,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -141,17 +141,17 @@ pub trait Unpin<Self>
 #[lang_item("discriminant_kind")]
 pub trait DiscriminantKind<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Discriminant>
-    parent_clause2 : [@TraitClause2]: Clone<Self::Discriminant>
-    parent_clause3 : [@TraitClause3]: Copy<Self::Discriminant>
-    parent_clause4 : [@TraitClause4]: Debug<Self::Discriminant>
-    parent_clause5 : [@TraitClause5]: Eq<Self::Discriminant>
-    parent_clause6 : [@TraitClause6]: PartialEq<Self::Discriminant, Self::Discriminant>
-    parent_clause7 : [@TraitClause7]: Hash<Self::Discriminant>
-    parent_clause8 : [@TraitClause8]: Send<Self::Discriminant>
-    parent_clause9 : [@TraitClause9]: Sync<Self::Discriminant>
-    parent_clause10 : [@TraitClause10]: Unpin<Self::Discriminant>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Discriminant: Sized)
+    proof ImpliedClause2: (Self::Discriminant: Clone)
+    proof ImpliedClause3: (Self::Discriminant: Copy)
+    proof ImpliedClause4: (Self::Discriminant: Debug)
+    proof ImpliedClause5: (Self::Discriminant: Eq)
+    proof ImpliedClause6: (Self::Discriminant: PartialEq<Self::Discriminant>)
+    proof ImpliedClause7: (Self::Discriminant: Hash)
+    proof ImpliedClause8: (Self::Discriminant: Send)
+    proof ImpliedClause9: (Self::Discriminant: Sync)
+    proof ImpliedClause10: (Self::Discriminant: Unpin)
     type Discriminant
     non-dyn-compatible
 }
@@ -159,15 +159,15 @@ pub trait DiscriminantKind<Self>
 // Full name: core::mem::Discriminant
 pub opaque type Discriminant<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 
 // Full name: core::mem::discriminant
 #[lang_item("mem_discriminant")]
-pub fn discriminant<'_0, T>(v_1: &'_0 T) -> Discriminant<T>[@TraitClause0]
+pub fn discriminant<'_0, T>(v_1: &'_0 T) -> Discriminant<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Discriminant<T>[@TraitClause0]; // return
+    let _0: Discriminant<T>[TraitClause0]; // return
     let v_1: &'1 T; // arg #1
     let _2: {built_in impl DiscriminantKind for T}::Discriminant; // anonymous local
 
@@ -179,17 +179,17 @@ where
 }
 
 // Full name: test_crate::f
-pub fn f<'_0, T>(x_1: &'_0 T) -> Discriminant<T>[@TraitClause0]
+pub fn f<'_0, T>(x_1: &'_0 T) -> Discriminant<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Discriminant<T>[@TraitClause0]; // return
+    let _0: Discriminant<T>[TraitClause0]; // return
     let x_1: &'1 T; // arg #1
     let _2: &'2 T; // anonymous local
 
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = discriminant<'4, T>[@TraitClause0](move _2)
+    _0 = discriminant<'4, T>[TraitClause0](move _2)
     storage_dead(_2)
     return
 }

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -25,14 +25,14 @@ where
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn foo<'_0_1> = test_crate::BoolTrait::foo<'_0_1, Self>[Self]
     vtable: test_crate::BoolTrait::{vtable}
 }
 
 pub fn test_crate::BoolTrait::foo<'_0, Self>(self_1: &'_0 Self)
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -42,27 +42,27 @@ where
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::foo
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::foo<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0])
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}::foo
+pub fn {impl BoolTrait for Option<T>[TraitClause0]}::foo<'_0, T>(self_1: &'_0 Option<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
 
     _0 = ()
     _0 = ()
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}
-impl<T> BoolTrait for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}
+impl<T> BoolTrait for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    fn foo<'_0_1> = {impl BoolTrait for Option<T>[@TraitClause0]}::foo<'_0_1, T>[@TraitClause0]
-    vtable: {impl BoolTrait for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    fn foo<'_0_1> = {impl BoolTrait for Option<T>[TraitClause0]}::foo<'_0_1, T>[TraitClause0]
+    vtable: {impl BoolTrait for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/simple/generic-impl-with-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-method.out
@@ -8,27 +8,27 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn method<'_0_1> = test_crate::Trait::method<'_0_1, Self>[Self]
     vtable: test_crate::Trait::{vtable}
 }
 
 pub fn test_crate::Trait::method<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Trait for T}::method
 pub fn {impl Trait for T}::method<'_0, T>(self_1: &'_0 T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let self_1: &'1 T; // arg #1
@@ -41,11 +41,11 @@ where
 // Full name: test_crate::{impl Trait for T}
 impl<T> Trait for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    fn method<'_0_1> = {impl Trait for T}::method<'_0_1, T>[@TraitClause0]
-    vtable: {impl Trait for T}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    fn method<'_0_1> = {impl Trait for T}::method<'_0_1, T>[TraitClause0]
+    vtable: {impl Trait for T}::{vtable}<T>[TraitClause0]
 }
 
 

--- a/charon/tests/ui/simple/generic-offset-of.out
+++ b/charon/tests/ui/simple/generic-offset-of.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::B
 struct B<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   y: u32,
   t: T,
@@ -24,15 +24,15 @@ where
 // Full name: test_crate::A
 struct A<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  x: B<T>[@TraitClause0],
+  x: B<T>[TraitClause0],
 }
 
 // Full name: test_crate::foo
 fn foo<T>()
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: usize; // anonymous local
@@ -46,9 +46,9 @@ where
     storage_live(_3)
     storage_live(_6)
     storage_live(_4)
-    _4 = offset_of(A<T>[@TraitClause0].x)<usize>
+    _4 = offset_of(A<T>[TraitClause0].x)<usize>
     storage_live(_5)
-    _5 = offset_of(B<T>[@TraitClause0].y)<usize>
+    _5 = offset_of(B<T>[TraitClause0].y)<usize>
     _6 = copy _4 panic.+ copy _5
     _3 = move _6
     storage_dead(_5)

--- a/charon/tests/ui/simple/impl-trait-in-arg.out
+++ b/charon/tests/ui/simple/impl-trait-in-arg.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,15 +27,15 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
 // Full name: test_crate::foo
 fn foo<T0>(_1: T0)
 where
-    [@TraitClause0]: Sized<T0>,
-    [@TraitClause1]: Trait<T0>,
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: Trait),
 {
     let _0: (); // return
     let _1: T0; // arg #1

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -42,28 +42,28 @@ impl Clone for u8 {
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 pub fn core::intrinsics::wrapping_add<T>(a_1: T, b_2: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <intrinsic:wrapping_add>
 
 // Full name: core::marker::{impl Copy for u8}
 impl Copy for u8 {
-    parent_clause0 = {built_in impl MetaSized for u8}
-    parent_clause1 = {impl Clone for u8}
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
+    proof ImpliedClause1: (u8: Clone) = {impl Clone for u8}
     non-dyn-compatible
 }
 
 pub fn test_crate::first::nested::wrapping_add<T>(lhs_1: T, rhs_2: T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 = <intrinsic:wrapping_add>
 
 pub fn test_crate::first::nested::call() -> u8

--- a/charon/tests/ui/simple/issue-1040-closure-upvar-lifetime.out
+++ b/charon/tests/ui/simple/issue-1040-closure-upvar-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::foo::closure
@@ -153,10 +153,10 @@ fn {impl FnOnce<()> for closure<'_0>}::call_once<'_0, '_1>(_1: closure<'_0>, _2:
 
 // Full name: test_crate::foo::{impl FnOnce<()> for closure<'_0>}
 impl<'_0, '_1> FnOnce<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for &'_ u8}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (&'_ u8: Sized) = {built_in impl Sized for &'_ u8}
     type Output = &'_ u8
     fn call_once = {impl FnOnce<()> for closure<'_0>}::call_once<'_0, '_1>
     non-dyn-compatible
@@ -164,20 +164,20 @@ impl<'_0, '_1> FnOnce<()> for closure<'_0> {
 
 // Full name: test_crate::foo::{impl FnMut<()> for closure<'_0>}
 impl<'_0, '_1> FnMut<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<()> for closure<'_0>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<()>) = {impl FnOnce<()> for closure<'_0>}<'_0, '_1>
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure<'_0>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo::{impl Fn<()> for closure<'_0>}
 impl<'_0, '_1> Fn<()> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnMut<()> for closure<'_0>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnMut<()>) = {impl FnMut<()> for closure<'_0>}<'_0, '_1>
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call<'_0_1> = {impl Fn<()> for closure<'_0>}::call<'_0, '_1, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/issue-988-closure-outlives.out
+++ b/charon/tests/ui/simple/issue-988-closure-outlives.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::call_fn_shared::closure
@@ -178,10 +178,10 @@ fn {impl FnOnce<(usize,)> for closure<'_0>}::call_once<'_0>(_1: closure<'_0>, _2
 
 // Full name: test_crate::call_fn_shared::{impl FnOnce<(usize,)> for closure<'_0>}
 impl<'_0> FnOnce<(usize,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for (usize,)}
-    parent_clause2 = {built_in impl Tuple for (usize,)}
-    parent_clause3 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause2: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause3: (u8: Sized) = {built_in impl Sized for u8}
     type Output = u8
     fn call_once = {impl FnOnce<(usize,)> for closure<'_0>}::call_once<'_0>
     non-dyn-compatible
@@ -189,20 +189,20 @@ impl<'_0> FnOnce<(usize,)> for closure<'_0> {
 
 // Full name: test_crate::call_fn_shared::{impl FnMut<(usize,)> for closure<'_0>}
 impl<'_0> FnMut<(usize,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<(usize,)> for closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (usize,)}
-    parent_clause3 = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<(usize,)>) = {impl FnOnce<(usize,)> for closure<'_0>}<'_0>
+    proof ImpliedClause2: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause3: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
     fn call_mut<'_0_1> = {impl FnMut<(usize,)> for closure<'_0>}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::call_fn_shared::{impl Fn<(usize,)> for closure<'_0>}
 impl<'_0> Fn<(usize,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnMut<(usize,)> for closure<'_0>}<'_0>
-    parent_clause2 = {built_in impl Sized for (usize,)}
-    parent_clause3 = {built_in impl Tuple for (usize,)}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnMut<(usize,)>) = {impl FnMut<(usize,)> for closure<'_0>}<'_0>
+    proof ImpliedClause2: ((usize,): Sized) = {built_in impl Sized for (usize,)}
+    proof ImpliedClause3: ((usize,): Tuple) = {built_in impl Tuple for (usize,)}
     fn call<'_0_1> = {impl Fn<(usize,)> for closure<'_0>}::call<'_0, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,7 +31,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -39,10 +39,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -52,38 +52,38 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::Option::{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[@TraitClause0])
+// Full name: core::option::Option::{impl Destruct for Option<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::panicking::AssertKind
@@ -96,11 +96,11 @@ pub enum AssertKind {
 // Full name: test_crate::LendingIterator
 pub trait LendingIterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type Item<'a, Self : 'a>
+    proof ImpliedClause0: (Self: MetaSized)
+    type Item<'a>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::Item>
-
+        TypeOutlives0: Self: 'a,
+        proof ImpliedClause0: (Self::Item: Sized);
     fn next<'a> = test_crate::LendingIterator::next<'a, Self>[Self]
     non-dyn-compatible
 }
@@ -125,15 +125,15 @@ impl<A> Destruct for (A,) {
     non-dyn-compatible
 }
 
-pub fn test_crate::LendingIterator::next<'a, Self>(_1: &'a mut Self) -> Option<@TraitClause0::Item>[(@TraitClause0::Item::[@TraitClause0])]
+pub fn test_crate::LendingIterator::next<'a, Self>(_1: &'a mut Self) -> Option<TraitClause0::Item>[TraitClause0::Item::ImpliedClause0]
 where
-    [@TraitClause0]: LendingIterator<Self>,
+    TraitClause0: (Self: LendingIterator),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]}::next
 pub fn {impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]}::next<'a, 'b, T>(self_1: &'b mut Option<&'a T>[{built_in impl Sized for &'a T}]) -> Option<&'b T>[{built_in impl Sized for &'b T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
     let self_1: &'13 mut Option<&'14 T>[{built_in impl Sized for &'14 T}]; // arg #1
@@ -170,33 +170,36 @@ where
 // Full name: test_crate::{impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]}
 impl<'a, T> LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<&'_ T>[{built_in impl Sized for &'_ T}]}
-    type Item<'b, Option<&'a T>[{built_in impl Sized for &'a T}] : 'b> = &'b T
-    fn next<'b> = {impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]}::next<'a, 'b, T>[@TraitClause0]
+    proof ImpliedClause0: (Option<&'_ T>[{built_in impl Sized for &'_ T}]: MetaSized) = {built_in impl MetaSized for Option<&'_ T>[{built_in impl Sized for &'_ T}]}
+    type Item<'b> = &'b T
+    where
+        TypeOutlives0: Option<&'a T>[{built_in impl Sized for &'a T}]: 'b,
+        proof ImpliedClause0: (&'_ T: Sized) = {built_in impl Sized for &'_ T};
+    fn next<'b> = {impl LendingIterator for Option<&'a T>[{built_in impl Sized for &'a T}]}::next<'a, 'b, T>[TraitClause0]
     non-dyn-compatible
 }
 
 // Full name: test_crate::for_each
 pub fn for_each<I, T1>(iter_1: I, f_2: T1)
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: Sized<T1>,
-    [@TraitClause2]: LendingIterator<I>,
-    [@TraitClause3]: for<'a> FnMut<T1, (@TraitClause2::Item,)>,
-    for<'a> @TraitClause3::parent_clause1::Output = (),
+    TraitClause0: (I: Sized),
+    TraitClause1: (T1: Sized),
+    TraitClause2: (I: LendingIterator),
+    TraitClause3: for<'a> (T1: FnMut<(TraitClause2::Item,)>),
+    TypeConstraint0: for<'a> TraitClause3::ImpliedClause1::Output = (),
 {
     let _0: (); // return
     let iter_1: I; // arg #1
     let f_2: T1; // arg #2
     let _3: (); // anonymous local
-    let _4: Option<@TraitClause2::Item>[(@TraitClause2::Item::[@TraitClause0])]; // anonymous local
+    let _4: Option<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]; // anonymous local
     let _5: &'1 mut I; // anonymous local
-    let item_6: @TraitClause2::Item; // local
+    let item_6: TraitClause2::Item; // local
     let _7: &'3 mut T1; // anonymous local
-    let _8: (@TraitClause2::Item,); // anonymous local
-    let _9: @TraitClause2::Item; // anonymous local
+    let _8: (TraitClause2::Item,); // anonymous local
+    let _9: TraitClause2::Item; // anonymous local
 
     storage_live(_3)
     _0 = ()
@@ -204,7 +207,7 @@ where
         storage_live(_4)
         storage_live(_5)
         _5 = &two-phase-mut iter_1
-        _4 = @TraitClause2::next<'5>(move _5)
+        _4 = TraitClause2::next<'5>(move _5)
         storage_dead(_5)
         match _4 {
             Option::Some => {
@@ -221,19 +224,19 @@ where
         storage_live(_9)
         _9 = move item_6
         _8 = (move _9,)
-        _3 = @TraitClause3::call_mut<'7>(move _7, move _8)
-        conditional_drop[{built_in impl Destruct for @TraitClause2::Item}::drop_in_place] _9
+        _3 = TraitClause3::call_mut<'7>(move _7, move _8)
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item}::drop_in_place] _9
         storage_dead(_9)
         storage_dead(_8)
         storage_dead(_7)
-        conditional_drop[{built_in impl Destruct for @TraitClause2::Item}::drop_in_place] item_6
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item}::drop_in_place] item_6
         storage_dead(item_6)
-        conditional_drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<@TraitClause2::Item>[(@TraitClause2::Item::[@TraitClause0])]] _4
+        conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]] _4
         storage_dead(_4)
         continue 0
     }
     _0 = ()
-    conditional_drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<@TraitClause2::Item>[(@TraitClause2::Item::[@TraitClause0])]] _4
+    conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]] _4
     storage_dead(_4)
     conditional_drop[{built_in impl Destruct for T1}::drop_in_place] f_2
     conditional_drop[{built_in impl Destruct for I}::drop_in_place] iter_1
@@ -290,10 +293,10 @@ fn {impl FnOnce<(&'_ i32,)> for closure<'_0>}::call_once<'_0, '_1>(_1: closure<'
 
 // Full name: test_crate::main::{impl FnOnce<(&'_ i32,)> for closure<'_0>}
 impl<'_0, '_1> FnOnce<(&'_ i32,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {built_in impl Sized for (&'_ i32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ i32,)}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((&'_ i32,): Sized) = {built_in impl Sized for (&'_ i32,)}
+    proof ImpliedClause2: ((&'_ i32,): Tuple) = {built_in impl Tuple for (&'_ i32,)}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<(&'_ i32,)> for closure<'_0>}::call_once<'_0, '_1>
     non-dyn-compatible
@@ -301,10 +304,10 @@ impl<'_0, '_1> FnOnce<(&'_ i32,)> for closure<'_0> {
 
 // Full name: test_crate::main::{impl FnMut<(&'_ i32,)> for closure<'_0>}
 impl<'_0, '_1> FnMut<(&'_ i32,)> for closure<'_0> {
-    parent_clause0 = {built_in impl MetaSized for closure<'_0>}
-    parent_clause1 = {impl FnOnce<(&'_ i32,)> for closure<'_0>}<'_0, '_1>
-    parent_clause2 = {built_in impl Sized for (&'_ i32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ i32,)}
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<(&'_ i32,)>) = {impl FnOnce<(&'_ i32,)> for closure<'_0>}<'_0, '_1>
+    proof ImpliedClause2: ((&'_ i32,): Sized) = {built_in impl Sized for (&'_ i32,)}
+    proof ImpliedClause3: ((&'_ i32,): Tuple) = {built_in impl Tuple for (&'_ i32,)}
     fn call_mut<'_0_1> = {impl FnMut<(&'_ i32,)> for closure<'_0>}::call_mut<'_0, '_1, '_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
+++ b/charon/tests/ui/simple/lifetime-unification-from-trait-impl.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,21 +28,21 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("const_ptr_cast")]
 pub fn cast<T, U>(_1: *const T) -> *const U
 where
-    [@TraitClause0]: Sized<U>,
+    TraitClause0: (U: Sized),
 = <opaque>
 
 // Full name: test_crate::Convert
 trait Convert<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
     fn method = test_crate::Convert::method<Self, T>[Self]
     non-dyn-compatible
 }
 
 fn test_crate::Convert::method<Self, T>(_1: Self) -> T
 where
-    [@TraitClause0]: Convert<Self, T>,
+    TraitClause0: (Self: Convert<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method
@@ -69,8 +69,8 @@ fn {impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method<'a>(self_1: &'a u32) 
 
 // Full name: test_crate::{impl Convert<&'a [u8; 4 : usize]> for &'a u32}
 impl<'a> Convert<&'a [u8; 4 : usize]> for &'a u32 {
-    parent_clause0 = {built_in impl Sized for &'_ u32}
-    parent_clause1 = {built_in impl Sized for &'_ [u8; 4 : usize]}
+    proof ImpliedClause0: (&'_ u32: Sized) = {built_in impl Sized for &'_ u32}
+    proof ImpliedClause1: (&'_ [u8; 4 : usize]: Sized) = {built_in impl Sized for &'_ [u8; 4 : usize]}
     fn method = {impl Convert<&'a [u8; 4 : usize]> for &'a u32}::method<'a>
     non-dyn-compatible
 }
@@ -78,9 +78,9 @@ impl<'a> Convert<&'a [u8; 4 : usize]> for &'a u32 {
 // Full name: test_crate::convert
 fn convert<T, U>(x_1: T) -> U
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Convert<T, U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Convert<U>),
 {
     let _0: U; // return
     let x_1: T; // arg #1
@@ -88,7 +88,7 @@ where
 
     storage_live(_2)
     _2 = move x_1
-    _0 = @TraitClause2::method(move _2)
+    _0 = TraitClause2::method(move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return

--- a/charon/tests/ui/simple/manual-drop-impl.out
+++ b/charon/tests/ui/simple/manual-drop-impl.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,14 +27,14 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("drop")]
 pub trait Drop<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn drop<'_0_1> = core::ops::drop::Drop::drop<'_0_1, Self>[Self]
     vtable: core::ops::drop::Drop::{vtable}
 }
 
 pub fn core::ops::drop::Drop::drop<'_0, Self>(_1: &'_0 mut Self)
 where
-    [@TraitClause0]: Drop<Self>,
+    TraitClause0: (Self: Drop),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -45,53 +45,53 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: test_crate::Foo
 struct Foo<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-  vec: Vec<T>[@TraitClause0, {built_in impl Sized for Global}],
+  vec: Vec<T>[TraitClause0, {built_in impl Sized for Global}],
 }
 
-// Full name: test_crate::Foo::{impl Destruct for Foo<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Foo<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Foo<T>[@TraitClause0])
+// Full name: test_crate::Foo::{impl Destruct for Foo<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Foo<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Foo<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::Foo::{impl Destruct for Foo<T>[@TraitClause0]}
-impl<T> Destruct for Foo<T>[@TraitClause0]
+// Full name: test_crate::Foo::{impl Destruct for Foo<T>[TraitClause0]}
+impl<T> Destruct for Foo<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for Foo<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for Foo<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Drop for Foo<T>[@TraitClause0]}::drop
-pub fn {impl Drop for Foo<T>[@TraitClause0]}::drop<'_0, T>(self_1: &'_0 mut Foo<T>[@TraitClause0])
+// Full name: test_crate::{impl Drop for Foo<T>[TraitClause0]}::drop
+pub fn {impl Drop for Foo<T>[TraitClause0]}::drop<'_0, T>(self_1: &'_0 mut Foo<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
-    let self_1: &'1 mut Foo<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 mut Foo<T>[TraitClause0]; // arg #1
 
     _0 = ()
     _0 = ()
     return
 }
 
-// Full name: test_crate::{impl Drop for Foo<T>[@TraitClause0]}
-impl<T> Drop for Foo<T>[@TraitClause0]
+// Full name: test_crate::{impl Drop for Foo<T>[TraitClause0]}
+impl<T> Drop for Foo<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Foo<T>[@TraitClause0]}
-    fn drop<'_0_1> = {impl Drop for Foo<T>[@TraitClause0]}::drop<'_0_1, T>[@TraitClause0]
-    vtable: {impl Drop for Foo<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Foo<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Foo<T>[TraitClause0]}
+    fn drop<'_0_1> = {impl Drop for Foo<T>[TraitClause0]}::drop<'_0_1, T>[TraitClause0]
+    vtable: {impl Drop for Foo<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::drop_foo
@@ -102,7 +102,7 @@ fn drop_foo(_1: Foo<u32>[{built_in impl Sized for u32}])
 
     _0 = ()
     _0 = ()
-    conditional_drop[{impl Destruct for Foo<T>[@TraitClause0]}::drop_in_place<u32>[{built_in impl Sized for u32}]] _1
+    conditional_drop[{impl Destruct for Foo<T>[TraitClause0]}::drop_in_place<u32>[{built_in impl Sized for u32}]] _1
     return
 }
 

--- a/charon/tests/ui/simple/min.out
+++ b/charon/tests/ui/simple/min.out
@@ -16,7 +16,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -24,8 +24,8 @@ pub trait Sized<Self>
 #[lang_item("cmp_ord_min")]
 pub fn {impl Ord for u64}::min(_1: u64, _2: u64) -> u64
 where
-    [@TraitClause0]: Sized<u64>,
-    [@TraitClause1]: Destruct<u64>,
+    TraitClause0: (u64: Sized),
+    TraitClause1: (u64: Destruct),
 = <opaque>
 
 // Full name: core::marker::Destruct::drop_in_place

--- a/charon/tests/ui/simple/nested-closure-lifetime.out
+++ b/charon/tests/ui/simple/nested-closure-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -43,7 +43,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -51,10 +51,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -64,65 +64,65 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 struct test_crate::foo::closure::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   &'_0 T,
 }
 
 struct test_crate::foo::closure<'_0, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   &'_0 T,
 }
 
-// Full name: test_crate::foo::{impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, '_3, T>(_1: &'_3 test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '_2, '_3, T>(_1: &'_3 test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<'1, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: &'3 test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::foo::closure::closure<'1, T>[TraitClause0, TraitClause1]; // return
+    let _1: &'3 test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
 
     _0 = test_crate::foo::closure::closure { 0: copy ((*_1)).0 }
@@ -130,15 +130,15 @@ where
 }
 
 // Full name: test_crate::foo
-fn foo<'a, T>(x_1: &'a T) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+fn foo<'a, T>(x_1: &'a T) -> test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<'1, T>[@TraitClause0, @TraitClause1]; // return
+    let _0: test_crate::foo::closure::closure<'1, T>[TraitClause0, TraitClause1]; // return
     let x_1: &'3 T; // arg #1
-    let f_2: test_crate::foo::closure<'5, T>[@TraitClause0, @TraitClause1]; // local
-    let _3: &'8 test_crate::foo::closure<'9, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let f_2: test_crate::foo::closure<'5, T>[TraitClause0, TraitClause1]; // local
+    let _3: &'8 test_crate::foo::closure<'9, T>[TraitClause0, TraitClause1]; // anonymous local
     let _4: (); // anonymous local
 
     storage_live(f_2)
@@ -147,214 +147,214 @@ where
     _3 = &f_2
     storage_live(_4)
     _4 = ()
-    _0 = {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'14, '15, '16, '17, T>[@TraitClause0, @TraitClause1](move _3, move _4)
+    _0 = {impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'14, '15, '16, '17, T>[TraitClause0, TraitClause1](move _3, move _4)
     storage_dead(_4)
     storage_dead(_3)
     storage_dead(f_2)
     return
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>(_1: *mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>(_1: *mut test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::foo::{impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], args_2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1], args_2: ()) -> test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<'0, T>[@TraitClause0, @TraitClause1]; // return
-    let state_1: &'_3 mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::foo::closure::closure<'0, T>[TraitClause0, TraitClause1]; // return
+    let state_1: &'_3 mut test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (); // arg #2
-    let _3: &'1 test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, '3, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '_2, '3, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once<'_0, '_1, '_2, T>(_1: test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once<'_0, '_1, '_2, T>(_1: test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1], _2: ()) -> test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<'1, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::foo::closure::closure<'1, T>[TraitClause0, TraitClause1]; // return
+    let _1: test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (); // arg #2
-    let _3: &'3 mut test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'3 mut test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, '9, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '_2, '9, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, '_2, T> FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, '_2, T> FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]}
-    type Output = test_crate::foo::closure::closure<'_, T>[@TraitClause0, @TraitClause1]
-    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once<'_0, '_1, '_2, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]: Sized) = {built_in impl Sized for test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]}
+    type Output = test_crate::foo::closure::closure<'_, T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once<'_0, '_1, '_2, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, '_2, T> FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, '_2, T> FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}<'_0, '_1, '_2, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]: FnOnce<()>) = {impl FnOnce<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}<'_0, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::{impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, '_2, T> Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, '_2, T> Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}<'_0, '_1, '_2, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]: FnMut<()>) = {impl FnMut<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}<'_0, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, T> Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, T> Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::foo::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::foo::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>(_1: *mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>(_1: *mut test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_2, T>(_1: &'_2 test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> &'_1 T
+// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '_2, T>(_1: &'_2 test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1], tupled_args_2: ()) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: &'0 T; // return
-    let _1: &'2 test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'2 test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
 
     _0 = copy ((*_1)).0
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_2, T>(state_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], args_2: ()) -> &'_1 T
+// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '_2, T>(state_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1], args_2: ()) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: &'_1 T; // return
-    let state_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_2 mut test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (); // arg #2
-    let _3: &'0 test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once<'_0, '_1, T>(_1: test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1], _2: ()) -> &'_1 T
+// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once<'_0, '_1, T>(_1: test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1], _2: ()) -> &'_1 T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: &'0 T; // return
-    let _1: test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (); // arg #2
-    let _3: &'2 mut test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'2 mut test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '7, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '7, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, T> FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, T> FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for &'_ T}
+    proof ImpliedClause0: (test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
     type Output = &'_ T
-    fn call_once = {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_once<'_0, '_1, T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_once<'_0, '_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, T> FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, T> FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}<'_0, '_1, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, '_1, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]: FnOnce<()>) = {impl FnOnce<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}<'_0, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call_mut<'_0, '_1, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, '_1, T> Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, '_1, T> Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}<'_0, '_1, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::call<'_0, '_1, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]: FnMut<()>) = {impl FnMut<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}<'_0, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::call<'_0, '_1, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}
-impl<'_0, T> Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}
+impl<'_0, T> Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::foo::closure::closure<'_0, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'_0, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::foo::closure::closure<'_0, T>[TraitClause0, TraitClause1]}::drop_in_place<'_0, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/nested-closure-trait-ref.out
+++ b/charon/tests/ui/simple/nested-closure-trait-ref.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -43,7 +43,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -51,10 +51,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -64,89 +64,89 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 struct test_crate::foo::closure::closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   T,
 }
 
 struct test_crate::foo::closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   T,
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once<T>(_1: test_crate::foo::closure<T>[TraitClause0, TraitClause1], tupled_args_2: ()) -> test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // return
-    let _1: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // return
+    let _1: test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
 
     _0 = test_crate::foo::closure::closure { 0: move (_1).0 }
-    conditional_drop[{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]] _1
+    conditional_drop[{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]] _1
     return
 }
 
 // Full name: test_crate::foo
-fn foo<T>(x_1: T) -> test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+fn foo<T>(x_1: T) -> test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // return
+    let _0: test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // return
     let x_1: T; // arg #1
-    let f_2: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // local
-    let _3: test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let f_2: test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // local
+    let _3: test_crate::foo::closure<T>[TraitClause0, TraitClause1]; // anonymous local
     let _4: (); // anonymous local
 
     storage_live(f_2)
@@ -155,150 +155,150 @@ where
     _3 = move f_2
     storage_live(_4)
     _4 = ()
-    _0 = {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1](move _3, move _4)
+    _0 = {impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1](move _3, move _4)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]] f_2
+    conditional_drop[{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]] f_2
     storage_dead(f_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
 }
 
-// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::{impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-    type Output = test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
-    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: Sized) = {built_in impl Sized for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+    type Output = test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::foo::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::foo::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> T
+// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call<'_0, T>(_1: &'_0 test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1], tupled_args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: &'1 test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
     let _3: &'3 T; // anonymous local
 
     storage_live(_3)
     _3 = &((*_1)).0
-    _0 = @TraitClause1::clone<'5>(move _3)
+    _0 = TraitClause1::clone<'5>(move _3)
     storage_dead(_3)
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], args_2: ()) -> T
+// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_mut<'_0, T>(state_1: &'_0 mut test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1], args_2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let state_1: &'_0 mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_0 mut test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (); // arg #2
-    let _3: &'0 test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call<'2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call<'2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1], _2: ()) -> T
+// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_once<T>(_1: test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1], _2: ()) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (); // arg #2
-    let _3: &'1 mut test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 mut test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'3, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_mut<'3, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = @TraitClause0
+    proof ImpliedClause0: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
     type Output = T
-    fn call_once = {impl FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call_mut<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: FnOnce<()>) = {impl FnOnce<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call_mut<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::{impl Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}<T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::call<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]: FnMut<()>) = {impl FnMut<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}<T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<()> for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::call<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::foo::closure::closure::{impl Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::foo::closure::closure<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::foo::closure::closure<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -43,7 +43,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -51,10 +51,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -64,66 +64,66 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::Foo
 struct Foo<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
   &'a T,
 }
 
-struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>
+struct test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   &'_1 T,
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args_2: (&'_2 u32,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: &'1 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: &'1 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (&'_2 u32,); // arg #2
     let _z_3: &'2 u32; // local
     let _4: &'3 T; // anonymous local
@@ -132,27 +132,27 @@ where
     _z_3 = move tupled_args_2.0
     storage_live(_4)
     _4 = &(*((*_1)).0)
-    _0 = @TraitClause1::clone<'6>(move _4)
+    _0 = TraitClause1::clone<'6>(move _4)
     storage_dead(_4)
     return
 }
 
-struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>
+struct test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   &'_1 T,
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'2, '3, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: &'5 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'2, '3, T>[TraitClause0, TraitClause1]; // return
+    let _1: &'5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (&'_2 u32,); // arg #2
     let _y_3: &'6 u32; // local
     let _4: &'7 T; // anonymous local
@@ -161,52 +161,52 @@ where
     _y_3 = move tupled_args_2.0
     storage_live(_4)
     _4 = &(*((*_1)).0)
-    _0 = test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure { 0: move _4 }
+    _0 = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure { 0: move _4 }
     storage_dead(_4)
     return
 }
 
-struct test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>
+struct test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
   &'_1 T,
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call
-fn {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(_1: &'_6 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], tupled_args_2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(_1: &'_6 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args_2: ()) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'2, '3, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: &'5 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'2, '3, T>[TraitClause0, TraitClause1]; // return
+    let _1: &'5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
     let _3: &'6 T; // anonymous local
 
     storage_live(_3)
     _3 = &(*((*_1)).0)
-    _0 = test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure { 0: move _3 }
+    _0 = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure { 0: move _3 }
     storage_dead(_3)
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures
 pub fn test_nested_closures<'a, 'b, T>(x_1: &'a &'b T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let x_1: &'3 &'4 T; // arg #1
-    let clo_2: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'7, '8, T>[@TraitClause0, @TraitClause1]; // local
+    let clo_2: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'7, '8, T>[TraitClause0, TraitClause1]; // local
     let _3: &'9 T; // anonymous local
-    let _4: &'15 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'16, '17, T>[@TraitClause0, @TraitClause1]; // anonymous local
-    let _5: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'18, '19, T>[@TraitClause0, @TraitClause1]; // anonymous local
-    let _6: &'25 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'26, '27, T>[@TraitClause0, @TraitClause1]; // anonymous local
-    let _7: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'28, '29, T>[@TraitClause0, @TraitClause1]; // anonymous local
-    let _8: &'33 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'34, '35, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _4: &'15 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'16, '17, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _5: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'18, '19, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _6: &'25 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'26, '27, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _7: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'28, '29, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _8: &'33 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'34, '35, T>[TraitClause0, TraitClause1]; // anonymous local
     let _9: (); // anonymous local
     let _10: (&'38 u32,); // anonymous local
     let _11: &'39 u32; // anonymous local
@@ -228,7 +228,7 @@ where
     storage_live(clo_2)
     storage_live(_3)
     _3 = &(*(*x_1))
-    clo_2 = test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure { 0: move _3 }
+    clo_2 = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure { 0: move _3 }
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -238,7 +238,7 @@ where
     _8 = &clo_2
     storage_live(_9)
     _9 = ()
-    _7 = {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'54, '55, '56, '57, '58, '59, '60, T>[@TraitClause0, @TraitClause1](move _8, move _9)
+    _7 = {impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'54, '55, '56, '57, '58, '59, '60, T>[TraitClause0, TraitClause1](move _8, move _9)
     storage_live(_18)
     storage_live(_20)
     storage_live(_21)
@@ -255,7 +255,7 @@ where
     _12 = &(*_17)
     _11 = &(*_12)
     _10 = (move _11,)
-    _5 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'71, '72, '73, '74, '75, '76, T>[@TraitClause0, @TraitClause1](move _6, move _10)
+    _5 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'71, '72, '73, '74, '75, '76, T>[TraitClause0, TraitClause1](move _6, move _10)
     storage_live(_19)
     storage_live(_22)
     storage_live(_23)
@@ -273,7 +273,7 @@ where
     _15 = &(*_16)
     _14 = &(*_15)
     _13 = (move _14,)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'87, '88, '89, '90, T>[@TraitClause0, @TraitClause1](move _4, move _13)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'87, '88, '89, '90, T>[TraitClause0, TraitClause1](move _4, move _13)
     storage_dead(_14)
     storage_dead(_13)
     storage_dead(_4)
@@ -285,288 +285,288 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(state_1: &'_6 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_6, T>(state_1: &'_6 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1], args_2: ()) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '0, T>[@TraitClause0, @TraitClause1]; // return
-    let state_1: &'_6 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_2, '0, T>[TraitClause0, TraitClause1]; // return
+    let state_1: &'_6 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (); // arg #2
-    let _3: &'1 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '3, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '3, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: ()) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1], _2: ()) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_2, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'2, '3, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'2, '3, T>[TraitClause0, TraitClause1]; // return
+    let _1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (); // arg #2
-    let _3: &'5 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'5 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '15, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '15, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, '_5, T> FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, '_5, T> FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_, '_, T>[@TraitClause0, @TraitClause1]}
-    type Output = test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'_, '_, T>[@TraitClause0, @TraitClause1]
-    fn call_once = {impl FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, '_5, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]: Sized) = {built_in impl Sized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]}
+    type Output = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, '_5, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, '_5, T> FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, '_5, T> FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, '_3, '_4, '_5, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<()>) = {impl FnOnce<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, '_5, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call_mut<'_0_1> = {impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::{impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, '_5, T> Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, '_5, T> Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, '_3, '_4, '_5, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
-    fn call<'_0_1> = {impl Fn<()> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<()>) = {impl FnMut<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, '_5, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
+    fn call<'_0_1> = {impl Fn<()> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(state_1: &'_5 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(state_1: &'_5 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], args_2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '0, T>[@TraitClause0, @TraitClause1]; // return
-    let state_1: &'_5 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '0, T>[TraitClause0, TraitClause1]; // return
+    let state_1: &'_5 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (&'_2 u32,); // arg #2
-    let _3: &'1 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'1 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '3, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '3, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>(_1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_3, '_, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    let _0: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'2, '3, T>[@TraitClause0, @TraitClause1]; // return
-    let _1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'2, '3, T>[TraitClause0, TraitClause1]; // return
+    let _1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (&'4 u32,); // arg #2
-    let _3: &'6 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'6 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '18, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '18, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u32,)}
-    parent_clause3 = {built_in impl Sized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_, '_, T>[@TraitClause0, @TraitClause1]}
-    type Output = test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'_, '_, T>[@TraitClause0, @TraitClause1]
-    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause3: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]: Sized) = {built_in impl Sized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]}
+    type Output = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'_, '_, T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>(_1: *mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <missing>
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], args_2: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(state_1: &'_3 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], args_2: (&'_2 u32,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let state_1: &'_3 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let state_1: &'_3 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let args_2: (&'_2 u32,); // arg #2
-    let _3: &'0 test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'0 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &(*state_1)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '2, T>[@TraitClause0, @TraitClause1](move _3, move args_2)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '2, T>[TraitClause0, TraitClause1](move _3, move args_2)
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, T>(_1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1], _2: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
-    let _1: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let _2: (&'0 u32,); // arg #2
-    let _3: &'2 mut test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _3: &'2 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '12, T>[@TraitClause0, @TraitClause1](move _3, move _2)
-    drop[{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]] _1
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '12, T>[TraitClause0, TraitClause1](move _3, move _2)
+    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]] _1
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause2 = {built_in impl Tuple for (&'_ u32,)}
-    parent_clause3 = @TraitClause0
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
     type Output = T
-    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_once<'a, '_1, '_2, T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call_mut<'a, '_1, '_2, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, '_2, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}<'a, '_1, '_2, T>[@TraitClause0, @TraitClause1]
-    parent_clause2 = {built_in impl Sized for (&'_ u32,)}
-    parent_clause3 = {built_in impl Tuple for (&'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::call<'a, '_1, '_2, '_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}
-impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[@TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[@TraitClause0, @TraitClause1]}::drop_in_place<'a, '_1, T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_in_place<'a, '_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/non-lifetime-gats.out
+++ b/charon/tests/ui/simple/non-lifetime-gats.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,82 +27,83 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("deref")]
 pub trait Deref<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self::Target>
+    proof ImpliedClause0: (Self::Target: MetaSized)
     type Target
     fn deref<'_0_1> = core::ops::deref::Deref::deref<'_0_1, Self>[Self]
     vtable: core::ops::deref::Deref::{vtable}<Self::Target>
 }
 
 #[lang_item("deref_method")]
-pub fn core::ops::deref::Deref::deref<'_0, Self>(_1: &'_0 Self) -> &'_0 @TraitClause0::Target
+pub fn core::ops::deref::Deref::deref<'_0, Self>(_1: &'_0 Self) -> &'_0 TraitClause0::Target
 where
-    [@TraitClause0]: Deref<Self>,
+    TraitClause0: (Self: Deref),
 = <opaque>
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref
-pub fn {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]) -> &'_0 T
+// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref
+pub fn {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}
+impl<T, A> Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 {
-    parent_clause0 = @TraitClause0
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0
     type Target = T
-    fn deref<'_0_1> = {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::deref<'_0_1, T, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Deref for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
+    fn deref<'_0_1> = {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref<'_0_1, T, A>[TraitClause0, TraitClause1]
+    vtable: {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::{vtable}<T, A>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::PointerFamily
 pub trait PointerFamily<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type Pointer<T, [@TraitClause0_1]: Sized<T>, (Self::Pointer::[@TraitClause1])::Target = T>
+    proof ImpliedClause0: (Self: MetaSized)
+    type Pointer<T>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::Pointer>
-        implied_clause_1 : [@TraitClause1_1]: Deref<Self::Pointer>
-
-    fn new<T, [@TraitClause0_1]: Sized<T>> = test_crate::PointerFamily::new<Self, T>[Self, @TraitClause0_1]
+        TraitClause0_1: (T: Sized),
+        TypeConstraint0: Self::Pointer::ImpliedClause1::Target = T,
+        proof ImpliedClause0: (Self::Pointer: Sized),
+        proof ImpliedClause1: (Self::Pointer: Deref);
+    fn new<T, TraitClause0_1: (T: Sized)> = test_crate::PointerFamily::new<Self, T>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
-pub fn test_crate::PointerFamily::new<Self, T>(_1: T) -> @TraitClause0::Pointer
+pub fn test_crate::PointerFamily::new<Self, T>(_1: T) -> TraitClause0::Pointer
 where
-    [@TraitClause0]: PointerFamily<Self>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (Self: PointerFamily),
+    TraitClause1: (T: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::BoxFamily
 pub struct BoxFamily {}
 
 // Full name: test_crate::{impl PointerFamily for BoxFamily}::new
-pub fn {impl PointerFamily for BoxFamily}::new<T>(value_1: T) -> alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
+pub fn {impl PointerFamily for BoxFamily}::new<T>(value_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: alloc::boxed::Box<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]; // return
+    let _0: alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // return
     let value_1: T; // arg #1
     let _2: T; // anonymous local
 
     storage_live(_2)
     _2 = move value_1
-    _0 = @BoxNew<T>[@TraitClause0](move _2)
+    _0 = @BoxNew<T>[TraitClause0](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] value_1
     return
@@ -110,26 +111,30 @@ where
 
 // Full name: test_crate::{impl PointerFamily for BoxFamily}
 impl PointerFamily for BoxFamily {
-    parent_clause0 = {built_in impl MetaSized for BoxFamily}
-    type Pointer<U, [@TraitClause0_1]: Sized<U>> = alloc::boxed::Box<U>[@TraitClause0_1::parent_clause0, {built_in impl Sized for Global}]
-    fn new<T, [@TraitClause0_1]: Sized<T>> = {impl PointerFamily for BoxFamily}::new<T>[@TraitClause0_1]
+    proof ImpliedClause0: (BoxFamily: MetaSized) = {built_in impl MetaSized for BoxFamily}
+    type Pointer<U> = alloc::boxed::Box<U>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]
+    where
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: (alloc::boxed::Box<U>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for alloc::boxed::Box<U>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]},
+        proof ImpliedClause1: (alloc::boxed::Box<U>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Deref) = {impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}<U, Global>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}];
+    fn new<T, TraitClause0_1: (T: Sized)> = {impl PointerFamily for BoxFamily}::new<T>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::make_pointer
-pub fn make_pointer<F, T>(x_1: T) -> @TraitClause2::Pointer
+pub fn make_pointer<F, T>(x_1: T) -> TraitClause2::Pointer
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: PointerFamily<F>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
+    TraitClause2: (F: PointerFamily),
 {
-    let _0: @TraitClause2::Pointer; // return
+    let _0: TraitClause2::Pointer; // return
     let x_1: T; // arg #1
     let _2: T; // anonymous local
 
     storage_live(_2)
     _2 = move x_1
-    _0 = @TraitClause2::new<T>[@TraitClause1](move _2)
+    _0 = TraitClause2::new<T>[TraitClause1](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
@@ -144,7 +149,7 @@ pub fn main()
     _0 = ()
     storage_live(_1)
     _1 = make_pointer<BoxFamily, i32>[{built_in impl Sized for BoxFamily}, {built_in impl Sized for i32}, {impl PointerFamily for BoxFamily}](const 42 : i32)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]] _1
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]] _1
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
+++ b/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
@@ -8,29 +8,29 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::opaque::Product
 pub trait Product<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::opaque::Product::{vtable}
 }
 
 // Full name: test_crate::opaque::Iterator
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo
 fn foo<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Iterator<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Iterator),
 {
     let _0: (); // return
 

--- a/charon/tests/ui/simple/opaque-vtable.out
+++ b/charon/tests/ui/simple/opaque-vtable.out
@@ -9,14 +9,14 @@ opaque type test_crate::x::Trait::{vtable}
 // Full name: test_crate::x::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn method<'_0_1> = test_crate::x::Trait::method<'_0_1, Self>[Self]
     vtable: test_crate::x::Trait::{vtable}
 }
 
 pub fn test_crate::x::Trait::method<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 = <opaque>
 
 // Full name: test_crate::x::{impl Trait for ()}::method
@@ -32,7 +32,7 @@ static {impl Trait for ()}::{vtable}: test_crate::x::Trait::{vtable} = {impl Tra
 
 // Full name: test_crate::x::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     fn method<'_0_1> = {impl Trait for ()}::method<'_0_1>
     vtable: {impl Trait for ()}::{vtable}
 }

--- a/charon/tests/ui/simple/partial-drop.out
+++ b/charon/tests/ui/simple/partial-drop.out
@@ -15,8 +15,8 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("mem_drop")]
 pub fn drop<T>(_1: T)
 where
-    [@TraitClause0]: Destruct<T>,
-    [@TraitClause1]: Destruct<T>,
+    TraitClause0: (T: Destruct),
+    TraitClause1: (T: Destruct),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -33,20 +33,20 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Destruct<T>,
-    [@TraitClause1]: Destruct<A>,
+    TraitClause0: (T: Destruct),
+    TraitClause1: (A: Destruct),
 = <opaque>
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}
+impl<T, A> Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Destruct<T>,
-    [@TraitClause1]: Destruct<A>,
+    TraitClause0: (T: Destruct),
+    TraitClause1: (A: Destruct),
 {
-    fn drop_in_place = {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -69,13 +69,13 @@ fn foo(f_1: Foo)
     storage_live(_2)
     storage_live(_3)
     _3 = move (f_1).x
-    _2 = drop<alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, {impl Destruct for Global}]>[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}], {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]](move _3)
+    _2 = drop<alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, {impl Destruct for Global}]>[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}], {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]](move _3)
     storage_dead(_3)
     storage_dead(_2)
     _0 = ()
     // Only `y` and `z` should be dropped here
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]] (f_1).y
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]] (f_1).z
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]] (f_1).y
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Destruct for u32}, {impl Destruct for Global}]] (f_1).z
     return
 }
 

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -36,10 +36,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
@@ -48,10 +48,10 @@ pub trait FnOnce<Self, Args, Self_Output>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args, Self_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args, Self_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args, Self_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = call_mut<'_0_1, Self, Args, Self_Clause1_Output>[Self]
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
@@ -60,29 +60,29 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
 #[lang_item("fn")]
 pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args, Self_Clause1_Clause1_Output>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args, Self_Clause1_Clause1_Output>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args, Self_Clause1_Clause1_Output>[Self]
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args, Clause0_Clause1_Clause1_Output>(_1: &'_0 Self, _2: Args) -> Clause0_Clause1_Clause1_Output
 where
-    [@TraitClause0]: Fn<Self, Args, Clause0_Clause1_Clause1_Output>,
+    TraitClause0: (Self: Fn<Args, Clause0_Clause1_Clause1_Output>),
 = <opaque>
 
 // Full name: core::ops::function::FnMut::call_mut
 pub extern "rust-call" fn call_mut<'_0, Self, Args, Clause0_Clause1_Output>(_1: &'_0 mut Self, _2: Args) -> Clause0_Clause1_Output
 where
-    [@TraitClause0]: FnMut<Self, Args, Clause0_Clause1_Output>,
+    TraitClause0: (Self: FnMut<Args, Clause0_Clause1_Output>),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce::call_once
 pub extern "rust-call" fn call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 // Full name: test_crate::flabada
@@ -97,8 +97,8 @@ pub fn flabada<'a>(x_1: &'a ()) -> &'a ()
 
 pub fn test_crate::call<'b, F>(_1: F)
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Fn<F, (&'b (),), &'b ()>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: Fn<(&'b (),), &'b ()>),
 {
     let _0: (); // return
     let _1: F; // arg #1

--- a/charon/tests/ui/simple/promoted-closure-no-warns.out
+++ b/charon/tests/ui/simple/promoted-closure-no-warns.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::foo::closure
@@ -164,10 +164,10 @@ fn {impl FnOnce<(u32,)> for closure}::call_once(_1: closure, _2: (u32,)) -> u32
 
 // Full name: test_crate::foo::{impl FnOnce<(u32,)> for closure}
 impl FnOnce<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
     fn call_once = {impl FnOnce<(u32,)> for closure}::call_once
     non-dyn-compatible
@@ -175,20 +175,20 @@ impl FnOnce<(u32,)> for closure {
 
 // Full name: test_crate::foo::{impl FnMut<(u32,)> for closure}
 impl FnMut<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(u32,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,)> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo::{impl Fn<(u32,)> for closure}
 impl Fn<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<(u32,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<(u32,)>) = {impl FnMut<(u32,)> for closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,)> for closure}::call<'_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::foo::closure
@@ -164,10 +164,10 @@ fn {impl FnOnce<(u32,)> for closure}::call_once(_1: closure, _2: (u32,)) -> u32
 
 // Full name: test_crate::foo::{impl FnOnce<(u32,)> for closure}
 impl FnOnce<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for (u32,)}
-    parent_clause2 = {built_in impl Tuple for (u32,)}
-    parent_clause3 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
     fn call_once = {impl FnOnce<(u32,)> for closure}::call_once
     non-dyn-compatible
@@ -175,20 +175,20 @@ impl FnOnce<(u32,)> for closure {
 
 // Full name: test_crate::foo::{impl FnMut<(u32,)> for closure}
 impl FnMut<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<(u32,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call_mut<'_0_1> = {impl FnMut<(u32,)> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo::{impl Fn<(u32,)> for closure}
 impl Fn<(u32,)> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<(u32,)> for closure}
-    parent_clause2 = {built_in impl Sized for (u32,)}
-    parent_clause3 = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<(u32,)>) = {impl FnMut<(u32,)> for closure}
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     fn call<'_0_1> = {impl Fn<(u32,)> for closure}::call<'_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/promoted-in-generic-fn.out
+++ b/charon/tests/ui/simple/promoted-in-generic-fn.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,13 +16,13 @@ pub trait Sized<Self>
 #[lang_item("mem_size_of")]
 pub fn size_of<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::f
 fn f<T>()
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: &'1 usize; // anonymous local
@@ -35,7 +35,7 @@ where
     storage_live(_4)
     storage_live(_5)
     // This can't be evaluated generically.
-    _5 = size_of<T>[@TraitClause0]()
+    _5 = size_of<T>[TraitClause0]()
     _4 = &_5
     _3 = move _4
     storage_live(_2)

--- a/charon/tests/ui/simple/promoted-inside-impl.out
+++ b/charon/tests/ui/simple/promoted-inside-impl.out
@@ -8,23 +8,23 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo
 pub struct Foo<F>
 where
-    [@TraitClause0]: Sized<F>,
+    TraitClause0: (F: Sized),
 {
   F,
 }
 
-// Full name: test_crate::{Foo<F>[@TraitClause0]}::method
+// Full name: test_crate::{Foo<F>[TraitClause0]}::method
 pub fn method<F, T>()
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (F: Sized),
+    TraitClause1: (T: Sized),
 {
     let _0: (); // return
     let _promoted_1: &'1 i32; // local

--- a/charon/tests/ui/simple/promoted_in_closure.out
+++ b/charon/tests/ui/simple/promoted_in_closure.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,39 +48,39 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::main::closure
@@ -165,10 +165,10 @@ fn {impl FnOnce<()> for closure}::call_once(_1: closure, _2: ())
 
 // Full name: test_crate::main::{impl FnOnce<()> for closure}
 impl FnOnce<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = {impl FnOnce<()> for closure}::call_once
     non-dyn-compatible
@@ -176,20 +176,20 @@ impl FnOnce<()> for closure {
 
 // Full name: test_crate::main::{impl FnMut<()> for closure}
 impl FnMut<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnOnce<()> for closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<()>) = {impl FnOnce<()> for closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call_mut<'_0_1> = {impl FnMut<()> for closure}::call_mut<'_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::main::{impl Fn<()> for closure}
 impl Fn<()> for closure {
-    parent_clause0 = {built_in impl MetaSized for closure}
-    parent_clause1 = {impl FnMut<()> for closure}
-    parent_clause2 = {built_in impl Sized for ()}
-    parent_clause3 = {built_in impl Tuple for ()}
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<()>) = {impl FnMut<()> for closure}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause3: ((): Tuple) = {built_in impl Tuple for ()}
     fn call<'_0_1> = {impl Fn<()> for closure}::call<'_0_1>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/promoted_in_default_method.out
+++ b/charon/tests/ui/simple/promoted_in_default_method.out
@@ -7,7 +7,7 @@ pub trait MetaSized<Self>
 // Full name: test_crate::Thing
 trait Thing<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn foo = foo<Self>[Self]
     non-dyn-compatible
 }
@@ -15,7 +15,7 @@ trait Thing<Self>
 // Full name: test_crate::Thing::foo
 fn foo<Self>()
 where
-    [@TraitClause0]: Thing<Self>,
+    TraitClause0: (Self: Thing),
 {
     let _0: (); // return
     let _1: &'1 i32; // anonymous local

--- a/charon/tests/ui/simple/ptr-from-raw-parts.out
+++ b/charon/tests/ui/simple/ptr-from-raw-parts.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -39,14 +39,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -62,7 +62,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -72,7 +72,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -81,8 +81,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = core::cmp::Ord::cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -90,13 +90,13 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
@@ -111,7 +111,7 @@ impl PartialEq<()> for () {
 
 // Full name: core::cmp::impls::{impl Eq for ()}
 impl Eq for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     non-dyn-compatible
 }
 
@@ -121,7 +121,7 @@ pub fn {impl PartialOrd<()> for ()}::partial_cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1
 
 // Full name: core::cmp::impls::{impl PartialOrd<()> for ()}
 impl PartialOrd<()> for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<()> for ()}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<()> for ()}::{vtable}
 }
@@ -132,8 +132,8 @@ pub fn {impl Ord for ()}::cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> Ordering
 
 // Full name: core::cmp::impls::{impl Ord for ()}
 impl Ord for () {
-    parent_clause0 = {impl Eq for ()}
-    parent_clause1 = {impl PartialOrd<()> for ()}
+    proof ImpliedClause0: ((): Eq) = {impl Eq for ()}
+    proof ImpliedClause1: ((): PartialOrd<()>) = {impl PartialOrd<()> for ()}
     fn cmp<'_0_1, '_1_1> = {impl Ord for ()}::cmp<'_0_1, '_1_1>
     non-dyn-compatible
 }
@@ -145,8 +145,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -162,7 +162,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for ()}::fmt
@@ -178,7 +178,7 @@ impl Debug for () {
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -188,39 +188,39 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}::hash
 pub fn {impl Hash for ()}::hash<'_0, '_1, H>(_1: &'_0 (), _2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}
 impl Hash for () {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -232,8 +232,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -252,8 +252,8 @@ pub trait Unpin<Self>
 // Full name: core::ptr::metadata::from_raw_parts
 pub fn from_raw_parts<T, T1>(data_pointer_1: *const T1, metadata_2: {built_in impl Pointee for T}::Metadata) -> *const T
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Thin<T1>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T1: Thin),
 {
     let _0: *const T; // return
     let data_pointer_1: *const T1; // arg #1

--- a/charon/tests/ui/simple/ptr_metadata.out
+++ b/charon/tests/ui/simple/ptr_metadata.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -39,14 +39,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -62,7 +62,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -72,7 +72,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -81,8 +81,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = core::cmp::Ord::cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -90,13 +90,13 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
@@ -111,7 +111,7 @@ impl PartialEq<()> for () {
 
 // Full name: core::cmp::impls::{impl Eq for ()}
 impl Eq for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     non-dyn-compatible
 }
 
@@ -121,7 +121,7 @@ pub fn {impl PartialOrd<()> for ()}::partial_cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1
 
 // Full name: core::cmp::impls::{impl PartialOrd<()> for ()}
 impl PartialOrd<()> for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<()> for ()}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<()> for ()}::{vtable}
 }
@@ -132,8 +132,8 @@ pub fn {impl Ord for ()}::cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> Ordering
 
 // Full name: core::cmp::impls::{impl Ord for ()}
 impl Ord for () {
-    parent_clause0 = {impl Eq for ()}
-    parent_clause1 = {impl PartialOrd<()> for ()}
+    proof ImpliedClause0: ((): Eq) = {impl Eq for ()}
+    proof ImpliedClause1: ((): PartialOrd<()>) = {impl PartialOrd<()> for ()}
     fn cmp<'_0_1, '_1_1> = {impl Ord for ()}::cmp<'_0_1, '_1_1>
     non-dyn-compatible
 }
@@ -145,8 +145,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -162,7 +162,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for ()}::fmt
@@ -178,7 +178,7 @@ impl Debug for () {
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -188,39 +188,39 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}::hash
 pub fn {impl Hash for ()}::hash<'_0, '_1, H>(_1: &'_0 (), _2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}
 impl Hash for () {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -232,8 +232,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -253,15 +253,15 @@ pub trait Unpin<Self>
 #[lang_item("pointee_trait")]
 pub trait Pointee<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self::Metadata>
-    parent_clause1 : [@TraitClause1]: Debug<Self::Metadata>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Metadata>
-    parent_clause3 : [@TraitClause3]: Send<Self::Metadata>
-    parent_clause4 : [@TraitClause4]: Sync<Self::Metadata>
-    parent_clause5 : [@TraitClause5]: Ord<Self::Metadata>
-    parent_clause6 : [@TraitClause6]: Hash<Self::Metadata>
-    parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
-    parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
+    proof ImpliedClause0: (Self::Metadata: Sized)
+    proof ImpliedClause1: (Self::Metadata: Debug)
+    proof ImpliedClause2: (Self::Metadata: Copy)
+    proof ImpliedClause3: (Self::Metadata: Send)
+    proof ImpliedClause4: (Self::Metadata: Sync)
+    proof ImpliedClause5: (Self::Metadata: Ord)
+    proof ImpliedClause6: (Self::Metadata: Hash)
+    proof ImpliedClause7: (Self::Metadata: Unpin)
+    proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
 }
@@ -269,19 +269,19 @@ pub trait Pointee<Self>
 // Full name: core::ptr::metadata::Thin
 pub trait Thin<Self>
 where
-    Self::parent_clause0::Metadata = (),
+    TypeConstraint0: Self::ImpliedClause0::Metadata = (),
 {
-    parent_clause0 : [@TraitClause0]: Pointee<Self>
+    proof ImpliedClause0: (Self: Pointee)
     non-dyn-compatible
 }
 
 // Full name: core::ptr::metadata::Thin::{impl Thin for Self}
 impl<Self> Thin for Self
 where
-    [@TraitClause0]: Pointee<Self>,
-    @TraitClause0::Metadata = (),
+    TraitClause0: (Self: Pointee),
+    TypeConstraint0: TraitClause0::Metadata = (),
 {
-    parent_clause0 = @TraitClause0
+    proof ImpliedClause0: (Self: Pointee) = TraitClause0
     non-dyn-compatible
 }
 
@@ -289,7 +289,7 @@ where
 #[lang_item("ptr_null")]
 pub fn null<T>() -> *const T
 where
-    [@TraitClause0]: Thin<T>,
+    TraitClause0: (T: Thin),
 = <opaque>
 
 // Full name: test_crate::main

--- a/charon/tests/ui/simple/range-iter.out
+++ b/charon/tests/ui/simple/range-iter.out
@@ -11,7 +11,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for usize}::clone
@@ -35,7 +35,7 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Ordering
@@ -57,7 +57,7 @@ pub enum Option<T> {
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -65,7 +65,7 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<usize> for usize}::eq
@@ -84,7 +84,7 @@ pub fn {impl PartialOrd<usize> for usize}::partial_cmp<'_0, '_1>(_1: &'_0 usize,
 
 // Full name: core::cmp::impls::{impl PartialOrd<usize> for usize}
 impl PartialOrd<usize> for usize {
-    parent_clause0 = {impl PartialEq<usize> for usize}
+    proof ImpliedClause0: (usize: PartialEq<usize>) = {impl PartialEq<usize> for usize}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<usize> for usize}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<usize> for usize}::{vtable}
 }
@@ -93,8 +93,8 @@ impl PartialOrd<usize> for usize {
 #[lang_item("range_step")]
 pub trait Step<Self>
 {
-    parent_clause0 : [@TraitClause0]: Clone<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Clone)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn steps_between<'_0_1, '_1_1> = core::iter::range::Step::steps_between<'_0_1, '_1_1, Self>[Self]
     fn forward_checked = core::iter::range::Step::forward_checked<Self>[Self]
     fn backward_checked = core::iter::range::Step::backward_checked<Self>[Self]
@@ -103,17 +103,17 @@ pub trait Step<Self>
 
 pub fn core::iter::range::Step::steps_between<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> (usize, Option<usize>)
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 pub fn core::iter::range::Step::forward_checked<Self>(_1: Self, _2: usize) -> Option<Self>
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 pub fn core::iter::range::Step::backward_checked<Self>(_1: Self, _2: usize) -> Option<Self>
 where
-    [@TraitClause0]: Step<Self>,
+    TraitClause0: (Self: Step),
 = <opaque>
 
 // Full name: core::iter::range::{impl Step for usize}::backward_checked
@@ -130,8 +130,8 @@ pub fn {impl Step for usize}::steps_between<'_0, '_1>(_1: &'_0 usize, _2: &'_1 u
 
 // Full name: core::iter::range::{impl Step for usize}
 impl Step for usize {
-    parent_clause0 = {impl Clone for usize}
-    parent_clause1 = {impl PartialOrd<usize> for usize}
+    proof ImpliedClause0: (usize: Clone) = {impl Clone for usize}
+    proof ImpliedClause1: (usize: PartialOrd<usize>) = {impl PartialOrd<usize> for usize}
     fn steps_between<'_0_1, '_1_1> = {impl Step for usize}::steps_between<'_0_1, '_1_1>
     fn forward_checked = {impl Step for usize}::forward_checked
     fn backward_checked = {impl Step for usize}::backward_checked
@@ -156,28 +156,28 @@ pub trait Iterator<Self, Self_Item>
 // Full name: core::iter::range::{impl Iterator<A> for Range<A>}::next
 pub fn {impl Iterator<A> for Range<A>}::next<'_0, A>(_1: &'_0 mut Range<A>) -> Option<A>
 where
-    [@TraitClause0]: Step<A>,
+    TraitClause0: (A: Step),
 = <opaque>
 
 // Full name: core::iter::range::{impl Iterator<A> for Range<A>}
 impl<A> Iterator<A> for Range<A>
 where
-    [@TraitClause0]: Step<A>,
+    TraitClause0: (A: Step),
 {
-    fn next<'_0_1> = {impl Iterator<A> for Range<A>}::next<'_0_1, A>[@TraitClause0]
-    vtable: {impl Iterator<A> for Range<A>}::{vtable}<A>[@TraitClause0]
+    fn next<'_0_1> = {impl Iterator<A> for Range<A>}::next<'_0_1, A>[TraitClause0]
+    vtable: {impl Iterator<A> for Range<A>}::{vtable}<A>[TraitClause0]
 }
 
 // Full name: core::iter::traits::collect::{impl IntoIterator<Clause0_Item, I> for I}::into_iter
 pub fn {impl IntoIterator<Clause0_Item, I> for I}::into_iter<I, Clause0_Item>(_1: I) -> I
 where
-    [@TraitClause0]: Iterator<I, Clause0_Item>,
+    TraitClause0: (I: Iterator<Clause0_Item>),
 = <opaque>
 
 #[lang_item("next")]
 pub fn core::iter::traits::iterator::Iterator::next<'_0, Self, Clause0_Item>(_1: &'_0 mut Self) -> Option<Clause0_Item>
 where
-    [@TraitClause0]: Iterator<Self, Clause0_Item>,
+    TraitClause0: (Self: Iterator<Clause0_Item>),
 = <opaque>
 
 // Full name: test_crate::iter

--- a/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -36,25 +36,25 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Output: Sized)
     type Output
     vtable: test_crate::HasAssoc::{vtable}<Self::Output>
 }
@@ -62,17 +62,17 @@ trait HasAssoc<Self>
 // Full name: test_crate::make_closure::closure
 struct closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {}
 
 // Full name: test_crate::make_closure
-fn make_closure<T>(x_1: T) -> closure<T>[@TraitClause0, @TraitClause1]
+fn make_closure<T>(x_1: T) -> closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {
-    let _0: closure<T>[@TraitClause0, @TraitClause1]; // return
+    let _0: closure<T>[TraitClause0, TraitClause1]; // return
     let x_1: T; // arg #1
 
     _0 = closure {  }
@@ -80,14 +80,14 @@ where
     return
 }
 
-// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once
-fn {impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>(_1: closure<T>[@TraitClause0, @TraitClause1], tupled_args_2: ())
+// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<()> for closure<T>[TraitClause0, TraitClause1]}::call_once<T>(_1: closure<T>[TraitClause0, TraitClause1], tupled_args_2: ())
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {
     let _0: (); // return
-    let _1: closure<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let _1: closure<T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args_2: (); // arg #2
 
     _0 = ()
@@ -95,18 +95,18 @@ where
     return
 }
 
-// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}
-impl<T> FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::make_closure::{impl FnOnce<()> for closure<T>[TraitClause0, TraitClause1]}
+impl<T> FnOnce<()> for closure<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (closure<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for closure<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<()> for closure<T>[@TraitClause0, @TraitClause1]}::call_once<T>[@TraitClause0, @TraitClause1]
+    fn call_once = {impl FnOnce<()> for closure<T>[TraitClause0, TraitClause1]}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -26,8 +26,8 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Output: Sized)
     type Output
     vtable: test_crate::HasAssoc::{vtable}<Self::Output>
 }
@@ -35,34 +35,34 @@ trait HasAssoc<Self>
 // Full name: test_crate::Direct
 struct Direct<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {
   T,
 }
 
-// Full name: test_crate::Direct::{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut Direct<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::Direct::{impl Destruct for Direct<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Direct<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut Direct<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 = <missing>
 
-// Full name: test_crate::Direct::{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for Direct<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::Direct::{impl Destruct for Direct<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for Direct<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: HasAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: HasAssoc),
 {
-    fn drop_in_place = {impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for Direct<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::BaseWithAssoc
 trait BaseWithAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     vtable: test_crate::BaseWithAssoc::{vtable}<Self::Item>
 }
@@ -70,49 +70,49 @@ trait BaseWithAssoc<Self>
 // Full name: test_crate::DerivedNoAssoc
 trait DerivedNoAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: BaseWithAssoc<Self>
-    vtable: test_crate::DerivedNoAssoc::{vtable}<Self::parent_clause1::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: BaseWithAssoc)
+    vtable: test_crate::DerivedNoAssoc::{vtable}<Self::ImpliedClause1::Item>
 }
 
 // Full name: test_crate::Transitive
 struct Transitive<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: DerivedNoAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: DerivedNoAssoc),
 {
   T,
 }
 
-// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>(_1: *mut Transitive<T>[@TraitClause0, @TraitClause1])
+// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Transitive<T>[TraitClause0, TraitClause1]}::drop_in_place<T>(_1: *mut Transitive<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: DerivedNoAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: DerivedNoAssoc),
 = <missing>
 
-// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}
-impl<T> Destruct for Transitive<T>[@TraitClause0, @TraitClause1]
+// Full name: test_crate::Transitive::{impl Destruct for Transitive<T>[TraitClause0, TraitClause1]}
+impl<T> Destruct for Transitive<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: DerivedNoAssoc<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: DerivedNoAssoc),
 {
-    fn drop_in_place = {impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for Transitive<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::MarkerParent
 trait MarkerParent<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::MarkerParent::{vtable}
 }
 
 // Full name: test_crate::MarkerChild
 trait MarkerChild<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MarkerParent<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: MarkerParent)
     vtable: test_crate::MarkerChild::{vtable}
 }
 
@@ -124,40 +124,40 @@ struct Marker<T> {
 // Full name: test_crate::Marker::{impl Destruct for Marker<T>}::drop_in_place
 unsafe fn {impl Destruct for Marker<T>}::drop_in_place<T>(_1: *mut Marker<T>)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: MarkerChild<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: MarkerChild),
 = <missing>
 
 // Full name: test_crate::Marker::{impl Destruct for Marker<T>}
 impl<T> Destruct for Marker<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: MarkerChild<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: MarkerChild),
 {
-    fn drop_in_place = {impl Destruct for Marker<T>}::drop_in_place<T>[@TraitClause0, @TraitClause1]
+    fn drop_in_place = {impl Destruct for Marker<T>}::drop_in_place<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::use_all
-fn use_all<T, U, V>(_x_1: Direct<T>[@TraitClause0, @TraitClause3], _y_2: Transitive<U>[@TraitClause1, @TraitClause4], _z_3: Marker<V>)
+fn use_all<T, U, V>(_x_1: Direct<T>[TraitClause0, TraitClause3], _y_2: Transitive<U>[TraitClause1, TraitClause4], _z_3: Marker<V>)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Sized<V>,
-    [@TraitClause3]: HasAssoc<T>,
-    [@TraitClause4]: DerivedNoAssoc<U>,
-    [@TraitClause5]: MarkerChild<V>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (V: Sized),
+    TraitClause3: (T: HasAssoc),
+    TraitClause4: (U: DerivedNoAssoc),
+    TraitClause5: (V: MarkerChild),
 {
     let _0: (); // return
-    let _x_1: Direct<T>[@TraitClause0, @TraitClause3]; // arg #1
-    let _y_2: Transitive<U>[@TraitClause1, @TraitClause4]; // arg #2
+    let _x_1: Direct<T>[TraitClause0, TraitClause3]; // arg #1
+    let _y_2: Transitive<U>[TraitClause1, TraitClause4]; // arg #2
     let _z_3: Marker<V>; // arg #3
 
     _0 = ()
     _0 = ()
-    conditional_drop[{impl Destruct for Marker<T>}::drop_in_place<V>[@TraitClause2, @TraitClause5]] _z_3
-    conditional_drop[{impl Destruct for Transitive<T>[@TraitClause0, @TraitClause1]}::drop_in_place<U>[@TraitClause1, @TraitClause4]] _y_2
-    conditional_drop[{impl Destruct for Direct<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T>[@TraitClause0, @TraitClause3]] _x_1
+    conditional_drop[{impl Destruct for Marker<T>}::drop_in_place<V>[TraitClause2, TraitClause5]] _z_3
+    conditional_drop[{impl Destruct for Transitive<T>[TraitClause0, TraitClause1]}::drop_in_place<U>[TraitClause1, TraitClause4]] _y_2
+    conditional_drop[{impl Destruct for Direct<T>[TraitClause0, TraitClause1]}::drop_in_place<T>[TraitClause0, TraitClause3]] _x_1
     return
 }
 

--- a/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -28,7 +28,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -36,39 +36,39 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args, Self_Output>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self_Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self_Output: Sized)
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args, Self_Output>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self_Output>
 }
 
 pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args, Clause0_Output>(_1: Self, _2: Args) -> Clause0_Output
 where
-    [@TraitClause0]: FnOnce<Self, Args, Clause0_Output>,
+    TraitClause0: (Self: FnOnce<Args, Clause0_Output>),
 = <opaque>
 
 // Full name: test_crate::GrandParent
 trait GrandParent<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::GrandParent::{vtable}
 }
 
 // Full name: test_crate::Parent
 trait Parent<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: GrandParent<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: GrandParent)
     vtable: test_crate::Parent::{vtable}
 }
 
 // Full name: test_crate::Child
 trait Child<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Parent<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Parent)
     vtable: test_crate::Child::{vtable}
 }
 
@@ -78,8 +78,8 @@ struct closure<T> {}
 // Full name: test_crate::make
 fn make<T>(x_1: T) -> closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Child<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Child),
 {
     let _0: closure<T>; // return
     let x_1: T; // arg #1
@@ -92,8 +92,8 @@ where
 // Full name: test_crate::make::{impl FnOnce<(), ()> for closure<T>}::call_once
 fn {impl FnOnce<(), ()> for closure<T>}::call_once<T>(_1: closure<T>, tupled_args_2: ())
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Child<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Child),
 {
     let _0: (); // return
     let _1: closure<T>; // arg #1
@@ -107,14 +107,14 @@ where
 // Full name: test_crate::make::{impl FnOnce<(), ()> for closure<T>}
 impl<T> FnOnce<(), ()> for closure<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Child<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Child),
 {
-    parent_clause0 = {built_in impl MetaSized for closure<T>}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {built_in impl Tuple for ()}
-    parent_clause3 = {built_in impl Sized for ()}
-    fn call_once = {impl FnOnce<(), ()> for closure<T>}::call_once<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (closure<T>: MetaSized) = {built_in impl MetaSized for closure<T>}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
+    fn call_once = {impl FnOnce<(), ()> for closure<T>}::call_once<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/remove-adt-clauses.out
+++ b/charon/tests/ui/simple/remove-adt-clauses.out
@@ -8,22 +8,22 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Type>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self_Type>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Type: Sized)
     vtable: test_crate::Trait::{vtable}<Self_Type>
 }
 
 // Full name: test_crate::{impl Trait<bool> for u32}
 impl Trait<bool> for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     vtable: {impl Trait<bool> for u32}::{vtable}
 }
 

--- a/charon/tests/ui/simple/rpitit-with-const-generic.out
+++ b/charon/tests/ui/simple/rpitit-with-const-generic.out
@@ -8,25 +8,24 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     type bar_ty<const N : usize>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::bar_ty>
-
+        proof ImpliedClause0: (Self::bar_ty: Sized);
     fn bar<const N : usize> = test_crate::Foo::bar<Self, N>[Self]
     non-dyn-compatible
 }
 
-pub fn test_crate::Foo::bar<Self, const N : usize>() -> @TraitClause0::bar_ty
+pub fn test_crate::Foo::bar<Self, const N : usize>() -> TraitClause0::bar_ty
 where
-    [@TraitClause0]: Foo<Self>,
+    TraitClause0: (Self: Foo),
 = <method_without_default_body>
 
 // Full name: test_crate::S
@@ -43,8 +42,10 @@ pub fn {impl Foo for S}::bar<const N : usize>() -> [u8; N]
 
 // Full name: test_crate::{impl Foo for S}
 impl Foo for S {
-    parent_clause0 = {built_in impl MetaSized for S}
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
     type bar_ty<const N : usize> = [u8; N]
+    where
+        proof ImpliedClause0: ([u8; N]: Sized) = {built_in impl Sized for [u8; N]};
     fn bar<const N : usize> = {impl Foo for S}::bar<N>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/rpitit-with-lifetime-bound.out
+++ b/charon/tests/ui/simple/rpitit-with-lifetime-bound.out
@@ -8,27 +8,29 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    type foo_ty<'a, '_1_1, Self : 'a, 'a : '_1_1, '_1_1 : 'a>
+    proof ImpliedClause0: (Self: MetaSized)
+    type foo_ty<'a, '_1_1>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::foo_ty>
-
-    fn foo<'a, Self : 'a> = foo<'a, Self>[Self]
+        TypeOutlives0: Self: 'a,
+        RegionOutlives0: 'a: '_1_1,
+        RegionOutlives1: '_1_1: 'a,
+        proof ImpliedClause0: (Self::foo_ty: Sized);
+    fn foo<'a, TypeOutlives0: Self: 'a> = foo<'a, Self>[Self]
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyTrait::foo
-pub fn foo<'a, Self>() -> @TraitClause0::foo_ty
+pub fn foo<'a, Self>() -> TraitClause0::foo_ty
 where
-    [@TraitClause0]: MyTrait<Self>,
-    Self : 'a,
+    TraitClause0: (Self: MyTrait),
+    TypeOutlives0: Self: 'a,
 = <method_without_default_body>
 
 

--- a/charon/tests/ui/simple/rpitit-with-lifetime.out
+++ b/charon/tests/ui/simple/rpitit-with-lifetime.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -26,8 +26,8 @@ where
 #[lang_item("iterator")]
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     fn next<'_0_1> = next<'_0_1, Self>[Self]
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
@@ -35,30 +35,33 @@ pub trait Iterator<Self>
 
 // Full name: core::iter::traits::iterator::Iterator::next
 #[lang_item("next")]
-pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<@TraitClause0::Item>[@TraitClause0::parent_clause1]
+pub fn next<'_0, Self>(_1: &'_0 mut Self) -> Option<TraitClause0::Item>[TraitClause0::ImpliedClause1]
 where
-    [@TraitClause0]: Iterator<Self>,
+    TraitClause0: (Self: Iterator),
 = <opaque>
 
 // Full name: test_crate::Foo
 trait Foo<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    type iter_ty<'a, '_1_1, T : 'a, 'a : '_1_1, '_1_1 : 'a, (Self::iter_ty::[@TraitClause1])::Item = &'_1_1 T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    type iter_ty<'a, '_1_1>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::iter_ty>
-        implied_clause_1 : [@TraitClause1_1]: Iterator<Self::iter_ty>
-
-    fn iter<'a, T : 'a> = iter<'a, Self, T>[Self]
+        TypeOutlives0: T: 'a,
+        RegionOutlives0: 'a: '_1_1,
+        RegionOutlives1: '_1_1: 'a,
+        TypeConstraint0: Self::iter_ty::ImpliedClause1::Item = &'_1_1 T,
+        proof ImpliedClause0: (Self::iter_ty: Sized),
+        proof ImpliedClause1: (Self::iter_ty: Iterator);
+    fn iter<'a, TypeOutlives0: T: 'a> = iter<'a, Self, T>[Self]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::iter
-fn iter<'a, Self, T>(_1: &'a Self) -> @TraitClause0::iter_ty
+fn iter<'a, Self, T>(_1: &'a Self) -> TraitClause0::iter_ty
 where
-    [@TraitClause0]: Foo<Self, T>,
-    T : 'a,
+    TraitClause0: (Self: Foo<T>),
+    TypeOutlives0: T: 'a,
 = <method_without_default_body>
 
 

--- a/charon/tests/ui/simple/rpitit.out
+++ b/charon/tests/ui/simple/rpitit.out
@@ -8,36 +8,36 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
 // Full name: test_crate::Foo
 trait Foo<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    type into_iter_ty<U, [@TraitClause0_1]: Sized<U>>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    type into_iter_ty<U>
     where
-        implied_clause_0 : [@TraitClause0_1]: Sized<Self::into_iter_ty>
-        implied_clause_1 : [@TraitClause1_1]: Trait<Self::into_iter_ty>
-
-    fn into_iter<U, [@TraitClause0_1]: Sized<U>> = into_iter<Self, T, U>[Self, @TraitClause0_1]
+        TraitClause0_1: (U: Sized),
+        proof ImpliedClause0: (Self::into_iter_ty: Sized),
+        proof ImpliedClause1: (Self::into_iter_ty: Trait);
+    fn into_iter<U, TraitClause0_1: (U: Sized)> = into_iter<Self, T, U>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::into_iter
-fn into_iter<Self, T, U>(_1: Self) -> @TraitClause0::into_iter_ty
+fn into_iter<Self, T, U>(_1: Self) -> TraitClause0::into_iter_ty
 where
-    [@TraitClause0]: Foo<Self, T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (Self: Foo<T>),
+    TraitClause1: (U: Sized),
 = <method_without_default_body>
 
 

--- a/charon/tests/ui/simple/single-variant-enum-drop-glue.out
+++ b/charon/tests/ui/simple/single-variant-enum-drop-glue.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,11 +27,11 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: test_crate::Thing
@@ -53,7 +53,7 @@ unsafe fn {impl Destruct for Thing}::drop_in_place(_1: *mut Thing)
         _ => {
         },
     }
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<(), Global>[{built_in impl MetaSized for ()}, {built_in impl Sized for Global}]] ((*_2) as variant Thing::A).0
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<(), Global>[{built_in impl MetaSized for ()}, {built_in impl Sized for Global}]] ((*_2) as variant Thing::A).0
     return
 }
 

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -17,7 +17,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -25,8 +25,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -473,20 +473,20 @@ fn compiletime<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool) -> !
 #[lang_item("RangeInclusive")]
 pub struct RangeInclusive<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
   exhausted: bool,
 }
 
-// Full name: core::ops::range::{RangeInclusive<Idx>[@TraitClause0]}::new
+// Full name: core::ops::range::{RangeInclusive<Idx>[TraitClause0]}::new
 #[lang_item("range_inclusive_new")]
-pub fn new<Idx>(start_1: Idx, end_2: Idx) -> RangeInclusive<Idx>[@TraitClause0]
+pub fn new<Idx>(start_1: Idx, end_2: Idx) -> RangeInclusive<Idx>[TraitClause0]
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
-    let _0: RangeInclusive<Idx>[@TraitClause0]; // return
+    let _0: RangeInclusive<Idx>[TraitClause0]; // return
     let start_1: Idx; // arg #1
     let end_2: Idx; // arg #2
 
@@ -498,7 +498,7 @@ where
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -564,7 +564,7 @@ pub fn panic_nounwind_fmt<'_0>(fmt_1: Arguments<'_0>, force_no_backtrace_2: bool
 // Full name: core::slice::index::private_slice_index::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
@@ -572,10 +572,10 @@ pub trait Sealed<Self>
 #[lang_item("SliceIndex")]
 pub trait SliceIndex<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sealed<Self>
-    parent_clause2 : [@TraitClause2]: MetaSized<T>
-    parent_clause3 : [@TraitClause3]: MetaSized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Sealed)
+    proof ImpliedClause2: (T: MetaSized)
+    proof ImpliedClause3: (Self::Output: MetaSized)
     type Output
     fn get<'_0_1> = core::slice::index::SliceIndex::get<'_0_1, Self, T>[Self]
     fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut<'_0_1, Self, T>[Self]
@@ -586,23 +586,23 @@ pub trait SliceIndex<Self, T>
     vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
-pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl Index<I> for [T]}::index
-pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 TraitClause2::Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T]>),
 {
-    let _0: &'1 @TraitClause2::Output; // return
+    let _0: &'1 TraitClause2::Output; // return
     let self_1: &'3 [T]; // arg #1
     let index_2: I; // arg #2
 
-    _0 = @TraitClause2::index<'5>(move index_2, move self_1)
+    _0 = TraitClause2::index<'5>(move index_2, move self_1)
     return
 }
 
@@ -703,39 +703,39 @@ fn slice_index_fail(start_1: usize, end_2: usize, len_3: usize) -> !
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}]}
 impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}] {
-    parent_clause0 = {built_in impl MetaSized for RangeInclusive<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause0: (RangeInclusive<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for RangeInclusive<usize>[{built_in impl Sized for usize}]}
     vtable: {impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}]}::{vtable}
 }
 
-pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 @TraitClause0::Output>[{built_in impl Sized for &'_0 @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 TraitClause0::Output>[{built_in impl Sized for &'_0 TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut @TraitClause0::Output>[{built_in impl Sized for &'_0 mut @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut TraitClause0::Output>[{built_in impl Sized for &'_0 mut TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut
 pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> &'_0 mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut [T]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -831,7 +831,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index
 pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 [T]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -994,7 +994,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
 pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: *mut [T]) -> *mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: *mut [T]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1115,7 +1115,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked
 pub unsafe fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: *const [T]) -> *const [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: *const [T]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1169,7 +1169,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut
 pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1257,7 +1257,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get
 pub fn {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(self_1: RangeInclusive<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
     let self_1: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1345,20 +1345,20 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}
 impl<T> SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for RangeInclusive<usize>[{built_in impl Sized for usize}]}
-    parent_clause1 = {impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for [T]}
-    parent_clause3 = {built_in impl MetaSized for [T]}
+    proof ImpliedClause0: (RangeInclusive<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for RangeInclusive<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause1: (RangeInclusive<usize>[{built_in impl Sized for usize}]: Sealed) = {impl Sealed for RangeInclusive<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause2: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause3: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
     type Output = [T]
-    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl SliceIndex<[T]> for RangeInclusive<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::slice_index_range

--- a/charon/tests/ui/simple/struct-with-drops.out
+++ b/charon/tests/ui/simple/struct-with-drops.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,15 +27,15 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("drop")]
 pub trait Drop<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Destruct<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
     fn drop<'_0_1> = core::ops::drop::Drop::drop<'_0_1, Self>[Self]
     vtable: core::ops::drop::Drop::{vtable}
 }
 
 pub fn core::ops::drop::Drop::drop<'_0, Self>(_1: &'_0 mut Self)
 where
-    [@TraitClause0]: Drop<Self>,
+    TraitClause0: (Self: Drop),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -52,13 +52,13 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
 // Full name: test_crate::B
@@ -100,8 +100,8 @@ unsafe fn {impl Destruct for B}::drop_in_place(_1: *mut B)
     _2 = &mut (*_1)
     _3 = &mut (*_2)
     _4 = {impl Drop for B}::drop<'4>(move _3)
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).x
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).y
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).x
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).y
     return
 }
 
@@ -115,7 +115,7 @@ unsafe fn {impl Destruct for A}::drop_in_place(_1: *mut A)
     storage_live(_2)
     _0 = ()
     _2 = &mut (*_1)
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).x
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<u32, Global>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, {impl Destruct for Global}]] ((*_2)).x
     drop[{impl Destruct for B}::drop_in_place] ((*_2)).b
     return
 }
@@ -146,8 +146,8 @@ fn takes_a(_1: A)
 
 // Full name: test_crate::{impl Drop for B}
 impl Drop for B {
-    parent_clause0 = {built_in impl MetaSized for B}
-    parent_clause1 = {impl Destruct for B}
+    proof ImpliedClause0: (B: MetaSized) = {built_in impl MetaSized for B}
+    proof ImpliedClause1: (B: Destruct) = {impl Destruct for B}
     fn drop<'_0_1> = {impl Drop for B}::drop<'_0_1>
     vtable: {impl Drop for B}::{vtable}
 }

--- a/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
@@ -8,15 +8,15 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Assoc>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Assoc: Sized)
     type Assoc
     vtable: test_crate::HasAssoc::{vtable}<Self::Assoc>
 }
@@ -24,39 +24,39 @@ trait HasAssoc<Self>
 // Full name: test_crate::SuperTrait
 trait SuperTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::SuperTrait::{vtable}
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: SuperTrait<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: SuperTrait)
     vtable: test_crate::Trait::{vtable}
 }
 
 // Full name: test_crate::{impl SuperTrait for T}
 impl<T> SuperTrait for T
 where
-    [@TraitClause0]: HasAssoc<T>,
-    [@TraitClause1]: Sized<T>,
-    @TraitClause0::Assoc = (),
+    TraitClause0: (T: HasAssoc),
+    TraitClause1: (T: Sized),
+    TypeConstraint0: TraitClause0::Assoc = (),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    vtable: {impl SuperTrait for T}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    vtable: {impl SuperTrait for T}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::{impl Trait for T}
 impl<T> Trait for T
 where
-    [@TraitClause0]: HasAssoc<T>,
-    [@TraitClause1]: Sized<T>,
-    @TraitClause0::Assoc = (),
+    TraitClause0: (T: HasAssoc),
+    TraitClause1: (T: Sized),
+    TypeConstraint0: TraitClause0::Assoc = (),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = {impl SuperTrait for T}<T>[@TraitClause0, @TraitClause1]
-    vtable: {impl Trait for T}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (T: SuperTrait) = {impl SuperTrait for T}<T>[TraitClause0, TraitClause1]
+    vtable: {impl Trait for T}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/simple/thread-local.out
+++ b/charon/tests/ui/simple/thread-local.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for !}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for !}::clone<'_0>(_1: &'_0 !) -> !
 
 // Full name: core::clone::impls::{impl Clone for !}
 impl Clone for ! {
-    parent_clause0 = {built_in impl Sized for !}
+    proof ImpliedClause0: (!: Sized) = {built_in impl Sized for !}
     fn clone<'_0_1> = {impl Clone for !}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -42,15 +42,15 @@ impl Clone for ! {
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
 // Full name: core::marker::{impl Copy for !}
 impl Copy for ! {
-    parent_clause0 = {built_in impl MetaSized for !}
-    parent_clause1 = {impl Clone for !}
+    proof ImpliedClause0: (!: MetaSized) = {built_in impl MetaSized for !}
+    proof ImpliedClause1: (!: Clone) = {impl Clone for !}
     non-dyn-compatible
 }
 
@@ -69,7 +69,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -77,17 +77,17 @@ pub trait Tuple<Self>
 #[lang_item("needs_drop")]
 pub fn needs_drop<T>() -> bool
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 = <opaque>
 
 // Full name: core::ops::function::FnOnce
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -97,46 +97,46 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -145,81 +145,81 @@ where
 // Full name: std::sys::thread_local::native::lazy::Storage
 pub opaque type Storage<T, D>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<D>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (D: Sized),
 
 // Full name: std::sys::thread_local::native::lazy::DestroyedState
 pub trait DestroyedState<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Copy<Self>
-    fn register_dtor<'_0_1, T, [@TraitClause0_1]: Sized<T>> = std::sys::thread_local::native::lazy::DestroyedState::register_dtor<'_0_1, Self, T>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Copy)
+    fn register_dtor<'_0_1, T, TraitClause0_1: (T: Sized)> = std::sys::thread_local::native::lazy::DestroyedState::register_dtor<'_0_1, Self, T>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
-pub fn std::sys::thread_local::native::lazy::DestroyedState::register_dtor<'_0, Self, T>(_1: &'_0 Storage<T, Self>[@TraitClause1, @TraitClause0::parent_clause0])
+pub fn std::sys::thread_local::native::lazy::DestroyedState::register_dtor<'_0, Self, T>(_1: &'_0 Storage<T, Self>[TraitClause1, TraitClause0::ImpliedClause0])
 where
-    [@TraitClause0]: DestroyedState<Self>,
-    [@TraitClause1]: Sized<T>,
+    TraitClause0: (Self: DestroyedState),
+    TraitClause1: (T: Sized),
 = <opaque>
 
 // Full name: std::sys::thread_local::native::lazy::{impl DestroyedState for !}::register_dtor
-pub fn {impl DestroyedState for !}::register_dtor<'_0, T>(_1: &'_0 Storage<T, !>[@TraitClause0, {built_in impl Sized for !}])
+pub fn {impl DestroyedState for !}::register_dtor<'_0, T>(_1: &'_0 Storage<T, !>[TraitClause0, {built_in impl Sized for !}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: std::sys::thread_local::native::lazy::{impl DestroyedState for !}
 impl DestroyedState for ! {
-    parent_clause0 = {built_in impl Sized for !}
-    parent_clause1 = {impl Copy for !}
-    fn register_dtor<'_0_1, T, [@TraitClause0_1]: Sized<T>> = {impl DestroyedState for !}::register_dtor<'_0_1, T>[@TraitClause0_1]
+    proof ImpliedClause0: (!: Sized) = {built_in impl Sized for !}
+    proof ImpliedClause1: (!: Copy) = {impl Copy for !}
+    fn register_dtor<'_0_1, T, TraitClause0_1: (T: Sized)> = {impl DestroyedState for !}::register_dtor<'_0_1, T>[TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: std::sys::thread_local::native::lazy::{impl DestroyedState for ()}::register_dtor
-pub fn {impl DestroyedState for ()}::register_dtor<'_0, T>(_1: &'_0 Storage<T, ()>[@TraitClause0, {built_in impl Sized for ()}])
+pub fn {impl DestroyedState for ()}::register_dtor<'_0, T>(_1: &'_0 Storage<T, ()>[TraitClause0, {built_in impl Sized for ()}])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: std::sys::thread_local::native::lazy::{impl DestroyedState for ()}
 impl DestroyedState for () {
-    parent_clause0 = {built_in impl Sized for ()}
-    parent_clause1 = {built_in impl Copy for ()}
-    fn register_dtor<'_0_1, T, [@TraitClause0_1]: Sized<T>> = {impl DestroyedState for ()}::register_dtor<'_0_1, T>[@TraitClause0_1]
+    proof ImpliedClause0: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause1: ((): Copy) = {built_in impl Copy for ()}
+    fn register_dtor<'_0_1, T, TraitClause0_1: (T: Sized)> = {impl DestroyedState for ()}::register_dtor<'_0_1, T>[TraitClause0_1]
     non-dyn-compatible
 }
 
-pub fn std::sys::thread_local::native::lazy::{Storage<T, D>[@TraitClause0, @TraitClause1]}::new<T, D>() -> Storage<T, D>[@TraitClause0, @TraitClause1]
+pub fn std::sys::thread_local::native::lazy::{Storage<T, D>[TraitClause0, TraitClause1]}::new<T, D>() -> Storage<T, D>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<D>,
-    [@TraitClause2]: DestroyedState<D>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (D: Sized),
+    TraitClause2: (D: DestroyedState),
 = <opaque>
 
-// Full name: std::sys::thread_local::native::lazy::{Storage<T, D>[@TraitClause0, @TraitClause1]}::get_or_init
-pub unsafe fn get_or_init<'_0, '_1, T, D, T2>(_1: &'_0 Storage<T, D>[@TraitClause0, @TraitClause1], _2: Option<&'_1 mut Option<T>[@TraitClause0]>[{built_in impl Sized for &'_1 mut Option<T>[@TraitClause0]}], _3: T2) -> *const T
+// Full name: std::sys::thread_local::native::lazy::{Storage<T, D>[TraitClause0, TraitClause1]}::get_or_init
+pub unsafe fn get_or_init<'_0, '_1, T, D, T2>(_1: &'_0 Storage<T, D>[TraitClause0, TraitClause1], _2: Option<&'_1 mut Option<T>[TraitClause0]>[{built_in impl Sized for &'_1 mut Option<T>[TraitClause0]}], _3: T2) -> *const T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<D>,
-    [@TraitClause2]: DestroyedState<D>,
-    [@TraitClause3]: Sized<T2>,
-    [@TraitClause4]: FnOnce<T2, ()>,
-    @TraitClause4::Output = T,
+    TraitClause0: (T: Sized),
+    TraitClause1: (D: Sized),
+    TraitClause2: (D: DestroyedState),
+    TraitClause3: (T2: Sized),
+    TraitClause4: (T2: FnOnce<()>),
+    TypeConstraint0: TraitClause4::Output = T,
 = <opaque>
 
 // Full name: std::thread::local::LocalKey
 #[lang_item("LocalKey")]
 pub opaque type LocalKey<T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'static,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
 
-pub unsafe fn std::thread::local::{LocalKey<T>[@TraitClause0]}::new<T>(_1: fn<'_0_1>(Option<&'_0_1 mut Option<T>[@TraitClause0]>[{built_in impl Sized for &'_0_1 mut Option<T>[@TraitClause0]}]) -> *const T) -> LocalKey<T>[@TraitClause0]
+pub unsafe fn std::thread::local::{LocalKey<T>[TraitClause0]}::new<T>(_1: fn<'_0_1>(Option<&'_0_1 mut Option<T>[TraitClause0]>[{built_in impl Sized for &'_0_1 mut Option<T>[TraitClause0]}]) -> *const T) -> LocalKey<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'static,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
 = <opaque>
 
 // Full name: test_crate::FOO::__rust_std_internal_init_fn
@@ -241,7 +241,7 @@ fn test_crate::FOO::{const}::closure::__RUST_STD_INTERNAL_VAL() -> Storage<u32, 
 {
     let _0: Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // return
 
-    _0 = std::sys::thread_local::native::lazy::{Storage<T, D>[@TraitClause0, @TraitClause1]}::new<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, {impl DestroyedState for ()}]()
+    _0 = std::sys::thread_local::native::lazy::{Storage<T, D>[TraitClause0, TraitClause1]}::new<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, {impl DestroyedState for ()}]()
     return
 }
 
@@ -304,10 +304,10 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
 
 // Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}
 impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
-    parent_clause1 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause2 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Sized for *const u32}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
+    proof ImpliedClause1: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: (*const u32: Sized) = {built_in impl Sized for *const u32}
     type Output = *const u32
     fn call_once = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}::call_once<'_0>
     non-dyn-compatible
@@ -315,20 +315,20 @@ impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bu
 
 // Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}
 impl<'_0> FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
-    parent_clause1 = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
+    proof ImpliedClause1: (test_crate::FOO::{const}::closure: FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}<'_0>
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
     fn call_mut<'_0_1> = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}
 impl<'_0> Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
-    parent_clause1 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}<'_0>
-    parent_clause2 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure}
+    proof ImpliedClause1: (test_crate::FOO::{const}::closure: FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}<'_0>
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
     fn call<'_0_1> = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure}::call<'_0, '_0_1>
     non-dyn-compatible
 }
@@ -364,7 +364,7 @@ fn test_crate::FOO::{const}::closure#1::__RUST_STD_INTERNAL_VAL() -> Storage<u32
 {
     let _0: Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // return
 
-    _0 = std::sys::thread_local::native::lazy::{Storage<T, D>[@TraitClause0, @TraitClause1]}::new<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}]()
+    _0 = std::sys::thread_local::native::lazy::{Storage<T, D>[TraitClause0, TraitClause1]}::new<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}]()
     return
 }
 
@@ -427,10 +427,10 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
 
 // Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}
 impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
-    parent_clause1 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause2 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Sized for *const u32}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
+    proof ImpliedClause1: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: (*const u32: Sized) = {built_in impl Sized for *const u32}
     type Output = *const u32
     fn call_once = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}::call_once<'_0>
     non-dyn-compatible
@@ -438,20 +438,20 @@ impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bu
 
 // Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}
 impl<'_0> FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
-    parent_clause1 = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}<'_0>
-    parent_clause2 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
+    proof ImpliedClause1: (test_crate::FOO::{const}::closure#1: FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}<'_0>
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
     fn call_mut<'_0_1> = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}::call_mut<'_0, '_0_1>
     non-dyn-compatible
 }
 
 // Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}
 impl<'_0> Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1 {
-    parent_clause0 = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
-    parent_clause1 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}<'_0>
-    parent_clause2 = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    parent_clause3 = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause0: (test_crate::FOO::{const}::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::closure#1}
+    proof ImpliedClause1: (test_crate::FOO::{const}::closure#1: FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}<'_0>
+    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
     fn call<'_0_1> = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::closure#1}::call<'_0, '_0_1>
     non-dyn-compatible
 }
@@ -504,7 +504,7 @@ fn FOO() -> LocalKey<u32>[{built_in impl Sized for u32}]
     }
     storage_dead(_3)
     _1 = move _2
-    _0 = std::thread::local::{LocalKey<T>[@TraitClause0]}::new<u32>[{built_in impl Sized for u32}](move _1)
+    _0 = std::thread::local::{LocalKey<T>[TraitClause0]}::new<u32>[{built_in impl Sized for u32}](move _1)
     return
 }
 

--- a/charon/tests/ui/simple/trait-alias.out
+++ b/charon/tests/ui/simple/trait-alias.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -43,7 +43,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -52,9 +52,9 @@ where
 // Full name: test_crate::Trait
 trait Trait<Self, T, Self_Item>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self_Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self_Item: Sized)
     vtable: test_crate::Trait::{vtable}<T, Self_Item>
 }
 
@@ -73,7 +73,7 @@ pub fn {impl Clone for Struct}::clone<'_0>(self_1: &'_0 Struct) -> Struct
 
 // Full name: test_crate::{impl Clone for Struct}
 impl Clone for Struct {
-    parent_clause0 = {built_in impl Sized for Struct}
+    proof ImpliedClause0: (Struct: Sized) = {built_in impl Sized for Struct}
     fn clone<'_0_1> = {impl Clone for Struct}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -81,44 +81,44 @@ impl Clone for Struct {
 // Full name: test_crate::{impl Trait<T, u32> for Struct}
 impl<T> Trait<T, u32> for Struct
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Struct}
-    parent_clause1 = @TraitClause0
-    parent_clause2 = {built_in impl Sized for u32}
-    vtable: {impl Trait<T, u32> for Struct}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Struct: MetaSized) = {built_in impl MetaSized for Struct}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    proof ImpliedClause2: (u32: Sized) = {built_in impl Sized for u32}
+    vtable: {impl Trait<T, u32> for Struct}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::Alias
 trait Alias<Self, U>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Trait<Self, Option<U>[Self::parent_clause3], u32>
-    parent_clause2 : [@TraitClause2]: Clone<Self>
-    parent_clause3 : [@TraitClause3]: Sized<U>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Trait<Option<U>[Self::ImpliedClause3], u32>)
+    proof ImpliedClause2: (Self: Clone)
+    proof ImpliedClause3: (U: Sized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Alias::{impl Alias<U> for Self}
 impl<Self, U> Alias<U> for Self
 where
-    [@TraitClause0]: MetaSized<Self>,
-    [@TraitClause1]: Trait<Self, Option<U>[@TraitClause3], u32>,
-    [@TraitClause2]: Clone<Self>,
-    [@TraitClause3]: Sized<U>,
+    TraitClause0: (Self: MetaSized),
+    TraitClause1: (Self: Trait<Option<U>[TraitClause3], u32>),
+    TraitClause2: (Self: Clone),
+    TraitClause3: (U: Sized),
 {
-    parent_clause0 = @TraitClause0
-    parent_clause1 = @TraitClause1
-    parent_clause2 = @TraitClause2
-    parent_clause3 = @TraitClause3
+    proof ImpliedClause0: (Self: MetaSized) = TraitClause0
+    proof ImpliedClause1: (Self: Trait<Option<U>[TraitClause3], u32>) = TraitClause1
+    proof ImpliedClause2: (Self: Clone) = TraitClause2
+    proof ImpliedClause3: (U: Sized) = TraitClause3
     non-dyn-compatible
 }
 
 // Full name: test_crate::takes_alias
 fn takes_alias<T>(x_1: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Alias<T, ()>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Alias<()>),
 {
     let _0: (); // return
     let x_1: T; // arg #1
@@ -129,7 +129,7 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = @TraitClause1::parent_clause2::clone<'3>(move _3)
+    _2 = TraitClause1::ImpliedClause2::clone<'3>(move _3)
     storage_dead(_3)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] _2
     storage_dead(_2)

--- a/charon/tests/ui/simple/trait-default-const-cross-crate.out
+++ b/charon/tests/ui/simple/trait-default-const-cross-crate.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: trait_default_const::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const FOO : usize
     non-dyn-compatible
 }
@@ -23,47 +23,47 @@ trait Trait<Self>
 // Full name: trait_default_const::Trait::FOO
 fn FOO<Self>() -> usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 = <missing>
 
 // Full name: trait_default_const::Trait::FOO
 const FOO<Self>: usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
  = FOO()
 
 // Full name: trait_default_const::{impl Trait for T}
 impl<T> Trait for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    const FOO = FOO<T>[{impl Trait for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    const FOO = FOO<T>[{impl Trait for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
 // Full name: trait_default_const::foo
 pub fn foo<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
-    _0 = const {impl Trait for T}<T>[@TraitClause0]::FOO
+    _0 = const {impl Trait for T}<T>[TraitClause0]::FOO
     return
 }
 
 // Full name: test_crate::bar
 fn bar<T>()
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let _1: usize; // anonymous local
 
     _0 = ()
     storage_live(_1)
-    _1 = foo<T>[@TraitClause0]()
+    _1 = foo<T>[TraitClause0]()
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/trait-default-const.out
+++ b/charon/tests/ui/simple/trait-default-const.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const FOO : usize
     non-dyn-compatible
 }
@@ -23,7 +23,7 @@ trait Trait<Self>
 // Full name: test_crate::Trait::FOO
 fn FOO<Self>() -> usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
 {
     let _0: usize; // return
 
@@ -34,27 +34,27 @@ where
 // Full name: test_crate::Trait::FOO
 const FOO<Self>: usize
 where
-    [@TraitClause0]: Trait<Self>,
+    TraitClause0: (Self: Trait),
  = FOO()
 
 // Full name: test_crate::{impl Trait for T}
 impl<T> Trait for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    const FOO = FOO<T>[{impl Trait for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    const FOO = FOO<T>[{impl Trait for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
 // Full name: test_crate::foo
 pub fn foo<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
-    _0 = const {impl Trait for T}<T>[@TraitClause0]::FOO
+    _0 = const {impl Trait for T}<T>[TraitClause0]::FOO
     return
 }
 

--- a/charon/tests/ui/simple/trivial_generic_function.out
+++ b/charon/tests/ui/simple/trivial_generic_function.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn drop_in_place<Self>(_1: *mut Self)
 // Full name: test_crate::ignore
 fn ignore<T>(t_1: T)
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: (); // return
     let t_1: T; // arg #1

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -33,7 +33,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -47,90 +47,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -161,48 +161,48 @@ impl Destruct for Global {
 // Full name: alloc::raw_vec::RawVec
 opaque type RawVec<T, A>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 
 // Full name: alloc::raw_vec::RawVecInner
 opaque type RawVecInner<A>
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 
-// Full name: alloc::raw_vec::{RawVec<T, A>[@TraitClause0, @TraitClause1]}::grow_one
-fn grow_one<'_0, T, A>(_1: &'_0 mut RawVec<T, A>[@TraitClause0, @TraitClause1])
+// Full name: alloc::raw_vec::{RawVec<T, A>[TraitClause0, TraitClause1]}::grow_one
+fn grow_one<'_0, T, A>(_1: &'_0 mut RawVec<T, A>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub struct Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 {
-  buf: RawVec<T, type_error("removed allocator parameter")>[@TraitClause0, @TraitClause1],
+  buf: RawVec<T, type_error("removed allocator parameter")>[TraitClause0, TraitClause1],
   len: usize,
 }
 
-// Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push_mut
-pub fn push_mut<'_0, T, A>(self_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], value_2: T) -> &'_0 mut T
+// Full name: alloc::vec::{Vec<T>[TraitClause0, TraitClause1]}::push_mut
+pub fn push_mut<'_0, T, A>(self_1: &'_0 mut Vec<T>[TraitClause0, TraitClause1], value_2: T) -> &'_0 mut T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Destruct),
 {
     let _0: &'1 mut T; // return
-    let self_1: &'3 mut Vec<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let self_1: &'3 mut Vec<T>[TraitClause0, TraitClause1]; // arg #1
     let value_2: T; // arg #2
     let len_3: usize; // local
     let _4: bool; // anonymous local
     let _5: usize; // anonymous local
     let _6: (); // anonymous local
-    let _7: &'7 mut RawVec<T, A>[@TraitClause0, @TraitClause1]; // anonymous local
+    let _7: &'7 mut RawVec<T, A>[TraitClause0, TraitClause1]; // anonymous local
     let end_8: *mut T; // local
     let self_9: *mut T; // local
     let src_10: T; // local
@@ -215,7 +215,7 @@ where
     len_3 = copy ((*self_1)).len
     storage_live(_4)
     storage_live(_5)
-    switch const {impl SizedTypeProperties for T}<T>[@TraitClause0]::SIZE {
+    switch const {impl SizedTypeProperties for T}<T>[TraitClause0]::SIZE {
         0 : usize => {
             _5 = const 18446744073709551615 : usize
         },
@@ -231,7 +231,7 @@ where
         storage_dead(_5)
         storage_live(_7)
         _7 = &two-phase-mut ((*self_1)).buf
-        _6 = grow_one<'11, T, A>[@TraitClause0, @TraitClause1, @TraitClause2](move _7)
+        _6 = grow_one<'11, T, A>[TraitClause0, TraitClause1, TraitClause2](move _7)
         storage_dead(_7)
     } else {
         storage_dead(_5)
@@ -253,21 +253,21 @@ where
     return
 }
 
-// Full name: alloc::vec::{Vec<T>[@TraitClause0, @TraitClause1]}::push
-pub fn push<'_0, T, A>(self_1: &'_0 mut Vec<T>[@TraitClause0, @TraitClause1], value_2: T)
+// Full name: alloc::vec::{Vec<T>[TraitClause0, TraitClause1]}::push
+pub fn push<'_0, T, A>(self_1: &'_0 mut Vec<T>[TraitClause0, TraitClause1], value_2: T)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Destruct),
 {
     let _0: (); // return
-    let self_1: &'1 mut Vec<T>[@TraitClause0, @TraitClause1]; // arg #1
+    let self_1: &'1 mut Vec<T>[TraitClause0, TraitClause1]; // arg #1
     let value_2: T; // arg #2
     let _3: &'3 mut T; // anonymous local
 
     _0 = ()
     storage_live(_3)
-    _3 = push_mut<'5, T, A>[@TraitClause0, @TraitClause1, @TraitClause2](move self_1, move value_2)
+    _3 = push_mut<'5, T, A>[TraitClause0, TraitClause1, TraitClause2](move self_1, move value_2)
     storage_dead(_3)
     return
 }

--- a/charon/tests/ui/simple/vec-with-capacity.out
+++ b/charon/tests/ui/simple/vec-with-capacity.out
@@ -12,7 +12,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -37,7 +37,7 @@ pub opaque type Alignment
 // Full name: core::mem::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     const SIZE : usize
     const ALIGN : usize
     const ALIGNMENT : Alignment
@@ -51,90 +51,90 @@ pub trait SizedTypeProperties<Self>
 #[lang_item("mem_size_const")]
 pub fn SIZE<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::SIZE
 #[lang_item("mem_size_const")]
 pub const SIZE<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = SIZE()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub fn ALIGN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
 pub const ALIGN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGN()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub const ALIGNMENT<Self>: Alignment
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = ALIGNMENT()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub const IS_ZST<Self>: bool
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = IS_ZST()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub const LAYOUT<Self>: Layout
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = LAYOUT()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
 = <opaque>
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub const MAX_SLICE_LEN<Self>: usize
 where
-    [@TraitClause0]: SizedTypeProperties<Self>,
+    TraitClause0: (Self: SizedTypeProperties),
  = MAX_SLICE_LEN()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> SizedTypeProperties for T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = @TraitClause0
-    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
-    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[@TraitClause0]]
+    proof ImpliedClause0: (T: Sized) = TraitClause0
+    const SIZE = SIZE<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGN = ALIGN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const ALIGNMENT = ALIGNMENT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const IS_ZST = IS_ZST<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const LAYOUT = LAYOUT<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
+    const MAX_SLICE_LEN = MAX_SLICE_LEN<T>[{impl SizedTypeProperties for T}<T>[TraitClause0]]
     non-dyn-compatible
 }
 
@@ -155,48 +155,48 @@ impl Destruct for Global {
 // Full name: alloc::raw_vec::RawVec
 opaque type RawVec<T, A>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 
 // Full name: alloc::raw_vec::RawVecInner
 opaque type RawVecInner<A>
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 
-// Full name: alloc::raw_vec::{RawVecInner<A>[@TraitClause0]}::with_capacity_in
-fn with_capacity_in<A>(_1: usize, _2: A, _3: Layout) -> RawVecInner<A>[@TraitClause0]
+// Full name: alloc::raw_vec::{RawVecInner<A>[TraitClause0]}::with_capacity_in
+fn with_capacity_in<A>(_1: usize, _2: A, _3: Layout) -> RawVecInner<A>[TraitClause0]
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: Destruct<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Destruct),
 = <opaque>
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub struct Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 {
-  buf: RawVec<T, type_error("removed allocator parameter")>[@TraitClause0, @TraitClause1],
+  buf: RawVec<T, type_error("removed allocator parameter")>[TraitClause0, TraitClause1],
   len: usize,
 }
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <missing>
 
-// Full name: alloc::vec::{Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}::with_capacity
+// Full name: alloc::vec::{Vec<T>[TraitClause0, {built_in impl Sized for Global}]}::with_capacity
 #[lang_item("vec_with_capacity")]
-pub fn with_capacity<T>(capacity_1: usize) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn with_capacity<T>(capacity_1: usize) -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    let _0: Vec<T>[@TraitClause0, {built_in impl Sized for Global}]; // return
+    let _0: Vec<T>[TraitClause0, {built_in impl Sized for Global}]; // return
     let capacity_1: usize; // arg #1
-    let _2: RawVec<T, Global>[@TraitClause0, {built_in impl Sized for Global}]; // anonymous local
+    let _2: RawVec<T, Global>[TraitClause0, {built_in impl Sized for Global}]; // anonymous local
     let _3: RawVecInner<Global>[{built_in impl Sized for Global}]; // anonymous local
     let _4: PhantomData<T>; // anonymous local
     let _5: Global; // anonymous local
@@ -205,7 +205,7 @@ where
     storage_live(_3)
     storage_live(_5)
     _5 = Global {  }
-    _3 = with_capacity_in<Global>[{built_in impl Sized for Global}, {impl Destruct for Global}](move capacity_1, move _5, const {impl SizedTypeProperties for T}<T>[@TraitClause0]::LAYOUT)
+    _3 = with_capacity_in<Global>[{built_in impl Sized for Global}, {impl Destruct for Global}](move capacity_1, move _5, const {impl SizedTypeProperties for T}<T>[TraitClause0]::LAYOUT)
     storage_live(_4)
     _4 = PhantomData {  }
     _2 = RawVec { 0: move _3, 1: move _4 }
@@ -224,7 +224,7 @@ fn vec()
     _0 = ()
     storage_live(_1)
     _1 = with_capacity<u32>[{built_in impl Sized for u32}](const 42 : usize)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] _1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u32, Global>[{built_in impl Sized for u32}, {built_in impl Sized for Global}]] _1
     storage_dead(_1)
     _0 = ()
     return

--- a/charon/tests/ui/simple/well-formedness-bound.out
+++ b/charon/tests/ui/simple/well-formedness-bound.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),

--- a/charon/tests/ui/skip-borrowck.out
+++ b/charon/tests/ui/skip-borrowck.out
@@ -8,14 +8,14 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: test_crate::choose
 fn choose<'a, T>(b_1: bool, x_2: &'a mut T, y_3: &'a mut T) -> &'a mut T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut T; // return
     let b_1: bool; // arg #1

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -8,9 +8,9 @@ pub trait MetaSized<Self>
 #[lang_item("index")]
 pub trait Index<Self, Idx>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Idx>
-    parent_clause2 : [@TraitClause2]: MetaSized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Idx: MetaSized)
+    proof ImpliedClause2: (Self::Output: MetaSized)
     type Output
     fn index<'_0_1> = core::ops::index::Index::index<'_0_1, Self, Idx>[Self]
     vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
@@ -20,16 +20,16 @@ pub trait Index<Self, Idx>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
 // Full name: core::array::{impl Index<I> for [T; N]}::index
-pub fn {impl Index<I> for [T; N]}::index<'_0, T, I, const N : usize>(_1: &'_0 [T; N], _2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T; N]}::index<'_0, T, I, const N : usize>(_1: &'_0 [T; N], _2: I) -> &'_0 TraitClause2::Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: Index<[T], I>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: ([T]: Index<I>),
 = <opaque>
 
 // Full name: core::fmt::Error
@@ -43,8 +43,8 @@ pub opaque type Arguments<'a>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -472,16 +472,16 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end_1: usize, len_2
     panic(core::panicking::panic_fmt)
 }
 
-pub fn core::ops::index::Index::index<'_0, Self, Idx>(_1: &'_0 Self, _2: Idx) -> &'_0 @TraitClause0::Output
+pub fn core::ops::index::Index::index<'_0, Self, Idx>(_1: &'_0 Self, _2: Idx) -> &'_0 TraitClause0::Output
 where
-    [@TraitClause0]: Index<Self, Idx>,
+    TraitClause0: (Self: Index<Idx>),
 = <opaque>
 
 // Full name: core::ops::range::Range
 #[lang_item("Range")]
 pub struct Range<Idx>
 where
-    [@TraitClause0]: Sized<Idx>,
+    TraitClause0: (Idx: Sized),
 {
   start: Idx,
   end: Idx,
@@ -491,7 +491,7 @@ where
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -540,7 +540,7 @@ pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
 // Full name: core::slice::index::private_slice_index::Sealed
 pub trait Sealed<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: core::slice::index::private_slice_index::Sealed::{vtable}
 }
 
@@ -548,10 +548,10 @@ pub trait Sealed<Self>
 #[lang_item("SliceIndex")]
 pub trait SliceIndex<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sealed<Self>
-    parent_clause2 : [@TraitClause2]: MetaSized<T>
-    parent_clause3 : [@TraitClause3]: MetaSized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Sealed)
+    proof ImpliedClause2: (T: MetaSized)
+    proof ImpliedClause3: (Self::Output: MetaSized)
     type Output
     fn get<'_0_1> = core::slice::index::SliceIndex::get<'_0_1, Self, T>[Self]
     fn get_mut<'_0_1> = core::slice::index::SliceIndex::get_mut<'_0_1, Self, T>[Self]
@@ -562,39 +562,39 @@ pub trait SliceIndex<Self, T>
     vtable: core::slice::index::SliceIndex::{vtable}<T, Self::Output>
 }
 
-pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index<'_0, Self, T>(_1: Self, _2: &'_0 T) -> &'_0 TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl Index<I> for [T]}::index
-pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 @TraitClause2::Output
+pub fn {impl Index<I> for [T]}::index<'_0, T, I>(self_1: &'_0 [T], index_2: I) -> &'_0 TraitClause2::Output
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T]>),
 {
-    let _0: &'1 @TraitClause2::Output; // return
+    let _0: &'1 TraitClause2::Output; // return
     let self_1: &'3 [T]; // arg #1
     let index_2: I; // arg #2
 
-    _0 = @TraitClause2::index<'5>(move index_2, move self_1)
+    _0 = TraitClause2::index<'5>(move index_2, move self_1)
     return
 }
 
 // Full name: core::slice::index::{impl Index<I> for [T]}
 impl<T, I> Index<I> for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<I>,
-    [@TraitClause2]: SliceIndex<I, [T]>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (I: Sized),
+    TraitClause2: (I: SliceIndex<[T]>),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = @TraitClause1::parent_clause0
-    parent_clause2 = @TraitClause2::parent_clause3
-    type Output = @TraitClause2::Output
-    fn index<'_0_1> = {impl Index<I> for [T]}::index<'_0_1, T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Index<I> for [T]}::{vtable}<T, I>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: (I: MetaSized) = TraitClause1::ImpliedClause0
+    proof ImpliedClause2: (TraitClause2::Output: MetaSized) = TraitClause2::ImpliedClause3
+    type Output = TraitClause2::Output
+    fn index<'_0_1> = {impl Index<I> for [T]}::index<'_0_1, T, I>[TraitClause0, TraitClause1, TraitClause2]
+    vtable: {impl Index<I> for [T]}::{vtable}<T, I>[TraitClause0, TraitClause1, TraitClause2]
 }
 
 // Full name: core::slice::index::slice_index_fail
@@ -694,39 +694,39 @@ fn slice_index_fail(start_1: usize, end_2: usize, len_3: usize) -> !
 
 // Full name: core::slice::index::private_slice_index::{impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
 impl Sealed for Range<usize>[{built_in impl Sized for usize}] {
-    parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause0: (Range<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
     vtable: {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}::{vtable}
 }
 
-pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 @TraitClause0::Output>[{built_in impl Sized for &'_0 @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get<'_0, Self, T>(_1: Self, _2: &'_0 T) -> Option<&'_0 TraitClause0::Output>[{built_in impl Sized for &'_0 TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut @TraitClause0::Output>[{built_in impl Sized for &'_0 mut @TraitClause0::Output}]
+pub fn core::slice::index::SliceIndex::get_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> Option<&'_0 mut TraitClause0::Output>[{built_in impl Sized for &'_0 mut TraitClause0::Output}]
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked<Self, T>(_1: Self, _2: *const T) -> *const TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut @TraitClause0::Output
+pub unsafe fn core::slice::index::SliceIndex::get_unchecked_mut<Self, T>(_1: Self, _2: *mut T) -> *mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
-pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut @TraitClause0::Output
+pub fn core::slice::index::SliceIndex::index_mut<'_0, Self, T>(_1: Self, _2: &'_0 mut T) -> &'_0 mut TraitClause0::Output
 where
-    [@TraitClause0]: SliceIndex<Self, T>,
+    TraitClause0: (Self: SliceIndex<T>),
 = <method_without_default_body>
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut
 pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> &'_0 mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 mut [T]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -799,7 +799,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index
 pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: &'1 [T]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -939,7 +939,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut
 pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: *mut [T]) -> *mut [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: *mut [T]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1058,7 +1058,7 @@ fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked
 pub unsafe fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: *const [T]) -> *const [T]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: *const [T]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1110,7 +1110,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut
 pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 mut [T]) -> Option<&'_0 mut [T]>[{built_in impl Sized for &'_0 mut [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1188,7 +1188,7 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get
 pub fn {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0, T>(self_1: Range<usize>[{built_in impl Sized for usize}], slice_2: &'_0 [T]) -> Option<&'_0 [T]>[{built_in impl Sized for &'_0 [T]}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
     let self_1: Range<usize>[{built_in impl Sized for usize}]; // arg #1
@@ -1266,20 +1266,20 @@ where
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}
 impl<T> SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause1 = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
-    parent_clause2 = {built_in impl MetaSized for [T]}
-    parent_clause3 = {built_in impl MetaSized for [T]}
+    proof ImpliedClause0: (Range<usize>[{built_in impl Sized for usize}]: MetaSized) = {built_in impl MetaSized for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause1: (Range<usize>[{built_in impl Sized for usize}]: Sealed) = {impl Sealed for Range<usize>[{built_in impl Sized for usize}]}
+    proof ImpliedClause2: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause3: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
     type Output = [T]
-    fn get<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[@TraitClause0]
-    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[@TraitClause0]
-    fn get_unchecked = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[@TraitClause0]
-    fn get_unchecked_mut = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[@TraitClause0]
-    fn index<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[@TraitClause0]
-    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[@TraitClause0]
-    vtable: {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[@TraitClause0]
+    fn get<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get<'_0_1, T>[TraitClause0]
+    fn get_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_mut<'_0_1, T>[TraitClause0]
+    fn get_unchecked = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked<T>[TraitClause0]
+    fn get_unchecked_mut = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut<T>[TraitClause0]
+    fn index<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index<'_0_1, T>[TraitClause0]
+    fn index_mut<'_0_1> = {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::index_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -11,7 +11,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -19,8 +19,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -36,7 +36,7 @@ pub trait Display<Self>
 
 pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Display<Self>,
+    TraitClause0: (Self: Display),
 = <opaque>
 
 // Full name: core::fmt::{impl Display for str}::fmt
@@ -60,8 +60,8 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
 // Full name: alloc::string::{impl ToString for T}::to_string
 pub fn {impl ToString for T}::to_string<'_0, T>(_1: &'_0 T) -> String
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Display<T>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (T: Display),
 = <opaque>
 
 // Full name: test_crate::FOO

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -27,7 +27,7 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("tuple_trait")]
 pub trait Tuple<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -35,10 +35,10 @@ pub trait Tuple<Self>
 #[lang_item("fn_once")]
 pub trait FnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Tuple<Args>
-    parent_clause3 : [@TraitClause3]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
     type Output
     fn call_once = core::ops::function::FnOnce::call_once<Self, Args>[Self]
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
@@ -48,63 +48,63 @@ pub trait FnOnce<Self, Args>
 #[lang_item("fn_mut")]
 pub trait FnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1> = core::ops::function::FnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::FnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
 // Full name: core::ops::function::Fn
 #[lang_item("fn")]
 pub trait Fn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
-    parent_clause3 : [@TraitClause3]: Tuple<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1> = core::ops::function::Fn::call<'_0_1, Self, Args>[Self]
-    vtable: core::ops::function::Fn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::Fn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: Fn<Self, Args>,
+    TraitClause0: (Self: Fn<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub extern "rust-call" fn core::ops::function::FnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: FnMut<Self, Args>,
+    TraitClause0: (Self: FnMut<Args>),
 = <opaque>
 
-pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub extern "rust-call" fn core::ops::function::FnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: FnOnce<Self, Args>,
+    TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
 }
 
-// Full name: core::option::Option::{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[@TraitClause0])
+// Full name: core::option::Option::{impl Destruct for Option<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Option<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::result::Result
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -117,7 +117,7 @@ pub opaque type String
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn get_bool<'_0_1> = test_crate::BoolTrait::get_bool<'_0_1, Self>[Self]
     fn ret_true<'_0_1> = test_crate::BoolTrait::ret_true<'_0_1, Self>[Self]
     vtable: test_crate::BoolTrait::{vtable}
@@ -126,7 +126,7 @@ pub trait BoolTrait<Self>
 // Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_in_place
 unsafe fn {impl Destruct for (A, B)}::drop_in_place<A, B>(_1: *mut (A, B))
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 {
     let _0: (); // return
     let _1: *mut (A, B); // arg #1
@@ -143,20 +143,20 @@ where
 // Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}
 impl<A, B> Destruct for (A, B)
 where
-    [@TraitClause0]: Sized<A>,
+    TraitClause0: (A: Sized),
 {
-    fn drop_in_place = {impl Destruct for (A, B)}::drop_in_place<A, B>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for (A, B)}::drop_in_place<A, B>[TraitClause0]
     non-dyn-compatible
 }
 
 pub fn test_crate::BoolTrait::get_bool<'_0, Self>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 = <method_without_default_body>
 
 pub fn test_crate::BoolTrait::ret_true<'_0, Self>(self_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: BoolTrait<Self>,
+    TraitClause0: (Self: BoolTrait),
 {
     let _0: bool; // return
     let self_1: &'1 Self; // arg #1
@@ -187,7 +187,7 @@ pub fn {impl BoolTrait for bool}::ret_true<'_0>(self_1: &'_0 bool) -> bool
 
 // Full name: test_crate::{impl BoolTrait for bool}
 impl BoolTrait for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
     fn get_bool<'_0_1> = {impl BoolTrait for bool}::get_bool<'_0_1>
     fn ret_true<'_0_1> = {impl BoolTrait for bool}::ret_true<'_0_1>
     vtable: {impl BoolTrait for bool}::{vtable}
@@ -220,13 +220,13 @@ pub fn test_bool_trait_bool(x_1: bool) -> bool
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::get_bool
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}::get_bool
+pub fn {impl BoolTrait for Option<T>[TraitClause0]}::get_bool<'_0, T>(self_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
 
     match (*self_1) {
         Option::None => {
@@ -240,64 +240,64 @@ where
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}::ret_true
-pub fn {impl BoolTrait for Option<T>[@TraitClause0]}::ret_true<'_0, T>(self_1: &'_0 Option<T>[@TraitClause0]) -> bool
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}::ret_true
+pub fn {impl BoolTrait for Option<T>[TraitClause0]}::ret_true<'_0, T>(self_1: &'_0 Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let self_1: &'1 Option<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 Option<T>[TraitClause0]; // arg #1
 
     _0 = const true
     return
 }
 
-// Full name: test_crate::{impl BoolTrait for Option<T>[@TraitClause0]}
-impl<T> BoolTrait for Option<T>[@TraitClause0]
+// Full name: test_crate::{impl BoolTrait for Option<T>[TraitClause0]}
+impl<T> BoolTrait for Option<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Option<T>[@TraitClause0]}
-    fn get_bool<'_0_1> = {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'_0_1, T>[@TraitClause0]
-    fn ret_true<'_0_1> = {impl BoolTrait for Option<T>[@TraitClause0]}::ret_true<'_0_1, T>[@TraitClause0]
-    vtable: {impl BoolTrait for Option<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0]
+    proof ImpliedClause0: (Option<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Option<T>[TraitClause0]}
+    fn get_bool<'_0_1> = {impl BoolTrait for Option<T>[TraitClause0]}::get_bool<'_0_1, T>[TraitClause0]
+    fn ret_true<'_0_1> = {impl BoolTrait for Option<T>[TraitClause0]}::ret_true<'_0_1, T>[TraitClause0]
+    vtable: {impl BoolTrait for Option<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
 }
 
 // Full name: test_crate::test_bool_trait_option
-pub fn test_bool_trait_option<T>(x_1: Option<T>[@TraitClause0]) -> bool
+pub fn test_bool_trait_option<T>(x_1: Option<T>[TraitClause0]) -> bool
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: bool; // return
-    let x_1: Option<T>[@TraitClause0]; // arg #1
+    let x_1: Option<T>[TraitClause0]; // arg #1
     let _2: bool; // anonymous local
-    let _3: &'1 Option<T>[@TraitClause0]; // anonymous local
-    let _4: &'2 Option<T>[@TraitClause0]; // anonymous local
+    let _3: &'1 Option<T>[TraitClause0]; // anonymous local
+    let _4: &'2 Option<T>[TraitClause0]; // anonymous local
 
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = {impl BoolTrait for Option<T>[@TraitClause0]}::get_bool<'4, T>[@TraitClause0](move _3)
+    _2 = {impl BoolTrait for Option<T>[TraitClause0]}::get_bool<'4, T>[TraitClause0](move _3)
     if move _2 {
         storage_dead(_3)
         storage_live(_4)
         _4 = &x_1
-        _0 = {impl BoolTrait for Option<T>[@TraitClause0]}::ret_true<'6, T>[@TraitClause0](move _4)
+        _0 = {impl BoolTrait for Option<T>[TraitClause0]}::ret_true<'6, T>[TraitClause0](move _4)
         storage_dead(_4)
     } else {
         storage_dead(_3)
         _0 = const false
     }
     storage_dead(_2)
-    conditional_drop[{impl Destruct for Option<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] x_1
     return
 }
 
 // Full name: test_crate::test_bool_trait
 pub fn test_bool_trait<T>(x_1: T) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: BoolTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: BoolTrait),
 {
     let _0: bool; // return
     let x_1: T; // arg #1
@@ -305,7 +305,7 @@ where
 
     storage_live(_2)
     _2 = &x_1
-    _0 = @TraitClause1::get_bool<'3>(move _2)
+    _0 = TraitClause1::get_bool<'3>(move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T}::drop_in_place] x_1
     return
@@ -314,14 +314,14 @@ where
 // Full name: test_crate::ToU64
 pub trait ToU64<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn to_u64 = test_crate::ToU64::to_u64<Self>[Self]
     vtable: test_crate::ToU64::{vtable}
 }
 
 pub fn test_crate::ToU64::to_u64<Self>(_1: Self) -> u64
 where
-    [@TraitClause0]: ToU64<Self>,
+    TraitClause0: (Self: ToU64),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl ToU64 for u64}::to_u64
@@ -336,7 +336,7 @@ pub fn {impl ToU64 for u64}::to_u64(self_1: u64) -> u64
 
 // Full name: test_crate::{impl ToU64 for u64}
 impl ToU64 for u64 {
-    parent_clause0 = {built_in impl MetaSized for u64}
+    proof ImpliedClause0: (u64: MetaSized) = {built_in impl MetaSized for u64}
     fn to_u64 = {impl ToU64 for u64}::to_u64
     vtable: {impl ToU64 for u64}::{vtable}
 }
@@ -344,8 +344,8 @@ impl ToU64 for u64 {
 // Full name: test_crate::{impl ToU64 for (A, A)}::to_u64
 pub fn {impl ToU64 for (A, A)}::to_u64<A>(self_1: (A, A)) -> u64
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: ToU64<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: ToU64),
 {
     let _0: u64; // return
     let self_1: (A, A); // arg #1
@@ -359,36 +359,36 @@ where
     storage_live(_2)
     storage_live(_3)
     _3 = move self_1.0
-    _2 = @TraitClause1::to_u64(move _3)
+    _2 = TraitClause1::to_u64(move _3)
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
     _5 = move self_1.1
-    _4 = @TraitClause1::to_u64(move _5)
+    _4 = TraitClause1::to_u64(move _5)
     storage_dead(_5)
     _6 = copy _2 panic.+ copy _4
     _0 = move _6
     storage_dead(_4)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<A, A>[@TraitClause0]] self_1
+    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<A, A>[TraitClause0]] self_1
     return
 }
 
 // Full name: test_crate::{impl ToU64 for (A, A)}
 impl<A> ToU64 for (A, A)
 where
-    [@TraitClause0]: Sized<A>,
-    [@TraitClause1]: ToU64<A>,
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: ToU64),
 {
-    parent_clause0 = {built_in impl MetaSized for (A, A)}
-    fn to_u64 = {impl ToU64 for (A, A)}::to_u64<A>[@TraitClause0, @TraitClause1]
-    vtable: {impl ToU64 for (A, A)}::{vtable}<A>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: ((A, A): MetaSized) = {built_in impl MetaSized for (A, A)}
+    fn to_u64 = {impl ToU64 for (A, A)}::to_u64<A>[TraitClause0, TraitClause1]
+    vtable: {impl ToU64 for (A, A)}::{vtable}<A>[TraitClause0, TraitClause1]
 }
 
 pub fn test_crate::f<T>(x_1: (T, T)) -> u64
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ToU64),
 {
     let _0: u64; // return
     let x_1: (T, T); // arg #1
@@ -396,17 +396,17 @@ where
 
     storage_live(_2)
     _2 = move x_1
-    _0 = {impl ToU64 for (A, A)}::to_u64<T>[@TraitClause0, @TraitClause1](move _2)
+    _0 = {impl ToU64 for (A, A)}::to_u64<T>[TraitClause0, TraitClause1](move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<T, T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<T, T>[TraitClause0]] x_1
     return
 }
 
 // Full name: test_crate::g
 pub fn g<T>(x_1: (T, T)) -> u64
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<(T, T)>,
+    TraitClause0: (T: Sized),
+    TraitClause1: ((T, T): ToU64),
 {
     let _0: u64; // return
     let x_1: (T, T); // arg #1
@@ -414,9 +414,9 @@ where
 
     storage_live(_2)
     _2 = move x_1
-    _0 = @TraitClause1::to_u64(move _2)
+    _0 = TraitClause1::to_u64(move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<T, T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for (A, B)}::drop_in_place<T, T>[TraitClause0]] x_1
     return
 }
 
@@ -437,53 +437,53 @@ pub fn h0(x_1: u64) -> u64
 // Full name: test_crate::Wrapper
 pub struct Wrapper<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   x: T,
 }
 
-// Full name: test_crate::Wrapper::{impl Destruct for Wrapper<T>[@TraitClause0]}::drop_in_place
-unsafe fn {impl Destruct for Wrapper<T>[@TraitClause0]}::drop_in_place<T>(_1: *mut Wrapper<T>[@TraitClause0])
+// Full name: test_crate::Wrapper::{impl Destruct for Wrapper<T>[TraitClause0]}::drop_in_place
+unsafe fn {impl Destruct for Wrapper<T>[TraitClause0]}::drop_in_place<T>(_1: *mut Wrapper<T>[TraitClause0])
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <missing>
 
-// Full name: test_crate::Wrapper::{impl Destruct for Wrapper<T>[@TraitClause0]}
-impl<T> Destruct for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::Wrapper::{impl Destruct for Wrapper<T>[TraitClause0]}
+impl<T> Destruct for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    fn drop_in_place = {impl Destruct for Wrapper<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]
+    fn drop_in_place = {impl Destruct for Wrapper<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64
-pub fn {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<T>(self_1: Wrapper<T>[@TraitClause0]) -> u64
+// Full name: test_crate::{impl ToU64 for Wrapper<T>[TraitClause0]}::to_u64
+pub fn {impl ToU64 for Wrapper<T>[TraitClause0]}::to_u64<T>(self_1: Wrapper<T>[TraitClause0]) -> u64
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ToU64),
 {
     let _0: u64; // return
-    let self_1: Wrapper<T>[@TraitClause0]; // arg #1
+    let self_1: Wrapper<T>[TraitClause0]; // arg #1
     let _2: T; // anonymous local
 
     storage_live(_2)
     _2 = move (self_1).x
-    _0 = @TraitClause1::to_u64(move _2)
+    _0 = TraitClause1::to_u64(move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for Wrapper<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] self_1
+    conditional_drop[{impl Destruct for Wrapper<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] self_1
     return
 }
 
-// Full name: test_crate::{impl ToU64 for Wrapper<T>[@TraitClause0]}
-impl<T> ToU64 for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::{impl ToU64 for Wrapper<T>[TraitClause0]}
+impl<T> ToU64 for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ToU64),
 {
-    parent_clause0 = {built_in impl MetaSized for Wrapper<T>[@TraitClause0]}
-    fn to_u64 = {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<T>[@TraitClause0, @TraitClause1]
-    vtable: {impl ToU64 for Wrapper<T>[@TraitClause0]}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Wrapper<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Wrapper<T>[TraitClause0]}
+    fn to_u64 = {impl ToU64 for Wrapper<T>[TraitClause0]}::to_u64<T>[TraitClause0, TraitClause1]
+    vtable: {impl ToU64 for Wrapper<T>[TraitClause0]}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::h1
@@ -495,41 +495,41 @@ pub fn h1(x_1: Wrapper<u64>[{built_in impl Sized for u64}]) -> u64
 
     storage_live(_2)
     _2 = move x_1
-    _0 = {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<u64>[{built_in impl Sized for u64}, {impl ToU64 for u64}](move _2)
+    _0 = {impl ToU64 for Wrapper<T>[TraitClause0]}::to_u64<u64>[{built_in impl Sized for u64}, {impl ToU64 for u64}](move _2)
     storage_dead(_2)
     return
 }
 
 // Full name: test_crate::h2
-pub fn h2<T>(x_1: Wrapper<T>[@TraitClause0]) -> u64
+pub fn h2<T>(x_1: Wrapper<T>[TraitClause0]) -> u64
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ToU64),
 {
     let _0: u64; // return
-    let x_1: Wrapper<T>[@TraitClause0]; // arg #1
-    let _2: Wrapper<T>[@TraitClause0]; // anonymous local
+    let x_1: Wrapper<T>[TraitClause0]; // arg #1
+    let _2: Wrapper<T>[TraitClause0]; // anonymous local
 
     storage_live(_2)
     _2 = move x_1
-    _0 = {impl ToU64 for Wrapper<T>[@TraitClause0]}::to_u64<T>[@TraitClause0, @TraitClause1](move _2)
+    _0 = {impl ToU64 for Wrapper<T>[TraitClause0]}::to_u64<T>[TraitClause0, TraitClause1](move _2)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for Wrapper<T>[@TraitClause0]}::drop_in_place<T>[@TraitClause0]] x_1
+    conditional_drop[{impl Destruct for Wrapper<T>[TraitClause0]}::drop_in_place<T>[TraitClause0]] x_1
     return
 }
 
 // Full name: test_crate::ToType
 pub trait ToType<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn to_type = test_crate::ToType::to_type<Self, T>[Self]
     vtable: test_crate::ToType::{vtable}<T>
 }
 
 pub fn test_crate::ToType::to_type<Self, T>(_1: Self) -> T
 where
-    [@TraitClause0]: ToType<Self, T>,
+    TraitClause0: (Self: ToType<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl ToType<bool> for u64}::to_type
@@ -548,8 +548,8 @@ pub fn {impl ToType<bool> for u64}::to_type(self_1: u64) -> bool
 
 // Full name: test_crate::{impl ToType<bool> for u64}
 impl ToType<bool> for u64 {
-    parent_clause0 = {built_in impl MetaSized for u64}
-    parent_clause1 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (u64: MetaSized) = {built_in impl MetaSized for u64}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
     fn to_type = {impl ToType<bool> for u64}::to_type
     vtable: {impl ToType<bool> for u64}::{vtable}
 }
@@ -557,26 +557,26 @@ impl ToType<bool> for u64 {
 // Full name: test_crate::OfType
 pub trait OfType<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn of_type<T, [@TraitClause0_1]: Sized<T>, [@TraitClause1_1]: ToType<T, Self>, [@TraitClause2_1]: Sized<Self>> = test_crate::OfType::of_type<Self, T>[Self, @TraitClause0_1, @TraitClause1_1, @TraitClause2_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    fn of_type<T, TraitClause0_1: (T: Sized), TraitClause1_1: (T: ToType<Self>), TraitClause2_1: (Self: Sized)> = test_crate::OfType::of_type<Self, T>[Self, TraitClause0_1, TraitClause1_1, TraitClause2_1]
     vtable: test_crate::OfType::{vtable}
 }
 
 pub fn test_crate::OfType::of_type<Self, T>(_1: T) -> Self
 where
-    [@TraitClause0]: OfType<Self>,
-    [@TraitClause1]: Sized<T>,
-    [@TraitClause2]: ToType<T, Self>,
-    [@TraitClause3]: Sized<Self>,
+    TraitClause0: (Self: OfType),
+    TraitClause1: (T: Sized),
+    TraitClause2: (T: ToType<Self>),
+    TraitClause3: (Self: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::h3
 pub fn h3<T1, T2>(y_1: T2) -> T1
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    [@TraitClause2]: OfType<T1>,
-    [@TraitClause3]: ToType<T2, T1>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TraitClause2: (T1: OfType),
+    TraitClause3: (T2: ToType<T1>),
 {
     let _0: T1; // return
     let y_1: T2; // arg #1
@@ -584,7 +584,7 @@ where
 
     storage_live(_2)
     _2 = move y_1
-    _0 = @TraitClause2::of_type<T2>[@TraitClause1, @TraitClause3, @TraitClause0](move _2)
+    _0 = TraitClause2::of_type<T2>[TraitClause1, TraitClause3, TraitClause0](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T2}::drop_in_place] y_1
     return
@@ -593,27 +593,27 @@ where
 // Full name: test_crate::OfTypeBis
 pub trait OfTypeBis<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: ToType<T, Self>
-    parent_clause3 : [@TraitClause3]: Sized<Self>
-    fn of_type<[@TraitClause0_1]: Sized<Self>> = test_crate::OfTypeBis::of_type<Self, T>[Self, @TraitClause0_1]
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (T: ToType<Self>)
+    proof ImpliedClause3: (Self: Sized)
+    fn of_type<TraitClause0_1: (Self: Sized)> = test_crate::OfTypeBis::of_type<Self, T>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 pub fn test_crate::OfTypeBis::of_type<Self, T>(_1: T) -> Self
 where
-    [@TraitClause0]: OfTypeBis<Self, T>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: OfTypeBis<T>),
+    TraitClause1: (Self: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::h4
 pub fn h4<T1, T2>(y_1: T2) -> T1
 where
-    [@TraitClause0]: Sized<T1>,
-    [@TraitClause1]: Sized<T2>,
-    [@TraitClause2]: OfTypeBis<T1, T2>,
-    [@TraitClause3]: ToType<T2, T1>,
+    TraitClause0: (T1: Sized),
+    TraitClause1: (T2: Sized),
+    TraitClause2: (T1: OfTypeBis<T2>),
+    TraitClause3: (T2: ToType<T1>),
 {
     let _0: T1; // return
     let y_1: T2; // arg #1
@@ -621,7 +621,7 @@ where
 
     storage_live(_2)
     _2 = move y_1
-    _0 = @TraitClause2::of_type[@TraitClause0](move _2)
+    _0 = TraitClause2::of_type[TraitClause0](move _2)
     storage_dead(_2)
     conditional_drop[{built_in impl Destruct for T2}::drop_in_place] y_1
     return
@@ -630,17 +630,17 @@ where
 // Full name: test_crate::TestType
 pub struct TestType<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   T,
 }
 
-// Full name: test_crate::{TestType<T>[@TraitClause0]}::test::TestType1
+// Full name: test_crate::{TestType<T>[TraitClause0]}::test::TestType1
 struct TestType1 {
   u64,
 }
 
-// Full name: test_crate::{TestType<T>[@TraitClause0]}::test::{impl TestTrait for TestType1}::test
+// Full name: test_crate::{TestType<T>[TraitClause0]}::test::{impl TestTrait for TestType1}::test
 fn {impl TestTrait for TestType1}::test<'_0>(self_1: &'_0 TestType1) -> bool
 {
     let _0: bool; // return
@@ -654,13 +654,13 @@ fn {impl TestTrait for TestType1}::test<'_0>(self_1: &'_0 TestType1) -> bool
     return
 }
 
-pub fn test_crate::{TestType<T>[@TraitClause0]}::test<'_0, T>(self_1: &'_0 TestType<T>[@TraitClause0], x_2: T) -> bool
+pub fn test_crate::{TestType<T>[TraitClause0]}::test<'_0, T>(self_1: &'_0 TestType<T>[TraitClause0], x_2: T) -> bool
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToU64<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ToU64),
 {
     let _0: bool; // return
-    let self_1: &'1 TestType<T>[@TraitClause0]; // arg #1
+    let self_1: &'1 TestType<T>[TraitClause0]; // arg #1
     let x_2: T; // arg #2
     let x_3: u64; // local
     let _4: T; // anonymous local
@@ -677,7 +677,7 @@ where
     // an impl must be bound by the impl block (can't come from outer
     // blocks).
     _4 = move x_2
-    x_3 = @TraitClause1::to_u64(move _4)
+    x_3 = TraitClause1::to_u64(move _4)
     storage_dead(_4)
     storage_live(y_5)
     y_5 = TestType1 { 0: const 0 : u64 }
@@ -702,22 +702,22 @@ where
     return
 }
 
-// Full name: test_crate::{TestType<T>[@TraitClause0]}::test::TestTrait
+// Full name: test_crate::{TestType<T>[TraitClause0]}::test::TestTrait
 trait TestTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    fn test<'_0_1> = test_crate::{TestType<T>[@TraitClause0]}::test::TestTrait::test<'_0_1, Self>[Self]
-    vtable: test_crate::{TestType<T>[@TraitClause0]}::test::TestTrait::{vtable}
+    proof ImpliedClause0: (Self: MetaSized)
+    fn test<'_0_1> = test_crate::{TestType<T>[TraitClause0]}::test::TestTrait::test<'_0_1, Self>[Self]
+    vtable: test_crate::{TestType<T>[TraitClause0]}::test::TestTrait::{vtable}
 }
 
-fn test_crate::{TestType<T>[@TraitClause0]}::test::TestTrait::test<'_0, Self>(_1: &'_0 Self) -> bool
+fn test_crate::{TestType<T>[TraitClause0]}::test::TestTrait::test<'_0, Self>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: TestTrait<Self>,
+    TraitClause0: (Self: TestTrait),
 = <method_without_default_body>
 
-// Full name: test_crate::{TestType<T>[@TraitClause0]}::test::{impl TestTrait for TestType1}
+// Full name: test_crate::{TestType<T>[TraitClause0]}::test::{impl TestTrait for TestType1}
 impl TestTrait for TestType1 {
-    parent_clause0 = {built_in impl MetaSized for TestType1}
+    proof ImpliedClause0: (TestType1: MetaSized) = {built_in impl MetaSized for TestType1}
     fn test<'_0_1> = {impl TestTrait for TestType1}::test<'_0_1>
     vtable: {impl TestTrait for TestType1}::{vtable}
 }
@@ -730,8 +730,8 @@ pub struct BoolWrapper {
 // Full name: test_crate::{impl ToType<T> for BoolWrapper}::to_type
 pub fn {impl ToType<T> for BoolWrapper}::to_type<T>(self_1: BoolWrapper) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToType<bool, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (bool: ToType<T>),
 {
     let _0: T; // return
     let self_1: BoolWrapper; // arg #1
@@ -739,7 +739,7 @@ where
 
     storage_live(_2)
     _2 = copy (self_1).0
-    _0 = @TraitClause1::to_type(move _2)
+    _0 = TraitClause1::to_type(move _2)
     storage_dead(_2)
     return
 }
@@ -747,22 +747,22 @@ where
 // Full name: test_crate::{impl ToType<T> for BoolWrapper}
 impl<T> ToType<T> for BoolWrapper
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToType<bool, T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (bool: ToType<T>),
 {
-    parent_clause0 = {built_in impl MetaSized for BoolWrapper}
-    parent_clause1 = @TraitClause0
-    fn to_type = {impl ToType<T> for BoolWrapper}::to_type<T>[@TraitClause0, @TraitClause1]
-    vtable: {impl ToType<T> for BoolWrapper}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (BoolWrapper: MetaSized) = {built_in impl MetaSized for BoolWrapper}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn to_type = {impl ToType<T> for BoolWrapper}::to_type<T>[TraitClause0, TraitClause1]
+    vtable: {impl ToType<T> for BoolWrapper}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::WithConstTy
 pub trait WithConstTy<Self, const LEN : usize>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::V>
-    parent_clause2 : [@TraitClause2]: Sized<Self::W>
-    parent_clause3 : [@TraitClause3]: ToU64<Self::W>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::V: Sized)
+    proof ImpliedClause2: (Self::W: Sized)
+    proof ImpliedClause3: (Self::W: ToU64)
     const LEN1 : usize
     const LEN2 : usize
     type V
@@ -774,7 +774,7 @@ pub trait WithConstTy<Self, const LEN : usize>
 // Full name: test_crate::WithConstTy::LEN2
 pub fn LEN2<Self, const LEN : usize>() -> usize
 where
-    [@TraitClause0]: WithConstTy<Self, LEN>,
+    TraitClause0: (Self: WithConstTy<LEN>),
 {
     let _0: usize; // return
 
@@ -785,12 +785,12 @@ where
 // Full name: test_crate::WithConstTy::LEN2
 pub const LEN2<Self, const LEN : usize>: usize
 where
-    [@TraitClause0]: WithConstTy<Self, LEN>,
+    TraitClause0: (Self: WithConstTy<LEN>),
  = LEN2()
 
-pub fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(_1: &'_0 mut @TraitClause0::W, _2: &'_1 [u8; LEN])
+pub fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(_1: &'_0 mut TraitClause0::W, _2: &'_1 [u8; LEN])
 where
-    [@TraitClause0]: WithConstTy<Self, LEN>,
+    TraitClause0: (Self: WithConstTy<LEN>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl WithConstTy<32 : usize> for bool}::f
@@ -819,10 +819,10 @@ pub const LEN1: usize = LEN1()
 
 // Full name: test_crate::{impl WithConstTy<32 : usize> for bool}
 impl WithConstTy<32 : usize> for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
-    parent_clause1 = {built_in impl Sized for u8}
-    parent_clause2 = {built_in impl Sized for u64}
-    parent_clause3 = {impl ToU64 for u64}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
+    proof ImpliedClause1: (u8: Sized) = {built_in impl Sized for u8}
+    proof ImpliedClause2: (u64: Sized) = {built_in impl Sized for u64}
+    proof ImpliedClause3: (u64: ToU64) = {impl ToU64 for u64}
     const LEN1 = LEN1
     const LEN2 = LEN2<bool, 32 : usize>[{impl WithConstTy<32 : usize> for bool}]
     type V = u8
@@ -834,53 +834,53 @@ impl WithConstTy<32 : usize> for bool {
 // Full name: test_crate::use_with_const_ty1
 pub fn use_with_const_ty1<H, const LEN : usize>() -> usize
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: WithConstTy<H, LEN>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: WithConstTy<LEN>),
 {
     let _0: usize; // return
 
-    _0 = const @TraitClause1::LEN1
+    _0 = const TraitClause1::LEN1
     return
 }
 
 // Full name: test_crate::use_with_const_ty2
-pub fn use_with_const_ty2<H, const LEN : usize>(_1: @TraitClause1::W)
+pub fn use_with_const_ty2<H, const LEN : usize>(_1: TraitClause1::W)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: WithConstTy<H, LEN>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: WithConstTy<LEN>),
 {
     let _0: (); // return
-    let _1: @TraitClause1::W; // arg #1
+    let _1: TraitClause1::W; // arg #1
 
     _0 = ()
     _0 = ()
-    conditional_drop[{built_in impl Destruct for @TraitClause1::W}::drop_in_place] _1
+    conditional_drop[{built_in impl Destruct for TraitClause1::W}::drop_in_place] _1
     return
 }
 
 // Full name: test_crate::use_with_const_ty3
-pub fn use_with_const_ty3<H, const LEN : usize>(x_1: @TraitClause1::W) -> u64
+pub fn use_with_const_ty3<H, const LEN : usize>(x_1: TraitClause1::W) -> u64
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: WithConstTy<H, LEN>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: WithConstTy<LEN>),
 {
     let _0: u64; // return
-    let x_1: @TraitClause1::W; // arg #1
-    let _2: @TraitClause1::W; // anonymous local
+    let x_1: TraitClause1::W; // arg #1
+    let _2: TraitClause1::W; // anonymous local
 
     storage_live(_2)
     _2 = move x_1
-    _0 = @TraitClause1::parent_clause3::to_u64(move _2)
+    _0 = TraitClause1::ImpliedClause3::to_u64(move _2)
     storage_dead(_2)
-    conditional_drop[{built_in impl Destruct for @TraitClause1::W}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::W}::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::test_where1
 pub fn test_where1<'a, T>(_x_1: &'a T)
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
 {
     let _0: (); // return
     let _x_1: &'1 T; // arg #1
@@ -893,9 +893,9 @@ where
 // Full name: test_crate::test_where2
 pub fn test_where2<T>(_x_1: u32)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: WithConstTy<T, 32 : usize>,
-    @TraitClause1::V = u32,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: WithConstTy<32 : usize>),
+    TypeConstraint0: TraitClause1::V = u32,
 {
     let _0: (); // return
     let _x_1: u32; // arg #1
@@ -908,8 +908,8 @@ where
 // Full name: test_crate::ParentTrait0
 pub trait ParentTrait0<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::W>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::W: Sized)
     type W
     fn get_name<'_0_1> = get_name<'_0_1, Self>[Self]
     fn get_w<'_0_1> = test_crate::ParentTrait0::get_w<'_0_1, Self>[Self]
@@ -919,35 +919,35 @@ pub trait ParentTrait0<Self>
 // Full name: test_crate::ParentTrait0::get_name
 pub fn get_name<'_0, Self>(_1: &'_0 Self) -> String
 where
-    [@TraitClause0]: ParentTrait0<Self>,
+    TraitClause0: (Self: ParentTrait0),
 = <method_without_default_body>
 
-pub fn test_crate::ParentTrait0::get_w<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::W
+pub fn test_crate::ParentTrait0::get_w<'_0, Self>(_1: &'_0 Self) -> TraitClause0::W
 where
-    [@TraitClause0]: ParentTrait0<Self>,
+    TraitClause0: (Self: ParentTrait0),
 = <method_without_default_body>
 
 // Full name: test_crate::ParentTrait1
 pub trait ParentTrait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::ParentTrait1::{vtable}
 }
 
 // Full name: test_crate::ChildTrait
 pub trait ChildTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: ParentTrait0<Self>
-    parent_clause2 : [@TraitClause2]: ParentTrait1<Self>
-    vtable: test_crate::ChildTrait::{vtable}<Self::parent_clause1::W>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: ParentTrait0)
+    proof ImpliedClause2: (Self: ParentTrait1)
+    vtable: test_crate::ChildTrait::{vtable}<Self::ImpliedClause1::W>
 }
 
 // Full name: test_crate::test_child_trait1
 pub fn test_child_trait1<'_0, T>(x_1: &'_0 T) -> String
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ChildTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ChildTrait),
 {
     let _0: String; // return
     let x_1: &'1 T; // arg #1
@@ -955,24 +955,24 @@ where
 
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = @TraitClause1::parent_clause1::get_name<'4>(move _2)
+    _0 = TraitClause1::ImpliedClause1::get_name<'4>(move _2)
     storage_dead(_2)
     return
 }
 
 // Full name: test_crate::test_child_trait2
-pub fn test_child_trait2<'_0, T>(x_1: &'_0 T) -> @TraitClause1::parent_clause1::W
+pub fn test_child_trait2<'_0, T>(x_1: &'_0 T) -> TraitClause1::ImpliedClause1::W
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ChildTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: ChildTrait),
 {
-    let _0: @TraitClause1::parent_clause1::W; // return
+    let _0: TraitClause1::ImpliedClause1::W; // return
     let x_1: &'1 T; // arg #1
     let _2: &'2 T; // anonymous local
 
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = @TraitClause1::parent_clause1::get_w<'4>(move _2)
+    _0 = TraitClause1::ImpliedClause1::get_w<'4>(move _2)
     storage_dead(_2)
     return
 }
@@ -980,11 +980,11 @@ where
 // Full name: test_crate::order1
 pub fn order1<T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: ParentTrait0<T>,
-    [@TraitClause3]: ParentTrait0<U>,
-    @TraitClause2::W = @TraitClause3::W,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: ParentTrait0),
+    TraitClause3: (U: ParentTrait0),
+    TypeConstraint0: TraitClause2::W = TraitClause3::W,
 {
     let _0: (); // return
 
@@ -996,29 +996,29 @@ where
 // Full name: test_crate::ChildTrait1
 pub trait ChildTrait1<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: ParentTrait1<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: ParentTrait1)
     vtable: test_crate::ChildTrait1::{vtable}
 }
 
 // Full name: test_crate::{impl ParentTrait1 for usize}
 impl ParentTrait1 for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
     vtable: {impl ParentTrait1 for usize}::{vtable}
 }
 
 // Full name: test_crate::{impl ChildTrait1 for usize}
 impl ChildTrait1 for usize {
-    parent_clause0 = {built_in impl MetaSized for usize}
-    parent_clause1 = {impl ParentTrait1 for usize}
+    proof ImpliedClause0: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause1: (usize: ParentTrait1) = {impl ParentTrait1 for usize}
     vtable: {impl ChildTrait1 for usize}::{vtable}
 }
 
 // Full name: test_crate::Iterator
 pub trait Iterator<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
     type Item
     vtable: test_crate::Iterator::{vtable}<Self::Item>
 }
@@ -1026,12 +1026,12 @@ pub trait Iterator<Self>
 // Full name: test_crate::IntoIterator
 pub trait IntoIterator<Self>
 where
-    Self::parent_clause3::Item = Self::Item,
+    TypeConstraint0: Self::ImpliedClause3::Item = Self::Item,
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: Sized<Self::IntoIter>
-    parent_clause3 : [@TraitClause3]: Iterator<Self::IntoIter>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    proof ImpliedClause2: (Self::IntoIter: Sized)
+    proof ImpliedClause3: (Self::IntoIter: Iterator)
     type Item
     type IntoIter
     fn into_iter = into_iter<Self>[Self]
@@ -1039,25 +1039,25 @@ where
 }
 
 // Full name: test_crate::IntoIterator::into_iter
-pub fn into_iter<Self>(_1: Self) -> @TraitClause0::IntoIter
+pub fn into_iter<Self>(_1: Self) -> TraitClause0::IntoIter
 where
-    [@TraitClause0]: IntoIterator<Self>,
+    TraitClause0: (Self: IntoIterator),
 = <method_without_default_body>
 
 // Full name: test_crate::FromResidual
 trait FromResidual<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::FromResidual::{vtable}<T>
 }
 
 // Full name: test_crate::Try
 trait Try<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: FromResidual<Self, Self::Residual>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Residual>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FromResidual<Self::Residual>)
+    proof ImpliedClause2: (Self::Residual: Sized)
     type Residual
     non-dyn-compatible
 }
@@ -1065,8 +1065,8 @@ trait Try<Self>
 // Full name: test_crate::WithTarget
 pub trait WithTarget<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Target>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Target: Sized)
     type Target
     vtable: test_crate::WithTarget::{vtable}<Self::Target>
 }
@@ -1074,9 +1074,9 @@ pub trait WithTarget<Self>
 // Full name: test_crate::ParentTrait2
 pub trait ParentTrait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::U>
-    parent_clause2 : [@TraitClause2]: WithTarget<Self::U>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::U: Sized)
+    proof ImpliedClause2: (Self::U: WithTarget)
     type U
     vtable: test_crate::ParentTrait2::{vtable}<Self::U>
 }
@@ -1084,30 +1084,30 @@ pub trait ParentTrait2<Self>
 // Full name: test_crate::ChildTrait2
 pub trait ChildTrait2<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: ParentTrait2<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: ParentTrait2)
     fn convert = test_crate::ChildTrait2::convert<Self>[Self]
     non-dyn-compatible
 }
 
-pub fn test_crate::ChildTrait2::convert<Self>(_1: @TraitClause0::parent_clause1::U) -> @TraitClause0::parent_clause1::parent_clause2::Target
+pub fn test_crate::ChildTrait2::convert<Self>(_1: TraitClause0::ImpliedClause1::U) -> TraitClause0::ImpliedClause1::ImpliedClause2::Target
 where
-    [@TraitClause0]: ChildTrait2<Self>,
+    TraitClause0: (Self: ChildTrait2),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl WithTarget for u32}
 impl WithTarget for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
     type Target = u32
     vtable: {impl WithTarget for u32}::{vtable}
 }
 
 // Full name: test_crate::{impl ParentTrait2 for u32}
 impl ParentTrait2 for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {built_in impl Sized for u32}
-    parent_clause2 = {impl WithTarget for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    proof ImpliedClause2: (u32: WithTarget) = {impl WithTarget for u32}
     type U = u32
     vtable: {impl ParentTrait2 for u32}::{vtable}
 }
@@ -1124,8 +1124,8 @@ pub fn {impl ChildTrait2 for u32}::convert(x_1: u32) -> u32
 
 // Full name: test_crate::{impl ChildTrait2 for u32}
 impl ChildTrait2 for u32 {
-    parent_clause0 = {built_in impl MetaSized for u32}
-    parent_clause1 = {impl ParentTrait2 for u32}
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: (u32: ParentTrait2) = {impl ParentTrait2 for u32}
     fn convert = {impl ChildTrait2 for u32}::convert
     non-dyn-compatible
 }
@@ -1133,77 +1133,77 @@ impl ChildTrait2 for u32 {
 // Full name: test_crate::CFnOnce
 pub trait CFnOnce<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Args>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Self::Output: Sized)
     type Output
     fn call_once = test_crate::CFnOnce::call_once<Self, Args>[Self]
     vtable: test_crate::CFnOnce::{vtable}<Args, Self::Output>
 }
 
-pub fn test_crate::CFnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> @TraitClause0::Output
+pub fn test_crate::CFnOnce::call_once<Self, Args>(_1: Self, _2: Args) -> TraitClause0::Output
 where
-    [@TraitClause0]: CFnOnce<Self, Args>,
+    TraitClause0: (Self: CFnOnce<Args>),
 = <method_without_default_body>
 
 // Full name: test_crate::CFnMut
 pub trait CFnMut<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: CFnOnce<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: CFnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
     fn call_mut<'_0_1> = test_crate::CFnMut::call_mut<'_0_1, Self, Args>[Self]
-    vtable: test_crate::CFnMut::{vtable}<Args, Self::parent_clause1::Output>
+    vtable: test_crate::CFnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
-pub fn test_crate::CFnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> @TraitClause0::parent_clause1::Output
+pub fn test_crate::CFnMut::call_mut<'_0, Self, Args>(_1: &'_0 mut Self, _2: Args) -> TraitClause0::ImpliedClause1::Output
 where
-    [@TraitClause0]: CFnMut<Self, Args>,
+    TraitClause0: (Self: CFnMut<Args>),
 = <method_without_default_body>
 
 // Full name: test_crate::CFn
 pub trait CFn<Self, Args>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: CFnMut<Self, Args>
-    parent_clause2 : [@TraitClause2]: Sized<Args>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: CFnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
     fn call<'_0_1> = test_crate::CFn::call<'_0_1, Self, Args>[Self]
-    vtable: test_crate::CFn::{vtable}<Args, Self::parent_clause1::parent_clause1::Output>
+    vtable: test_crate::CFn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-pub fn test_crate::CFn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> @TraitClause0::parent_clause1::parent_clause1::Output
+pub fn test_crate::CFn::call<'_0, Self, Args>(_1: &'_0 Self, _2: Args) -> TraitClause0::ImpliedClause1::ImpliedClause1::Output
 where
-    [@TraitClause0]: CFn<Self, Args>,
+    TraitClause0: (Self: CFn<Args>),
 = <method_without_default_body>
 
 // Full name: test_crate::GetTrait
 pub trait GetTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::W>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::W: Sized)
     type W
     fn get_w<'_0_1> = test_crate::GetTrait::get_w<'_0_1, Self>[Self]
     vtable: test_crate::GetTrait::{vtable}<Self::W>
 }
 
-pub fn test_crate::GetTrait::get_w<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::W
+pub fn test_crate::GetTrait::get_w<'_0, Self>(_1: &'_0 Self) -> TraitClause0::W
 where
-    [@TraitClause0]: GetTrait<Self>,
+    TraitClause0: (Self: GetTrait),
 = <method_without_default_body>
 
 // Full name: test_crate::test_get_trait
-pub fn test_get_trait<'_0, T>(x_1: &'_0 T) -> @TraitClause1::W
+pub fn test_get_trait<'_0, T>(x_1: &'_0 T) -> TraitClause1::W
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: GetTrait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: GetTrait),
 {
-    let _0: @TraitClause1::W; // return
+    let _0: TraitClause1::W; // return
     let x_1: &'1 T; // arg #1
     let _2: &'2 T; // anonymous local
 
     storage_live(_2)
     _2 = &(*x_1)
-    _0 = @TraitClause1::get_w<'4>(move _2)
+    _0 = TraitClause1::get_w<'4>(move _2)
     storage_dead(_2)
     return
 }
@@ -1211,7 +1211,7 @@ where
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     const LEN : usize
     non-dyn-compatible
 }
@@ -1219,7 +1219,7 @@ pub trait Trait<Self>
 // Full name: test_crate::{impl Trait for [T; N]}::LEN
 pub fn {impl Trait for [T; N]}::LEN<T, const N : usize>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
     let _0: usize; // return
 
@@ -1230,24 +1230,24 @@ where
 // Full name: test_crate::{impl Trait for [T; N]}::LEN
 pub const {impl Trait for [T; N]}::LEN<T, const N : usize>: usize
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
  = {impl Trait for [T; N]}::LEN()
 
 // Full name: test_crate::{impl Trait for [T; N]}
 impl<T, const N : usize> Trait for [T; N]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for [T; N]}
-    const LEN = {impl Trait for [T; N]}::LEN<T, N>[@TraitClause0]
+    proof ImpliedClause0: ([T; N]: MetaSized) = {built_in impl MetaSized for [T; N]}
+    const LEN = {impl Trait for [T; N]}::LEN<T, N>[TraitClause0]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait for Wrapper<T>[@TraitClause0]}::LEN
-pub fn {impl Trait for Wrapper<T>[@TraitClause0]}::LEN<T>() -> usize
+// Full name: test_crate::{impl Trait for Wrapper<T>[TraitClause0]}::LEN
+pub fn {impl Trait for Wrapper<T>[TraitClause0]}::LEN<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
 {
     let _0: usize; // return
 
@@ -1255,108 +1255,108 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait for Wrapper<T>[@TraitClause0]}::LEN
-pub const {impl Trait for Wrapper<T>[@TraitClause0]}::LEN<T>: usize
+// Full name: test_crate::{impl Trait for Wrapper<T>[TraitClause0]}::LEN
+pub const {impl Trait for Wrapper<T>[TraitClause0]}::LEN<T>: usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
- = {impl Trait for Wrapper<T>[@TraitClause0]}::LEN()
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
+ = {impl Trait for Wrapper<T>[TraitClause0]}::LEN()
 
-// Full name: test_crate::{impl Trait for Wrapper<T>[@TraitClause0]}
-impl<T> Trait for Wrapper<T>[@TraitClause0]
+// Full name: test_crate::{impl Trait for Wrapper<T>[TraitClause0]}
+impl<T> Trait for Wrapper<T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
 {
-    parent_clause0 = {built_in impl MetaSized for Wrapper<T>[@TraitClause0]}
-    const LEN = {impl Trait for Wrapper<T>[@TraitClause0]}::LEN<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Wrapper<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for Wrapper<T>[TraitClause0]}
+    const LEN = {impl Trait for Wrapper<T>[TraitClause0]}::LEN<T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::use_wrapper_len
 pub fn use_wrapper_len<T>() -> usize
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Trait),
 {
     let _0: usize; // return
 
-    _0 = copy {impl Trait for Wrapper<T>[@TraitClause0]}::LEN<T>[@TraitClause0, @TraitClause1]
+    _0 = copy {impl Trait for Wrapper<T>[TraitClause0]}::LEN<T>[TraitClause0, TraitClause1]
     return
 }
 
 // Full name: test_crate::Foo
 pub struct Foo<T, U>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
 {
   x: T,
   y: U,
 }
 
-// Full name: test_crate::{Foo<T, U>[@TraitClause0, @TraitClause1]}::FOO
-pub fn FOO<T, U>() -> Result<T, i32>[@TraitClause0, {built_in impl Sized for i32}]
+// Full name: test_crate::{Foo<T, U>[TraitClause0, TraitClause1]}::FOO
+pub fn FOO<T, U>() -> Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Trait),
 {
-    let _0: Result<T, i32>[@TraitClause0, {built_in impl Sized for i32}]; // return
+    let _0: Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]; // return
 
     _0 = Result::Err { 0: const 0 : i32 }
     return
 }
 
-// Full name: test_crate::{Foo<T, U>[@TraitClause0, @TraitClause1]}::FOO
-pub const FOO<T, U>: Result<T, i32>[@TraitClause0, {built_in impl Sized for i32}]
+// Full name: test_crate::{Foo<T, U>[TraitClause0, TraitClause1]}::FOO
+pub const FOO<T, U>: Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Trait),
  = FOO()
 
 // Full name: test_crate::use_foo1
-pub fn use_foo1<T, U>() -> Result<T, i32>[@TraitClause0, {built_in impl Sized for i32}]
+pub fn use_foo1<T, U>() -> Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Trait<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Trait),
 {
-    let _0: Result<T, i32>[@TraitClause0, {built_in impl Sized for i32}]; // return
+    let _0: Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]; // return
 
-    _0 = copy FOO<T, U>[@TraitClause0, @TraitClause1, @TraitClause2]
+    _0 = copy FOO<T, U>[TraitClause0, TraitClause1, TraitClause2]
     return
 }
 
 // Full name: test_crate::use_foo2
-pub fn use_foo2<T, U>() -> Result<U, i32>[@TraitClause1, {built_in impl Sized for i32}]
+pub fn use_foo2<T, U>() -> Result<U, i32>[TraitClause1, {built_in impl Sized for i32}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Trait<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: Trait),
 {
-    let _0: Result<U, i32>[@TraitClause1, {built_in impl Sized for i32}]; // return
+    let _0: Result<U, i32>[TraitClause1, {built_in impl Sized for i32}]; // return
 
-    _0 = copy FOO<U, T>[@TraitClause1, @TraitClause0, @TraitClause2]
+    _0 = copy FOO<U, T>[TraitClause1, TraitClause0, TraitClause2]
     return
 }
 
 // Full name: test_crate::RecursiveImpl
 trait RecursiveImpl<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Item>
-    parent_clause2 : [@TraitClause2]: RecursiveImpl<Self::Item>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    proof ImpliedClause2: (Self::Item: RecursiveImpl)
     type Item
     vtable: test_crate::RecursiveImpl::{vtable}<Self::Item>
 }
 
 // Full name: test_crate::{impl RecursiveImpl for ()}
 impl RecursiveImpl for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
-    parent_clause1 = {built_in impl Sized for ()}
-    parent_clause2 = {impl RecursiveImpl for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): RecursiveImpl) = {impl RecursiveImpl for ()}
     type Item = ()
     vtable: {impl RecursiveImpl for ()}::{vtable}
 }
@@ -1372,9 +1372,9 @@ pub fn flabada<'a>(_x_1: &'a ()) -> Wrapper<(bool, &'a ())>[{built_in impl Sized
 
 pub fn test_crate::call<'a, F>(_1: F)
 where
-    [@TraitClause0]: Sized<F>,
-    [@TraitClause1]: Fn<F, (&'a (),)>,
-    @TraitClause1::parent_clause1::parent_clause1::Output = Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}],
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: Fn<(&'a (),)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::ImpliedClause1::Output = Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}],
 {
     let _0: (); // return
     let _1: F; // arg #1
@@ -1402,19 +1402,19 @@ pub fn flibidi()
 // Full name: test_crate::assoc_ty_trait_ref::SliceIndex
 trait SliceIndex<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Output>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Output: Sized)
     type Output
     vtable: test_crate::assoc_ty_trait_ref::SliceIndex::{vtable}<Self::Output>
 }
 
 // Full name: test_crate::assoc_ty_trait_ref::index
-fn index<I>() -> @TraitClause1::Output
+fn index<I>() -> TraitClause1::Output
 where
-    [@TraitClause0]: Sized<I>,
-    [@TraitClause1]: SliceIndex<I>,
+    TraitClause0: (I: Sized),
+    TraitClause1: (I: SliceIndex),
 {
-    let _0: @TraitClause1::Output; // return
+    let _0: TraitClause1::Output; // return
 
     panic(core::panicking::panic)
 }

--- a/charon/tests/ui/traits/pointee-metadata-bounds.out
+++ b/charon/tests/ui/traits/pointee-metadata-bounds.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -40,14 +40,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -63,7 +63,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -73,7 +73,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -82,8 +82,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -92,14 +92,14 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 // Full name: core::cmp::PartialOrd::partial_cmp
 #[lang_item("cmp_partialord_cmp")]
 pub fn partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::fmt::Error
@@ -109,8 +109,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -127,13 +127,13 @@ pub trait Debug<Self>
 // Full name: core::fmt::Debug::fmt
 pub fn fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -143,28 +143,28 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 // Full name: core::hash::Hash::hash
 pub fn hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::marker::Send
@@ -175,8 +175,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -196,15 +196,15 @@ pub trait Unpin<Self>
 #[lang_item("pointee_trait")]
 pub trait Pointee<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self::Metadata>
-    parent_clause1 : [@TraitClause1]: Debug<Self::Metadata>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Metadata>
-    parent_clause3 : [@TraitClause3]: Send<Self::Metadata>
-    parent_clause4 : [@TraitClause4]: Sync<Self::Metadata>
-    parent_clause5 : [@TraitClause5]: Ord<Self::Metadata>
-    parent_clause6 : [@TraitClause6]: Hash<Self::Metadata>
-    parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
-    parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
+    proof ImpliedClause0: (Self::Metadata: Sized)
+    proof ImpliedClause1: (Self::Metadata: Debug)
+    proof ImpliedClause2: (Self::Metadata: Copy)
+    proof ImpliedClause3: (Self::Metadata: Send)
+    proof ImpliedClause4: (Self::Metadata: Sync)
+    proof ImpliedClause5: (Self::Metadata: Ord)
+    proof ImpliedClause6: (Self::Metadata: Hash)
+    proof ImpliedClause7: (Self::Metadata: Unpin)
+    proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
 }
@@ -212,8 +212,8 @@ pub trait Pointee<Self>
 // Full name: test_crate::assert_copy
 fn assert_copy<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Copy<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Copy),
 {
     let _0: (); // return
 
@@ -225,12 +225,12 @@ where
 // Full name: test_crate::foo
 fn foo<T>()
 where
-    [@TraitClause0]: MetaSized<T>,
+    TraitClause0: (T: MetaSized),
 {
     let _0: (); // return
 
     _0 = ()
-    _0 = assert_copy<{built_in impl Pointee for T}::Metadata>[{built_in impl Pointee for T}::parent_clause0, {built_in impl Pointee for T}::parent_clause2]()
+    _0 = assert_copy<{built_in impl Pointee for T}::Metadata>[{built_in impl Pointee for T}::ImpliedClause0, {built_in impl Pointee for T}::ImpliedClause2]()
     return
 }
 

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,8 +16,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -26,18 +26,18 @@ where
 // Full name: test_crate::From
 pub trait From<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Sized<Self::Error>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self::Error: Sized)
     type Error
-    fn from<[@TraitClause0_1]: Sized<Self>> = test_crate::From::from<Self, T>[Self, @TraitClause0_1]
+    fn from<TraitClause0_1: (Self: Sized)> = test_crate::From::from<Self, T>[Self, TraitClause0_1]
     vtable: test_crate::From::{vtable}<T, Self::Error>
 }
 
-pub fn test_crate::From::from<Self, T>(_1: T) -> Result<Self, @TraitClause0::Error>[@TraitClause1, @TraitClause0::parent_clause2]
+pub fn test_crate::From::from<Self, T>(_1: T) -> Result<Self, TraitClause0::Error>[TraitClause1, TraitClause0::ImpliedClause2]
 where
-    [@TraitClause0]: From<Self, T>,
-    [@TraitClause1]: Sized<Self>,
+    TraitClause0: (Self: From<T>),
+    TraitClause1: (Self: Sized),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl From<&'_0 bool> for bool}::from
@@ -56,9 +56,9 @@ pub fn {impl From<&'_0 bool> for bool}::from<'_0>(v_1: &'_0 bool) -> Result<bool
 
 // Full name: test_crate::{impl From<&'_0 bool> for bool}
 impl<'_0> From<&'_0 bool> for bool {
-    parent_clause0 = {built_in impl MetaSized for bool}
-    parent_clause1 = {built_in impl Sized for &'_ bool}
-    parent_clause2 = {built_in impl Sized for ()}
+    proof ImpliedClause0: (bool: MetaSized) = {built_in impl MetaSized for bool}
+    proof ImpliedClause1: (&'_ bool: Sized) = {built_in impl Sized for &'_ bool}
+    proof ImpliedClause2: ((): Sized) = {built_in impl Sized for ()}
     type Error = ()
     fn from = {impl From<&'_0 bool> for bool}::from<'_0>
     vtable: {impl From<&'_0 bool> for bool}::{vtable}<'_0>

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -8,22 +8,22 @@ pub trait MetaSized<Self>
 #[lang_item("Borrow")]
 pub trait Borrow<Self, Borrowed>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: MetaSized<Borrowed>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Borrowed: MetaSized)
     fn borrow<'_0_1> = core::borrow::Borrow::borrow<'_0_1, Self, Borrowed>[Self]
     vtable: core::borrow::Borrow::{vtable}<Borrowed>
 }
 
 pub fn core::borrow::Borrow::borrow<'_0, Self, Borrowed>(_1: &'_0 Self) -> &'_0 Borrowed
 where
-    [@TraitClause0]: Borrow<Self, Borrowed>,
+    TraitClause0: (Self: Borrow<Borrowed>),
 = <opaque>
 
 // Full name: core::marker::Sized
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -31,7 +31,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -40,7 +40,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: alloc::alloc::Global
@@ -51,77 +51,77 @@ pub struct Global {}
 #[lang_item("ToOwned")]
 pub trait ToOwned<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Owned>
-    parent_clause2 : [@TraitClause2]: Borrow<Self::Owned, Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Owned: Sized)
+    proof ImpliedClause2: (Self::Owned: Borrow<Self>)
     type Owned
     fn to_owned<'_0_1> = alloc::borrow::ToOwned::to_owned<'_0_1, Self>[Self]
     non-dyn-compatible
 }
 
 #[lang_item("to_owned_method")]
-pub fn alloc::borrow::ToOwned::to_owned<'_0, Self>(_1: &'_0 Self) -> @TraitClause0::Owned
+pub fn alloc::borrow::ToOwned::to_owned<'_0, Self>(_1: &'_0 Self) -> TraitClause0::Owned
 where
-    [@TraitClause0]: ToOwned<Self>,
+    TraitClause0: (Self: ToOwned),
 = <opaque>
 
 // Full name: alloc::borrow::Cow
 #[lang_item("Cow")]
 pub enum Cow<'a, B>
 where
-    [@TraitClause0]: MetaSized<B>,
-    [@TraitClause1]: ToOwned<B>,
-    B : 'a,
-    B : 'a,
+    TraitClause0: (B: MetaSized),
+    TraitClause1: (B: ToOwned),
+    TypeOutlives0: B: 'a,
+    TypeOutlives1: B: 'a,
 {
   Borrowed(&'a B),
-  Owned(@TraitClause1::Owned),
+  Owned(TraitClause1::Owned),
 }
 
 // Full name: alloc::vec::Vec
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow
-pub fn {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0, T, A>(_1: &'_0 Vec<T>[@TraitClause0, @TraitClause1]) -> &'_0 [T]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow
+pub fn {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow<'_0, T, A>(_1: &'_0 Vec<T>[TraitClause0, TraitClause1]) -> &'_0 [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}
-impl<T, A> Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]
+// Full name: alloc::slice::{impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}
+impl<T, A> Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 {
-    parent_clause0 = {built_in impl MetaSized for Vec<T>[@TraitClause0, @TraitClause1]}
-    parent_clause1 = {built_in impl MetaSized for [T]}
-    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::borrow<'_0_1, T, A>[@TraitClause0, @TraitClause1]
-    vtable: {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}::{vtable}<T, A>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (Vec<T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for Vec<T>[TraitClause0, TraitClause1]}
+    proof ImpliedClause1: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    fn borrow<'_0_1> = {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::borrow<'_0_1, T, A>[TraitClause0, TraitClause1]
+    vtable: {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}::{vtable}<T, A>[TraitClause0, TraitClause1]
 }
 
 // Full name: alloc::slice::{impl ToOwned for [T]}::to_owned
-pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(_1: &'_0 [T]) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn {impl ToOwned for [T]}::to_owned<'_0, T>(_1: &'_0 [T]) -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <opaque>
 
 // Full name: alloc::slice::{impl ToOwned for [T]}
 impl<T> ToOwned for [T]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for [T]}
-    parent_clause1 = {built_in impl Sized for Vec<T>[@TraitClause0, {built_in impl Sized for Global}]}
-    parent_clause2 = {impl Borrow<[T]> for Vec<T>[@TraitClause0, @TraitClause1]}<T, Global>[@TraitClause0, {built_in impl Sized for Global}]
-    type Owned = Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
-    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: ([T]: MetaSized) = {built_in impl MetaSized for [T]}
+    proof ImpliedClause1: (Vec<T>[TraitClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for Vec<T>[TraitClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause2: (Vec<T>[TraitClause0, {built_in impl Sized for Global}]: Borrow<[T]>) = {impl Borrow<[T]> for Vec<T>[TraitClause0, TraitClause1]}<T, Global>[TraitClause0, {built_in impl Sized for Global}]
+    type Owned = Vec<T>[TraitClause0, {built_in impl Sized for Global}]
+    fn to_owned<'_0_1> = {impl ToOwned for [T]}::to_owned<'_0_1, T>[TraitClause0, TraitClause1]
     non-dyn-compatible
 }
 
@@ -131,19 +131,19 @@ pub type Usize = usize
 // Full name: test_crate::Generic
 pub type Generic<'a, T>
 where
-    [@TraitClause0]: Sized<T>, = &'a T
+    TraitClause0: (T: Sized), = &'a T
 
 // Full name: test_crate::Generic2
 pub type Generic2<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[@TraitClause0, @TraitClause1]]
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone), = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, {impl ToOwned for [T]}<T>[TraitClause0, TraitClause1]]
 
 // Full name: test_crate::GenericWithoutBound
 pub type GenericWithoutBound<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: ToOwned<[T]>, = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, @TraitClause1]
+    TraitClause0: (T: Sized),
+    TraitClause1: ([T]: ToOwned), = Cow<'a, [T]>[{built_in impl MetaSized for [T]}, TraitClause1]
 
 
 

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Default")]
 pub trait Default<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn default = core::default::Default::default<Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Default<Self>
 #[lang_item("default_fn")]
 pub fn core::default::Default::default<Self>() -> Self
 where
-    [@TraitClause0]: Default<Self>,
+    TraitClause0: (Self: Default),
 = <opaque>
 
 // Full name: core::default::{impl Default for bool}::default
@@ -33,7 +33,7 @@ pub fn {impl Default for bool}::default() -> bool
 
 // Full name: core::default::{impl Default for bool}
 impl Default for bool {
-    parent_clause0 = {built_in impl Sized for bool}
+    proof ImpliedClause0: (bool: Sized) = {built_in impl Sized for bool}
     fn default = {impl Default for bool}::default
     non-dyn-compatible
 }
@@ -57,8 +57,8 @@ pub unsafe fn new<'a, const N : usize, const M : usize>(_1: &'a [u8; N], _2: &'a
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -74,7 +74,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for bool}::fmt
@@ -90,8 +90,8 @@ impl Debug for bool {
 // Full name: core::fmt::rt::{Argument<'_0>}::new_debug
 pub fn new_debug<'_0, '_1, T>(_1: &'_1 T) -> Argument<'_1>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Debug<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Debug),
 = <opaque>
 
 // Full name: core::marker::Destruct
@@ -113,42 +113,42 @@ pub fn _print<'_0>(_1: Arguments<'_0>)
 // Full name: test_crate::Left
 trait Left<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Left::{vtable}<T>
 }
 
 // Full name: test_crate::Right
 trait Right<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     vtable: test_crate::Right::{vtable}<T>
 }
 
 // Full name: test_crate::Join
 trait Join<Self, U>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<U>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (U: Sized)
     fn test = test_crate::Join::test<Self, U>[Self]
     non-dyn-compatible
 }
 
 fn test_crate::Join::test<Self, U>()
 where
-    [@TraitClause0]: Join<Self, U>,
+    TraitClause0: (Self: Join<U>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Join<U> for T}::test
 fn {impl Join<U> for T}::test<T, U>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Left<T, U>,
-    [@TraitClause3]: Right<T, U>,
-    [@TraitClause4]: Default<U>,
-    [@TraitClause5]: Debug<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Left<U>),
+    TraitClause3: (T: Right<U>),
+    TraitClause4: (U: Default),
+    TraitClause5: (U: Debug),
 {
     let _0: (); // return
     let _1: (); // anonymous local
@@ -172,7 +172,7 @@ where
     storage_live(args_3)
     storage_live(_4)
     storage_live(_5)
-    _5 = @TraitClause4::default()
+    _5 = TraitClause4::default()
     _4 = &_5
     args_3 = (move _4,)
     storage_dead(_4)
@@ -180,7 +180,7 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*args_3.0)
-    _7 = new_debug<'21, '23, U>[@TraitClause1, @TraitClause5](move _8)
+    _7 = new_debug<'21, '23, U>[TraitClause1, TraitClause5](move _8)
     storage_dead(_8)
     args_6 = [move _7]
     storage_dead(_7)
@@ -215,58 +215,58 @@ where
 // Full name: test_crate::{impl Join<U> for T}
 impl<T, U> Join<U> for T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Left<T, U>,
-    [@TraitClause3]: Right<T, U>,
-    [@TraitClause4]: Default<U>,
-    [@TraitClause5]: Debug<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (T: Left<U>),
+    TraitClause3: (T: Right<U>),
+    TraitClause4: (U: Default),
+    TraitClause5: (U: Debug),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1
-    fn test = {impl Join<U> for T}::test<T, U>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3, @TraitClause4, @TraitClause5]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (U: Sized) = TraitClause1
+    fn test = {impl Join<U> for T}::test<T, U>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5]
     non-dyn-compatible
 }
 
 // Full name: test_crate::{impl Left<U> for T}
 impl<T, U> Left<U> for T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Default<U>,
-    [@TraitClause3]: Debug<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: Default),
+    TraitClause3: (U: Debug),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1
-    vtable: {impl Left<U> for T}::{vtable}<T, U>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (U: Sized) = TraitClause1
+    vtable: {impl Left<U> for T}::{vtable}<T, U>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 }
 
 // Full name: test_crate::{impl Right<U> for T}
 impl<T, U> Right<U> for T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<U>,
-    [@TraitClause2]: Default<U>,
-    [@TraitClause3]: Debug<U>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (U: Sized),
+    TraitClause2: (U: Default),
+    TraitClause3: (U: Debug),
 {
-    parent_clause0 = @TraitClause0::parent_clause0
-    parent_clause1 = @TraitClause1
-    vtable: {impl Right<U> for T}::{vtable}<T, U>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+    proof ImpliedClause0: (T: MetaSized) = TraitClause0::ImpliedClause0
+    proof ImpliedClause1: (U: Sized) = TraitClause1
+    vtable: {impl Right<U> for T}::{vtable}<T, U>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 }
 
 // Full name: test_crate::try_it
 fn try_it<T>()
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Default<T>,
-    [@TraitClause2]: Debug<T>,
-    [@TraitClause3]: Left<T, bool>,
-    [@TraitClause4]: Right<T, ()>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Default),
+    TraitClause2: (T: Debug),
+    TraitClause3: (T: Left<bool>),
+    TraitClause4: (T: Right<()>),
 {
     let _0: (); // return
 
     _0 = ()
-    _0 = {impl Join<U> for T}::test<T, bool>[@TraitClause0, {built_in impl Sized for bool}, @TraitClause3, {impl Right<U> for T}<T, bool>[@TraitClause0, {built_in impl Sized for bool}, {impl Default for bool}, {impl Debug for bool}], {impl Default for bool}, {impl Debug for bool}]()
+    _0 = {impl Join<U> for T}::test<T, bool>[TraitClause0, {built_in impl Sized for bool}, TraitClause3, {impl Right<U> for T}<T, bool>[TraitClause0, {built_in impl Sized for bool}, {impl Default for bool}, {impl Debug for bool}], {impl Default for bool}, {impl Debug for bool}]()
     return
 }
 

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -25,7 +25,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::cmp::PartialEq
@@ -39,14 +39,14 @@ pub trait PartialEq<Self, Rhs>
 #[lang_item("cmp_partialeq_eq")]
 pub fn core::cmp::PartialEq::eq<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> bool
 where
-    [@TraitClause0]: PartialEq<Self, Rhs>,
+    TraitClause0: (Self: PartialEq<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::Eq
 #[lang_item("Eq")]
 pub trait Eq<Self>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Self>
+    proof ImpliedClause0: (Self: PartialEq<Self>)
     non-dyn-compatible
 }
 
@@ -62,7 +62,7 @@ pub enum Ordering {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -72,7 +72,7 @@ where
 #[lang_item("partial_ord")]
 pub trait PartialOrd<Self, Rhs>
 {
-    parent_clause0 : [@TraitClause0]: PartialEq<Self, Rhs>
+    proof ImpliedClause0: (Self: PartialEq<Rhs>)
     fn partial_cmp<'_0_1, '_1_1> = core::cmp::PartialOrd::partial_cmp<'_0_1, '_1_1, Self, Rhs>[Self]
     vtable: core::cmp::PartialOrd::{vtable}<Rhs>
 }
@@ -81,8 +81,8 @@ pub trait PartialOrd<Self, Rhs>
 #[lang_item("Ord")]
 pub trait Ord<Self>
 {
-    parent_clause0 : [@TraitClause0]: Eq<Self>
-    parent_clause1 : [@TraitClause1]: PartialOrd<Self, Self>
+    proof ImpliedClause0: (Self: Eq)
+    proof ImpliedClause1: (Self: PartialOrd<Self>)
     fn cmp<'_0_1, '_1_1> = core::cmp::Ord::cmp<'_0_1, '_1_1, Self>[Self]
     non-dyn-compatible
 }
@@ -90,13 +90,13 @@ pub trait Ord<Self>
 #[lang_item("ord_cmp_method")]
 pub fn core::cmp::Ord::cmp<'_0, '_1, Self>(_1: &'_0 Self, _2: &'_1 Self) -> Ordering
 where
-    [@TraitClause0]: Ord<Self>,
+    TraitClause0: (Self: Ord),
 = <opaque>
 
 #[lang_item("cmp_partialord_cmp")]
 pub fn core::cmp::PartialOrd::partial_cmp<'_0, '_1, Self, Rhs>(_1: &'_0 Self, _2: &'_1 Rhs) -> Option<Ordering>[{built_in impl Sized for Ordering}]
 where
-    [@TraitClause0]: PartialOrd<Self, Rhs>,
+    TraitClause0: (Self: PartialOrd<Rhs>),
 = <opaque>
 
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
@@ -111,7 +111,7 @@ impl PartialEq<()> for () {
 
 // Full name: core::cmp::impls::{impl Eq for ()}
 impl Eq for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     non-dyn-compatible
 }
 
@@ -121,7 +121,7 @@ pub fn {impl PartialOrd<()> for ()}::partial_cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1
 
 // Full name: core::cmp::impls::{impl PartialOrd<()> for ()}
 impl PartialOrd<()> for () {
-    parent_clause0 = {impl PartialEq<()> for ()}
+    proof ImpliedClause0: ((): PartialEq<()>) = {impl PartialEq<()> for ()}
     fn partial_cmp<'_0_1, '_1_1> = {impl PartialOrd<()> for ()}::partial_cmp<'_0_1, '_1_1>
     vtable: {impl PartialOrd<()> for ()}::{vtable}
 }
@@ -132,8 +132,8 @@ pub fn {impl Ord for ()}::cmp<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> Ordering
 
 // Full name: core::cmp::impls::{impl Ord for ()}
 impl Ord for () {
-    parent_clause0 = {impl Eq for ()}
-    parent_clause1 = {impl PartialOrd<()> for ()}
+    proof ImpliedClause0: ((): Eq) = {impl Eq for ()}
+    proof ImpliedClause1: ((): PartialOrd<()>) = {impl PartialOrd<()> for ()}
     fn cmp<'_0_1, '_1_1> = {impl Ord for ()}::cmp<'_0_1, '_1_1>
     non-dyn-compatible
 }
@@ -145,8 +145,8 @@ pub struct Error {}
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -162,7 +162,7 @@ pub trait Debug<Self>
 
 pub fn core::fmt::Debug::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Debug<Self>,
+    TraitClause0: (Self: Debug),
 = <opaque>
 
 // Full name: core::fmt::{impl Debug for ()}::fmt
@@ -178,7 +178,7 @@ impl Debug for () {
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn finish<'_0_1> = finish<'_0_1, Self>[Self]
     fn write<'_0_1, '_1_1> = write<'_0_1, '_1_1, Self>[Self]
     vtable: core::hash::Hasher::{vtable}
@@ -188,39 +188,39 @@ pub trait Hasher<Self>
 #[lang_item("Hash")]
 pub trait Hash<Self>
 {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, @TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = core::hash::Hash::hash<'_0_1, '_1_1, Self, H>[Self, TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
 pub fn core::hash::Hash::hash<'_0, '_1, Self, H>(_1: &'_0 Self, _2: &'_1 mut H)
 where
-    [@TraitClause0]: Hash<Self>,
-    [@TraitClause1]: Sized<H>,
-    [@TraitClause2]: Hasher<H>,
+    TraitClause0: (Self: Hash),
+    TraitClause1: (H: Sized),
+    TraitClause2: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::finish
 pub fn finish<'_0, Self>(_1: &'_0 Self) -> u64
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::Hasher::write
 pub fn write<'_0, '_1, Self>(_1: &'_0 mut Self, _2: &'_1 [u8])
 where
-    [@TraitClause0]: Hasher<Self>,
+    TraitClause0: (Self: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}::hash
 pub fn {impl Hash for ()}::hash<'_0, '_1, H>(_1: &'_0 (), _2: &'_1 mut H)
 where
-    [@TraitClause0]: Sized<H>,
-    [@TraitClause1]: Hasher<H>,
+    TraitClause0: (H: Sized),
+    TraitClause1: (H: Hasher),
 = <opaque>
 
 // Full name: core::hash::impls::{impl Hash for ()}
 impl Hash for () {
-    fn hash<'_0_1, '_1_1, H, [@TraitClause0_1]: Sized<H>, [@TraitClause1_1]: Hasher<H>> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[@TraitClause0_1, @TraitClause1_1]
+    fn hash<'_0_1, '_1_1, H, TraitClause0_1: (H: Sized), TraitClause1_1: (H: Hasher)> = {impl Hash for ()}::hash<'_0_1, '_1_1, H>[TraitClause0_1, TraitClause1_1]
     non-dyn-compatible
 }
 
@@ -235,8 +235,8 @@ pub trait Send<Self>
 #[lang_item("copy")]
 pub trait Copy<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Clone<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Clone)
     non-dyn-compatible
 }
 
@@ -255,22 +255,22 @@ pub trait Unpin<Self>
 // Full name: core::ptr::const_ptr::{*const T}::read
 pub unsafe fn read<T>(_1: *const T) -> T
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::ptr::metadata::Pointee
 #[lang_item("pointee_trait")]
 pub trait Pointee<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self::Metadata>
-    parent_clause1 : [@TraitClause1]: Debug<Self::Metadata>
-    parent_clause2 : [@TraitClause2]: Copy<Self::Metadata>
-    parent_clause3 : [@TraitClause3]: Send<Self::Metadata>
-    parent_clause4 : [@TraitClause4]: Sync<Self::Metadata>
-    parent_clause5 : [@TraitClause5]: Ord<Self::Metadata>
-    parent_clause6 : [@TraitClause6]: Hash<Self::Metadata>
-    parent_clause7 : [@TraitClause7]: Unpin<Self::Metadata>
-    parent_clause8 : [@TraitClause8]: Freeze<Self::Metadata>
+    proof ImpliedClause0: (Self::Metadata: Sized)
+    proof ImpliedClause1: (Self::Metadata: Debug)
+    proof ImpliedClause2: (Self::Metadata: Copy)
+    proof ImpliedClause3: (Self::Metadata: Send)
+    proof ImpliedClause4: (Self::Metadata: Sync)
+    proof ImpliedClause5: (Self::Metadata: Ord)
+    proof ImpliedClause6: (Self::Metadata: Hash)
+    proof ImpliedClause7: (Self::Metadata: Unpin)
+    proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
 }
@@ -279,7 +279,7 @@ pub trait Pointee<Self>
 #[lang_item("ptr_null")]
 pub fn null<T>() -> *const T
 where
-    [@TraitClause0]: Thin<T>,
+    TraitClause0: (T: Thin),
 = <opaque>
 
 // Full name: test_crate::call_unsafe_fn
@@ -325,13 +325,13 @@ fn deref_raw_ptr()
 // Full name: test_crate::Trait
 trait Trait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     vtable: test_crate::Trait::{vtable}
 }
 
 // Full name: test_crate::{impl Trait for ()}
 impl Trait for () {
-    parent_clause0 = {built_in impl MetaSized for ()}
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
     vtable: {impl Trait for ()}::{vtable}
 }
 

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -13,7 +13,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -21,8 +21,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -38,37 +38,37 @@ pub trait Display<Self>
 
 pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Display<Self>,
+    TraitClause0: (Self: Display),
 = <opaque>
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: alloc::rc::Rc
 #[lang_item("Rc")]
 pub opaque type Rc<T>
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
-// Full name: alloc::rc::Rc::{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Rc<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::rc::Rc::{impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Rc<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-pub fn alloc::rc::{Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]
+pub fn alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: alloc::string::String
@@ -149,21 +149,21 @@ fn foo()
     _7 = copy array_1
     _6 = @BoxNew<[i32; 2 : usize]>[{built_in impl Sized for [i32; 2 : usize]}](move _7)
     _5 = unsize_cast<alloc::boxed::Box<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2 : usize>(move _6)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] _6
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] _6
     storage_dead(_7)
     storage_dead(_6)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
     storage_dead(_5)
     storage_live(_8)
     storage_live(_9)
     storage_live(_10)
     _10 = copy array_1
-    _9 = alloc::rc::{Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new<[i32; 2 : usize]>[{built_in impl Sized for [i32; 2 : usize]}](move _10)
+    _9 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2 : usize]>[{built_in impl Sized for [i32; 2 : usize]}](move _10)
     _8 = unsize_cast<Rc<[i32; 2 : usize]>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], ?>(move _9)
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] _9
+    conditional_drop[{impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place<[i32; 2 : usize], Global>[{built_in impl MetaSized for [i32; 2 : usize]}, {built_in impl Sized for Global}]] _9
     storage_dead(_10)
     storage_dead(_9)
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[{impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place<[i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
     storage_dead(_8)
     storage_live(string_11)
     string_11 = alloc::string::{String}::new()
@@ -185,10 +185,10 @@ fn foo()
     storage_dead(_18)
     _16 = @BoxNew<String>[{built_in impl Sized for String}](move _17)
     _15 = unsize_cast<alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], alloc::boxed::Box<(dyn Display + '30)>[{built_in impl MetaSized for (dyn Display + '31)}, {built_in impl Sized for Global}], &{impl Display for String}::{vtable}>(move _16)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _16
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _16
     storage_dead(_17)
     storage_dead(_16)
-    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1]}::drop_in_place<(dyn Display + '38), Global>[{built_in impl MetaSized for (dyn Display + '38)}, {built_in impl Sized for Global}]] _15
+    conditional_drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_in_place<(dyn Display + '38), Global>[{built_in impl MetaSized for (dyn Display + '38)}, {built_in impl Sized for Global}]] _15
     storage_dead(_15)
     storage_live(_19)
     storage_live(_20)
@@ -197,12 +197,12 @@ fn foo()
     _22 = &string_11
     _21 = {impl Clone for String}::clone<'42>(move _22)
     storage_dead(_22)
-    _20 = alloc::rc::{Rc<T>[@TraitClause0::parent_clause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _21)
+    _20 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _21)
     _19 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '52)>[{built_in impl MetaSized for (dyn Display + '53)}, {built_in impl Sized for Global}], ?>(move _20)
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place<String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _20
+    conditional_drop[{impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place<String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _20
     storage_dead(_21)
     storage_dead(_20)
-    conditional_drop[{impl Destruct for Rc<T>[@TraitClause0, @TraitClause1]}::drop_in_place<(dyn Display + '60), Global>[{built_in impl MetaSized for (dyn Display + '60)}, {built_in impl Sized for Global}]] _19
+    conditional_drop[{impl Destruct for Rc<T>[TraitClause0, TraitClause1]}::drop_in_place<(dyn Display + '60), Global>[{built_in impl MetaSized for (dyn Display + '60)}, {built_in impl Sized for Global}]] _19
     storage_dead(_19)
     _0 = ()
     conditional_drop[{impl Destruct for String}::drop_in_place] string_11

--- a/charon/tests/ui/unsized-string-consts.out
+++ b/charon/tests/ui/unsized-string-consts.out
@@ -11,7 +11,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -19,8 +19,8 @@ pub trait Sized<Self>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -36,7 +36,7 @@ pub trait Display<Self>
 
 pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Display<Self>,
+    TraitClause0: (Self: Display),
 = <opaque>
 
 // Full name: core::fmt::{impl Display for str}::fmt
@@ -60,8 +60,8 @@ unsafe fn {impl Destruct for String}::drop_in_place(_1: *mut String)
 // Full name: alloc::string::{impl ToString for T}::to_string
 pub fn {impl ToString for T}::to_string<'_0, T>(_1: &'_0 T) -> String
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Display<T>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (T: Display),
 = <opaque>
 
 // Full name: test_crate::FOO

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -26,21 +26,21 @@ where
 #[lang_item("SliceIter")]
 pub opaque type Iter<'a, T>
 where
-    [@TraitClause0]: Sized<T>,
-    T : 'a,
-    T : 'a,
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'a,
+    TypeOutlives1: T: 'a,
 
-// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[@TraitClause0]}::next
-pub fn {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[@TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
+// Full name: core::slice::iter::{impl Iterator for Iter<'a, T>[TraitClause0]}::next
+pub fn {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'a, '_1, T>(_1: &'_1 mut Iter<'a, T>[TraitClause0]) -> Option<&'a T>[{built_in impl Sized for &'a T}]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: core::slice::{[T]}::iter
 #[lang_item("slice_iter")]
-pub fn iter<'_0, T>(_1: &'_0 [T]) -> Iter<'_0, T>[@TraitClause0]
+pub fn iter<'_0, T>(_1: &'_0 [T]) -> Iter<'_0, T>[TraitClause0]
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 = <opaque>
 
 // Full name: test_crate::main
@@ -84,7 +84,7 @@ fn main()
     _6 = iter<'25, i32>[{built_in impl Sized for i32}](move _7)
     _5 = &two-phase-mut _6
     storage_dead(_7)
-    _4 = {impl Iterator for Iter<'a, T>[@TraitClause0]}::next<'26, '28, i32>[{built_in impl Sized for i32}](move _5)
+    _4 = {impl Iterator for Iter<'a, T>[TraitClause0]}::next<'26, '28, i32>[{built_in impl Sized for i32}](move _5)
     storage_dead(_5)
     storage_dead(_6)
     storage_dead(_4)

--- a/charon/tests/ui/vec-reconstruct-move-values.out
+++ b/charon/tests/ui/vec-reconstruct-move-values.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -20,21 +20,21 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: test_crate::NoCopy
@@ -108,14 +108,14 @@ fn move_values(flag_1: bool)
         ret_12 = into_vec<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}](move y_14)
         _w_7 = move ret_12
         _0 = ()
-        conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]] _w_7
+        conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]] _w_7
         storage_dead(_w_7)
         storage_dead(y_6)
     } else {
         _0 = ()
     }
     storage_dead(_5)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]] _v_3
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]] _v_3
     storage_dead(_v_3)
     storage_dead(x_2)
     return

--- a/charon/tests/ui/vec-reconstruct-multiple-adjacent.out
+++ b/charon/tests/ui/vec-reconstruct-multiple-adjacent.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -16,7 +16,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -24,7 +24,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for u8}::clone
@@ -33,7 +33,7 @@ pub fn {impl Clone for u8}::clone<'_0>(_1: &'_0 u8) -> u8
 
 // Full name: core::clone::impls::{impl Clone for u8}
 impl Clone for u8 {
-    parent_clause0 = {built_in impl Sized for u8}
+    proof ImpliedClause0: (u8: Sized) = {built_in impl Sized for u8}
     fn clone<'_0_1> = {impl Clone for u8}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -46,29 +46,29 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: alloc::vec::from_elem
 #[lang_item("vec_from_elem")]
-pub fn from_elem<T>(_1: T, _2: usize) -> Vec<T>[@TraitClause0, {built_in impl Sized for Global}]
+pub fn from_elem<T>(_1: T, _2: usize) -> Vec<T>[TraitClause0, {built_in impl Sized for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 = <opaque>
 
 // Full name: test_crate::multiple_adjacent
@@ -138,11 +138,11 @@ fn multiple_adjacent()
     ret_10 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_12)
     _c_3 = move ret_10
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _c_3
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _c_3
     storage_dead(_c_3)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _b_2
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _b_2
     storage_dead(_b_2)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
     storage_dead(_a_1)
     return
 }
@@ -174,7 +174,7 @@ fn multiple_values()
     ret_2 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_4)
     _a_1 = move ret_2
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
     storage_dead(_a_1)
     return
 }
@@ -223,7 +223,7 @@ fn with_fn_calls()
     ret_4 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_6)
     _a_1 = move ret_4
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
     storage_dead(_a_1)
     return
 }
@@ -238,7 +238,7 @@ fn repeated()
     storage_live(_a_1)
     _a_1 = from_elem<u8>[{built_in impl Sized for u8}, {impl Clone for u8}](const 1 : u8, const 3 : usize)
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _a_1
     storage_dead(_a_1)
     return
 }

--- a/charon/tests/ui/vec-reconstruct-nested.out
+++ b/charon/tests/ui/vec-reconstruct-nested.out
@@ -8,7 +8,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -20,21 +20,21 @@ pub struct Global {}
 #[lang_item("Vec")]
 pub opaque type Vec<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<type_error("removed allocator parameter")>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, @TraitClause1]) -> Vec<T>[@TraitClause0, @TraitClause1]
+pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
-// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place
-unsafe fn {impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[@TraitClause0, @TraitClause1])
+// Full name: alloc::vec::Vec::{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place
+unsafe fn {impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<T, A>(_1: *mut Vec<T>[TraitClause0, TraitClause1])
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<A>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (A: Sized),
 = <opaque>
 
 // Full name: test_crate::nested_vecs
@@ -92,9 +92,9 @@ fn nested_vecs()
     _3 = move ret_7
     storage_live(_13)
     _13 = [move _2, move _3]
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _3
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _3
     storage_dead(_3)
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _2
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _2
     storage_dead(_2)
     storage_live(_14)
     _14 = @BoxNew<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2 : usize], Global>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2 : usize]}, {built_in impl Sized for Global}](move _13)
@@ -108,7 +108,7 @@ fn nested_vecs()
     ret_10 = into_vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}](move y_12)
     _nested_1 = move ret_10
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]] _nested_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]] _nested_1
     storage_dead(_nested_1)
     return
 }
@@ -148,7 +148,7 @@ fn nested_single()
     _2 = move ret_3
     storage_live(_9)
     _9 = [move _2]
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _2
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]] _2
     storage_dead(_2)
     storage_live(_10)
     _10 = @BoxNew<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1 : usize], Global>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1 : usize]}, {built_in impl Sized for Global}](move _9)
@@ -162,7 +162,7 @@ fn nested_single()
     ret_6 = into_vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}](move y_8)
     _nested_1 = move ret_6
     _0 = ()
-    conditional_drop[{impl Destruct for Vec<T>[@TraitClause0, @TraitClause1]}::drop_in_place<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]] _nested_1
+    conditional_drop[{impl Destruct for Vec<T>[TraitClause0, TraitClause1]}::drop_in_place<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]] _nested_1
     storage_dead(_nested_1)
     return
 }

--- a/charon/tests/ui/vtable-simple.out
+++ b/charon/tests/ui/vtable-simple.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -26,7 +26,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -35,7 +35,7 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -51,22 +51,22 @@ struct test_crate::Modifiable::{vtable}<T> {
 // Full name: test_crate::Modifiable
 trait Modifiable<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn modify<'_0_1, '_1_1> = test_crate::Modifiable::modify<'_0_1, '_1_1, Self, T>[Self]
     vtable: test_crate::Modifiable::{vtable}<T>
 }
 
 fn test_crate::Modifiable::modify<'_0, '_1, Self, T>(_1: &'_0 mut Self, _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Modifiable<Self, T>,
+    TraitClause0: (Self: Modifiable<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify
 fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(self_1: &'_0 mut i32, arg_2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let self_1: &'1 mut i32; // arg #1
@@ -79,7 +79,7 @@ where
     (*self_1) = move _3
     storage_live(_4)
     _4 = &(*arg_2)
-    _0 = @TraitClause1::clone<'6>(move _4)
+    _0 = TraitClause1::clone<'6>(move _4)
     storage_dead(_4)
     return
 }
@@ -87,8 +87,8 @@ where
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify::{vtable_method}
 fn {vtable_method}<'_0, '_1, T>(_1: &'_0 mut (dyn Modifiable<T>), _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let _1: &'_0 mut (dyn Modifiable<T> + '0); // arg #1
@@ -97,15 +97,15 @@ where
 
     storage_live(_3)
     _3 = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut i32>(move _1)
-    _0 = {impl Modifiable<T> for i32}::modify<'_0, '_1, T>[@TraitClause0, @TraitClause1](move _3, move _2)
+    _0 = {impl Modifiable<T> for i32}::modify<'_0, '_1, T>[TraitClause0, TraitClause1](move _3, move _2)
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable_drop_shim}
 unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Modifiable<T> + '0); // arg #1
@@ -120,8 +120,8 @@ where
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
 fn {impl Modifiable<T> for i32}::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let ret_0: test_crate::Modifiable::{vtable}<T>; // return
     let size_1: usize; // local
@@ -131,34 +131,34 @@ where
     size_1 = size_of<i32>
     storage_live(align_2)
     align_2 = align_of<i32>
-    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[@TraitClause0, @TraitClause1], method_modify: const {vtable_method}<'1, '2, T>[@TraitClause0, @TraitClause1], super_trait_0: const &vtable_of({built_in impl MetaSized for i32}) }
+    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[TraitClause0, TraitClause1], method_modify: const {vtable_method}<'1, '2, T>[TraitClause0, TraitClause1], super_trait_0: const &vtable_of({built_in impl MetaSized for i32}) }
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
 static {impl Modifiable<T> for i32}::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
  = {impl Modifiable<T> for i32}::{vtable}()
 
 // Full name: test_crate::{impl Modifiable<T> for i32}
 impl<T> Modifiable<T> for i32
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = @TraitClause0
-    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for i32}::modify<'_0_1, '_1_1, T>[@TraitClause0, @TraitClause1]
-    vtable: {impl Modifiable<T> for i32}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for i32}::modify<'_0_1, '_1_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl Modifiable<T> for i32}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::modify_trait_object
 fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let arg_1: &'1 T; // arg #1
@@ -176,7 +176,7 @@ where
     _5 = const 199 : i32
     _4 = &mut _5
     _3 = &mut (*_4)
-    x_2 = unsize_cast<&'8 mut i32, &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for i32}::{vtable}<T>[@TraitClause0, @TraitClause1]>(move _3)
+    x_2 = unsize_cast<&'8 mut i32, &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for i32}::{vtable}<T>[TraitClause0, TraitClause1]>(move _3)
     storage_dead(_3)
     storage_dead(_4)
     storage_live(_6)

--- a/charon/tests/ui/vtable_drop.out
+++ b/charon/tests/ui/vtable_drop.out
@@ -18,7 +18,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -26,8 +26,8 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
-    parent_clause1 : [@TraitClause1]: Destruct<Self>
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (Self: Destruct)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -35,7 +35,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -44,8 +44,8 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
-    parent_clause1 = {built_in impl Destruct for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
+    proof ImpliedClause1: (i32: Destruct) = {built_in impl Destruct for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -57,12 +57,12 @@ unsafe fn core::marker::Destruct::drop_in_place<Self>(_1: *mut Self)
 #[lang_item("NonNull")]
 pub opaque type NonNull<T>
 where
-    [@TraitClause0]: Destruct<T>,
+    TraitClause0: (T: Destruct),
 
 // Full name: core::ptr::unique::Unique
 pub opaque type Unique<T>
 where
-    [@TraitClause0]: Destruct<T>,
+    TraitClause0: (T: Destruct),
 
 // Full name: alloc::alloc::Global
 #[lang_item("global_alloc_ty")]
@@ -78,24 +78,24 @@ impl Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place
-unsafe fn {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3])
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place
+unsafe fn {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>(_1: *mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 = <opaque>
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}
-impl<T, A> Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}
+impl<T, A> Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Sized<A>,
-    [@TraitClause2]: Destruct<T>,
-    [@TraitClause3]: Destruct<A>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (A: Destruct),
 {
-    fn drop_in_place = {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<T, A>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]
+    fn drop_in_place = {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<T, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
     non-dyn-compatible
 }
 
@@ -110,25 +110,25 @@ struct test_crate::Modifiable::{vtable}<T> {
 // Full name: test_crate::Modifiable
 trait Modifiable<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
-    parent_clause2 : [@TraitClause2]: Destruct<Self>
-    parent_clause3 : [@TraitClause3]: Destruct<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    proof ImpliedClause2: (Self: Destruct)
+    proof ImpliedClause3: (T: Destruct)
     fn modify<'_0_1, '_1_1> = test_crate::Modifiable::modify<'_0_1, '_1_1, Self, T>[Self]
     vtable: test_crate::Modifiable::{vtable}<T>
 }
 
 fn test_crate::Modifiable::modify<'_0, '_1, Self, T>(_1: &'_0 mut Self, _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Modifiable<Self, T>,
+    TraitClause0: (Self: Modifiable<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify
 fn {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0, '_1, T>(self_1: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}], arg_2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
     let _0: T; // return
     let self_1: &'1 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]; // arg #1
@@ -160,7 +160,7 @@ where
     (*_10) = move _3.0
     storage_live(_4)
     _4 = &(*arg_2)
-    _0 = @TraitClause1::clone<'6>(move _4)
+    _0 = TraitClause1::clone<'6>(move _4)
     storage_dead(_4)
     return
 }
@@ -168,9 +168,9 @@ where
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify::{vtable_method}
 fn {vtable_method}<'_0, '_1, T>(_1: &'_0 mut (dyn Modifiable<T>), _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
     let _0: T; // return
     let _1: &'_0 mut (dyn Modifiable<T> + '0); // arg #1
@@ -179,16 +179,16 @@ where
 
     storage_live(_3)
     _3 = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]>(move _1)
-    _0 = {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0, '_1, T>[@TraitClause0, @TraitClause1, @TraitClause2](move _3, move _2)
+    _0 = {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0, '_1, T>[TraitClause0, TraitClause1, TraitClause2](move _3, move _2)
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable_drop_shim}
 unsafe fn {vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Modifiable<T> + '0); // arg #1
@@ -197,16 +197,16 @@ where
     ret_0 = ()
     storage_live(target_self_2)
     target_self_2 = concretize<*mut (dyn Modifiable<T> + '1), *mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]>(move dyn_self_1)
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]] (*target_self_2)
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]] (*target_self_2)
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}
 fn {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
     let ret_0: test_crate::Modifiable::{vtable}<T>; // return
     let size_1: usize; // local
@@ -216,39 +216,39 @@ where
     size_1 = size_of<alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]>
     storage_live(align_2)
     align_2 = align_of<alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]>
-    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[@TraitClause0, @TraitClause1, @TraitClause2], method_modify: const {vtable_method}<'1, '2, T>[@TraitClause0, @TraitClause1, @TraitClause2], super_trait_0: const &vtable_of({built_in impl MetaSized for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}) }
+    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {vtable_drop_shim}<T>[TraitClause0, TraitClause1, TraitClause2], method_modify: const {vtable_method}<'1, '2, T>[TraitClause0, TraitClause1, TraitClause2], super_trait_0: const &vtable_of({built_in impl MetaSized for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}) }
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}
 static {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
  = {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}()
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}
 impl<T> Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
-    parent_clause0 = {built_in impl MetaSized for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}
-    parent_clause1 = @TraitClause0
-    parent_clause2 = {impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]
-    parent_clause3 = @TraitClause2
-    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0_1, '_1_1, T>[@TraitClause0, @TraitClause1, @TraitClause2]
-    vtable: {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>[@TraitClause0, @TraitClause1, @TraitClause2]
+    proof ImpliedClause0: (alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    proof ImpliedClause2: (alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]: Destruct) = {impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]
+    proof ImpliedClause3: (T: Destruct) = TraitClause2
+    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::modify<'_0_1, '_1_1, T>[TraitClause0, TraitClause1, TraitClause2]
+    vtable: {impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]
 }
 
 // Full name: test_crate::modify_trait_object
 fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
-    [@TraitClause2]: Destruct<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
+    TraitClause2: (T: Destruct),
 {
     let _0: T; // return
     let arg_1: &'1 T; // arg #1
@@ -266,7 +266,7 @@ where
     _5 = @BoxNew<i32>[{built_in impl Sized for i32}, {built_in impl Destruct for i32}](const 199 : i32)
     _4 = &mut _5
     _3 = &mut (*_4)
-    x_2 = unsize_cast<&'8 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}], &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>[@TraitClause0, @TraitClause1, @TraitClause2]>(move _3)
+    x_2 = unsize_cast<&'8 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}], &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]}::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]>(move _3)
     storage_dead(_3)
     storage_dead(_4)
     storage_live(_6)
@@ -276,7 +276,7 @@ where
     _0 = (copy ((*_6.metadata)).method_modify)(move _6, move _7)
     storage_dead(_7)
     storage_dead(_6)
-    drop[{impl Destruct for alloc::boxed::Box<T>[@TraitClause0, @TraitClause1, @TraitClause2, @TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]] _5
+    drop[{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_in_place<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, {impl Destruct for Global}]] _5
     storage_dead(_5)
     storage_dead(x_2)
     return

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -10,7 +10,7 @@ pub trait MetaSized<Self>
 #[lang_item("sized")]
 pub trait Sized<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
 
@@ -18,7 +18,7 @@ pub trait Sized<Self>
 #[lang_item("clone")]
 pub trait Clone<Self>
 {
-    parent_clause0 : [@TraitClause0]: Sized<Self>
+    proof ImpliedClause0: (Self: Sized)
     fn clone<'_0_1> = core::clone::Clone::clone<'_0_1, Self>[Self]
     non-dyn-compatible
 }
@@ -26,7 +26,7 @@ pub trait Clone<Self>
 #[lang_item("clone_fn")]
 pub fn core::clone::Clone::clone<'_0, Self>(_1: &'_0 Self) -> Self
 where
-    [@TraitClause0]: Clone<Self>,
+    TraitClause0: (Self: Clone),
 = <opaque>
 
 // Full name: core::clone::impls::{impl Clone for i32}::clone
@@ -35,7 +35,7 @@ pub fn {impl Clone for i32}::clone<'_0>(_1: &'_0 i32) -> i32
 
 // Full name: core::clone::impls::{impl Clone for i32}
 impl Clone for i32 {
-    parent_clause0 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: Sized) = {built_in impl Sized for i32}
     fn clone<'_0_1> = {impl Clone for i32}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -51,8 +51,8 @@ pub opaque type Arguments<'a>
 #[lang_item("Result")]
 pub enum Result<T, E>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Sized<E>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
 {
   Ok(T),
   Err(E),
@@ -68,7 +68,7 @@ pub trait Display<Self>
 
 pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
 where
-    [@TraitClause0]: Display<Self>,
+    TraitClause0: (Self: Display),
 = <opaque>
 
 // Full name: core::fmt::{impl Display for str}::fmt
@@ -85,7 +85,7 @@ impl Display for str {
 #[lang_item("Option")]
 pub enum Option<T>
 where
-    [@TraitClause0]: Sized<T>,
+    TraitClause0: (T: Sized),
 {
   None,
   Some(T),
@@ -116,7 +116,7 @@ pub fn {impl Clone for String}::clone<'_0>(_1: &'_0 String) -> String
 
 // Full name: alloc::string::{impl Clone for String}
 impl Clone for String {
-    parent_clause0 = {built_in impl Sized for String}
+    proof ImpliedClause0: (String: Sized) = {built_in impl Sized for String}
     fn clone<'_0_1> = {impl Clone for String}::clone<'_0_1>
     non-dyn-compatible
 }
@@ -124,8 +124,8 @@ impl Clone for String {
 // Full name: alloc::string::{impl ToString for T}::to_string
 pub fn {impl ToString for T}::to_string<'_0, T>(_1: &'_0 T) -> String
 where
-    [@TraitClause0]: MetaSized<T>,
-    [@TraitClause1]: Display<T>,
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (T: Display),
 = <opaque>
 
 struct test_crate::Super::{vtable}<T> {
@@ -139,15 +139,15 @@ struct test_crate::Super::{vtable}<T> {
 // Full name: test_crate::Super
 trait Super<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn super_method<'_0_1> = test_crate::Super::super_method<'_0_1, Self, T>[Self]
     vtable: test_crate::Super::{vtable}<T>
 }
 
 fn test_crate::Super::super_method<'_0, Self, T>(_1: &'_0 Self, _2: T) -> i32
 where
-    [@TraitClause0]: Super<Self, T>,
+    TraitClause0: (Self: Super<T>),
 = <method_without_default_body>
 
 struct test_crate::Checkable::{vtable}<T> {
@@ -162,16 +162,16 @@ struct test_crate::Checkable::{vtable}<T> {
 // Full name: test_crate::Checkable
 trait Checkable<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Super<Self, T>
-    parent_clause2 : [@TraitClause2]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Super<T>)
+    proof ImpliedClause2: (T: Sized)
     fn check<'_0_1> = test_crate::Checkable::check<'_0_1, Self, T>[Self]
     vtable: test_crate::Checkable::{vtable}<T>
 }
 
 fn test_crate::Checkable::check<'_0, Self, T>(_1: &'_0 Self) -> bool
 where
-    [@TraitClause0]: Checkable<Self, T>,
+    TraitClause0: (Self: Checkable<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Super<i32> for i32}::super_method
@@ -243,8 +243,8 @@ static {impl Super<i32> for i32}::{vtable}: test_crate::Super::{vtable}<i32> = {
 
 // Full name: test_crate::{impl Super<i32> for i32}
 impl Super<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     fn super_method<'_0_1> = {impl Super<i32> for i32}::super_method<'_0_1>
     vtable: {impl Super<i32> for i32}::{vtable}
 }
@@ -316,9 +316,9 @@ static {impl Checkable<i32> for i32}::{vtable}: test_crate::Checkable::{vtable}<
 
 // Full name: test_crate::{impl Checkable<i32> for i32}
 impl Checkable<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {impl Super<i32> for i32}
-    parent_clause2 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Super<i32>) = {impl Super<i32> for i32}
+    proof ImpliedClause2: (i32: Sized) = {built_in impl Sized for i32}
     fn check<'_0_1> = {impl Checkable<i32> for i32}::check<'_0_1>
     vtable: {impl Checkable<i32> for i32}::{vtable}
 }
@@ -334,14 +334,14 @@ struct test_crate::NoParam::{vtable} {
 // Full name: test_crate::NoParam
 trait NoParam<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
+    proof ImpliedClause0: (Self: MetaSized)
     fn dummy<'_0_1> = test_crate::NoParam::dummy<'_0_1, Self>[Self]
     vtable: test_crate::NoParam::{vtable}
 }
 
 fn test_crate::NoParam::dummy<'_0, Self>(_1: &'_0 Self)
 where
-    [@TraitClause0]: NoParam<Self>,
+    TraitClause0: (Self: NoParam),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl NoParam for i32}::dummy
@@ -370,7 +370,7 @@ fn {impl NoParam for i32}::dummy<'_0>(self_1: &'_0 i32)
 
 // Full name: test_crate::{impl NoParam for i32}
 impl NoParam for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
     fn dummy<'_0_1> = {impl NoParam for i32}::dummy<'_0_1>
     vtable: {impl NoParam for i32}::{vtable}
 }
@@ -378,8 +378,8 @@ impl NoParam for i32 {
 // Full name: test_crate::to_dyn_obj
 fn to_dyn_obj<'_0, T>(arg_1: &'_0 T) -> &'_0 (dyn NoParam + '_0)
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: NoParam<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: NoParam),
 {
     let _0: &'3 (dyn NoParam + '4); // return
     let arg_1: &'6 T; // arg #1
@@ -391,7 +391,7 @@ where
     storage_live(_3)
     storage_live(_4)
     _4 = &(*arg_1)
-    _3 = unsize_cast<&'11 T, &'12 (dyn NoParam + '13), &vtable_of(@TraitClause1)>(move _4)
+    _3 = unsize_cast<&'11 T, &'12 (dyn NoParam + '13), &vtable_of(TraitClause1)>(move _4)
     storage_dead(_4)
     _2 = &(*_3) with_metadata(copy _3.metadata)
     _0 = unsize_cast<&'7 (dyn NoParam + '8), &'15 (dyn NoParam + '16),  at []>(move _2)
@@ -411,22 +411,22 @@ struct test_crate::Modifiable::{vtable}<T> {
 // Full name: test_crate::Modifiable
 trait Modifiable<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn modify<'_0_1, '_1_1> = test_crate::Modifiable::modify<'_0_1, '_1_1, Self, T>[Self]
     vtable: test_crate::Modifiable::{vtable}<T>
 }
 
 fn test_crate::Modifiable::modify<'_0, '_1, Self, T>(_1: &'_0 mut Self, _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Modifiable<Self, T>,
+    TraitClause0: (Self: Modifiable<T>),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify
 fn {impl Modifiable<T> for i32}::modify<'_0, '_1, T>(self_1: &'_0 mut i32, arg_2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let self_1: &'1 mut i32; // arg #1
@@ -439,7 +439,7 @@ where
     (*self_1) = move _3
     storage_live(_4)
     _4 = &(*arg_2)
-    _0 = @TraitClause1::clone<'6>(move _4)
+    _0 = TraitClause1::clone<'6>(move _4)
     storage_dead(_4)
     return
 }
@@ -447,8 +447,8 @@ where
 // Full name: test_crate::{impl Modifiable<T> for i32}::modify::{vtable_method}
 fn {impl Modifiable<T> for i32}::modify::{vtable_method}<'_0, '_1, T>(_1: &'_0 mut (dyn Modifiable<T>), _2: &'_1 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let _1: &'_0 mut (dyn Modifiable<T> + '0); // arg #1
@@ -457,15 +457,15 @@ where
 
     storage_live(_3)
     _3 = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut i32>(move _1)
-    _0 = {impl Modifiable<T> for i32}::modify<'_0, '_1, T>[@TraitClause0, @TraitClause1](move _3, move _2)
+    _0 = {impl Modifiable<T> for i32}::modify<'_0, '_1, T>[TraitClause0, TraitClause1](move _3, move _2)
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable_drop_shim}
 unsafe fn {impl Modifiable<T> for i32}::{vtable_drop_shim}<T>(dyn_self_1: *mut (dyn Modifiable<T>))
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let ret_0: (); // return
     let dyn_self_1: *mut (dyn Modifiable<T> + '0); // arg #1
@@ -480,8 +480,8 @@ where
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
 fn {impl Modifiable<T> for i32}::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let ret_0: test_crate::Modifiable::{vtable}<T>; // return
     let size_1: usize; // local
@@ -491,34 +491,34 @@ where
     size_1 = size_of<i32>
     storage_live(align_2)
     align_2 = align_of<i32>
-    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {impl Modifiable<T> for i32}::{vtable_drop_shim}<T>[@TraitClause0, @TraitClause1], method_modify: const {impl Modifiable<T> for i32}::modify::{vtable_method}<'1, '2, T>[@TraitClause0, @TraitClause1], super_trait_0: const &vtable_of({built_in impl MetaSized for i32}) }
+    ret_0 = test_crate::Modifiable::{vtable} { size: move size_1, align: move align_2, drop: const {impl Modifiable<T> for i32}::{vtable_drop_shim}<T>[TraitClause0, TraitClause1], method_modify: const {impl Modifiable<T> for i32}::modify::{vtable_method}<'1, '2, T>[TraitClause0, TraitClause1], super_trait_0: const &vtable_of({built_in impl MetaSized for i32}) }
     return
 }
 
 // Full name: test_crate::{impl Modifiable<T> for i32}::{vtable}
 static {impl Modifiable<T> for i32}::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
  = {impl Modifiable<T> for i32}::{vtable}()
 
 // Full name: test_crate::{impl Modifiable<T> for i32}
 impl<T> Modifiable<T> for i32
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = @TraitClause0
-    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for i32}::modify<'_0_1, '_1_1, T>[@TraitClause0, @TraitClause1]
-    vtable: {impl Modifiable<T> for i32}::{vtable}<T>[@TraitClause0, @TraitClause1]
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (T: Sized) = TraitClause0
+    fn modify<'_0_1, '_1_1> = {impl Modifiable<T> for i32}::modify<'_0_1, '_1_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl Modifiable<T> for i32}::{vtable}<T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::modify_trait_object
 fn modify_trait_object<'_0, T>(arg_1: &'_0 T) -> T
 where
-    [@TraitClause0]: Sized<T>,
-    [@TraitClause1]: Clone<T>,
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Clone),
 {
     let _0: T; // return
     let arg_1: &'1 T; // arg #1
@@ -536,7 +536,7 @@ where
     _5 = const 199 : i32
     _4 = &mut _5
     _3 = &mut (*_4)
-    x_2 = unsize_cast<&'8 mut i32, &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for i32}::{vtable}<T>[@TraitClause0, @TraitClause1]>(move _3)
+    x_2 = unsize_cast<&'8 mut i32, &'13 mut (dyn Modifiable<T> + '14), &{impl Modifiable<T> for i32}::{vtable}<T>[TraitClause0, TraitClause1]>(move _3)
     storage_dead(_3)
     storage_dead(_4)
     storage_live(_6)
@@ -562,15 +562,15 @@ struct test_crate::BaseOn::{vtable}<T> {
 // Full name: test_crate::BaseOn
 trait BaseOn<Self, T>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<T>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
     fn operate_on<'_0_1, '_1_1> = test_crate::BaseOn::operate_on<'_0_1, '_1_1, Self, T>[Self]
     vtable: test_crate::BaseOn::{vtable}<T>
 }
 
 fn test_crate::BaseOn::operate_on<'_0, '_1, Self, T>(_1: &'_0 Self, _2: &'_1 T)
 where
-    [@TraitClause0]: BaseOn<Self, T>,
+    TraitClause0: (Self: BaseOn<T>),
 = <method_without_default_body>
 
 struct test_crate::Both32And64::{vtable} {
@@ -586,16 +586,16 @@ struct test_crate::Both32And64::{vtable} {
 // Full name: test_crate::Both32And64
 trait Both32And64<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: BaseOn<Self, i32>
-    parent_clause2 : [@TraitClause2]: BaseOn<Self, i64>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: BaseOn<i32>)
+    proof ImpliedClause2: (Self: BaseOn<i64>)
     fn both_operate<'_0_1, '_1_1, '_2_1> = test_crate::Both32And64::both_operate<'_0_1, '_1_1, '_2_1, Self>[Self]
     vtable: test_crate::Both32And64::{vtable}
 }
 
 fn test_crate::Both32And64::both_operate<'_0, '_1, '_2, Self>(self_1: &'_0 Self, t32_2: &'_1 i32, t64_3: &'_2 i64)
 where
-    [@TraitClause0]: Both32And64<Self>,
+    TraitClause0: (Self: Both32And64),
 {
     let _0: (); // return
     let self_1: &'1 Self; // arg #1
@@ -614,7 +614,7 @@ where
     _5 = &(*self_1) with_metadata(copy self_1.metadata)
     storage_live(_6)
     _6 = &(*t32_2)
-    _4 = @TraitClause0::parent_clause1::operate_on<'12, '13>(move _5, move _6)
+    _4 = TraitClause0::ImpliedClause1::operate_on<'12, '13>(move _5, move _6)
     storage_dead(_6)
     storage_dead(_5)
     storage_dead(_4)
@@ -623,7 +623,7 @@ where
     _8 = &(*self_1) with_metadata(copy self_1.metadata)
     storage_live(_9)
     _9 = &(*t64_3)
-    _7 = @TraitClause0::parent_clause2::operate_on<'16, '17>(move _8, move _9)
+    _7 = TraitClause0::ImpliedClause2::operate_on<'16, '17>(move _8, move _9)
     storage_dead(_9)
     storage_dead(_8)
     storage_dead(_7)
@@ -709,8 +709,8 @@ static {impl BaseOn<i32> for i32}::{vtable}: test_crate::BaseOn::{vtable}<i32> =
 
 // Full name: test_crate::{impl BaseOn<i32> for i32}
 impl BaseOn<i32> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     fn operate_on<'_0_1, '_1_1> = {impl BaseOn<i32> for i32}::operate_on<'_0_1, '_1_1>
     vtable: {impl BaseOn<i32> for i32}::{vtable}
 }
@@ -797,8 +797,8 @@ static {impl BaseOn<i64> for i32}::{vtable}: test_crate::BaseOn::{vtable}<i64> =
 
 // Full name: test_crate::{impl BaseOn<i64> for i32}
 impl BaseOn<i64> for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i64}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i64: Sized) = {built_in impl Sized for i64}
     fn operate_on<'_0_1, '_1_1> = {impl BaseOn<i64> for i32}::operate_on<'_0_1, '_1_1>
     vtable: {impl BaseOn<i64> for i32}::{vtable}
 }
@@ -860,7 +860,7 @@ fn {impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(self_1: &'_0 i32, t32
     _5 = &(*self_1)
     storage_live(_6)
     _6 = &(*t32_2)
-    _4 = {impl Both32And64 for i32}::parent_clause1::operate_on<'12, '13>(move _5, move _6)
+    _4 = {impl Both32And64 for i32}::ImpliedClause1::operate_on<'12, '13>(move _5, move _6)
     storage_dead(_6)
     storage_dead(_5)
     storage_dead(_4)
@@ -869,7 +869,7 @@ fn {impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(self_1: &'_0 i32, t32
     _8 = &(*self_1)
     storage_live(_9)
     _9 = &(*t64_3)
-    _7 = {impl Both32And64 for i32}::parent_clause2::operate_on<'16, '17>(move _8, move _9)
+    _7 = {impl Both32And64 for i32}::ImpliedClause2::operate_on<'16, '17>(move _8, move _9)
     storage_dead(_9)
     storage_dead(_8)
     storage_dead(_7)
@@ -879,9 +879,9 @@ fn {impl Both32And64 for i32}::both_operate<'_0, '_1, '_2>(self_1: &'_0 i32, t32
 
 // Full name: test_crate::{impl Both32And64 for i32}
 impl Both32And64 for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {impl BaseOn<i32> for i32}
-    parent_clause2 = {impl BaseOn<i64> for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: BaseOn<i32>) = {impl BaseOn<i32> for i32}
+    proof ImpliedClause2: (i32: BaseOn<i64>) = {impl BaseOn<i64> for i32}
     fn both_operate<'_0_1, '_1_1, '_2_1> = {impl Both32And64 for i32}::both_operate<'_0_1, '_1_1, '_2_1>
     vtable: {impl Both32And64 for i32}::{vtable}
 }
@@ -889,8 +889,8 @@ impl Both32And64 for i32 {
 // Full name: test_crate::Alias
 trait Alias<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Both32And64<Self>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Both32And64)
     vtable: test_crate::Alias::{vtable}
 }
 
@@ -905,16 +905,16 @@ struct test_crate::LifetimeTrait::{vtable}<Ty0> {
 // Full name: test_crate::LifetimeTrait
 trait LifetimeTrait<Self>
 {
-    parent_clause0 : [@TraitClause0]: MetaSized<Self>
-    parent_clause1 : [@TraitClause1]: Sized<Self::Ty>
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Ty: Sized)
     type Ty
     fn lifetime_method<'a, '_1_1> = test_crate::LifetimeTrait::lifetime_method<'a, '_1_1, Self>[Self]
     vtable: test_crate::LifetimeTrait::{vtable}<Self::Ty>
 }
 
-fn test_crate::LifetimeTrait::lifetime_method<'a, '_1, Self>(_1: &'_1 Self, _2: &'a @TraitClause0::Ty) -> &'a @TraitClause0::Ty
+fn test_crate::LifetimeTrait::lifetime_method<'a, '_1, Self>(_1: &'_1 Self, _2: &'a TraitClause0::Ty) -> &'a TraitClause0::Ty
 where
-    [@TraitClause0]: LifetimeTrait<Self>,
+    TraitClause0: (Self: LifetimeTrait),
 = <method_without_default_body>
 
 // Full name: test_crate::{impl LifetimeTrait for i32}::lifetime_method
@@ -993,8 +993,8 @@ static {impl LifetimeTrait for i32}::{vtable}: test_crate::LifetimeTrait::{vtabl
 
 // Full name: test_crate::{impl LifetimeTrait for i32}
 impl LifetimeTrait for i32 {
-    parent_clause0 = {built_in impl MetaSized for i32}
-    parent_clause1 = {built_in impl Sized for i32}
+    proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
+    proof ImpliedClause1: (i32: Sized) = {built_in impl Sized for i32}
     type Ty = i32
     fn lifetime_method<'a, '_1_1> = {impl LifetimeTrait for i32}::lifetime_method<'a, '_1_1>
     vtable: {impl LifetimeTrait for i32}::{vtable}


### PR DESCRIPTION
This changes how we print predicates to make the mlook more like generic arguments/associated items. This gets closer to the style I've been using in [my blog posts](https://nadrieril.github.io/blog/2026/05/14/when-can-traits-depend-on-themselves.html).

ci: use https://github.com/AeneasVerif/eurydice/pull/415