### PR TITLE
lift-assoc-tys: add constraints in scope when adding extra assoc tys

### DIFF
--- a/charon/src/ast/types_utils.rs
+++ b/charon/src/ast/types_utils.rs
@@ -1258,6 +1258,11 @@ pub trait TyVisitable: Sized + AstVisitable {
         let pred = tref.trait_decl_ref.clone().erase();
         self.substitute_with_self(&pred.generics, &tref.kind)
     }
+    /// Substitute the generic variables as well as the `TraitRefKind::SelfId` trait ref.
+    fn try_substitute_with_tref(self, tref: &TraitRef) -> Result<Self, GenericsMismatch> {
+        let pred = tref.trait_decl_ref.clone().erase();
+        self.try_substitute_with_self(&pred.generics, &tref.kind)
+    }
 
     fn try_substitute(self, generics: &GenericArgs) -> Result<Self, GenericsMismatch> {
         SubstVisitor::new(generics, None, false).visit(self)

--- a/charon/src/ids/index_map.rs
+++ b/charon/src/ids/index_map.rs
@@ -68,6 +68,10 @@ where
         self.vector.len()
     }
 
+    /// The next id that would be assigned when pushing an element.
+    pub fn next_id(&self) -> I {
+        self.vector.next_idx()
+    }
     /// Reserve a spot in the vector.
     pub fn reserve_slot(&mut self) -> I {
         // Push a `None` to ensure we don't reuse the id.

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -189,7 +189,7 @@ mod trait_ref_path {
                 let tdecl = krate.get_item(tref.trait_id())?;
                 let tdecl = tdecl.as_trait_decl()?;
                 let clause = &tdecl.implied_clauses[parent_id];
-                let pred = clause.trait_.clone().substitute_with_tref(&tref);
+                let pred = clause.trait_.clone().try_substitute_with_tref(&tref).ok()?;
                 tref = TraitRef::new(TraitRefKind::ParentClause(Box::new(tref), parent_id), pred);
             }
             Some(tref)
@@ -259,7 +259,7 @@ mod trait_ref_path {
     }
 
     /// The path to an associated type that depends on a local clause.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct AssocTypePath {
         /// The trait clause that has the associated type.
         pub tref: TraitRefPath,
@@ -574,6 +574,9 @@ struct ItemModifications {
     /// Associated item paths for which we don't know a type they correspond to, so we will have to
     /// add a new type parameter to the signature of the item.
     required_extra_paths: Vec<AssocTypePath>,
+    /// For self-referential traits, the first id available for the new associated types added to
+    /// replace `required_extra_paths`.
+    next_assoc_type_id: Option<AssocTypeId>,
     /// These constraints refer to now-removed associated types. We have taken them into account,
     /// they should be removed.
     remove_constraints: HashSet<TraitTypeConstraintId>,
@@ -589,6 +592,7 @@ impl ItemModifications {
         Self {
             type_constraints,
             required_extra_paths: Default::default(),
+            next_assoc_type_id: None,
             remove_constraints: Default::default(),
             add_type_params,
         }
@@ -636,6 +640,45 @@ impl ItemModifications {
         }
         .into_iter()
         .flatten()
+    }
+
+    /// Iterate over the paths that require adding new associated types, paired with the ids of
+    /// those new associated types.
+    fn required_extra_assoc_types_with_ids(
+        &self,
+    ) -> impl Iterator<Item = (&AssocTypePath, AssocTypeId)> {
+        if self.add_type_params {
+            None
+        } else {
+            let next_assoc_type_id = self.next_assoc_type_id.unwrap();
+            Some(
+                self.required_extra_paths
+                    .iter()
+                    .enumerate()
+                    .map(move |(offset, path)| (path, next_assoc_type_id + offset)),
+            )
+        }
+        .into_iter()
+        .flatten()
+    }
+
+    /// Iterate over the constraints that a `Self: Trait` clause makes available.
+    fn iter_self_constraints_for_tref<'a>(
+        &'a self,
+        tref: &'a TraitRef,
+    ) -> impl Iterator<Item = (AssocTypePath, Ty)> + use<'a> {
+        let base_path = tref.to_path().unwrap();
+        let assoc_type_constraints =
+            self.required_extra_assoc_types_with_ids()
+                .map(move |(path, type_id)| {
+                    let path = path.on_tref(&base_path);
+                    let ty =
+                        TyKind::TraitType(tref.clone(), type_id, GenericArgs::empty()).into_ty();
+                    (path, ty)
+                });
+        self.type_constraints
+            .iter_self_paths_subst(tref)
+            .chain(assoc_type_constraints)
     }
 
     /// Compute the type replacements needed to update the body of this item. We use the provided
@@ -713,7 +756,7 @@ impl<'a> ComputeItemModifications<'a> {
                 .compute_trait_modifications(tref.trait_id())
                 .as_processed()
             {
-                for (path, ty) in trait_mods.type_constraints.iter_self_paths_subst(&tref) {
+                for (path, ty) in trait_mods.iter_self_constraints_for_tref(&tref) {
                     type_constraints.insert_path(&path, ty);
                 }
             }
@@ -787,6 +830,7 @@ impl<'a> ComputeItemModifications<'a> {
             let type_constraints = self.compute_constraint_set(&tr.generics);
             let mut modifications =
                 ItemModifications::from_constraint_set(type_constraints, remove_assoc_types);
+            modifications.next_assoc_type_id = Some(tr.types.next_id());
             if modifications.add_type_params {
                 // Remove all associated types and turn them into new parameters. We add these
                 // before the paths in `replace` because this gives a better output.
@@ -1114,7 +1158,7 @@ impl UpdateItemBody<'_> {
                 .item_modifications
                 .get(&GenericsSource::item(tref.trait_id()))
             {
-                for (path, ty) in tmods.type_constraints.iter_self_paths_subst(&tref) {
+                for (path, ty) in tmods.iter_self_constraints_for_tref(&tref) {
                     type_constraints.insert_path(&path, ty);
                 }
             }

--- a/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
+++ b/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
@@ -1,0 +1,9 @@
+error: Could not compute the value of TraitClauseBound(1, 1)::ImpliedClause2::Packing (on TraitClauseBound(1, 1)::ImpliedClause2) needed to update item reference test_crate::Field<TraitClauseBound(1, 1)::Sub>.
+       Constraints in scope:
+       
+  --> tests/ui/associated_types/issue-1260-generics-mismatch.rs:14:13
+   |
+14 |     let _ = R::Sub::ZERO;
+   |             ^^^^^^^^^^^^
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
+++ b/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
@@ -1,9 +1,67 @@
-error: Could not compute the value of TraitClauseBound(1, 1)::ImpliedClause2::Packing (on TraitClauseBound(1, 1)::ImpliedClause2) needed to update item reference test_crate::Field<TraitClauseBound(1, 1)::Sub>.
-       Constraints in scope:
-       
-  --> tests/ui/associated_types/issue-1260-generics-mismatch.rs:14:13
-   |
-14 |     let _ = R::Sub::ZERO;
-   |             ^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct
+#[lang_item("destruct")]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1> = drop_glue<'_0_1, Self>
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Destruct::drop_glue
+unsafe fn drop_glue<'_0, Self>(_1: &'_0 mut Self)
+= <opaque>
+
+// Full name: test_crate::Ring
+trait Ring<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Sub: Sized)
+    proof ImpliedClause2: (Self::Sub: Field<Self::Self_Clause2_Packing>)
+    const ZERO : Self
+    type Sub
+    type Self_Clause2_Packing
+    non-dyn-compatible
+}
+
+// Full name: test_crate::Field
+trait Field<Self, Self_Packing>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Ring)
+    proof ImpliedClause2: (Self_Packing: Sized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::zero
+fn zero<R>()
+where
+    TraitClause0: (R: Sized),
+    TraitClause1: (R: Ring),
+{
+    let _0: (); // return
+    let _1: TraitClause1::Sub; // anonymous local
+
+    _0 = ()
+    storage_live(_1)
+    _1 = const TraitClause1::ImpliedClause2::ImpliedClause1::ZERO
+    conditional_drop[{built_in impl Destruct for TraitClause1::Sub}::drop_glue<'0>] _1
+    storage_dead(_1)
+    _0 = ()
+    return
+}
+
+
+

--- a/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.rs
+++ b/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--lift-associated-types=*
 
 trait Ring {

--- a/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.rs
+++ b/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.rs
@@ -1,0 +1,15 @@
+//@ known-failure
+//@ charon-args=--lift-associated-types=*
+
+trait Ring {
+    type Sub: Field;
+    const ZERO: Self;
+}
+
+trait Field: Ring {
+    type Packing;
+}
+
+fn zero<R: Ring>() {
+    let _ = R::Sub::ZERO;
+}


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/charon/issues/1260