### PR TITLE
Avoid running Charon when the crate has errors

### DIFF
--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -12,6 +12,7 @@ use rustc_interface::interface::Compiler;
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_session::config::{OutputType, OutputTypes};
+use rustc_span::ErrorGuaranteed;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, fmt};
 
@@ -97,6 +98,34 @@ fn setup_compiler(config: &mut Config, options: &CliOpts, do_translate: bool) {
         set_parallel_frontend(config);
     }
     set_mir_options(config);
+}
+
+/// Run a couple of rustc queries that don't involve MIR (so that they don't steal it). Returns
+/// whether rustc reported errors. This lets us avoid running Charon translation on crates rustc
+/// already rejects.
+fn precheck_rustc_errors(tcx: TyCtxt<'_>) -> bool {
+    type QueryResult = Result<(), ErrorGuaranteed>;
+
+    tcx.par_hir_for_each_module(|module| {
+        tcx.ensure_ok().check_mod_attrs(module);
+        tcx.ensure_ok().check_mod_unstable_api_usage(module);
+    });
+
+    let _: QueryResult = tcx.ensure_result().check_type_wf(());
+    for &trait_def_id in tcx.all_local_trait_impls(()).keys() {
+        let _: QueryResult = tcx.ensure_result().coherent_trait(trait_def_id);
+    }
+    let _: QueryResult = tcx.ensure_result().crate_inherent_impls_validity_check(());
+    let _: QueryResult = tcx.ensure_result().crate_inherent_impls_overlap_check(());
+
+    tcx.par_hir_body_owners(|def_id| {
+        let def_kind = tcx.def_kind(def_id);
+        if !matches!(def_kind, rustc_hir::def::DefKind::AnonConst) && !def_kind.is_typeck_child() {
+            tcx.ensure_ok().typeck(def_id);
+        }
+    });
+
+    tcx.dcx().has_errors().is_some()
 }
 
 /// Run the rustc driver with our custom hooks. Returns `None` if the crate was not compiled with
@@ -196,6 +225,10 @@ impl<'a> Callbacks for CharonCallbacks<'a> {
         // Set up our own `DefId` debug routine.
         rustc_hir::def_id::DEF_ID_DEBUG
             .swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
+
+        if precheck_rustc_errors(tcx) {
+            return Compilation::Continue;
+        }
 
         self.transform_ctx = translate_crate::translate(
             tcx,

--- a/charon/tests/ui/unsupported/unbound-lifetime.out
+++ b/charon/tests/ui/unsupported/unbound-lifetime.out
@@ -9,12 +9,6 @@ help: consider introducing lifetime `'a` here
 5 | fn get<'a>(_x: &'a u32) {}
   |       ++++
 
-error: Unexpected region kind: Region { kind: ReError(ErrorGuaranteed { todo: "ErrorGuaranteed(())" }) }
- --> tests/ui/unsupported/unbound-lifetime.rs:5:1
-  |
-5 | fn get(_x: &'a u32) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0261`.

--- a/nix/rustc-tests.py
+++ b/nix/rustc-tests.py
@@ -19,6 +19,7 @@ UNSUPPORTED_FEATURES = (
 )
 
 EXPENSIVE_RUSTC_STRESS_TESTS = {
+    "associated-consts/issue-93775.rs",
     "bench/issue-32062.rs",
     "closures/issue-72408-nested-closures-exponential.rs",
     "codegen/no-codegen-blowup-in-deeply-nested-struct.rs",


### PR DESCRIPTION
This is regularly the cause of baffling errors because Charon assumed well-formed input.