### PR TITLE
Add `ConstantExprKind::Call`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.211"
+let supported_charon_version = "0.1.212"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -172,6 +172,13 @@ let has_body : body -> bool = function
   | MissingBody
   | ErrorBody _ -> false
 
+(** Returns the ID of this global's initializer, to mimic the now removed
+    [global_decl.init] field. *)
+let init_fun_id_of_global (global : global_decl) : fun_decl_id option =
+  match global.value.kind with
+  | CCall ({ kind = FunId (FRegular id); _ }, []) -> Some id
+  | _ -> None
+
 (** Split a module's declarations between types, functions and globals *)
 let split_declarations (decls : declaration_group list) :
     type_declaration_group list

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -502,6 +502,10 @@ and pp_constant_expr (env : fmt_env) (fmt : Format.formatter)
       Format.fprintf fmt "%a::%s" (pp_trait_ref env) trait_ref name
   | CVTableRef trait_ref ->
       Format.fprintf fmt "&vtable_of(%a)" (pp_trait_ref env) trait_ref
+  | CCall (fn_ptr, args) ->
+      Format.fprintf fmt "%a(%a)" (pp_fn_ptr env) fn_ptr
+        (pp_sep_list ", " (pp_constant_expr env))
+        args
   | CFnDef fn_ptr -> pp_fn_ptr env fmt fn_ptr
   | CFnPtr fn_ptr -> Format.fprintf fmt "fnptr(%a)" (pp_fn_ptr env) fn_ptr
   | CTypeId ty -> Format.fprintf fmt "TypeId(%a)" (pp_ty env) ty
@@ -1606,7 +1610,7 @@ let pp_trait_decl (env : fmt_env) (indent : string) (indent_incr : string)
         Format.fprintf fmt "%stype %s%s" indent1 bound_ty.binder_value.name
           params;
         Option.iter
-          (fun default ->
+          (fun (default : trait_assoc_ty_impl) ->
             Format.fprintf fmt " = %s" (ty_to_string env default.value))
           bound_ty.binder_value.default;
         let clauses =
@@ -1728,10 +1732,9 @@ let pp_global_decl (env : fmt_env) (indent : string) (indent_incr : string)
   let params =
     if params <> [] then "<" ^ String.concat ", " params ^ ">" else ""
   in
-  Format.fprintf fmt "%s%s: %a%s%s= %a()" intro params (pp_ty env) def.ty
-    clauses
+  Format.fprintf fmt "%s%s: %a%s%s= %a" intro params (pp_ty env) def.ty clauses
     (if clauses = "" then " " else "\n ")
-    (pp_fun_decl_id env) def.init
+    (pp_constant_expr env) def.value
 
 module Llbc = struct
   (** Pretty-printing for LLBC AST (generic functions) *)

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -174,9 +174,11 @@ type global_decl = {
       (** The context of the global: distinguishes top-level items from
           trait-associated items. *)
   global_kind : global_kind;  (** The kind of global (static or const). *)
-  init : fun_decl_id;
-      (** The initializer function used to compute the initial value for this
-          constant/static. It uses the same generic parameters as the global. *)
+  value : constant_expr;
+      (** The value of this constant/static. By default this is a
+          [[ConstantExprKind::Call]] to the initializer function that computes
+          the value (the function uses the same generic parameters as the
+          global). *)
 }
 
 and global_kind =

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -467,6 +467,10 @@ and constant_expr_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Var", var) ] ->
         let* var = de_bruijn_var_of_json const_generic_var_id_of_json ctx var in
         Ok (CVar var)
+    | `Assoc [ ("Call", `List [ x_0; x_1 ]) ] ->
+        let* x_0 = fn_ptr_of_json ctx x_0 in
+        let* x_1 = list_of_json constant_expr_of_json ctx x_1 in
+        Ok (CCall (x_0, x_1))
     | `Assoc [ ("FnDef", fn_def) ] ->
         let* fn_def = fn_ptr_of_json ctx fn_def in
         Ok (CFnDef fn_def)
@@ -2439,7 +2443,7 @@ and global_decl_of_json (ctx : of_json_ctx) (js : json) :
           ("ty", ty);
           ("src", src);
           ("global_kind", global_kind);
-          ("init", init);
+          ("value", value);
         ] ->
         let* def_id = global_decl_id_of_json ctx def_id in
         let* item_meta = item_meta_of_json ctx item_meta in
@@ -2447,9 +2451,9 @@ and global_decl_of_json (ctx : of_json_ctx) (js : json) :
         let* ty = ty_of_json ctx ty in
         let* src = item_source_of_json ctx src in
         let* global_kind = global_kind_of_json ctx global_kind in
-        let* init = fun_decl_id_of_json ctx init in
+        let* value = constant_expr_of_json ctx value in
         Ok
-          ({ def_id; item_meta; generics; ty; src; global_kind; init }
+          ({ def_id; item_meta; generics; ty; src; global_kind; value }
             : global_decl)
     | _ -> Error "")
 

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -439,20 +439,24 @@ and constant_expr_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
          Ok (CVar x_0)
      | 9 ->
          let* x_0 = fn_ptr_of_postcard ctx st in
-         Ok (CFnDef x_0)
+         let* x_1 = list_of_postcard constant_expr_of_postcard ctx st in
+         Ok (CCall (x_0, x_1))
      | 10 ->
          let* x_0 = fn_ptr_of_postcard ctx st in
-         Ok (CFnPtr x_0)
+         Ok (CFnDef x_0)
      | 11 ->
+         let* x_0 = fn_ptr_of_postcard ctx st in
+         Ok (CFnPtr x_0)
+     | 12 ->
          let* x_0 = ty_of_postcard ctx st in
          Ok (CTypeId x_0)
-     | 12 ->
+     | 13 ->
          let* x_0 = big_uint_of_postcard ctx st in
          Ok (CPtrNoProvenance x_0)
-     | 13 ->
+     | 14 ->
          let* x_0 = list_of_postcard byte_of_postcard ctx st in
          Ok (CRawMemory x_0)
-     | 14 ->
+     | 15 ->
          let* x_0 = string_of_postcard ctx st in
          Ok (COpaque x_0)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
@@ -2083,9 +2087,9 @@ and global_decl_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* ty = ty_of_postcard ctx st in
      let* src = item_source_of_postcard ctx st in
      let* global_kind = global_kind_of_postcard ctx st in
-     let* init = fun_decl_id_of_postcard ctx st in
+     let* value = constant_expr_of_postcard ctx st in
      Ok
-       ({ def_id; item_meta; generics; ty; src; global_kind; init }
+       ({ def_id; item_meta; generics; ty; src; global_kind; value }
          : global_decl))
 
 and global_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -427,6 +427,8 @@ and constant_expr_kind =
 
           We eliminate this case in a micro-pass. *)
   | CVar of const_generic_var_id de_bruijn_var  (** A const generic var *)
+  | CCall of fn_ptr * constant_expr list
+      (** A call to a [const fn] or a constant's initializer. *)
   | CFnDef of fn_ptr  (** Function definition -- this is a ZST constant *)
   | CFnPtr of fn_ptr
       (** A function pointer to a function item; this is an actual pointer to

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.211"
+version = "0.1.212"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.211"
+version = "0.1.212"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -644,6 +644,8 @@ pub enum ConstantExprKind {
     Ptr(RefKind, Box<ConstantExpr>, Option<UnsizingMetadata>),
     /// A const generic var
     Var(ConstGenericDbVar),
+    /// A call to a `const fn` or a constant's initializer.
+    Call(FnPtr, Vec<ConstantExpr>),
     /// Function definition -- this is a ZST constant
     FnDef(FnPtr),
     /// A function pointer to a function item; this is an actual pointer to that function item.

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -272,9 +272,10 @@ pub struct GlobalDecl {
     /// The kind of global (static or const).
     #[drive(skip)]
     pub global_kind: GlobalKind,
-    /// The initializer function used to compute the initial value for this constant/static. It
-    /// uses the same generic parameters as the global.
-    pub init: FunDeclId,
+    /// The value of this constant/static. By default this is a [`ConstantExprKind::Call`] to the
+    /// initializer function that computes the value (the function uses the same generic parameters
+    /// as the global).
+    pub value: ConstantExpr,
 }
 
 /// Reference to a global declaration.

--- a/charon/src/ast/gast_utils.rs
+++ b/charon/src/ast/gast_utils.rs
@@ -8,6 +8,19 @@ impl FnPtrKind {
     }
 }
 
+impl GlobalDecl {
+    /// If this global's value is a call to its initializer function, returns the initializer's id.
+    pub fn init_fun_id(&self) -> Option<FunDeclId> {
+        match &self.value.kind {
+            ConstantExprKind::Call(fn_ptr, _) => match &*fn_ptr.kind {
+                FnPtrKind::Fun(FunId::Regular(id)) => Some(*id),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
 impl Body {
     /// Whether there is an actual body with statements etc, as opposed to the body being missing
     /// for some reason.

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -622,6 +622,16 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
 
         let initializer = self.register_item(span, def.this(), TransItemSourceKind::Fun);
+        let value = ConstantExpr {
+            kind: ConstantExprKind::Call(
+                FnPtr::new(
+                    FnPtrKind::Fun(FunId::Regular(initializer)),
+                    self.outermost_generics().identity_args(),
+                ),
+                vec![],
+            ),
+            ty: ty.clone(),
+        };
 
         Ok(GlobalDecl {
             def_id,
@@ -630,7 +640,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             ty,
             src: item_source,
             global_kind,
-            init: initializer,
+            value,
         })
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -761,6 +761,17 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             impl_def.this(),
             TransItemSourceKind::VTableInstanceInitializer(*impl_kind),
         );
+        let ty = Ty::new(TyKind::Adt(vtable_struct_ref));
+        let value = ConstantExpr {
+            kind: ConstantExprKind::Call(
+                FnPtr::new(
+                    FnPtrKind::Fun(FunId::Regular(init)),
+                    self.outermost_generics().identity_args(),
+                ),
+                vec![],
+            ),
+            ty: ty.clone(),
+        };
 
         Ok(GlobalDecl {
             def_id: global_id,
@@ -769,8 +780,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             src,
             // it should be static to have its own address
             global_kind: GlobalKind::Static,
-            ty: Ty::new(TyKind::Adt(vtable_struct_ref)),
-            init,
+            ty,
+            value,
         })
     }
 

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -807,9 +807,6 @@ impl VisitAstMut for IdRefMapperVisitor<'_> {
             _ => {}
         }
     }
-    fn enter_global_decl(&mut self, x: &mut GlobalDecl) {
-        self.map(&mut x.init);
-    }
     fn enter_fun_decl(&mut self, x: &mut FunDecl) {
         if let Some(id) = &mut x.is_global_initializer {
             self.map(id);

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -969,9 +969,9 @@ where
         }
         write!(f, " ")?;
 
-        // Decl name
-        let initializer = self.init.with_ctx(ctx);
-        write!(f, "= {initializer}()")?;
+        // Value
+        let value = self.value.with_ctx(ctx);
+        write!(f, "= {value}")?;
 
         Ok(())
     }
@@ -1497,6 +1497,10 @@ impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
                 }
             }
             ConstantExprKind::Var(id) => write!(f, "{}", id.with_ctx(ctx)),
+            ConstantExprKind::Call(fp, args) => {
+                let args = args.iter().map(|arg| arg.with_ctx(ctx)).format(", ");
+                write!(f, "{}({args})", fp.with_ctx(ctx))
+            }
             ConstantExprKind::FnDef(fp) => {
                 write!(f, "{}", fp.with_ctx(ctx))
             }

--- a/charon/src/transform/simplify_output/anon_const_to_call.rs
+++ b/charon/src/transform/simplify_output/anon_const_to_call.rs
@@ -16,7 +16,7 @@ impl Transform {
             .global_decls
             .iter()
             .filter(|gdecl| matches!(gdecl.global_kind, GlobalKind::AnonConst))
-            .map(|gdecl| (gdecl.def_id, gdecl.init))
+            .filter_map(|gdecl| Some((gdecl.def_id, gdecl.init_fun_id()?)))
             .collect();
         CowBox::Owned(Box::new(Transform { anon_consts }))
     }

--- a/charon/src/transform/simplify_output/remove_unused_self_clause.rs
+++ b/charon/src/transform/simplify_output/remove_unused_self_clause.rs
@@ -40,11 +40,11 @@ impl VisitAst for UsesClauseVisitor {
 }
 
 #[derive(Visitor)]
-struct RemoveSelfVisitor {
-    remove_in: HashSet<ItemId>,
+struct RemoveSelfVisitor<'a> {
+    remove_in: &'a HashSet<ItemId>,
 }
 
-impl RemoveSelfVisitor {
+impl RemoveSelfVisitor<'_> {
     fn process_item(&self, id: impl Into<ItemId>, args: &mut GenericArgs) {
         if self.remove_in.contains(&id.into()) {
             args.trait_refs
@@ -52,7 +52,7 @@ impl RemoveSelfVisitor {
         }
     }
 }
-impl VisitAstMut for RemoveSelfVisitor {
+impl VisitAstMut for RemoveSelfVisitor<'_> {
     fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
         match x.id {
             TypeId::Adt(id) => self.process_item(id, &mut x.generics),
@@ -97,7 +97,7 @@ impl TransformPass for Transform {
                 .iter()
                 .filter_map(|cst| cst.default.as_ref())
                 .filter_map(|gref| ctx.translated.global_decls.get(gref.id))
-                .map(|gdecl| gdecl.init);
+                .filter_map(|gdecl| gdecl.init_fun_id());
             let funs = methods
                 .chain(consts)
                 .filter_map(|id: FunDeclId| ctx.translated.fun_decls.get(id));
@@ -114,6 +114,16 @@ impl TransformPass for Transform {
             }
         }
 
+        // Remove the now-unused `Self` argument from any `GenericArgs` destined for the items
+        // we're about to change. We do this before renumbering the clauses below: a global's
+        // `value` is a call to its initializer that forwards the global's own generics (including
+        // the `Self` clause as argument 0); removing that argument here keeps the renumbering below
+        // from underflowing on the `Self` clause.
+        RemoveSelfVisitor {
+            remove_in: &doesnt_use_self,
+        }
+        .visit_by_val_infallible(&mut ctx.translated);
+
         // In each item, remove the first clause and renumber the others.
         for &id in &doesnt_use_self {
             let Some(mut item) = ctx.translated.get_item_mut(id) else {
@@ -126,11 +136,5 @@ impl TransformPass for Transform {
                 *clause_id = TraitClauseId::from_usize(clause_id.index() - 1);
             });
         }
-
-        // Update any `GenericArgs` destined for the items we just changed.
-        RemoveSelfVisitor {
-            remove_in: doesnt_use_self,
-        }
-        .visit_by_val_infallible(&mut ctx.translated);
     }
 }

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -33,7 +33,7 @@ where
 const test_crate::{V<T, N>[TraitClause0]}::LEN<T, const N : usize>: usize
 where
     TraitClause0: (T: Sized),
- = test_crate::{V<T, N>[TraitClause0]}::LEN()
+ = test_crate::{V<T, N>[TraitClause0]}::LEN<T, N>[TraitClause0]()
 
 // Full name: test_crate::HasLen
 trait HasLen<Self>
@@ -53,7 +53,7 @@ fn {impl HasLen for [(); N]}::LEN<const N : usize>() -> usize
 }
 
 // Full name: test_crate::{impl HasLen for [(); N]}::LEN
-const {impl HasLen for [(); N]}::LEN<const N : usize>: usize = {impl HasLen for [(); N]}::LEN()
+const {impl HasLen for [(); N]}::LEN<const N : usize>: usize = {impl HasLen for [(); N]}::LEN<N>()
 
 // Full name: test_crate::{impl HasLen for [(); N]}
 impl<const N : usize> HasLen for [(); N] {
@@ -75,7 +75,7 @@ fn {impl HasLen for [bool; N]}::LEN<const N : usize>() -> usize
 }
 
 // Full name: test_crate::{impl HasLen for [bool; N]}::LEN
-const {impl HasLen for [bool; N]}::LEN<const N : usize>: usize = {impl HasLen for [bool; N]}::LEN()
+const {impl HasLen for [bool; N]}::LEN<const N : usize>: usize = {impl HasLen for [bool; N]}::LEN<N>()
 
 // Full name: test_crate::{impl HasLen for [bool; N]}
 impl<const N : usize> HasLen for [bool; N] {
@@ -109,7 +109,7 @@ const impl_HasLen_for_Wrapper::LEN<T>: usize
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: HasLen),
- = impl_HasLen_for_Wrapper::LEN()
+ = impl_HasLen_for_Wrapper::LEN<T>[TraitClause0, TraitClause1]()
 
 // Full name: test_crate::{impl HasLen for Wrapper<T>[TraitClause0]}
 impl<T> "impl_HasLen_for_Wrapper" HasLen for Wrapper<T>[TraitClause0]
@@ -143,7 +143,7 @@ where
 pub const test_crate::HasDefaultLen::LEN<Self, const M : usize>: usize
 where
     TraitClause0: (Self: HasDefaultLen<M>),
- = test_crate::HasDefaultLen::LEN()
+ = test_crate::HasDefaultLen::LEN<Self, M>[TraitClause0]()
 
 // Full name: test_crate::{impl HasDefaultLen<N> for [(); N]}
 impl<const N : usize> HasDefaultLen<N> for [(); N] {
@@ -170,7 +170,7 @@ pub fn {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>() -> usize
 }
 
 // Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}::LEN
-pub const {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>: usize = {impl HasDefaultLen<N> for [bool; N]}::LEN()
+pub const {impl HasDefaultLen<N> for [bool; N]}::LEN<const N : usize>: usize = {impl HasDefaultLen<N> for [bool; N]}::LEN<N>()
 
 // Full name: test_crate::{impl HasDefaultLen<N> for [bool; N]}
 impl<const N : usize> HasDefaultLen<N> for [bool; N] {
@@ -206,7 +206,7 @@ where
 const ALSO_LEN<Self>: usize
 where
     TraitClause0: (Self: AlsoHasLen),
- = ALSO_LEN()
+ = ALSO_LEN<Self>[TraitClause0]()
 
 // Full name: test_crate::{impl AlsoHasLen for [(); N]}
 impl<const N : usize> "impl_AlsoHasLen_for_array" AlsoHasLen for [(); N] {

--- a/charon/tests/ui/associated_types/issue-968-default-assoc-const.out
+++ b/charon/tests/ui/associated_types/issue-968-default-assoc-const.out
@@ -46,7 +46,7 @@ pub fn LEN2<Self, Clause0_W, const LEN : usize>() -> usize
 }
 
 // Full name: test_crate::WithConstTy::LEN2
-pub const LEN2<Self, Clause0_W, const LEN : usize>: usize = LEN2()
+pub const LEN2<Self, Clause0_W, const LEN : usize>: usize = LEN2<Self, Clause0_W, LEN>()
 
 
 

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -437,7 +437,7 @@ where
 pub const LEN<T, const N : usize>: usize
 where
     TraitClause0: (T: Sized),
- = LEN()
+ = LEN<T, N>[TraitClause0]()
 
 // Full name: test_crate::use_v
 pub fn use_v<T, const N : usize>() -> usize

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -426,7 +426,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -445,7 +445,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::option::unwrap_failed
 fn unwrap_failed() -> !
@@ -496,7 +496,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -513,7 +513,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -530,7 +530,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 pub fn core::num::{usize}::MAX() -> usize
 {
@@ -594,7 +594,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T

--- a/charon/tests/ui/filtering/opaque-trait.out
+++ b/charon/tests/ui/filtering/opaque-trait.out
@@ -37,7 +37,7 @@ where
 const test_crate::Trait::CONST1<Self>: usize
 where
     TraitClause0: (Self: Trait),
- = test_crate::Trait::CONST1()
+ = test_crate::Trait::CONST1<Self>[TraitClause0]()
 
 fn test_crate::Trait::CONST2<Self>() -> usize
 where
@@ -52,7 +52,7 @@ where
 const test_crate::Trait::CONST2<Self>: usize
 where
     TraitClause0: (Self: Trait),
- = test_crate::Trait::CONST2()
+ = test_crate::Trait::CONST2<Self>[TraitClause0]()
 
 fn test_crate::Trait::CONST3<Self>() -> usize
 where
@@ -67,7 +67,7 @@ where
 const test_crate::Trait::CONST3<Self>: usize
 where
     TraitClause0: (Self: Trait),
- = test_crate::Trait::CONST3()
+ = test_crate::Trait::CONST3<Self>[TraitClause0]()
 
 fn test_crate::Trait::method1<Self>()
 where

--- a/charon/tests/ui/multi-target/default-trait-assoc-const.out
+++ b/charon/tests/ui/multi-target/default-trait-assoc-const.out
@@ -21,7 +21,7 @@ where
 const test_crate::Trait::VALUE<Self>: usize
 where
     TraitClause0: (Self: test_crate::Trait),
- = test_crate::Trait::VALUE()
+ = test_crate::Trait::VALUE<Self>[TraitClause0]()
 
 // Full name: test_crate::{impl test_crate::Trait for ()}
 impl test_crate::Trait for () {

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -56,7 +56,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -70,7 +70,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
@@ -82,7 +82,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -94,7 +94,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -106,7 +106,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
@@ -118,7 +118,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -1477,7 +1477,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -1496,7 +1496,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::option::unwrap_failed
 fn unwrap_failed() -> !
@@ -1547,7 +1547,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -1564,7 +1564,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -1581,7 +1581,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 pub fn core::num::{usize}::MAX() -> usize
 {
@@ -1656,7 +1656,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T

--- a/charon/tests/ui/simple/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/simple/box-dyn-fnonce-raw.out
@@ -118,7 +118,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -132,7 +132,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
@@ -144,7 +144,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -156,7 +156,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -168,7 +168,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
@@ -180,7 +180,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T
@@ -549,7 +549,7 @@ where
     TraitClause3: (Args: Tuple),
     TraitClause4: (F: FnOnce<Args>),
     TraitClause5: (A: Allocator),
- = impl_FnOnce_for_Box::{vtable}()
+ = impl_FnOnce_for_Box::{vtable}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5]()
 
 // Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}
 impl<Args, F, A> "impl_FnOnce_for_Box" FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]

--- a/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/dyn-broken-assoc-type-constraint.out
@@ -136,7 +136,7 @@ where
 static impl_Broken_for_T::{vtable}<T>: test_crate::Broken::{vtable}<()>
 where
     TraitClause0: (T: Sized),
- = impl_Broken_for_T::{vtable}()
+ = impl_Broken_for_T::{vtable}<T>[TraitClause0]()
 
 // Full name: test_crate::{impl Broken for T}
 impl<T> "impl_Broken_for_T" Broken for T

--- a/charon/tests/ui/simple/trait-default-const-cross-crate.out
+++ b/charon/tests/ui/simple/trait-default-const-cross-crate.out
@@ -30,7 +30,7 @@ where
 const FOO<Self>: usize
 where
     TraitClause0: (Self: Trait),
- = FOO()
+ = FOO<Self>[TraitClause0]()
 
 // Full name: trait_default_const::{impl Trait for T}
 impl<T> "impl_Trait_for_T" Trait for T

--- a/charon/tests/ui/simple/trait-default-const.out
+++ b/charon/tests/ui/simple/trait-default-const.out
@@ -35,7 +35,7 @@ where
 const FOO<Self>: usize
 where
     TraitClause0: (Self: Trait),
- = FOO()
+ = FOO<Self>[TraitClause0]()
 
 // Full name: test_crate::{impl Trait for T}
 impl<T> "impl_Trait_for_T" Trait for T

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -55,7 +55,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -69,7 +69,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
@@ -81,7 +81,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -93,7 +93,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -105,7 +105,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
@@ -117,7 +117,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T

--- a/charon/tests/ui/simple/vec-with-capacity.out
+++ b/charon/tests/ui/simple/vec-with-capacity.out
@@ -59,7 +59,7 @@ where
 pub const SIZE<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = SIZE()
+ = SIZE<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGN
 #[lang_item("mem_align_const")]
@@ -73,7 +73,7 @@ where
 pub const ALIGN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGN()
+ = ALIGN<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::ALIGNMENT
 pub fn ALIGNMENT<Self>() -> Alignment
@@ -85,7 +85,7 @@ where
 pub const ALIGNMENT<Self>: Alignment
 where
     TraitClause0: (Self: SizedTypeProperties),
- = ALIGNMENT()
+ = ALIGNMENT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::IS_ZST
 pub fn IS_ZST<Self>() -> bool
@@ -97,7 +97,7 @@ where
 pub const IS_ZST<Self>: bool
 where
     TraitClause0: (Self: SizedTypeProperties),
- = IS_ZST()
+ = IS_ZST<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::LAYOUT
 pub fn LAYOUT<Self>() -> Layout
@@ -109,7 +109,7 @@ where
 pub const LAYOUT<Self>: Layout
 where
     TraitClause0: (Self: SizedTypeProperties),
- = LAYOUT()
+ = LAYOUT<Self>[TraitClause0]()
 
 // Full name: core::mem::SizedTypeProperties::MAX_SLICE_LEN
 pub fn MAX_SLICE_LEN<Self>() -> usize
@@ -121,7 +121,7 @@ where
 pub const MAX_SLICE_LEN<Self>: usize
 where
     TraitClause0: (Self: SizedTypeProperties),
- = MAX_SLICE_LEN()
+ = MAX_SLICE_LEN<Self>[TraitClause0]()
 
 // Full name: core::mem::{impl SizedTypeProperties for T}
 impl<T> "impl_SizedTypeProperties_for_T" SizedTypeProperties for T

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -790,7 +790,7 @@ where
 pub const LEN2<Self, const LEN : usize>: usize
 where
     TraitClause0: (Self: WithConstTy<LEN>),
- = LEN2()
+ = LEN2<Self, LEN>[TraitClause0]()
 
 pub fn test_crate::WithConstTy::f<'_0, '_1, Self, const LEN : usize>(_1: &'_0 mut TraitClause0::W, _2: &'_1 [u8; LEN])
 where
@@ -1235,7 +1235,7 @@ where
 pub const impl_Trait_for_array::LEN<T, const N : usize>: usize
 where
     TraitClause0: (T: Sized),
- = impl_Trait_for_array::LEN()
+ = impl_Trait_for_array::LEN<T, N>[TraitClause0]()
 
 // Full name: test_crate::{impl Trait for [T; N]}
 impl<T, const N : usize> "impl_Trait_for_array" Trait for [T; N]
@@ -1264,7 +1264,7 @@ pub const impl_Trait_for_Wrapper::LEN<T>: usize
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait),
- = impl_Trait_for_Wrapper::LEN()
+ = impl_Trait_for_Wrapper::LEN<T>[TraitClause0, TraitClause1]()
 
 // Full name: test_crate::{impl Trait for Wrapper<T>[TraitClause0]}
 impl<T> "impl_Trait_for_Wrapper" Trait for Wrapper<T>[TraitClause0]
@@ -1318,7 +1318,7 @@ where
     TraitClause0: (T: Sized),
     TraitClause1: (U: Sized),
     TraitClause2: (T: Trait),
- = FOO()
+ = FOO<T, U>[TraitClause0, TraitClause1, TraitClause2]()
 
 // Full name: test_crate::use_foo1
 pub fn use_foo1<T, U>() -> Result<T, i32>[TraitClause0, {built_in impl Sized for i32}]

--- a/charon/tests/ui/vtable-simple.out
+++ b/charon/tests/ui/vtable-simple.out
@@ -146,7 +146,7 @@ static impl_Modifiable_for_i32::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
- = impl_Modifiable_for_i32::{vtable}()
+ = impl_Modifiable_for_i32::{vtable}<T>[TraitClause0, TraitClause1]()
 
 // Full name: test_crate::{impl Modifiable<T> for i32}
 impl<T> "impl_Modifiable_for_i32" Modifiable<T> for i32

--- a/charon/tests/ui/vtable_drop.out
+++ b/charon/tests/ui/vtable_drop.out
@@ -212,7 +212,7 @@ where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TraitClause2: (T: Destruct),
- = impl_Modifiable_for_Box_i32_Global::{vtable}()
+ = impl_Modifiable_for_Box_i32_Global::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]()
 
 // Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}
 impl<T> "impl_Modifiable_for_Box_i32_Global" Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]

--- a/charon/tests/ui/vtables.out
+++ b/charon/tests/ui/vtables.out
@@ -518,7 +518,7 @@ static impl_Modifiable_for_i32::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
- = impl_Modifiable_for_i32::{vtable}()
+ = impl_Modifiable_for_i32::{vtable}<T>[TraitClause0, TraitClause1]()
 
 // Full name: test_crate::{impl Modifiable<T> for i32}
 impl<T> "impl_Modifiable_for_i32" Modifiable<T> for i32


### PR DESCRIPTION
Add `ConstantExprKind::Call`

<details><summary>outdated</summary>

Let me know if you have any opinions!

Draft, I still need to:
- clean up a couple transformations around const inlining/simplification
- add const evaluation of VTables (bc why not) 

(I ran out of tokens and I got more important things to do manually)


One thing is that this now has some odd interaction with `--raw-consts`, and it's not clear to me what it is x) 
- possibly a clearer alternative is `--consts={raw,unevaluated,evaluated}`...?
- maybe `--consts={initializer,evaluated}` and `--consts-inline={true,false}` are the two axis? and then for #1168 we can add `--consts=bytes` which doesn't even unevaluate?

</details>

ci: use https://github.com/AeneasVerif/eurydice/pull/423

ci: use https://github.com/AeneasVerif/aeneas/pull/1104