### PR TITLE
Translate GAT arguments

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.206"
+let supported_charon_version = "0.1.207"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -626,8 +626,8 @@ and match_expr_with_ty (ctx : ctx) (c : match_config) (m : maps) (pty : expr)
       && match_expr_with_ty ctx c m pty ty
       && match_ref_kind prk rk
   | EVar v, _ -> opt_update_tmap c m v ty
-  | EComp pid, TTraitType (trait_ref, type_id) ->
-      match_trait_type ctx c m pid trait_ref type_id
+  | EComp pid, TTraitType (trait_ref, type_id, generics) ->
+      match_trait_type ctx c m pid trait_ref type_id generics
   | EArrow (pinputs, pout), TFnPtr binder -> begin
       (* Push a region group in the map, if necessary - TODO: make this more precise *)
       let m =
@@ -692,9 +692,10 @@ and match_trait_decl_ref_item (ctx : ctx) (c : match_config) (m : maps)
   else raise (Failure "Unimplemented")
 
 and match_trait_type (ctx : ctx) (c : match_config) (m : maps) (pid : pattern)
-    (tr : T.trait_ref) (type_id : T.assoc_type_id) : bool =
+    (tr : T.trait_ref) (type_id : T.assoc_type_id) (generics : T.generic_args) :
+    bool =
   match_trait_decl_ref_item ctx c m pid tr.trait_decl_ref (AssocIdType type_id)
-    TypesUtils.empty_generic_args
+    generics
 
 and match_generic_args (ctx : ctx) (c : match_config) (m : maps)
     (pgenerics : generic_args) (generics : T.generic_args) : bool =
@@ -1055,14 +1056,14 @@ and ty_to_pattern_aux (ctx : ctx) (c : to_pat_config) (m : constraints)
         ( region_to_pattern m r,
           ty_to_pattern_aux ctx c m ty,
           ref_kind_to_pattern rk )
-  | TTraitType (trait_ref, type_id) ->
+  | TTraitType (trait_ref, type_id, generics) ->
       let type_name =
         GAstUtils.get_assoc_type_name ctx.crate
           trait_ref.trait_decl_ref.binder_value.id type_id
       in
       let name =
         trait_ref_item_with_generics_to_pattern ctx c m trait_ref type_name
-          TypesUtils.empty_generic_args
+          generics
       in
       EComp name
   | TFnPtr binder ->

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -580,12 +580,13 @@ and pp_ty (env : fmt_env) (fmt : Format.formatter) (ty : ty) : unit =
   | TLiteral lit_ty -> pp_literal_type fmt lit_ty
   | TPattern (ty, pat) ->
       Format.fprintf fmt "%a is %a" (pp_ty env) ty (pp_type_pattern env) pat
-  | TTraitType (trait_ref, type_id) ->
+  | TTraitType (trait_ref, type_id, generics) ->
       let type_name =
         GAstUtils.get_assoc_type_name env.crate
           trait_ref.trait_decl_ref.binder_value.id type_id
       in
-      Format.fprintf fmt "%a::%s" (pp_trait_ref env) trait_ref type_name
+      Format.fprintf fmt "%a::%s%a" (pp_trait_ref env) trait_ref type_name
+        (pp_generic_args env) generics
   | TRef (r, rty, ref_kind) -> (
       match ref_kind with
       | RMut ->

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -1403,10 +1403,11 @@ and ty_kind_of_json (ctx : of_json_ctx) (js : json) : (ty_kind, string) result =
         let* x_0 = ty_of_json ctx x_0 in
         let* x_1 = ref_kind_of_json ctx x_1 in
         Ok (TRawPtr (x_0, x_1))
-    | `Assoc [ ("TraitType", `List [ x_0; x_1 ]) ] ->
+    | `Assoc [ ("TraitType", `List [ x_0; x_1; x_2 ]) ] ->
         let* x_0 = trait_ref_of_json ctx x_0 in
         let* x_1 = assoc_type_id_of_json ctx x_1 in
-        Ok (TTraitType (x_0, x_1))
+        let* x_2 = generic_args_of_json ctx x_2 in
+        Ok (TTraitType (x_0, x_1, x_2))
     | `Assoc [ ("DynTrait", dyn_trait) ] ->
         let* dyn_trait = dyn_predicate_of_json ctx dyn_trait in
         Ok (TDynTrait dyn_trait)

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1259,7 +1259,8 @@ and ty_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      | 6 ->
          let* x_0 = trait_ref_of_postcard ctx st in
          let* x_1 = assoc_type_id_of_postcard ctx st in
-         Ok (TTraitType (x_0, x_1))
+         let* x_2 = generic_args_of_postcard ctx st in
+         Ok (TTraitType (x_0, x_1, x_2))
      | 7 ->
          let* x_0 = dyn_predicate_of_postcard ctx st in
          Ok (TDynTrait x_0)

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -770,7 +770,7 @@ and ty_kind =
           eventually disappears from the AST. *)
   | TRef of region * ty * ref_kind  (** A borrow *)
   | TRawPtr of ty * ref_kind  (** A raw pointer. *)
-  | TTraitType of trait_ref * assoc_type_id
+  | TTraitType of trait_ref * assoc_type_id * generic_args
       (** A trait associated type
 
           Ex.:

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.206"
+version = "0.1.207"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -888,7 +888,7 @@ pub enum TyKind {
     ///   type Bar; // type associated to the trait Foo
     /// }
     /// ```
-    TraitType(TraitRef, AssocTypeId),
+    TraitType(TraitRef, AssocTypeId, GenericArgs),
     /// `dyn Trait`
     DynTrait(DynPredicate),
     /// Function pointer type. This is a literal pointer to a region of memory that

--- a/charon/src/bin/charon-driver/hax/rustc_utils.rs
+++ b/charon/src/bin/charon-driver/hax/rustc_utils.rs
@@ -217,7 +217,10 @@ pub fn assoc_tys_for_trait<'tcx>(
             tcx.associated_items(tref.def_id)
                 .in_definition_order()
                 .filter(|assoc| matches!(assoc.kind, ty::AssocKind::Type { .. }))
-                .filter(|assoc| tcx.generics_of(assoc.def_id).own_params.is_empty())
+                .filter(|assoc| {
+                    tcx.generics_of(assoc.def_id).own_params.is_empty()
+                        && tcx.predicates_of(assoc.def_id).predicates.is_empty()
+                })
                 .map(|assoc| ty::AliasTy::new(tcx, assoc.def_id, tref.args)),
         );
         for clause in tcx

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -615,12 +615,7 @@ pub struct Alias {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum AliasKind {
     /// The projection of a trait type: `<Ty as Trait<...>>::Type<...>`
-    Projection {
-        /// The `impl Trait for Ty` in `Ty: Trait<..., Type = U>`.
-        trait_proof: TraitProof,
-        /// The `Type` in `Ty: Trait<..., Type = U>`.
-        assoc_item: AssocItem,
-    },
+    Projection(ItemRef),
     /// An associated type in an inherent impl.
     Inherent,
     /// An `impl Trait` opaque type.
@@ -653,8 +648,7 @@ impl Alias {
 
         let kind = match alias_kind {
             RustAliasKind::Projection => {
-                let trait_ref = alias_ty.trait_ref(tcx);
-                // In a case like:
+                // FIXME: In a case like:
                 // ```
                 // impl<T, U> Trait for Result<T, U>
                 // where
@@ -666,12 +660,9 @@ impl Alias {
                 // yet we dont have a binder around (could even be several). Binding this correctly
                 // is therefore difficult. Since our trait resolution ignores lifetimes anyway, we
                 // just erase them. See also https://github.com/hacspec/hax/issues/747.
-                let trait_ref = crate::hax::traits::erase_free_regions(tcx, trait_ref);
-                let item = tcx.associated_item(alias_ty.def_id);
-                AliasKind::Projection {
-                    assoc_item: AssocItem::sfrom(s, &item),
-                    trait_proof: solve_trait(s, ty::Binder::dummy(trait_ref)),
-                }
+                // FIXME: at least only erase the trait regions
+                let args = crate::hax::traits::erase_free_regions(tcx, alias_ty.args);
+                AliasKind::Projection(ItemRef::translate(s, alias_ty.def_id, args))
             }
             RustAliasKind::Inherent => AliasKind::Inherent,
             RustAliasKind::Opaque => {

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -141,14 +141,18 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             hax::TyKind::Never => TyKind::Never,
 
             hax::TyKind::Alias(alias) => match &alias.kind {
-                hax::AliasKind::Projection {
-                    trait_proof,
-                    assoc_item,
-                } => {
-                    let trait_ref = self.translate_trait_proof(span, trait_proof)?;
+                hax::AliasKind::Projection(item) => {
+                    let trait_ref = self.translate_trait_proof(
+                        span,
+                        item.in_trait
+                            .as_ref()
+                            .expect("projection without a trait_ref?"),
+                    )?;
                     let assoc_type_id =
-                        self.translate_assoc_type_id(trait_ref.trait_id(), &assoc_item.def_id)?;
-                    TyKind::TraitType(trait_ref, assoc_type_id)
+                        self.translate_assoc_type_id(trait_ref.trait_id(), &item.def_id)?;
+                    let generics =
+                        self.translate_generic_args(span, &item.generic_args, &item.trait_proofs)?;
+                    TyKind::TraitType(trait_ref, assoc_type_id, generics)
                 }
                 hax::AliasKind::Opaque { hidden_ty, .. } => {
                     return self.translate_ty(span, hidden_ty);

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -855,6 +855,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for GenericsSource {
         match self {
             GenericsSource::Item(id) => write!(f, "{}", id.with_ctx(ctx)),
             GenericsSource::Method(id, name) => write!(f, "{}::{name}", id.with_ctx(ctx)),
+            GenericsSource::TraitType(id, name) => {
+                write!(f, "{}::", id.with_ctx(ctx))?;
+                ctx.format_assoc_type_name(f, *id, *name)
+            }
             GenericsSource::Builtin => write!(f, "<builtin>"),
             GenericsSource::Other => write!(f, "<unknown>"),
         }
@@ -2324,9 +2328,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for Ty {
             TyKind::Slice(ty) => {
                 write!(f, "[{}]", ty.with_ctx(ctx))
             }
-            TyKind::TraitType(trait_ref, type_id) => {
+            TyKind::TraitType(trait_ref, type_id, generics) => {
                 write!(f, "{}::", trait_ref.with_ctx(ctx))?;
-                ctx.format_assoc_type_name(f, trait_ref.trait_id(), *type_id)
+                ctx.format_assoc_type_name(f, trait_ref.trait_id(), *type_id)?;
+                write!(f, "{}", generics.with_ctx(ctx))
             }
             TyKind::DynTrait(pred) => {
                 write!(f, "(dyn {})", pred.with_ctx(ctx))

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -326,7 +326,7 @@ mod trait_ref_path {
         /// that.
         pub fn on_real_tref(&self, krate: &TranslatedCrate, tref: TraitRef) -> Option<Ty> {
             let tref = self.tref.on_real_tref(krate, tref)?;
-            let ty = TyKind::TraitType(tref, self.type_id).into_ty();
+            let ty = TyKind::TraitType(tref, self.type_id, GenericArgs::empty()).into_ty();
             Some(ty)
         }
 
@@ -926,7 +926,7 @@ impl UpdateItemBody<'_> {
         };
         let ty = self.type_replacements[dbid].find(&path)?;
         let mut ty = ty.clone().move_under_binders(dbid);
-        if let TyKind::TraitType(tref, type_id) = ty.kind() {
+        if let TyKind::TraitType(tref, type_id, _args) = ty.kind() {
             let path = TraitRefPath::self_ref(tref.trait_id()).with_assoc_type(*type_id);
             // Unnormalizable types may very well show up, e.g. when trait loopiness forces us to
             // create new assoc types.
@@ -1302,7 +1302,7 @@ impl VisitAstMut for UpdateItemBody<'_> {
 
     // Normalize associated types.
     fn visit_ty_kind(&mut self, kind: &mut TyKind) -> ControlFlow<Self::Break> {
-        if let TyKind::TraitType(tref, type_id) = kind {
+        if let TyKind::TraitType(tref, type_id, _args) = kind {
             let path = TraitRefPath::self_ref(tref.trait_id()).with_assoc_type(*type_id);
             if let Some(new_ty) = self.lookup_path_on_trait_ref(&path, tref) {
                 *kind = new_ty.kind().clone();
@@ -1401,7 +1401,7 @@ impl TransformPass for Transform {
                             implied_clauses: Default::default(),
                         },
                     ));
-                    TyKind::TraitType(self_tref.clone(), new_type_id).into_ty()
+                    TyKind::TraitType(self_tref.clone(), new_type_id, GenericArgs::empty()).into_ty()
                 })
             } else {
                 modifications.compute_replacements(|path| {

--- a/charon/src/transform/simplify_output/lift_associated_item_clauses.rs
+++ b/charon/src/transform/simplify_output/lift_associated_item_clauses.rs
@@ -27,31 +27,41 @@ impl TransformPass for Transform {
                 .iter_mut_enumerated()
                 .filter(|(_, assoc_ty)| !assoc_ty.params.has_explicits())
             {
-                let id_map = mem::take(&mut assoc_ty.skip_binder.implied_clauses).map(|clause| {
-                    let mut clause = clause.move_from_under_binder().unwrap();
-                    decl.implied_clauses.push_with(|id| {
-                        clause.clause_id = id;
-                        clause
-                    })
-                });
-                if assoc_ty.params.trait_clauses.is_empty() {
-                    // Move non-trait-clause-predicates of non-GAT types to be predicates on
-                    // the trait itself.
-                    decl.generics.take_predicates_from(
-                        mem::take(&mut assoc_ty.params)
-                            .move_from_under_binder()
-                            .unwrap(),
-                    );
+                // Try to move them all out of the binder, or bail.
+                if let Some(clauses) = assoc_ty
+                    .skip_binder
+                    .clone()
+                    .implied_clauses
+                    .move_from_under_binder()
+                {
+                    assoc_ty.skip_binder.implied_clauses.clear();
+                    let id_map = clauses.map(|mut clause| {
+                        decl.implied_clauses.push_with(|id| {
+                            clause.clause_id = id;
+                            clause
+                        })
+                    });
+                    if assoc_ty.params.trait_clauses.is_empty() {
+                        // Move non-trait-clause-predicates of non-GAT types to be predicates on
+                        // the trait itself.
+                        decl.generics.take_predicates_from(
+                            mem::take(&mut assoc_ty.params)
+                                .move_from_under_binder()
+                                .unwrap(),
+                        );
+                    }
+                    map.set_slot_extend(type_id, id_map);
                 }
-                map.set_slot_extend(type_id, id_map);
             }
             map
         });
 
         // Move the item-local trait refs to match what we did in the trait declarations.
         for timpl in ctx.translated.trait_impls.iter_mut() {
-            for assoc_ty in timpl.types.iter_mut() {
-                if !assoc_ty.params.has_explicits() {
+            for (type_id, assoc_ty) in timpl.types.iter_mut_indexed() {
+                if let Some(m) = trait_item_clause_ids.get(timpl.impl_trait.id)
+                    && m.get(type_id).is_some()
+                {
                     for trait_ref in mem::take(&mut assoc_ty.skip_binder.implied_trait_refs) {
                         let trait_ref = trait_ref.move_from_under_binder().unwrap();
                         // Note: this assumes that we listed the types in the same order as in the

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -165,6 +165,13 @@ impl TypeCheckVisitor<'_> {
     }
 
     fn match_generics(&mut self, a: &GenericArgs, b: &GenericArgs) -> Result<(), TypeError> {
+        if a.regions.len() != b.regions.len()
+            || a.types.len() != b.types.len()
+            || a.const_generics.len() != b.const_generics.len()
+            || a.trait_refs.len() != b.trait_refs.len()
+        {
+            return Err(TypeError);
+        }
         for (a, b) in a.regions.iter().zip(b.regions.iter()) {
             self.match_regions(a, b)?;
         }
@@ -375,6 +382,28 @@ impl TypeCheckVisitor<'_> {
             let _ = self.assert_matches(&fmt, &bound_fn.params, args, target);
         }
     }
+
+    fn assert_matches_trait_type(
+        &mut self,
+        trait_ref: &TraitRef,
+        type_id: AssocTypeId,
+        args: &mut GenericArgs,
+    ) {
+        let trait_id = trait_ref.trait_id();
+        let target = &GenericsSource::TraitType(trait_id, type_id);
+        let Some(trait_decl) = self.ctx.translated.trait_decls.get(trait_id) else {
+            return;
+        };
+        let Some(bound_ty) = trait_decl.types.get(type_id) else {
+            return;
+        };
+        if let Ok(bound_ty) = Substituted::new_for_trait_ref(bound_ty, trait_ref).try_substitute() {
+            let fmt1 = self.ctx.into_fmt();
+            let fmt2 = fmt1.push_binder(Cow::Borrowed(&trait_decl.generics));
+            let fmt = fmt2.push_binder(Cow::Borrowed(&bound_ty.params));
+            let _ = self.assert_matches(&fmt, &bound_ty.params, args, target);
+        }
+    }
 }
 
 impl VisitAstMut for TypeCheckVisitor<'_> {
@@ -394,10 +423,14 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
         }
     }
     fn enter_ty_kind(&mut self, x: &mut TyKind) {
-        if let TyKind::TypeVar(var) = x
-            && self.binder_stack.get_var(*var).is_none()
-        {
-            self.error(format!("Found incorrect type var: {var}"));
+        match x {
+            TyKind::TypeVar(var) if self.binder_stack.get_var(*var).is_none() => {
+                self.error(format!("Found incorrect type var: {var}"));
+            }
+            TyKind::TraitType(trait_ref, type_id, args) => {
+                self.assert_matches_trait_type(trait_ref, *type_id, args);
+            }
+            _ => {}
         }
     }
     fn enter_constant_expr(&mut self, x: &mut ConstantExpr) {

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -1,9 +1,9 @@
 use crate::ast::*;
-use crate::formatter::FmtCtx;
+use crate::formatter::{AstFormatter, FmtCtx};
 use crate::pretty::FmtWithCtx;
 use derive_generic_visitor::*;
 use macros::EnumIsA;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 /// Each `GenericArgs` is meant for a corresponding `GenericParams`; this describes which one.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, EnumIsA, Drive, DriveMut)]
@@ -12,6 +12,8 @@ pub enum GenericsSource {
     Item(ItemId),
     /// A trait method.
     Method(TraitDeclId, TraitMethodId),
+    /// A trait associated type.
+    TraitType(TraitDeclId, AssocTypeId),
     /// A builtin item like `Box`.
     Builtin,
     /// Some other use of generics outside the main Charon ast.
@@ -31,6 +33,14 @@ impl GenericsSource {
                 "{}::{method_name}",
                 translated.item_name(*trait_id).to_string_with_ctx(fmt_ctx),
             ),
+            GenericsSource::TraitType(trait_id, type_id) => {
+                let type_name =
+                    fmt::from_fn(|f| fmt_ctx.format_assoc_type_name(f, *trait_id, *type_id));
+                format!(
+                    "{}::{type_name}",
+                    translated.item_name(*trait_id).to_string_with_ctx(fmt_ctx),
+                )
+            }
             GenericsSource::Builtin => "<built-in>".to_string(),
             GenericsSource::Other => "<unknown>".to_string(),
         }

--- a/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
+++ b/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
@@ -16,11 +16,11 @@ pub trait Sized<Self>
 pub trait MyTrait<Self>
 {
     proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Self::Ret: Sized)
     type Ret = ()
     where
-        TraitClause0_1: (Self: Sized);
-    vtable: test_crate::MyTrait::{vtable}<Self::Ret>
+        TraitClause0_1: (Self: Sized),
+        proof ImpliedClause0: (Self::Ret[TraitClause0_1]: Sized);
+    vtable: test_crate::MyTrait::{vtable}
 }
 
 // Full name: test_crate::S
@@ -29,10 +29,10 @@ pub struct S {}
 // Full name: test_crate::{impl MyTrait for S}
 impl MyTrait for S {
     proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
-    proof ImpliedClause1: ({impl MyTrait for S}::Ret: Sized) = {impl MyTrait for S}::ImpliedClause1
     type Ret = ()
     where
-        TraitClause0_1: (S: Sized);
+        TraitClause0_1: (S: Sized),
+        proof ImpliedClause0: ({impl MyTrait for S}::Ret[TraitClause0_1]: Sized) = {impl MyTrait for S}::Ret::ImpliedClause0;
     vtable: {impl MyTrait for S}::{vtable}
 }
 

--- a/charon/tests/ui/associated_types/gat-used-in-method.out
+++ b/charon/tests/ui/associated_types/gat-used-in-method.out
@@ -19,13 +19,13 @@ trait Foo<Self>
     type T<A>
     where
         TraitClause0_1: (A: Sized),
-        proof ImpliedClause0: (Self::T: Sized);
+        proof ImpliedClause0: (Self::T<A>[TraitClause0_1]: Sized);
     fn f<A, TraitClause0_1: (A: Sized)> = f<Self, A>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::f
-fn f<Self, A>(_1: TraitClause0::T)
+fn f<Self, A>(_1: TraitClause0::T<A>[TraitClause1])
 where
     TraitClause0: (Self: Foo),
     TraitClause1: (A: Sized),

--- a/charon/tests/ui/gat-causes-unhandled-ty-clause.out
+++ b/charon/tests/ui/gat-causes-unhandled-ty-clause.out
@@ -30,7 +30,7 @@ trait HasGAT<Self>
     type GAT<T>
     where
         TraitClause0_1: (T: Sized),
-        proof ImpliedClause0: (Self::GAT: Sized);
+        proof ImpliedClause0: (Self::GAT<T>[TraitClause0_1]: Sized);
     type Friend
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/defaulted-rpitit.2.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.2.out
@@ -16,12 +16,12 @@ pub trait Sized<Self>
 pub trait MyTrait<Self>
 {
     proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Self::foo_ty: Sized)
     type foo_ty = ()
     where
-        TraitClause0_1: (Self: Sized);
+        TraitClause0_1: (Self: Sized),
+        proof ImpliedClause0: (Self::foo_ty[TraitClause0_1]: Sized);
     fn foo<TraitClause0_1: (Self: Sized)> = test_crate::MyTrait::foo<Self>[Self, TraitClause0_1]
-    vtable: test_crate::MyTrait::{vtable}<Self::foo_ty>
+    vtable: test_crate::MyTrait::{vtable}
 }
 
 pub fn test_crate::MyTrait::foo<Self>()
@@ -54,10 +54,10 @@ where
 // Full name: test_crate::{impl MyTrait for S}
 impl MyTrait for S {
     proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
-    proof ImpliedClause1: ({impl MyTrait for S}::foo_ty: Sized) = {impl MyTrait for S}::ImpliedClause1
     type foo_ty = ()
     where
-        TraitClause0_1: (S: Sized);
+        TraitClause0_1: (S: Sized),
+        proof ImpliedClause0: ({impl MyTrait for S}::foo_ty[TraitClause0_1]: Sized) = {impl MyTrait for S}::foo_ty::ImpliedClause0;
     fn foo<TraitClause0_1: (S: Sized)> = {impl MyTrait for S}::foo[TraitClause0_1]
     vtable: {impl MyTrait for S}::{vtable}
 }

--- a/charon/tests/ui/simple/defaulted-rpitit.3.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.3.out
@@ -60,8 +60,8 @@ pub trait MyTrait<Self, T>
     type rows_ty<'_0_1> = Empty<T>[Self::ImpliedClause1]
     where
         TypeConstraint0: Self::rows_ty::ImpliedClause1::Item = T,
-        proof ImpliedClause0: (Self::rows_ty: Sized),
-        proof ImpliedClause1: (Self::rows_ty: Iterator);
+        proof ImpliedClause0: (Self::rows_ty<'_>: Sized),
+        proof ImpliedClause1: (Self::rows_ty<'_>: Iterator);
     fn rows<'_0_1> = test_crate::MyTrait::rows<'_0_1, Self, T>[Self]
     non-dyn-compatible
 }
@@ -99,8 +99,8 @@ where
     type rows_ty<'_0_1> = Empty<T>[{impl MyTrait<T> for ()}<T>[TraitClause0]::ImpliedClause1]
     where
         TypeConstraint0: {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause1::Item = T,
-        proof ImpliedClause0: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty: Sized) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause0,
-        proof ImpliedClause1: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty: Iterator) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause1;
+        proof ImpliedClause0: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty<'_>: Sized) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause0,
+        proof ImpliedClause1: ({impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty<'_>: Iterator) = {impl MyTrait<T> for ()}<T>[TraitClause0]::rows_ty::ImpliedClause1;
     fn rows<'_0_1> = {impl MyTrait<T> for ()}::rows<'_0_1, T>[TraitClause0]
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/defaulted-rpitit.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.out
@@ -18,7 +18,7 @@ pub trait Foo<Self>
     proof ImpliedClause0: (Self: MetaSized)
     type bar_ty<const N : usize> = [u8; N]
     where
-        proof ImpliedClause0: (Self::bar_ty: Sized);
+        proof ImpliedClause0: (Self::bar_ty<N>: Sized);
     fn bar<const N : usize> = test_crate::Foo::bar<Self, N>[Self]
     non-dyn-compatible
 }
@@ -50,7 +50,7 @@ impl Foo for S {
     proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
     type bar_ty<const N : usize> = [u8; N]
     where
-        proof ImpliedClause0: ({impl Foo for S}::bar_ty: Sized) = {impl Foo for S}::bar_ty::ImpliedClause0;
+        proof ImpliedClause0: ({impl Foo for S}::bar_ty<N>: Sized) = {impl Foo for S}::bar_ty::ImpliedClause0;
     fn bar<const N : usize> = {impl Foo for S}::bar<N>
     non-dyn-compatible
 }

--- a/charon/tests/ui/simple/gat-check-binder-levels.out
+++ b/charon/tests/ui/simple/gat-check-binder-levels.out
@@ -49,8 +49,8 @@ pub trait Trait<Self, T>
     type Type<U>
     where
         TraitClause0_1: (U: Sized),
-        proof ImpliedClause0: (Self::Type: Sized),
-        proof ImpliedClause1: (Self::Type: Link<T>);
+        proof ImpliedClause0: (Self::Type<U>[TraitClause0_1]: Sized),
+        proof ImpliedClause1: (Self::Type<U>[TraitClause0_1]: Link<T>);
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/gat-complex-lifetimes.out
+++ b/charon/tests/ui/simple/gat-complex-lifetimes.out
@@ -45,21 +45,21 @@ pub trait Bar<'a, Self>
     proof ImpliedClause0: (Self: MetaSized)
     type Type<'b>
     where
-        proof ImpliedClause0: (Self::Type: Sized),
-        proof ImpliedClause1: for<'c> (Self::Type: Foo<&'a &'b &'c ()>);
+        proof ImpliedClause0: (Self::Type<'_>: Sized),
+        proof ImpliedClause1: for<'c> (Self::Type<'_>: Foo<&'a &'b &'c ()>);
     non-dyn-compatible
 }
 
 // Full name: test_crate::bar
-pub fn bar<'x, 'y, 'z, T>(x_1: TraitClause1::Type) -> &'x &'y &'z ()
+pub fn bar<'x, 'y, 'z, T>(x_1: TraitClause1::Type<'_>) -> &'x &'y &'z ()
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Bar<'x>),
 {
     let _0: &'6 &'7 &'8 (); // return
-    let x_1: TraitClause1::Type; // arg #1
-    let _2: &'11 &'12 &'13 (); // anonymous local
-    let _3: TraitClause1::Type; // anonymous local
+    let x_1: TraitClause1::Type<'12>; // arg #1
+    let _2: &'13 &'14 &'15 (); // anonymous local
+    let _3: TraitClause1::Type<'17>; // anonymous local
 
     storage_live(_2)
     storage_live(_3)
@@ -68,7 +68,7 @@ where
     _0 = &(*_2)
     storage_dead(_3)
     storage_dead(_2)
-    conditional_drop[{built_in impl Destruct for TraitClause1::Type}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::Type<'41>}::drop_in_place] x_1
     return
 }
 

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -30,7 +30,7 @@ trait Collection<Self>
     type Sibling<U> = Vec<U>[TraitClause0_1, {built_in impl Sized for Global}]
     where
         TraitClause0_1: (U: Sized),
-        proof ImpliedClause0: (Self::Sibling: Sized);
+        proof ImpliedClause0: (Self::Sibling<U>[TraitClause0_1]: Sized);
     non-dyn-compatible
 }
 
@@ -40,7 +40,7 @@ impl Collection for () {
     type Sibling<U> = Vec<U>[TraitClause0_1, {built_in impl Sized for Global}]
     where
         TraitClause0_1: (U: Sized),
-        proof ImpliedClause0: ({impl Collection for ()}::Sibling: Sized) = {impl Collection for ()}::Sibling::ImpliedClause0;
+        proof ImpliedClause0: ({impl Collection for ()}::Sibling<U>[TraitClause0_1]: Sized) = {impl Collection for ()}::Sibling::ImpliedClause0;
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/gat-implied-clause.out
+++ b/charon/tests/ui/simple/gat-implied-clause.out
@@ -46,50 +46,50 @@ trait Trait<Self>
     proof ImpliedClause0: (Self: MetaSized)
     type LifetimeGat<'a>
     where
-        proof ImpliedClause0: (Self::LifetimeGat: Sized),
-        proof ImpliedClause1: (Self::LifetimeGat: Clone);
+        proof ImpliedClause0: (Self::LifetimeGat<'_>: Sized),
+        proof ImpliedClause1: (Self::LifetimeGat<'_>: Clone);
     type NonLifetimeGat<T>
     where
         TraitClause0_1: (T: Sized),
-        proof ImpliedClause0: (Self::NonLifetimeGat: Sized),
-        proof ImpliedClause1: (Self::NonLifetimeGat: Clone);
+        proof ImpliedClause0: (Self::NonLifetimeGat<T>[TraitClause0_1]: Sized),
+        proof ImpliedClause1: (Self::NonLifetimeGat<T>[TraitClause0_1]: Clone);
     non-dyn-compatible
 }
 
 // Full name: test_crate::lifetime_gat_bound
-fn lifetime_gat_bound<'_0, X>(x_1: TraitClause1::LifetimeGat)
+fn lifetime_gat_bound<'_0, X>(x_1: TraitClause1::LifetimeGat<'_>)
 where
     TraitClause0: (X: Sized),
     TraitClause1: (X: Trait),
 {
     let _0: (); // return
-    let x_1: TraitClause1::LifetimeGat; // arg #1
-    let _2: TraitClause1::LifetimeGat; // anonymous local
-    let _3: &'1 TraitClause1::LifetimeGat; // anonymous local
+    let x_1: TraitClause1::LifetimeGat<'1>; // arg #1
+    let _2: TraitClause1::LifetimeGat<'2>; // anonymous local
+    let _3: &'5 TraitClause1::LifetimeGat<'6>; // anonymous local
 
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &x_1
-    _2 = TraitClause1::LifetimeGat::ImpliedClause1::clone<'3>(move _3)
+    _2 = TraitClause1::LifetimeGat::ImpliedClause1::clone<'10>(move _3)
     storage_dead(_3)
-    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat}::drop_in_place] _2
+    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat<'14>}::drop_in_place] _2
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::LifetimeGat<'16>}::drop_in_place] x_1
     return
 }
 
 // Full name: test_crate::non_lifetime_gat_bound
-fn non_lifetime_gat_bound<X>(x_1: TraitClause1::NonLifetimeGat)
+fn non_lifetime_gat_bound<X>(x_1: TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}])
 where
     TraitClause0: (X: Sized),
     TraitClause1: (X: Trait),
 {
     let _0: (); // return
-    let x_1: TraitClause1::NonLifetimeGat; // arg #1
-    let _2: TraitClause1::NonLifetimeGat; // anonymous local
-    let _3: &'1 TraitClause1::NonLifetimeGat; // anonymous local
+    let x_1: TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}]; // arg #1
+    let _2: TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}]; // anonymous local
+    let _3: &'1 TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}]; // anonymous local
 
     _0 = ()
     storage_live(_2)
@@ -97,10 +97,10 @@ where
     _3 = &x_1
     _2 = TraitClause1::NonLifetimeGat::ImpliedClause1::clone<'3>(move _3)
     storage_dead(_3)
-    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat}::drop_in_place] _2
+    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}]}::drop_in_place] _2
     storage_dead(_2)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat}::drop_in_place] x_1
+    conditional_drop[{built_in impl Destruct for TraitClause1::NonLifetimeGat<u8>[{built_in impl Sized for u8}]}::drop_in_place] x_1
     return
 }
 

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -100,7 +100,7 @@ pub trait LendingIterator<Self>
     type Item<'a>
     where
         TypeOutlives0: Self: 'a,
-        proof ImpliedClause0: (Self::Item: Sized);
+        proof ImpliedClause0: (Self::Item<'_>: Sized);
     fn next<'a> = test_crate::LendingIterator::next<'a, Self>[Self]
     non-dyn-compatible
 }
@@ -125,7 +125,7 @@ impl<A> Destruct for (A,) {
     non-dyn-compatible
 }
 
-pub fn test_crate::LendingIterator::next<'a, Self>(_1: &'a mut Self) -> Option<TraitClause0::Item>[TraitClause0::Item::ImpliedClause0]
+pub fn test_crate::LendingIterator::next<'a, Self>(_1: &'a mut Self) -> Option<TraitClause0::Item<'_>>[TraitClause0::Item::ImpliedClause0]
 where
     TraitClause0: (Self: LendingIterator),
 = <method_without_default_body>
@@ -187,19 +187,19 @@ where
     TraitClause0: (I: Sized),
     TraitClause1: (T1: Sized),
     TraitClause2: (I: LendingIterator),
-    TraitClause3: for<'a> (T1: FnMut<(TraitClause2::Item,)>),
+    TraitClause3: for<'a> (T1: FnMut<(TraitClause2::Item<'_>,)>),
     TypeConstraint0: for<'a> TraitClause3::ImpliedClause1::Output = (),
 {
     let _0: (); // return
     let iter_1: I; // arg #1
     let f_2: T1; // arg #2
     let _3: (); // anonymous local
-    let _4: Option<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]; // anonymous local
-    let _5: &'1 mut I; // anonymous local
-    let item_6: TraitClause2::Item; // local
-    let _7: &'3 mut T1; // anonymous local
-    let _8: (TraitClause2::Item,); // anonymous local
-    let _9: TraitClause2::Item; // anonymous local
+    let _4: Option<TraitClause2::Item<'4>>[TraitClause2::Item::ImpliedClause0]; // anonymous local
+    let _5: &'7 mut I; // anonymous local
+    let item_6: TraitClause2::Item<'8>; // local
+    let _7: &'10 mut T1; // anonymous local
+    let _8: (TraitClause2::Item<'12>,); // anonymous local
+    let _9: TraitClause2::Item<'13>; // anonymous local
 
     storage_live(_3)
     _0 = ()
@@ -207,7 +207,7 @@ where
         storage_live(_4)
         storage_live(_5)
         _5 = &two-phase-mut iter_1
-        _4 = TraitClause2::next<'5>(move _5)
+        _4 = TraitClause2::next<'15>(move _5)
         storage_dead(_5)
         match _4 {
             Option::Some => {
@@ -224,19 +224,19 @@ where
         storage_live(_9)
         _9 = move item_6
         _8 = (move _9,)
-        _3 = TraitClause3::call_mut<'7>(move _7, move _8)
-        conditional_drop[{built_in impl Destruct for TraitClause2::Item}::drop_in_place] _9
+        _3 = TraitClause3::call_mut<'32>(move _7, move _8)
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'38>}::drop_in_place] _9
         storage_dead(_9)
         storage_dead(_8)
         storage_dead(_7)
-        conditional_drop[{built_in impl Destruct for TraitClause2::Item}::drop_in_place] item_6
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'42>}::drop_in_place] item_6
         storage_dead(item_6)
-        conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]] _4
+        conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item<'51>>[TraitClause2::Item::ImpliedClause0]] _4
         storage_dead(_4)
         continue 0
     }
     _0 = ()
-    conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item>[TraitClause2::Item::ImpliedClause0]] _4
+    conditional_drop[{impl Destruct for Option<T>[TraitClause0]}::drop_in_place<TraitClause2::Item<'22>>[TraitClause2::Item::ImpliedClause0]] _4
     storage_dead(_4)
     conditional_drop[{built_in impl Destruct for T1}::drop_in_place] f_2
     conditional_drop[{built_in impl Destruct for I}::drop_in_place] iter_1

--- a/charon/tests/ui/simple/non-lifetime-gats.out
+++ b/charon/tests/ui/simple/non-lifetime-gats.out
@@ -77,13 +77,13 @@ pub trait PointerFamily<Self>
     where
         TraitClause0_1: (T: Sized),
         TypeConstraint0: Self::Pointer::ImpliedClause1::Target = T,
-        proof ImpliedClause0: (Self::Pointer: Sized),
-        proof ImpliedClause1: (Self::Pointer: Deref);
+        proof ImpliedClause0: (Self::Pointer<T>[TraitClause0_1]: Sized),
+        proof ImpliedClause1: (Self::Pointer<T>[TraitClause0_1]: Deref);
     fn new<T, TraitClause0_1: (T: Sized)> = test_crate::PointerFamily::new<Self, T>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
-pub fn test_crate::PointerFamily::new<Self, T>(_1: T) -> TraitClause0::Pointer
+pub fn test_crate::PointerFamily::new<Self, T>(_1: T) -> TraitClause0::Pointer<T>[TraitClause1]
 where
     TraitClause0: (Self: PointerFamily),
     TraitClause1: (T: Sized),
@@ -122,13 +122,13 @@ impl PointerFamily for BoxFamily {
 }
 
 // Full name: test_crate::make_pointer
-pub fn make_pointer<F, T>(x_1: T) -> TraitClause2::Pointer
+pub fn make_pointer<F, T>(x_1: T) -> TraitClause2::Pointer<T>[TraitClause1]
 where
     TraitClause0: (F: Sized),
     TraitClause1: (T: Sized),
     TraitClause2: (F: PointerFamily),
 {
-    let _0: TraitClause2::Pointer; // return
+    let _0: TraitClause2::Pointer<T>[TraitClause1]; // return
     let x_1: T; // arg #1
     let _2: T; // anonymous local
 

--- a/charon/tests/ui/simple/rpitit-with-const-generic.out
+++ b/charon/tests/ui/simple/rpitit-with-const-generic.out
@@ -18,12 +18,12 @@ pub trait Foo<Self>
     proof ImpliedClause0: (Self: MetaSized)
     type bar_ty<const N : usize>
     where
-        proof ImpliedClause0: (Self::bar_ty: Sized);
+        proof ImpliedClause0: (Self::bar_ty<N>: Sized);
     fn bar<const N : usize> = test_crate::Foo::bar<Self, N>[Self]
     non-dyn-compatible
 }
 
-pub fn test_crate::Foo::bar<Self, const N : usize>() -> TraitClause0::bar_ty
+pub fn test_crate::Foo::bar<Self, const N : usize>() -> TraitClause0::bar_ty<N>
 where
     TraitClause0: (Self: Foo),
 = <method_without_default_body>

--- a/charon/tests/ui/simple/rpitit-with-lifetime-bound.out
+++ b/charon/tests/ui/simple/rpitit-with-lifetime-bound.out
@@ -21,13 +21,13 @@ pub trait MyTrait<Self>
         TypeOutlives0: Self: 'a,
         RegionOutlives0: 'a: '_1_1,
         RegionOutlives1: '_1_1: 'a,
-        proof ImpliedClause0: (Self::foo_ty: Sized);
+        proof ImpliedClause0: (Self::foo_ty<'_, '_>: Sized);
     fn foo<'a, TypeOutlives0: Self: 'a> = foo<'a, Self>[Self]
     non-dyn-compatible
 }
 
 // Full name: test_crate::MyTrait::foo
-pub fn foo<'a, Self>() -> TraitClause0::foo_ty
+pub fn foo<'a, Self>() -> TraitClause0::foo_ty<'_, '_>
 where
     TraitClause0: (Self: MyTrait),
     TypeOutlives0: Self: 'a,

--- a/charon/tests/ui/simple/rpitit-with-lifetime.out
+++ b/charon/tests/ui/simple/rpitit-with-lifetime.out
@@ -51,14 +51,14 @@ trait Foo<Self, T>
         RegionOutlives0: 'a: '_1_1,
         RegionOutlives1: '_1_1: 'a,
         TypeConstraint0: Self::iter_ty::ImpliedClause1::Item = &'_1_1 T,
-        proof ImpliedClause0: (Self::iter_ty: Sized),
-        proof ImpliedClause1: (Self::iter_ty: Iterator);
+        proof ImpliedClause0: (Self::iter_ty<'_, '_>: Sized),
+        proof ImpliedClause1: (Self::iter_ty<'_, '_>: Iterator);
     fn iter<'a, TypeOutlives0: T: 'a> = iter<'a, Self, T>[Self]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::iter
-fn iter<'a, Self, T>(_1: &'a Self) -> TraitClause0::iter_ty
+fn iter<'a, Self, T>(_1: &'a Self) -> TraitClause0::iter_ty<'_, '_>
 where
     TraitClause0: (Self: Foo<T>),
     TypeOutlives0: T: 'a,

--- a/charon/tests/ui/simple/rpitit.out
+++ b/charon/tests/ui/simple/rpitit.out
@@ -27,14 +27,14 @@ trait Foo<Self, T>
     type into_iter_ty<U>
     where
         TraitClause0_1: (U: Sized),
-        proof ImpliedClause0: (Self::into_iter_ty: Sized),
-        proof ImpliedClause1: (Self::into_iter_ty: Trait);
+        proof ImpliedClause0: (Self::into_iter_ty<U>[TraitClause0_1]: Sized),
+        proof ImpliedClause1: (Self::into_iter_ty<U>[TraitClause0_1]: Trait);
     fn into_iter<U, TraitClause0_1: (U: Sized)> = into_iter<Self, T, U>[Self, TraitClause0_1]
     non-dyn-compatible
 }
 
 // Full name: test_crate::Foo::into_iter
-fn into_iter<Self, T, U>(_1: Self) -> TraitClause0::into_iter_ty
+fn into_iter<Self, T, U>(_1: Self) -> TraitClause0::into_iter_ty<U>[TraitClause1]
 where
     TraitClause0: (Self: Foo<T>),
     TraitClause1: (U: Sized),


### PR DESCRIPTION
Somehow we never translated the generics used when we refer to a GAT x) Fixed now.

ci: use https://github.com/AeneasVerif/aeneas/pull/1090

ci: use https://github.com/AeneasVerif/eurydice/pull/416