### PR TITLE
Add `--consts=<values|initializers>`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.218"
+let supported_charon_version = "0.1.219"

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -71,7 +71,7 @@ and cli_options = {
       (** If activated, this skips borrow-checking of the crate. *)
   mir : mir_level option;
       (** The MIR stage to extract. This is only relevant for the current crate;
-          for dpendencies only MIR optimized is available. *)
+          for dependencies only MIR optimized is available. *)
   rustc_args : string list;  (** Extra flags to pass to rustc. *)
   targets : string list;
       (** A list of target architectures to translate for. Charon will run the
@@ -167,6 +167,12 @@ and cli_options = {
   treat_box_as_builtin : bool;
       (** Treat [Box<T>] as if it was a built-in type. *)
   raw_consts : bool;  (** Do not inline or evaluate constants. *)
+  consts : const_handling option;
+      (** How to handle constants and statics: whether they should be
+          represented as a call to their initializer function, or whether we
+          should attempt to evaluate them into a value. When evaluation isn't
+          possible (e.g. the constant is generic, or for recursive statics), we
+          fall back to the initializer call. *)
   unsized_strings : bool;
       (** Replace string literal constants with a constant u8 array that gets
           unsized, expliciting the fact a string constant has a hidden
@@ -215,6 +221,16 @@ and cli_options = {
   error_on_warnings : bool;  (** Consider any warnings to be errors. *)
   preset : preset option;  (** Named builtin sets of options. *)
 }
+
+(** How to handle constants and statics. *)
+and const_handling =
+  | Initializers
+      (** Keep consts as calls to their initializer with
+          [ConstantExprKind::Call], without attempting to do any
+          const-evaluation. This is the default. *)
+  | Values
+      (** Try evaluating consts and statics to their final value. If evaluation
+          fails, we fall back to the initializer call. *)
 
 (** A (group of) top-level declaration(s), properly reordered. *)
 and declaration_group =

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2055,6 +2055,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("index_to_function_calls", index_to_function_calls);
           ("treat_box_as_builtin", treat_box_as_builtin);
           ("raw_consts", raw_consts);
+          ("consts", consts);
           ("unsized_strings", unsized_strings);
           ("reconstruct_fallible_operations", reconstruct_fallible_operations);
           ("reconstruct_asserts", reconstruct_asserts);
@@ -2118,6 +2119,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         in
         let* treat_box_as_builtin = bool_of_json ctx treat_box_as_builtin in
         let* raw_consts = bool_of_json ctx raw_consts in
+        let* consts = option_of_json const_handling_of_json ctx consts in
         let* unsized_strings = bool_of_json ctx unsized_strings in
         let* reconstruct_fallible_operations =
           bool_of_json ctx reconstruct_fallible_operations
@@ -2174,6 +2176,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              index_to_function_calls;
              treat_box_as_builtin;
              raw_consts;
+             consts;
              unsized_strings;
              reconstruct_fallible_operations;
              reconstruct_asserts;
@@ -2235,6 +2238,14 @@ and closure_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `String "Fn" -> Ok Fn
     | `String "FnMut" -> Ok FnMut
     | `String "FnOnce" -> Ok FnOnce
+    | _ -> Error "")
+
+and const_handling_of_json (ctx : of_json_ctx) (js : json) :
+    (const_handling, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `String "Initializers" -> Ok Initializers
+    | `String "Values" -> Ok Values
     | _ -> Error "")
 
 and declaration_group_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1813,6 +1813,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* index_to_function_calls = bool_of_postcard ctx st in
      let* treat_box_as_builtin = bool_of_postcard ctx st in
      let* raw_consts = bool_of_postcard ctx st in
+     let* consts = option_of_postcard const_handling_of_postcard ctx st in
      let* unsized_strings = bool_of_postcard ctx st in
      let* reconstruct_fallible_operations = bool_of_postcard ctx st in
      let* reconstruct_asserts = bool_of_postcard ctx st in
@@ -1865,6 +1866,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           index_to_function_calls;
           treat_box_as_builtin;
           raw_consts;
+          consts;
           unsized_strings;
           reconstruct_fallible_operations;
           reconstruct_asserts;
@@ -1914,6 +1916,15 @@ and closure_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      | 0 -> Ok Fn
      | 1 -> Ok FnMut
      | 2 -> Ok FnOnce
+     | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
+
+and const_handling_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
+    (const_handling, string) result =
+  combine_error_msgs st __FUNCTION__
+    (let* __tag = int_of_postcard ctx st in
+     match __tag with
+     | 0 -> Ok Initializers
+     | 1 -> Ok Values
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
 and declaration_group_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.218"
+version = "0.1.219"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.218"
+version = "0.1.219"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/bin/charon-driver/translate/get_mir.rs
+++ b/charon/src/bin/charon-driver/translate/get_mir.rs
@@ -99,11 +99,13 @@ fn get_mir_for_def_id_and_level<'tcx>(
                     | hax::DefKind::AssocConst { .. }
                     | hax::DefKind::InlineConst
             );
+            let is_static = matches!(def_id.kind, hax::DefKind::Static { .. });
             let mir_available = tcx.is_mir_available(rust_def_id);
 
-            if mir_available && !is_global {
+            if mir_available && !is_global && !is_static {
                 Some(tcx.optimized_mir(rust_def_id).clone())
             } else if (is_global && !tcx.is_trivial_const(rust_def_id))
+                || (is_static && rust_def_id.is_local())
                 || tcx.is_const_fn(rust_def_id)
             {
                 Some(tcx.mir_for_ctfe(rust_def_id).clone())

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -154,30 +154,21 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // Retrieve the body
         if let Some(body) = self.get_mir(def.this(), span)? {
             Ok(self.translate_body(span, body, &def.source_text))
+        } else if let Some(value) = self.evaluate_const_def(def) {
+            // For globals without MIR, generate a body by evaluating the global.
+            // TODO: we lost the MIR of some consts on a rustc update. A trait assoc const
+            // default value no longer has a cross-crate MIR so it's unclear how to retreive
+            // the value. See the `trait-default-const-cross-crate` test.
+            let c = self.translate_constant_expr(span, &value)?;
+            let mut bb = BodyBuilder::new(span, 0);
+            let ret = bb.new_var(None, c.ty.clone());
+            bb.push_statement(StatementKind::Assign(
+                ret,
+                Rvalue::Use(Operand::Const(Box::new(c)), WithRetag::No),
+            ));
+            Ok(Body::Unstructured(bb.build()))
         } else {
-            let evaluated_global = match def.kind() {
-                hax::FullDefKind::Const { .. } | hax::FullDefKind::AssocConst { .. } => {
-                    def.const_value(self.hax_state_with_id())
-                }
-                hax::FullDefKind::Static { .. } => def.static_value(self.hax_state_with_id()),
-                _ => None,
-            };
-            if let Some(value) = evaluated_global {
-                // For globals without MIR, generate a body by evaluating the global.
-                // TODO: we lost the MIR of some consts on a rustc update. A trait assoc const
-                // default value no longer has a cross-crate MIR so it's unclear how to retreive
-                // the value. See the `trait-default-const-cross-crate` test.
-                let c = self.translate_constant_expr(span, &value)?;
-                let mut bb = BodyBuilder::new(span, 0);
-                let ret = bb.new_var(None, c.ty.clone());
-                bb.push_statement(StatementKind::Assign(
-                    ret,
-                    Rvalue::Use(Operand::Const(Box::new(c)), WithRetag::No),
-                ));
-                Ok(Body::Unstructured(bb.build()))
-            } else {
-                Ok(Body::Missing)
-            }
+            Ok(Body::Missing)
         }
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -189,4 +189,18 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let c = self.catch_sinto(span, c)?;
         self.translate_constant_expr(span, &c)
     }
+
+    /// Evaluates a constant definition and returns the result as a [`ConstantExpr`], if one exists.
+    pub(crate) fn evaluate_const_def(
+        &mut self,
+        def: &hax::FullDef<'tcx>,
+    ) -> Option<hax::Decorated<hax::ConstantExprKind>> {
+        match def.kind() {
+            hax::FullDefKind::Const { .. } | hax::FullDefKind::AssocConst { .. } => {
+                def.const_value(self.hax_state_with_id())
+            }
+            hax::FullDefKind::Static { .. } => def.static_value(self.hax_state_with_id()),
+            _ => None,
+        }
+    }
 }

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -4,6 +4,7 @@ use crate::hax;
 use crate::hax::SInto;
 use charon_lib::ast::*;
 use charon_lib::formatter::IntoFormatter;
+use charon_lib::options::ConstHandling;
 use charon_lib::pretty::FmtWithCtx;
 use derive_generic_visitor::Visitor;
 use itertools::Itertools;
@@ -611,16 +612,27 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             _ => panic!("Unexpected def for constant: {def:?}"),
         };
 
-        let initializer = self.register_item(span, def.this(), TransItemSourceKind::Fun);
-        let value = ConstantExpr {
-            kind: ConstantExprKind::Call(
-                FnPtr::new(
-                    FnPtrKind::Fun(FunId::Regular(initializer)),
-                    self.outermost_generics().identity_args(),
+        // With `--consts=values`, try to evaluate the constant/static into a value. This
+        // isn't always possible (e.g. for generic constants or recursive statics), in which
+        // case we fall back to a call to the initializer below.
+        let value = if matches!(self.options.consts, ConstHandling::Values)
+            && let Some(evaluated) = self.evaluate_const_def(def)
+        {
+            self.translate_constant_expr(span, &evaluated)?
+        } else {
+            // Default: the value is a call to the initializer function, which uses the same
+            // generic parameters as the global.
+            let initializer = self.register_item(span, def.this(), TransItemSourceKind::Fun);
+            ConstantExpr {
+                kind: ConstantExprKind::Call(
+                    FnPtr::new(
+                        FnPtrKind::Fun(FunId::Regular(initializer)),
+                        self.outermost_generics().identity_args(),
+                    ),
+                    vec![],
                 ),
-                vec![],
-            ),
-            ty: ty.clone(),
+                ty: ty.clone(),
+            }
         };
 
         Ok(GlobalDecl {

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -46,7 +46,7 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub skip_borrowck: bool,
-    /// The MIR stage to extract. This is only relevant for the current crate; for dpendencies only
+    /// The MIR stage to extract. This is only relevant for the current crate; for dependencies only
     /// MIR optimized is available.
     #[arg(long)]
     pub mir: Option<MirLevel>,
@@ -225,6 +225,13 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub raw_consts: bool,
+    /// How to handle constants and statics: whether they should be represented as a call to their
+    /// initializer function, or whether we should attempt to evaluate them into a value. When
+    /// evaluation isn't possible (e.g. the constant is generic, or for recursive statics), we fall
+    /// back to the initializer call.
+    #[clap(long)]
+    #[serde(default)]
+    pub consts: Option<ConstHandling>,
     /// Replace string literal constants with a constant u8 array that gets unsized,
     /// expliciting the fact a string constant has a hidden reference.
     #[clap(long)]
@@ -342,6 +349,20 @@ pub enum Preset {
     Eurydice,
     Soteria,
     Tests,
+}
+
+/// How to handle constants and statics.
+#[derive(
+    Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Serialize, Deserialize,
+)]
+pub enum ConstHandling {
+    /// Keep consts as calls to their initializer with `ConstantExprKind::Call`, without attempting
+    /// to do any const-evaluation. This is the default.
+    #[default]
+    Initializers,
+    /// Try evaluating consts and statics to their final value. If evaluation fails, we fall back to the
+    /// initializer call.
+    Values,
 }
 
 #[derive(
@@ -462,7 +483,7 @@ impl CliOpts {
                     self.monomorphize = true;
                     self.no_normalize = true;
                     self.precise_drops = true;
-                    self.raw_consts = true;
+                    self.consts = Some(ConstHandling::Values);
                     self.ullbc = true;
                 }
                 Preset::Tests => {
@@ -622,6 +643,9 @@ pub struct TranslateOptions {
     pub treat_box_as_builtin: bool,
     /// Don't inline or evaluate constants.
     pub raw_consts: bool,
+    /// Whether to evaluate the value of named constants and statics, or to keep a call
+    /// to their initializer function.
+    pub consts: ConstHandling,
     /// Replace string literal constants with a constant u8 array that gets unsized,
     /// expliciting the fact a string constant has a hidden reference.
     pub unsized_strings: bool,
@@ -780,6 +804,7 @@ impl TranslateOptions {
             item_opacities,
             treat_box_as_builtin: options.treat_box_as_builtin,
             raw_consts: options.raw_consts,
+            consts: options.consts.unwrap_or_default(),
             unsized_strings: options.unsized_strings,
             reconstruct_fallible_operations: options.reconstruct_fallible_operations,
             reconstruct_asserts: options.reconstruct_asserts,

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -19,7 +19,7 @@ Options:
           If activated, this skips borrow-checking of the crate
 
       --mir <MIR>
-          The MIR stage to extract. This is only relevant for the current crate; for dpendencies only MIR optimized is available
+          The MIR stage to extract. This is only relevant for the current crate; for dependencies only MIR optimized is available
 
           Possible values:
           - built:      The MIR just after MIR lowering
@@ -128,6 +128,13 @@ Options:
 
       --raw-consts
           Do not inline or evaluate constants
+
+      --consts <CONSTS>
+          How to handle constants and statics: whether they should be represented as a call to their initializer function, or whether we should attempt to evaluate them into a value. When evaluation isn't possible (e.g. the constant is generic, or for recursive statics), we fall back to the initializer call
+
+          Possible values:
+          - initializers: Keep consts as calls to their initializer with `ConstantExprKind::Call`, without attempting to do any const-evaluation. This is the default
+          - values:       Try evaluating consts and statics to their final value. If evaluation fails, we fall back to the initializer call
 
       --unsized-strings
           Replace string literal constants with a constant u8 array that gets unsized, expliciting the fact a string constant has a hidden reference

--- a/charon/tests/ui/consts/evaluate-consts-inline.out
+++ b/charon/tests/ui/consts/evaluate-consts-inline.out
@@ -1,0 +1,136 @@
+# Final LLBC before serialization:
+
+// Full name: test_crate::promoted_scalar
+pub fn promoted_scalar() -> &'static i32
+{
+    let _0: &'1 i32; // return
+    let _1: &'2 i32; // anonymous local
+    let _2: &'3 i32; // anonymous local
+    let _3: &'4 i32; // anonymous local
+    let _4: &'5 i32; // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = const 42i32
+    _4 = &_5
+    _3 = move _4
+    storage_live(_2)
+    storage_live(_1)
+    _2 = move _3
+    _1 = &(*_2)
+    _0 = &(*_1)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::promoted_array
+pub fn promoted_array() -> &'static [i32; 3usize]
+{
+    let _0: &'1 [i32; 3usize]; // return
+    let _1: &'2 [i32; 3usize]; // anonymous local
+    let _2: &'3 [i32; 3usize]; // anonymous local
+    let _3: &'4 [i32; 3usize]; // anonymous local
+    let _4: &'5 [i32; 3usize]; // anonymous local
+    let _5: [i32; 3usize]; // anonymous local
+
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = [const 1i32, const 2i32, const 3i32]
+    _4 = &_5
+    _3 = move _4
+    storage_live(_2)
+    storage_live(_1)
+    _2 = move _3
+    _1 = &(*_2)
+    _0 = &(*_1)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::promoted_local
+pub fn promoted_local() -> i32
+{
+    let _0: i32; // return
+    let r: &'1 i32; // local
+    let _2: i32; // anonymous local
+    let _3: &'2 i32; // anonymous local
+    let _4: &'3 i32; // anonymous local
+    let _5: &'4 i32; // anonymous local
+    let _6: i32; // anonymous local
+    let _7: i32; // anonymous local
+
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(r)
+    _2 = const 2i32 panic.+ const 3i32
+    storage_live(_4)
+    storage_live(_5)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = const 2i32 wrap.+ const 3i32
+    _6 = move _7
+    _5 = &_6
+    _4 = move _5
+    _3 = move _4
+    r = &(*_3)
+    _0 = copy (*r)
+    storage_dead(r)
+    return
+}
+
+// Full name: test_crate::inline_ref_scalar
+pub fn inline_ref_scalar() -> &'static i32
+{
+    let _0: &'1 i32; // return
+    let _1: i32; // anonymous local
+    let _2: &'2 i32; // anonymous local
+
+    storage_live(_1)
+    _1 = const 42i32
+    storage_live(_2)
+    _2 = &_1
+    _0 = move _2
+    return
+}
+
+// Full name: test_crate::inline_ref_array
+pub fn inline_ref_array() -> &'static [i32; 3usize]
+{
+    let _0: &'1 [i32; 3usize]; // return
+    let _1: [i32; 3usize]; // anonymous local
+    let _2: &'2 [i32; 3usize]; // anonymous local
+
+    storage_live(_1)
+    _1 = [const 1i32, const 2i32, const 3i32]
+    storage_live(_2)
+    _2 = &_1
+    _0 = move _2
+    return
+}
+
+// Full name: test_crate::inline_block
+pub fn inline_block() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 5u32
+    return
+}
+
+// Full name: test_crate::inline_pair
+pub fn inline_pair() -> (u32, u32)
+{
+    let _0: (u32, u32); // return
+    let _1: (u32, u32); // anonymous local
+
+    storage_live(_1)
+    _1 = (const 1u32, const 2u32)
+    _0 = move _1
+    return
+}
+
+
+

--- a/charon/tests/ui/consts/evaluate-consts-inline.rs
+++ b/charon/tests/ui/consts/evaluate-consts-inline.rs
@@ -1,0 +1,30 @@
+//@ charon-args=--consts=values
+
+pub fn promoted_scalar() -> &'static i32 {
+    &42
+}
+
+pub fn promoted_array() -> &'static [i32; 3] {
+    &[1, 2, 3]
+}
+
+pub fn promoted_local() -> i32 {
+    let r = &(2 + 3);
+    *r
+}
+
+pub fn inline_ref_scalar() -> &'static i32 {
+    const { &42 }
+}
+
+pub fn inline_ref_array() -> &'static [i32; 3] {
+    const { &[1, 2, 3] }
+}
+
+pub fn inline_block() -> u32 {
+    const { 2 + 3 }
+}
+
+pub fn inline_pair() -> (u32, u32) {
+    const { (1, 2) }
+}

--- a/charon/tests/ui/consts/evaluate-consts-mono.out
+++ b/charon/tests/ui/consts/evaluate-consts-mono.out
@@ -1,0 +1,89 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized::{vtable}
+opaque type {vtable}
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: test_crate::HasLen
+trait HasLen<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasLen for [u8; 4usize]}
+impl "impl_HasLen_for_array" HasLen for [u8; 4usize] {
+    proof ImpliedClause0: ([u8; 4usize]: MetaSized) = {built_in impl MetaSized for [u8; 4usize]}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasLen for [u8; 4usize]}::LEN::<u8, 4usize>
+const LEN::<u8, 4usize>: usize = 4usize
+
+// Full name: test_crate::use_len
+pub fn use_len() -> usize
+{
+    let _0: usize; // return
+
+    _0 = copy LEN::<u8, 4usize>
+    return
+}
+
+// Full name: test_crate::HasSize
+trait HasSize<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasSize for u8}
+impl "impl_HasSize_for_u8" HasSize for u8 {
+    proof ImpliedClause0: (u8: MetaSized) = {built_in impl MetaSized for u8}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasSize for u64}
+impl "impl_HasSize_for_u64" HasSize for u64 {
+    proof ImpliedClause0: (u64: MetaSized) = {built_in impl MetaSized for u64}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasSize for [u32; 3usize]}
+impl "impl_HasSize_for_array" HasSize for [u32; 3usize] {
+    proof ImpliedClause0: ([u32; 3usize]: MetaSized) = {built_in impl MetaSized for [u32; 3usize]}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasSize for u8}::SIZE::<u8>
+const impl_HasSize_for_u8::SIZE::<u8>: usize = 1usize
+
+// Full name: test_crate::{impl HasSize for u64}::SIZE::<u64>
+const impl_HasSize_for_u64::SIZE::<u64>: usize = 8usize
+
+// Full name: test_crate::{impl HasSize for [u32; 3usize]}::SIZE::<[u32; 3usize]>
+const impl_HasSize_for_array::SIZE::<[u32; 3usize]>: usize = 12usize
+
+// Full name: test_crate::use_size
+pub fn use_size() -> usize
+{
+    let _0: usize; // return
+    let _1: usize; // anonymous local
+    let _2: usize; // anonymous local
+    let _3: usize; // anonymous local
+
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_1)
+    _2 = copy impl_HasSize_for_u8::SIZE::<u8> panic.+ copy impl_HasSize_for_u64::SIZE::<u64>
+    _1 = move _2
+    _3 = copy _1 panic.+ copy impl_HasSize_for_array::SIZE::<[u32; 3usize]>
+    _0 = move _3
+    storage_dead(_1)
+    return
+}
+
+
+

--- a/charon/tests/ui/consts/evaluate-consts-mono.rs
+++ b/charon/tests/ui/consts/evaluate-consts-mono.rs
@@ -1,0 +1,25 @@
+//@ charon-args=--consts=values --monomorphize
+
+trait HasLen {
+    const LEN: usize;
+}
+
+impl<T, const N: usize> HasLen for [T; N] {
+    const LEN: usize = N;
+}
+
+pub fn use_len() -> usize {
+    <[u8; 4] as HasLen>::LEN
+}
+
+trait HasSize {
+    const SIZE: usize;
+}
+
+impl<T> HasSize for T {
+    const SIZE: usize = core::mem::size_of::<T>();
+}
+
+pub fn use_size() -> usize {
+    <u8 as HasSize>::SIZE + <u64 as HasSize>::SIZE + <[u32; 3] as HasSize>::SIZE
+}

--- a/charon/tests/ui/consts/evaluate-consts-recursive-static.out
+++ b/charon/tests/ui/consts/evaluate-consts-recursive-static.out
@@ -1,0 +1,105 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::cell::Cell
+#[lang_item("Cell")]
+pub opaque type Cell<T>
+where
+    TraitClause0: (T: MetaSized),
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::cell::{Cell<T>[TraitClause0::ImpliedClause0]}::new
+pub fn new<T>(_1: T) -> Cell<T>[TraitClause0::ImpliedClause0]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+// Full name: core::marker::Sync
+#[lang_item("sync")]
+pub trait Sync<Self>
+
+// Full name: test_crate::Node
+pub struct Node {
+  value: u32,
+  next: Cell<&'static Node>[{built_in impl MetaSized for &'static Node}],
+}
+
+// Full name: test_crate::{impl Sync for Node}
+impl "impl_Sync_for_Node" Sync for Node {
+    vtable: impl_Sync_for_Node::{vtable}
+}
+
+// Full name: test_crate::CYCLE_A
+pub fn CYCLE_A() -> Node
+{
+    let _0: Node; // return
+    let _1: Cell<&'4 Node>[{built_in impl MetaSized for &'4 Node}]; // anonymous local
+    let _2: &'6 Node; // anonymous local
+    let _3: &'7 Node; // anonymous local
+    let _4: &'8 Node; // anonymous local
+    let _5: &'9 Node; // anonymous local
+
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &CYCLE_B
+    _4 = move _5
+    _3 = &(*_4)
+    _2 = &(*_3)
+    _1 = new<&'11 Node>[{built_in impl Sized for &'11 Node}](move _2)
+    storage_dead(_2)
+    _0 = Node { value: const 1u32, next: move _1 }
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::CYCLE_A
+pub static CYCLE_A: Node = CYCLE_A()
+
+// Full name: test_crate::CYCLE_B
+pub fn CYCLE_B() -> Node
+{
+    let _0: Node; // return
+    let _1: Cell<&'4 Node>[{built_in impl MetaSized for &'4 Node}]; // anonymous local
+    let _2: &'6 Node; // anonymous local
+    let _3: &'7 Node; // anonymous local
+    let _4: &'8 Node; // anonymous local
+    let _5: &'9 Node; // anonymous local
+
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &CYCLE_A
+    _4 = move _5
+    _3 = &(*_4)
+    _2 = &(*_3)
+    _1 = new<&'11 Node>[{built_in impl Sized for &'11 Node}](move _2)
+    storage_dead(_2)
+    _0 = Node { value: const 2u32, next: move _1 }
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::CYCLE_B
+pub static CYCLE_B: Node = CYCLE_B()
+
+
+

--- a/charon/tests/ui/consts/evaluate-consts-recursive-static.rs
+++ b/charon/tests/ui/consts/evaluate-consts-recursive-static.rs
@@ -1,0 +1,20 @@
+//@ charon-args=--consts=values
+
+// A constant/static that genuinely cannot be evaluated to a value because of recursiveness.
+
+use core::cell::Cell;
+
+pub struct Node {
+    value: u32,
+    next: Cell<&'static Node>,
+}
+unsafe impl Sync for Node {}
+
+pub static CYCLE_A: Node = Node {
+    value: 1,
+    next: Cell::new(&CYCLE_B),
+};
+pub static CYCLE_B: Node = Node {
+    value: 2,
+    next: Cell::new(&CYCLE_A),
+};

--- a/charon/tests/ui/consts/evaluate-consts.out
+++ b/charon/tests/ui/consts/evaluate-consts.out
@@ -1,0 +1,107 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::SIMPLE
+pub const SIMPLE: u32 = 42u32
+
+// Full name: test_crate::COMPUTED
+pub const COMPUTED: u32 = 43u32
+
+// Full name: test_crate::PAIR
+pub const PAIR: (u32, bool) = (43u32, true)
+
+// Full name: test_crate::ARRAY
+pub const ARRAY: [u8; 3usize] = [1u8, 2u8, 3u8]
+
+// Full name: test_crate::STATIC
+pub static STATIC: u32 = 100u32
+
+// Full name: test_crate::Node
+pub struct Node {
+  &'static Node,
+}
+
+// Full name: test_crate::REC_A
+pub static REC_A: Node = Node { 0: &REC_B }
+
+// Full name: test_crate::REC_B
+pub static REC_B: Node = Node { 0: &REC_A }
+
+// Full name: test_crate::HasLen
+trait HasLen<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    const LEN : usize
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl HasLen for [T; 4usize]}::LEN
+fn LEN<T>() -> usize
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: usize; // return
+
+    _0 = const 4usize
+    return
+}
+
+// Full name: test_crate::{impl HasLen for [T; 4usize]}::LEN
+const LEN<T>: usize
+where
+    TraitClause0: (T: Sized),
+ = LEN<T>[TraitClause0]()
+
+// Full name: test_crate::{impl HasLen for [T; 4usize]}
+impl<T> "impl_HasLen_for_array" HasLen for [T; 4usize]
+where
+    TraitClause0: (T: Sized),
+{
+    proof ImpliedClause0: ([T; 4usize]: MetaSized) = {built_in impl MetaSized for [T; 4usize]}
+    const LEN = LEN<T>[TraitClause0]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::use_consts
+pub fn use_consts() -> u32
+{
+    let _0: u32; // return
+    let _1: u32; // anonymous local
+    let _2: u32; // anonymous local
+    let _3: u32; // anonymous local
+    let _4: &'1 u32; // anonymous local
+    let _5: u32; // anonymous local
+    let _6: &'2 u32; // anonymous local
+
+    storage_live(_2)
+    storage_live(_5)
+    storage_live(_1)
+    _2 = copy SIMPLE panic.+ copy COMPUTED
+    _1 = move _2
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_6)
+    _6 = &STATIC
+    _4 = move _6
+    _3 = copy (*_4)
+    _5 = copy _1 panic.+ copy _3
+    _0 = move _5
+    storage_dead(_3)
+    storage_dead(_1)
+    storage_dead(_4)
+    return
+}
+
+
+

--- a/charon/tests/ui/consts/evaluate-consts.rs
+++ b/charon/tests/ui/consts/evaluate-consts.rs
@@ -1,0 +1,22 @@
+//@ charon-args=--consts=values
+
+pub const SIMPLE: u32 = 42;
+pub const COMPUTED: u32 = SIMPLE + 1;
+pub const PAIR: (u32, bool) = (COMPUTED, true);
+pub const ARRAY: [u8; 3] = [1, 2, 3];
+pub static STATIC: u32 = 100;
+pub struct Node(&'static Node);
+pub static REC_A: Node = Node(&REC_B);
+pub static REC_B: Node = Node(&REC_A);
+
+trait HasLen {
+    const LEN: usize;
+}
+
+impl<T> HasLen for [T; 4] {
+    const LEN: usize = 4;
+}
+
+pub fn use_consts() -> u32 {
+    SIMPLE + COMPUTED + STATIC
+}

--- a/charon/tests/ui/multi-target/evaluate-consts-size-of.out
+++ b/charon/tests/ui/multi-target/evaluate-consts-size-of.out
@@ -1,0 +1,48 @@
+opaque type core::marker::MetaSized::{vtable}
+
+#[lang_item("meta_sized")]
+pub trait core::marker::MetaSized<Self>
+
+trait test_crate::HasSize<Self>
+{
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl test_crate::HasSize for usize}
+impl test_crate::HasSize for usize {
+    proof ImpliedClause0: (usize: core::marker::MetaSized) = {built_in impl core::marker::MetaSized for usize}
+    non-dyn-compatible
+}
+
+const test_crate::{impl test_crate::HasSize for usize}::SIZE::<usize>::x86_64-unknown-linux-gnu: usize = 8usize
+
+const test_crate::{impl test_crate::HasSize for usize}::SIZE::<usize>::i686-unknown-linux-gnu: usize = 4usize
+
+const test_crate::USIZE_SIZE::x86_64-unknown-linux-gnu: usize = 8usize
+
+const test_crate::USIZE_SIZE::i686-unknown-linux-gnu: usize = 4usize
+
+pub fn test_crate::usize_size::x86_64-unknown-linux-gnu() -> usize
+{
+    let _0: usize; // return
+
+    _0 = copy test_crate::{impl test_crate::HasSize for usize}::SIZE::<usize>::x86_64-unknown-linux-gnu
+    return
+}
+
+pub fn test_crate::usize_size::i686-unknown-linux-gnu() -> usize
+{
+    let _0: usize; // return
+
+    _0 = copy test_crate::{impl test_crate::HasSize for usize}::SIZE::<usize>::i686-unknown-linux-gnu
+    return
+}
+
+pub fn test_crate::usize_size() -> usize
+= target_dispatch {
+    x86_64-unknown-linux-gnu => test_crate::usize_size::x86_64-unknown-linux-gnu,
+    i686-unknown-linux-gnu => test_crate::usize_size::i686-unknown-linux-gnu,
+}
+
+

--- a/charon/tests/ui/multi-target/evaluate-consts-size-of.rs
+++ b/charon/tests/ui/multi-target/evaluate-consts-size-of.rs
@@ -1,0 +1,15 @@
+//@ charon-args=--consts=values --monomorphize --targets=x86_64-unknown-linux-gnu,i686-unknown-linux-gnu
+
+trait HasSize {
+    const SIZE: usize;
+}
+
+impl<T> HasSize for T {
+    const SIZE: usize = core::mem::size_of::<T>();
+}
+
+const USIZE_SIZE: usize = <usize as HasSize>::SIZE;
+
+pub fn usize_size() -> usize {
+    <usize as HasSize>::SIZE
+}


### PR DESCRIPTION

Continuation of #1268 

Add a `--consts` arg, with either `values` for evaluating constants into a value, or `initializers` for preserving the constant's initialiser (default).

One thing is that this now has some odd interaction with `--raw-consts`, and it's not clear to me what it is x) 
- possibly a clearer alternative is `--consts={raw,unevaluated,evaluated}`...?
- maybe `--consts={initializer,evaluated}` and `--consts-inline={true,false}` are the two axis? and then for #1168 we can add `--consts=bytes` which doesn't even unevaluate?


Related to #1167 