### PR TITLE
Fix last std failure

### DIFF
--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -41,6 +41,12 @@ struct TypeCheckVisitor<'a> {
     /// Remember the names of the types visited up to here.
     visit_stack: Vec<&'static str>,
     body_lt_unifier: Option<UnionFind<RegionId>>,
+    /// Copies of default methods may have contradictory premises like `Self::Item = bool` and
+    /// `Self::Item = u32` which may equate entirely different types. We don't try to reason about
+    /// this and instead accept this fact. It's fine because the original methods will be
+    /// type-checked.
+    /// Example where this matters: tests/ui/traits/default-method-with-item-bound.6.rs
+    accept_type_errors: bool,
 }
 
 impl VisitorWithSpan for TypeCheckVisitor<'_> {
@@ -118,6 +124,7 @@ impl TypeCheckVisitor<'_> {
             (TyKind::TraitType(..), _) | (_, TyKind::TraitType(..)) => {}
             (TyKind::PtrMetadata(..), _) | (_, TyKind::PtrMetadata(..)) => {}
             (TyKind::Error(_), _) | (_, TyKind::Error(_)) => {}
+            _ if self.accept_type_errors => {}
             _ => return Err(TypeError),
         }
         Ok(())
@@ -640,6 +647,18 @@ impl TransformPass for Check {
     }
     fn transform_ctx(&self, ctx: &mut TransformCtx) {
         ctx.for_each_item_mut(|ctx, mut item| {
+            // Accept type errors within copies of default methods. See docs for
+            // `accept_type_errors` for why.
+            let accept_type_errors = matches!(
+                &item,
+                ItemRefMut::Fun(FunDecl {
+                    src: ItemSource::TraitImpl {
+                        reuses_default: true,
+                        ..
+                    },
+                    ..
+                })
+            );
             let mut visitor = TypeCheckVisitor {
                 ctx,
                 phase: *self,
@@ -647,6 +666,7 @@ impl TransformPass for Check {
                 binder_stack: BindingStack::empty(),
                 visit_stack: Default::default(),
                 body_lt_unifier: None,
+                accept_type_errors,
             };
             let _ = item.drive_mut(&mut visitor);
         });

--- a/charon/tests/ui/traits/default-method-with-item-bound.6.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.6.out
@@ -1,22 +1,117 @@
-error: Type error after transformations:
-       Incoherent trait reference:
-            got: {impl Takes<bool> for ()}: Takes<(), u32>
-       Visitor stack:
-         charon_lib::ast::expressions::FnPtr
-         charon_lib::ast::gast::FnOperand
-         charon_lib::ast::gast::Call
-         charon_lib::ast::llbc_ast::StatementKind
-         charon_lib::ast::llbc_ast::Statement
-         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
-         charon_lib::ast::llbc_ast::Block
-         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
-         charon_lib::ast::gast::Body
-         charon_lib::ast::gast::FunDecl
-       Binding stack (depth 1):
-         0: <'_0, TraitClause0: ((): @TraitDecl1), TypeConstraint0: @TraitImpl1::@AssocType0 = bool>
-  --> tests/ui/traits/default-method-with-item-bound.6.rs:16:9
-   |
-16 |         self.consume::<()>();
-   |         ^^^^^^^^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::Takes
+trait Takes<Self, T>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (T: Sized)
+    vtable: test_crate::Takes::{vtable}<T>
+}
+
+// Full name: test_crate::{impl Takes<bool> for ()}
+impl Takes<bool> for () {
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (bool: Sized) = {built_in impl Sized for bool}
+    vtable: {impl Takes<bool> for ()}::{vtable}
+}
+
+// Full name: test_crate::Trait
+trait Trait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    type Item
+    fn consume<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: Takes<Self::Item>)> = test_crate::Trait::consume<'_0_1, Self, P>[Self, TraitClause0_1, TraitClause1_1]
+    fn provided<'_0_1, TraitClause0_1: (Self: Trait), TypeConstraint0: Self::Item = bool> = test_crate::Trait::provided<'_0_1, Self>[Self, TraitClause0_1]
+    non-dyn-compatible
+}
+
+fn test_crate::Trait::consume<'_0, Self, P>(_1: &'_0 Self)
+where
+    TraitClause0: (Self: Trait),
+    TraitClause1: (P: Sized),
+    TraitClause2: (P: Takes<TraitClause0::Item>),
+= <method_without_default_body>
+
+fn test_crate::Trait::provided<'_0, Self>(self_1: &'_0 Self)
+where
+    TraitClause0: (Self: Trait),
+    TraitClause1: (Self: Trait),
+    TypeConstraint0: TraitClause0::Item = bool,
+{
+    let _0: (); // return
+    let self_1: &'1 Self; // arg #1
+    let _2: (); // anonymous local
+    let _3: &'2 Self; // anonymous local
+
+    _0 = ()
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*self_1) with_metadata(copy self_1.metadata)
+    _2 = TraitClause0::consume<'4, ()>[{built_in impl Sized for ()}, {impl Takes<bool> for ()}](move _3)
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl Trait for ()}::consume
+fn {impl Trait for ()}::consume<'_0, P>(self_1: &'_0 ())
+where
+    TraitClause0: (P: Sized),
+    TraitClause1: (P: Takes<u32>),
+{
+    let _0: (); // return
+    let self_1: &'1 (); // arg #1
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl Trait for ()}::provided
+fn {impl Trait for ()}::provided<'_0>(self_1: &'_0 ())
+where
+    TraitClause0: ((): Trait),
+    TypeConstraint0: {impl Trait for ()}::Item = bool,
+{
+    let _0: (); // return
+    let self_1: &'1 (); // arg #1
+    let _2: (); // anonymous local
+    let _3: &'2 (); // anonymous local
+
+    _0 = ()
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*self_1)
+    _2 = {impl Trait for ()}::consume<'4, ()>[{built_in impl Sized for ()}, {impl Takes<bool> for ()}](move _3)
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl Trait for ()}
+impl Trait for () {
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    type Item = u32
+    fn consume<'_0_1, P, TraitClause0_1: (P: Sized), TraitClause1_1: (P: Takes<u32>)> = {impl Trait for ()}::consume<'_0_1, P>[TraitClause0_1, TraitClause1_1]
+    fn provided<'_0_1, TraitClause0_1: ((): Trait), TypeConstraint0: {impl Trait for ()}::Item = bool> = {impl Trait for ()}::provided<'_0_1>[TraitClause0_1]
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/traits/default-method-with-item-bound.6.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.6.out
@@ -1,0 +1,22 @@
+error: Type error after transformations:
+       Incoherent trait reference:
+            got: {impl Takes<bool> for ()}: Takes<(), u32>
+       Visitor stack:
+         charon_lib::ast::expressions::FnPtr
+         charon_lib::ast::gast::FnOperand
+         charon_lib::ast::gast::Call
+         charon_lib::ast::llbc_ast::StatementKind
+         charon_lib::ast::llbc_ast::Statement
+         alloc::vec::Vec<charon_lib::ast::llbc_ast::Statement>
+         charon_lib::ast::llbc_ast::Block
+         charon_lib::ast::gast::GExprBody<charon_lib::ast::llbc_ast::Block>
+         charon_lib::ast::gast::Body
+         charon_lib::ast::gast::FunDecl
+       Binding stack (depth 1):
+         0: <'_0, TraitClause0: ((): @TraitDecl1), TypeConstraint0: @TraitImpl1::@AssocType0 = bool>
+  --> tests/ui/traits/default-method-with-item-bound.6.rs:16:9
+   |
+16 |         self.consume::<()>();
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/traits/default-method-with-item-bound.6.rs
+++ b/charon/tests/ui/traits/default-method-with-item-bound.6.rs
@@ -1,0 +1,27 @@
+//@ known-failure
+
+trait Takes<T> {}
+
+impl Takes<bool> for () {}
+
+trait Trait {
+    type Item;
+
+    fn consume<P: Takes<Self::Item>>(&self);
+
+    fn provided(&self)
+    where
+        Self: Trait<Item = bool>,
+    {
+        self.consume::<()>();
+    }
+}
+
+impl Trait for () {
+    type Item = u32;
+
+    fn consume<P: Takes<Self::Item>>(&self) {}
+
+    // This gets a copy of `provided` which passes a proof of `(): Takes<bool>` to `consume`, which
+    // is fine because we're inside an incoherent context but my typechecker doesn't know that.
+}

--- a/charon/tests/ui/traits/default-method-with-item-bound.6.rs
+++ b/charon/tests/ui/traits/default-method-with-item-bound.6.rs
@@ -1,5 +1,3 @@
-//@ known-failure
-
 trait Takes<T> {}
 
 impl Takes<bool> for () {}


### PR DESCRIPTION
This fixes the last error (outside of `async` being unsupported) we got when running `--start-from=std --include=std --include=alloc --include=core` as instructed [here](https://github.com/AeneasVerif/charon/issues/863)!