### PR TITLE
Make charon work inside cargo workspaces

### DIFF
--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -5,7 +5,9 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
 use std::cell::{RefCell, RefMut};
 
-use crate::{BoundsOptions, ItemPredicates, PredicateSearcher, TraitProof, TraitProofContents};
+use crate::{
+    BoundsOptions, ItemId, ItemPredicates, PredicateSearcher, TraitProof, TraitProofContents,
+};
 
 mod intern {
     use rustc_data_structures::intern::Interned;
@@ -71,21 +73,41 @@ mod intern {
     }
 }
 
-#[derive(Clone, Copy)]
-pub struct ElaborationCtx<'tcx> {
+pub struct ElaborationCtx<'tcx, Id: ItemId = DefId> {
     pub tcx: ty::TyCtxt<'tcx>,
-    data: &'tcx ElaborationData<'tcx>,
+    data: &'tcx ElaborationData<'tcx, Id>,
 }
 
-#[derive(Default)]
-struct ElaborationData<'tcx> {
+impl<'tcx, Id: ItemId> Clone for ElaborationCtx<'tcx, Id> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'tcx, Id: ItemId> Copy for ElaborationCtx<'tcx, Id> {}
+
+struct ElaborationData<'tcx, Id: ItemId = DefId> {
     bounds_options: BoundsOptions,
     trait_proofs: intern::TraitProofInterner<'tcx>,
     trait_proofs_arena: TypedArena<TraitProofContents<'tcx>>,
-    predicate_searchers: RefCell<FxHashMap<DefId, PredicateSearcher<'tcx>>>,
+    predicate_searchers: RefCell<FxHashMap<Id, PredicateSearcher<'tcx, Id>>>,
     required_predicates: PredicateCache<'tcx>,
     required_recursively_predicates: PredicateCache<'tcx>,
     implied_predicates: PredicateCache<'tcx>,
+}
+
+impl<'tcx, Id: ItemId> Default for ElaborationData<'tcx, Id> {
+    fn default() -> Self {
+        Self {
+            bounds_options: Default::default(),
+            trait_proofs: Default::default(),
+            trait_proofs_arena: Default::default(),
+            predicate_searchers: Default::default(),
+            required_predicates: Default::default(),
+            required_recursively_predicates: Default::default(),
+            implied_predicates: Default::default(),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -108,7 +130,7 @@ impl<'tcx> PredicateCache<'tcx> {
     }
 }
 
-impl<'tcx> ElaborationData<'tcx> {
+impl<'tcx, Id: ItemId> ElaborationData<'tcx, Id> {
     fn intern_trait_proof(&'tcx self, contents: TraitProofContents<'tcx>) -> TraitProof<'tcx> {
         let interned = self
             .trait_proofs
@@ -117,7 +139,7 @@ impl<'tcx> ElaborationData<'tcx> {
     }
 }
 
-impl<'tcx> ElaborationCtx<'tcx> {
+impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
     /// Warning: only create a single one.
     pub fn new(tcx: ty::TyCtxt<'tcx>, bounds_options: BoundsOptions) -> Self {
         // `TraitProof` is a copyable `Interned<'tcx, _>` and may outlive the `PredicateSearcher`
@@ -138,11 +160,25 @@ impl<'tcx> ElaborationCtx<'tcx> {
         self.data.intern_trait_proof(contents)
     }
 
-    pub fn predicate_searcher_for(&self, def_id: DefId) -> RefMut<'_, PredicateSearcher<'tcx>> {
+    pub fn predicate_searcher_for(
+        &self,
+        state: &Id::State<'tcx>,
+        def_id: Id,
+    ) -> RefMut<'_, PredicateSearcher<'tcx, Id>> {
+        self.predicate_searcher_for_with(def_id.clone(), || {
+            PredicateSearcher::new_for_owner(*self, state, def_id)
+        })
+    }
+
+    pub fn predicate_searcher_for_with(
+        &self,
+        def_id: Id,
+        make: impl FnOnce() -> PredicateSearcher<'tcx, Id>,
+    ) -> RefMut<'_, PredicateSearcher<'tcx, Id>> {
         let mut predicate_searchers = self.data.predicate_searchers.borrow_mut();
         predicate_searchers
-            .entry(def_id)
-            .or_insert_with(|| PredicateSearcher::new_for_owner(*self, self, def_id));
+            .entry(def_id.clone())
+            .or_insert_with(make);
         RefMut::map(predicate_searchers, |predicate_searchers| {
             predicate_searchers.get_mut(&def_id).unwrap()
         })

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -91,9 +91,9 @@ struct ElaborationData<'tcx, Id: ItemId = DefId> {
     trait_proofs: intern::TraitProofInterner<'tcx>,
     trait_proofs_arena: TypedArena<TraitProofContents<'tcx>>,
     predicate_searchers: RefCell<FxHashMap<Id, PredicateSearcher<'tcx, Id>>>,
-    required_predicates: PredicateCache<'tcx>,
-    required_recursively_predicates: PredicateCache<'tcx>,
-    implied_predicates: PredicateCache<'tcx>,
+    required_predicates: PredicateCache<'tcx, DefId>,
+    required_recursively_predicates: PredicateCache<'tcx, Id>,
+    implied_predicates: PredicateCache<'tcx, DefId>,
 }
 
 impl<'tcx, Id: ItemId> Default for ElaborationData<'tcx, Id> {
@@ -110,15 +110,22 @@ impl<'tcx, Id: ItemId> Default for ElaborationData<'tcx, Id> {
     }
 }
 
-#[derive(Default)]
-struct PredicateCache<'tcx> {
-    values: ShardedHashMap<DefId, ItemPredicates<'tcx>>,
+struct PredicateCache<'tcx, Id: ItemId> {
+    values: ShardedHashMap<Id, ItemPredicates<'tcx>>,
 }
 
-impl<'tcx> PredicateCache<'tcx> {
+impl<'tcx, Id: ItemId> Default for PredicateCache<'tcx, Id> {
+    fn default() -> Self {
+        Self {
+            values: Default::default(),
+        }
+    }
+}
+
+impl<'tcx, Id: ItemId> PredicateCache<'tcx, Id> {
     fn get_or_insert_with(
         &'tcx self,
-        def_id: DefId,
+        def_id: Id,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
         if let Some(predicates) = self.values.get(&def_id) {
@@ -196,7 +203,7 @@ impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
 
     pub(crate) fn cached_required_recursively_predicates(
         &self,
-        def_id: DefId,
+        def_id: Id,
         compute: impl FnOnce() -> ItemPredicates<'tcx>,
     ) -> ItemPredicates<'tcx> {
         self.data

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -142,7 +142,7 @@ impl<'tcx> ElaborationCtx<'tcx> {
         let mut predicate_searchers = self.data.predicate_searchers.borrow_mut();
         predicate_searchers
             .entry(def_id)
-            .or_insert_with(|| PredicateSearcher::new_for_owner(*self, def_id));
+            .or_insert_with(|| PredicateSearcher::new_for_owner(*self, self, def_id));
         RefMut::map(predicate_searchers, |predicate_searchers| {
             predicate_searchers.get_mut(&def_id).unwrap()
         })

--- a/charon/rustc_trait_elaboration/src/ctx.rs
+++ b/charon/rustc_trait_elaboration/src/ctx.rs
@@ -15,17 +15,24 @@ mod intern {
     use std::borrow::Borrow;
     use std::hash::{Hash, Hasher};
 
-    use crate::TraitProofContents;
+    use crate::{ItemId, TraitProofContents};
 
-    #[derive(Default)]
-    pub struct TraitProofInterner<'tcx>(ShardedHashMap<InternedTraitProof<'tcx>, ()>);
+    pub struct TraitProofInterner<'tcx, Id: ItemId>(
+        ShardedHashMap<InternedTraitProof<'tcx, Id>, ()>,
+    );
 
-    impl<'tcx> TraitProofInterner<'tcx> {
+    impl<'tcx, Id: ItemId> Default for TraitProofInterner<'tcx, Id> {
+        fn default() -> Self {
+            Self(Default::default())
+        }
+    }
+
+    impl<'tcx, Id: ItemId> TraitProofInterner<'tcx, Id> {
         pub(crate) fn intern(
             &self,
-            contents: TraitProofContents<'tcx>,
-            f: impl Fn(TraitProofContents<'tcx>) -> &'tcx TraitProofContents<'tcx>,
-        ) -> Interned<'tcx, TraitProofContents<'tcx>> {
+            contents: TraitProofContents<'tcx, Id>,
+            f: impl Fn(TraitProofContents<'tcx, Id>) -> &'tcx TraitProofContents<'tcx, Id>,
+        ) -> Interned<'tcx, TraitProofContents<'tcx, Id>> {
             let interned = self
                 .0
                 .intern(contents, |contents| InternedTraitProof(f(contents)));
@@ -36,37 +43,37 @@ mod intern {
     // This mirrors rustc's `InternedInSet`: the value lives in the arena and the set stores this
     // copyable pointer wrapper. Equality and hashing still use the pointed-to contents, so
     // `ShardedHashMap::intern` can find an existing arena value before allocating a new one.
-    struct InternedTraitProof<'tcx>(&'tcx TraitProofContents<'tcx>);
+    struct InternedTraitProof<'tcx, Id: ItemId>(&'tcx TraitProofContents<'tcx, Id>);
 
-    impl<'tcx> Clone for InternedTraitProof<'tcx> {
+    impl<'tcx, Id: ItemId> Clone for InternedTraitProof<'tcx, Id> {
         fn clone(&self) -> Self {
             *self
         }
     }
 
-    impl<'tcx> Copy for InternedTraitProof<'tcx> {}
+    impl<'tcx, Id: ItemId> Copy for InternedTraitProof<'tcx, Id> {}
 
-    impl<'tcx> IntoPointer for InternedTraitProof<'tcx> {
+    impl<'tcx, Id: ItemId> IntoPointer for InternedTraitProof<'tcx, Id> {
         fn into_pointer(&self) -> *const () {
             self.0 as *const _ as *const ()
         }
     }
 
-    impl<'tcx> Borrow<TraitProofContents<'tcx>> for InternedTraitProof<'tcx> {
-        fn borrow(&self) -> &TraitProofContents<'tcx> {
+    impl<'tcx, Id: ItemId> Borrow<TraitProofContents<'tcx, Id>> for InternedTraitProof<'tcx, Id> {
+        fn borrow(&self) -> &TraitProofContents<'tcx, Id> {
             self.0
         }
     }
 
-    impl<'tcx> PartialEq for InternedTraitProof<'tcx> {
+    impl<'tcx, Id: ItemId> PartialEq for InternedTraitProof<'tcx, Id> {
         fn eq(&self, other: &Self) -> bool {
             self.0 == other.0
         }
     }
 
-    impl<'tcx> Eq for InternedTraitProof<'tcx> {}
+    impl<'tcx, Id: ItemId> Eq for InternedTraitProof<'tcx, Id> {}
 
-    impl<'tcx> Hash for InternedTraitProof<'tcx> {
+    impl<'tcx, Id: ItemId> Hash for InternedTraitProof<'tcx, Id> {
         fn hash<H: Hasher>(&self, state: &mut H) {
             self.0.hash(state);
         }
@@ -88,12 +95,12 @@ impl<'tcx, Id: ItemId> Copy for ElaborationCtx<'tcx, Id> {}
 
 struct ElaborationData<'tcx, Id: ItemId = DefId> {
     bounds_options: BoundsOptions,
-    trait_proofs: intern::TraitProofInterner<'tcx>,
-    trait_proofs_arena: TypedArena<TraitProofContents<'tcx>>,
+    trait_proofs: intern::TraitProofInterner<'tcx, Id>,
+    trait_proofs_arena: TypedArena<TraitProofContents<'tcx, Id>>,
     predicate_searchers: RefCell<FxHashMap<Id, PredicateSearcher<'tcx, Id>>>,
-    required_predicates: PredicateCache<'tcx, DefId>,
+    required_predicates: PredicateCache<'tcx, Id>,
     required_recursively_predicates: PredicateCache<'tcx, Id>,
-    implied_predicates: PredicateCache<'tcx, DefId>,
+    implied_predicates: PredicateCache<'tcx, Id>,
 }
 
 impl<'tcx, Id: ItemId> Default for ElaborationData<'tcx, Id> {
@@ -111,7 +118,7 @@ impl<'tcx, Id: ItemId> Default for ElaborationData<'tcx, Id> {
 }
 
 struct PredicateCache<'tcx, Id: ItemId> {
-    values: ShardedHashMap<Id, ItemPredicates<'tcx>>,
+    values: ShardedHashMap<Id, ItemPredicates<'tcx, Id>>,
 }
 
 impl<'tcx, Id: ItemId> Default for PredicateCache<'tcx, Id> {
@@ -126,8 +133,8 @@ impl<'tcx, Id: ItemId> PredicateCache<'tcx, Id> {
     fn get_or_insert_with(
         &'tcx self,
         def_id: Id,
-        compute: impl FnOnce() -> ItemPredicates<'tcx>,
-    ) -> ItemPredicates<'tcx> {
+        compute: impl FnOnce() -> ItemPredicates<'tcx, Id>,
+    ) -> ItemPredicates<'tcx, Id> {
         if let Some(predicates) = self.values.get(&def_id) {
             return predicates;
         }
@@ -138,7 +145,10 @@ impl<'tcx, Id: ItemId> PredicateCache<'tcx, Id> {
 }
 
 impl<'tcx, Id: ItemId> ElaborationData<'tcx, Id> {
-    fn intern_trait_proof(&'tcx self, contents: TraitProofContents<'tcx>) -> TraitProof<'tcx> {
+    fn intern_trait_proof(
+        &'tcx self,
+        contents: TraitProofContents<'tcx, Id>,
+    ) -> TraitProof<'tcx, Id> {
         let interned = self
             .trait_proofs
             .intern(contents, |contents| self.trait_proofs_arena.alloc(contents));
@@ -163,7 +173,10 @@ impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
         &self.data.bounds_options
     }
 
-    pub fn intern_trait_proof(&self, contents: TraitProofContents<'tcx>) -> TraitProof<'tcx> {
+    pub fn intern_trait_proof(
+        &self,
+        contents: TraitProofContents<'tcx, Id>,
+    ) -> TraitProof<'tcx, Id> {
         self.data.intern_trait_proof(contents)
     }
 
@@ -193,9 +206,9 @@ impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
 
     pub(crate) fn cached_required_predicates(
         &self,
-        def_id: DefId,
-        compute: impl FnOnce() -> ItemPredicates<'tcx>,
-    ) -> ItemPredicates<'tcx> {
+        def_id: Id,
+        compute: impl FnOnce() -> ItemPredicates<'tcx, Id>,
+    ) -> ItemPredicates<'tcx, Id> {
         self.data
             .required_predicates
             .get_or_insert_with(def_id, compute)
@@ -204,8 +217,8 @@ impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
     pub(crate) fn cached_required_recursively_predicates(
         &self,
         def_id: Id,
-        compute: impl FnOnce() -> ItemPredicates<'tcx>,
-    ) -> ItemPredicates<'tcx> {
+        compute: impl FnOnce() -> ItemPredicates<'tcx, Id>,
+    ) -> ItemPredicates<'tcx, Id> {
         self.data
             .required_recursively_predicates
             .get_or_insert_with(def_id, compute)
@@ -213,9 +226,9 @@ impl<'tcx, Id: ItemId> ElaborationCtx<'tcx, Id> {
 
     pub(crate) fn cached_implied_predicates(
         &self,
-        def_id: DefId,
-        compute: impl FnOnce() -> ItemPredicates<'tcx>,
-    ) -> ItemPredicates<'tcx> {
+        def_id: Id,
+        compute: impl FnOnce() -> ItemPredicates<'tcx, Id>,
+    ) -> ItemPredicates<'tcx, Id> {
         self.data
             .implied_predicates
             .get_or_insert_with(def_id, compute)

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -131,7 +131,9 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             id: ItemPredicateId::TraitSelf,
             clause,
         }));
-        out.insert_bound_predicates(owner_id.required_predicates(state).predicates);
+        out.insert_bound_predicates(
+            ItemPredicates::required_recursively(elab_ctx, state, owner_id).predicates,
+        );
         out
     }
 
@@ -480,7 +482,11 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         def_id: Id,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<TraitProof<'tcx>> {
-        self.resolve_predicates(state, def_id.required_predicates(state), generics)
+        self.resolve_predicates(
+            state,
+            ItemPredicates::required_recursively(self.elab_ctx, state, def_id),
+            generics,
+        )
     }
 
     /// Resolve the predicates implied by the given item.

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -34,7 +34,7 @@ fn initial_self_pred<'tcx, Id: ItemId>(
 
 #[tracing::instrument(level = "trace", skip(elab_ctx))]
 fn parents_trait_predicates<'tcx>(
-    elab_ctx: ElaborationCtx<'tcx>,
+    elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
     self_trait_ref: PolyTraitRef<'tcx>,
 ) -> Vec<PolyTraitRef<'tcx>> {
     let tcx = elab_ctx.tcx;
@@ -57,9 +57,9 @@ struct Candidate<'tcx> {
 }
 
 impl<'tcx> TraitProof<'tcx> {
-    fn push(
+    fn push<Id: ItemId>(
         self,
-        elab_ctx: ElaborationCtx<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx, Id>,
         new_pred: PolyTraitRef<'tcx>,
         path_chunk: ImpliedPredicate<'tcx>,
     ) -> Self {
@@ -81,9 +81,9 @@ impl<'tcx> Candidate<'tcx> {
         }
     }
 
-    fn push(
+    fn push<Id: ItemId>(
         &self,
-        elab_ctx: ElaborationCtx<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx, Id>,
         new_pred: PolyTraitRef<'tcx>,
         path_chunk: ImpliedPredicate<'tcx>,
     ) -> Self {
@@ -97,7 +97,7 @@ impl<'tcx> Candidate<'tcx> {
 /// Stores a set of predicates along with where they came from.
 #[derive(Clone)]
 pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
-    pub(crate) elab_ctx: ElaborationCtx<'tcx>,
+    pub(crate) elab_ctx: ElaborationCtx<'tcx, Id>,
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
     candidates: HashMap<PolyTraitRef<'tcx>, Candidate<'tcx>>,
@@ -114,7 +114,7 @@ pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
 impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// Initialize the elaborator with the predicates accessible within this item.
     pub fn new_for_owner(
-        elab_ctx: ElaborationCtx<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx, Id>,
         state: &Id::State<'tcx>,
         owner_id: Id,
     ) -> Self {

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -9,9 +9,9 @@ use rustc_middle::traits::CodegenObligationError;
 use rustc_middle::ty::{self, *};
 use rustc_trait_selection::traits::ImplSource;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-struct ItemClause<'tcx> {
-    id: ItemPredicateId,
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct ItemClause<'tcx, Id = DefId> {
+    id: ItemPredicateId<Id>,
     clause: PolyTraitRef<'tcx>,
 }
 
@@ -32,13 +32,15 @@ fn initial_self_pred<'tcx, Id: ItemId>(
     }
 }
 
-#[tracing::instrument(level = "trace", skip(elab_ctx))]
-fn parents_trait_predicates<'tcx>(
-    elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
+#[tracing::instrument(level = "trace", skip(elab_ctx, state))]
+fn parents_trait_predicates<'tcx, Id: ItemId>(
+    elab_ctx: ElaborationCtx<'tcx, Id>,
+    state: &Id::State<'tcx>,
     self_trait_ref: PolyTraitRef<'tcx>,
 ) -> Vec<PolyTraitRef<'tcx>> {
     let tcx = elab_ctx.tcx;
-    ItemPredicates::implied(elab_ctx, self_trait_ref.def_id())
+    let def_id = Id::from_rust_def_id(state, self_trait_ref.def_id());
+    ItemPredicates::implied(elab_ctx, state, def_id)
         .iter()
         // Substitute with the `self` args so that the clause makes sense in the
         // outside context.
@@ -50,18 +52,18 @@ fn parents_trait_predicates<'tcx>(
 
 /// A trait proof we have in our context.
 #[derive(Debug, Clone)]
-struct Candidate<'tcx> {
+struct Candidate<'tcx, Id: ItemId = DefId> {
     /// This is the same predicate as `origin.pred`, but normalized and erased for comparison.
     pred: PolyTraitRef<'tcx>,
-    proof: TraitProof<'tcx>,
+    proof: TraitProof<'tcx, Id>,
 }
 
-impl<'tcx> TraitProof<'tcx> {
-    fn push<Id: ItemId>(
+impl<'tcx, Id: ItemId> TraitProof<'tcx, Id> {
+    fn push(
         self,
         elab_ctx: ElaborationCtx<'tcx, Id>,
         new_pred: PolyTraitRef<'tcx>,
-        path_chunk: ImpliedPredicate<'tcx>,
+        path_chunk: ImpliedPredicate<'tcx, Id>,
     ) -> Self {
         elab_ctx.intern_trait_proof(TraitProofContents {
             pred: new_pred,
@@ -73,19 +75,19 @@ impl<'tcx> TraitProof<'tcx> {
     }
 }
 
-impl<'tcx> Candidate<'tcx> {
-    fn from_trait_proof(origin: TraitProof<'tcx>) -> Self {
+impl<'tcx, Id: ItemId> Candidate<'tcx, Id> {
+    fn from_trait_proof(origin: TraitProof<'tcx, Id>) -> Self {
         Candidate {
             pred: origin.pred,
             proof: origin,
         }
     }
 
-    fn push<Id: ItemId>(
+    fn push(
         &self,
         elab_ctx: ElaborationCtx<'tcx, Id>,
         new_pred: PolyTraitRef<'tcx>,
-        path_chunk: ImpliedPredicate<'tcx>,
+        path_chunk: ImpliedPredicate<'tcx, Id>,
     ) -> Self {
         Candidate {
             pred: new_pred,
@@ -100,7 +102,7 @@ pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
     pub(crate) elab_ctx: ElaborationCtx<'tcx, Id>,
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
-    candidates: HashMap<PolyTraitRef<'tcx>, Candidate<'tcx>>,
+    candidates: HashMap<PolyTraitRef<'tcx>, Candidate<'tcx, Id>>,
     /// Whether we're in a trait declaration context where an implicit `Self: Trait` clause is
     /// accessible.
     implicit_self_clause: bool,
@@ -108,7 +110,7 @@ pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
     pub(crate) item_refs_cache:
         HashMap<(Id, ty::GenericArgsRef<'tcx>, AssocItemResolution), ItemRef<'tcx, Id>>,
     /// Cache of trait refs to resolved trait proofs.
-    trait_proofs_cache: HashMap<ty::PolyTraitRef<'tcx>, TraitProof<'tcx>>,
+    trait_proofs_cache: HashMap<ty::PolyTraitRef<'tcx>, TraitProof<'tcx, Id>>,
 }
 
 impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
@@ -127,11 +129,15 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             item_refs_cache: Default::default(),
             trait_proofs_cache: Default::default(),
         };
-        out.insert_predicates(initial_self_pred.map(|clause| ItemClause {
-            id: ItemPredicateId::TraitSelf,
-            clause,
-        }));
+        out.insert_predicates(
+            state,
+            initial_self_pred.map(|clause| ItemClause {
+                id: ItemPredicateId::TraitSelf,
+                clause,
+            }),
+        );
         out.insert_bound_predicates(
+            state,
             ItemPredicates::required_recursively(elab_ctx, state, owner_id).predicates,
         );
         out
@@ -142,14 +148,18 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// insertion order.
     pub fn insert_bound_predicates(
         &mut self,
-        preds: impl IntoIterator<Item = ItemPredicate<'tcx>>,
+        state: &Id::State<'tcx>,
+        preds: impl IntoIterator<Item = ItemPredicate<'tcx, Id>>,
     ) {
-        self.insert_predicates(preds.into_iter().filter_map(|pred| {
-            pred.clause.as_trait_clause().map(|clause| ItemClause {
-                id: pred.id,
-                clause: clause.to_poly_trait_ref(),
-            })
-        }));
+        self.insert_predicates(
+            state,
+            preds.into_iter().filter_map(|pred| {
+                pred.clause.as_trait_clause().map(|clause| ItemClause {
+                    id: pred.id,
+                    clause: clause.to_poly_trait_ref(),
+                })
+            }),
+        );
     }
 
     /// Override the param env; we use this when resolving `dyn` predicates to add more clauses to
@@ -160,24 +170,37 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
 
     /// Insert annotated predicates in the search context. Prefer inserting them all at once as
     /// this will give priority to shorter resolution paths.
-    fn insert_predicates(&mut self, preds: impl IntoIterator<Item = ItemClause<'tcx>>) {
+    fn insert_predicates(
+        &mut self,
+        state: &Id::State<'tcx>,
+        preds: impl IntoIterator<Item = ItemClause<'tcx, Id>>,
+    ) {
         let elab_ctx = self.elab_ctx;
         let implicit_self_clause = self.implicit_self_clause;
-        self.insert_candidates(preds.into_iter().map(|clause| {
-            let origin = elab_ctx.intern_trait_proof(TraitProofContents {
-                pred: clause.clause,
-                kind: match clause.id {
-                    ItemPredicateId::TraitSelf if implicit_self_clause => TraitProofKind::SelfProof,
-                    _ => TraitProofKind::LocalBound(clause.id),
-                },
-            });
-            Candidate::from_trait_proof(origin)
-        }))
+        self.insert_candidates(
+            state,
+            preds.into_iter().map(|clause| {
+                let origin = elab_ctx.intern_trait_proof(TraitProofContents {
+                    pred: clause.clause,
+                    kind: match clause.id {
+                        ItemPredicateId::TraitSelf if implicit_self_clause => {
+                            TraitProofKind::SelfProof
+                        }
+                        id => TraitProofKind::LocalBound(id),
+                    },
+                });
+                Candidate::from_trait_proof(origin)
+            }),
+        )
     }
 
     /// Insert new candidates and all their parent predicates. This deduplicates predicates
     /// to avoid divergence.
-    fn insert_candidates(&mut self, candidates: impl IntoIterator<Item = Candidate<'tcx>>) {
+    fn insert_candidates(
+        &mut self,
+        state: &Id::State<'tcx>,
+        candidates: impl IntoIterator<Item = Candidate<'tcx, Id>>,
+    ) {
         let tcx = self.elab_ctx.tcx;
         // Filter out duplicated candidates.
         let mut new_candidates = Vec::new();
@@ -191,25 +214,32 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         }
         if !new_candidates.is_empty() {
             // Insert the parents all at once.
-            self.insert_candidate_parents(new_candidates);
+            self.insert_candidate_parents(state, new_candidates);
         }
     }
 
     /// Add the parents of these candidates. This is a separate function to avoid
     /// polymorphic recursion due to the closures capturing the type parameters of this
     /// function.
-    fn insert_candidate_parents(&mut self, new_candidates: Vec<Candidate<'tcx>>) {
+    fn insert_candidate_parents(
+        &mut self,
+        state: &Id::State<'tcx>,
+        new_candidates: Vec<Candidate<'tcx, Id>>,
+    ) {
         let elab_ctx = self.elab_ctx;
         // Then recursively add their parents. This way ensures a breadth-first order,
         // which means we select the shortest path when looking up predicates.
-        self.insert_candidates(new_candidates.into_iter().flat_map(|candidate| {
-            parents_trait_predicates(elab_ctx, candidate.pred)
-                .into_iter()
-                .enumerate()
-                .map(move |(index, parent_pred)| {
-                    candidate.push(elab_ctx, parent_pred, ImpliedPredicate::Parent { index })
-                })
-        }));
+        self.insert_candidates(
+            state,
+            new_candidates.into_iter().flat_map(|candidate| {
+                parents_trait_predicates(elab_ctx, state, candidate.pred)
+                    .into_iter()
+                    .enumerate()
+                    .map(move |(index, parent_pred)| {
+                        candidate.push(elab_ctx, parent_pred, ImpliedPredicate::Parent { index })
+                    })
+            }),
+        );
     }
 
     /// If the type is a trait associated type, we add any relevant bounds to our context.
@@ -235,11 +265,16 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         if matches!(proof.kind, TraitProofKind::Error(_)) {
             return;
         }
-        let item_ref =
-            self.resolve_rust_item_reference(state, *def_id, args, AssocItemResolution::ImplItem);
+        let item_ref = self.resolve_item_reference(
+            state,
+            Id::from_rust_def_id(state, *def_id),
+            args,
+            AssocItemResolution::ImplItem,
+        );
 
         // The bounds that hold on the associated type.
-        let item_bounds = ItemPredicates::implied(self.elab_ctx, *def_id);
+        let item_bounds =
+            ItemPredicates::implied(self.elab_ctx, state, Id::from_rust_def_id(state, *def_id));
         let item_bounds = item_bounds
             .iter_trait_clauses()
             // Substitute the item generics
@@ -251,16 +286,19 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             .enumerate();
 
         // Add all the bounds on the corresponding associated item.
-        self.insert_candidates(item_bounds.map(|(index, pred)| {
-            Candidate::from_trait_proof(proof.push(
-                elab_ctx,
-                pred,
-                ImpliedPredicate::AssocItem {
-                    item: item_ref.clone(),
-                    index,
-                },
-            ))
-        }));
+        self.insert_candidates(
+            state,
+            item_bounds.map(|(index, pred)| {
+                Candidate::from_trait_proof(proof.push(
+                    elab_ctx,
+                    pred,
+                    ImpliedPredicate::AssocItem {
+                        item: item_ref.clone(),
+                        index,
+                    },
+                ))
+            }),
+        );
     }
 
     /// Resolve a local clause by looking it up in this set. If the predicate applies to an
@@ -269,7 +307,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         &mut self,
         state: &Id::State<'tcx>,
         target: PolyTraitRef<'tcx>,
-    ) -> Option<Candidate<'tcx>> {
+    ) -> Option<Candidate<'tcx, Id>> {
         tracing::trace!("Looking for {target:?}");
 
         // Look up the predicate
@@ -300,7 +338,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         &mut self,
         state: &Id::State<'tcx>,
         tref: &PolyTraitRef<'tcx>,
-    ) -> TraitProof<'tcx> {
+    ) -> TraitProof<'tcx, Id> {
         if let Some(trait_proof) = self.trait_proofs_cache.get(tref).copied() {
             return trait_proof;
         }
@@ -336,9 +374,9 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                 impl_def_id,
                 args: generics,
                 ..
-            }) => TraitProofKind::Concrete(self.resolve_rust_item_reference(
+            }) => TraitProofKind::Concrete(self.resolve_item_reference(
                 state,
-                impl_def_id,
+                Id::from_rust_def_id(state, impl_def_id),
                 generics,
                 AssocItemResolution::ImplItem,
             )),
@@ -358,7 +396,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                 // clauses better all over.
                 let trait_proofs = self.resolve_item_implied_predicates(
                     state,
-                    trait_def_id,
+                    Id::from_rust_def_id(state, trait_def_id),
                     erased_tref.skip_binder().args,
                 );
                 let types = tcx
@@ -384,7 +422,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                         }
                         let trait_proofs = self.resolve_item_implied_predicates(
                             state,
-                            assoc.def_id,
+                            Id::from_rust_def_id(state, assoc.def_id),
                             erased_tref.skip_binder().args,
                         );
                         Some((assoc.def_id, ty, trait_proofs))
@@ -481,7 +519,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         state: &Id::State<'tcx>,
         def_id: Id,
         generics: GenericArgsRef<'tcx>,
-    ) -> Vec<TraitProof<'tcx>> {
+    ) -> Vec<TraitProof<'tcx, Id>> {
         self.resolve_predicates(
             state,
             ItemPredicates::required_recursively(self.elab_ctx, state, def_id),
@@ -493,24 +531,24 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     pub fn resolve_item_implied_predicates(
         &mut self,
         state: &Id::State<'tcx>,
-        def_id: DefId,
+        def_id: Id,
         generics: GenericArgsRef<'tcx>,
-    ) -> Vec<TraitProof<'tcx>> {
+    ) -> Vec<TraitProof<'tcx, Id>> {
         self.resolve_predicates(
             state,
-            ItemPredicates::implied(self.elab_ctx, def_id),
+            ItemPredicates::implied(self.elab_ctx, state, def_id),
             generics,
         )
     }
 
     /// Apply the given generics to the provided clauses and resolve the trait references in the
     /// current context.
-    pub fn resolve_predicates(
+    pub fn resolve_predicates<PredicateId: Clone>(
         &mut self,
         state: &Id::State<'tcx>,
-        predicates: ItemPredicates<'tcx>,
+        predicates: ItemPredicates<'tcx, PredicateId>,
         generics: GenericArgsRef<'tcx>,
-    ) -> Vec<TraitProof<'tcx>> {
+    ) -> Vec<TraitProof<'tcx, Id>> {
         let tcx = self.elab_ctx.tcx;
         predicates
             .iter_trait_clauses()

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -18,17 +18,17 @@ struct ItemClause<'tcx> {
 /// Returns the predicate to resolve as `Self`, if that makes sense in the current item.
 /// Currently this predicate is only used inside trait declarations and their asosciated types.
 fn initial_self_pred<'tcx, Id: ItemId>(
-    tcx: TyCtxt<'tcx>,
+    state: &Id::State<'tcx>,
     def_id: &Id,
 ) -> Option<PolyTraitRef<'tcx>> {
-    if let Some(parent) = def_id.parent_of_assoc(tcx) {
-        if def_id.takes_explicit_self_clause(tcx) {
+    if let Some(parent) = def_id.parent_of_assoc(state) {
+        if def_id.takes_explicit_self_clause(state) {
             None
         } else {
-            parent.self_pred(tcx)
+            parent.self_pred(state)
         }
     } else {
-        def_id.self_pred(tcx)
+        def_id.self_pred(state)
     }
 }
 
@@ -113,12 +113,15 @@ pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
 
 impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// Initialize the elaborator with the predicates accessible within this item.
-    pub(crate) fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: Id) -> Self {
-        let tcx = elab_ctx.tcx;
-        let initial_self_pred = initial_self_pred(tcx, &owner_id);
+    pub fn new_for_owner(
+        elab_ctx: ElaborationCtx<'tcx>,
+        state: &Id::State<'tcx>,
+        owner_id: Id,
+    ) -> Self {
+        let initial_self_pred = initial_self_pred(state, &owner_id);
         let mut out = Self {
             elab_ctx,
-            typing_env: TypingEnv::new(owner_id.param_env(tcx), TypingMode::PostAnalysis),
+            typing_env: TypingEnv::new(owner_id.param_env(state), TypingMode::PostAnalysis),
             candidates: Default::default(),
             implicit_self_clause: initial_self_pred.is_some(),
             item_refs_cache: Default::default(),
@@ -128,7 +131,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             id: ItemPredicateId::TraitSelf,
             clause,
         }));
-        out.insert_bound_predicates(owner_id.required_predicates(elab_ctx).predicates);
+        out.insert_bound_predicates(owner_id.required_predicates(state).predicates);
         out
     }
 
@@ -208,7 +211,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     }
 
     /// If the type is a trait associated type, we add any relevant bounds to our context.
-    fn add_associated_type_refs(&mut self, ty: Binder<'tcx, Ty<'tcx>>) {
+    fn add_associated_type_refs(&mut self, state: &Id::State<'tcx>, ty: Binder<'tcx, Ty<'tcx>>) {
         let elab_ctx = self.elab_ctx;
         let tcx = self.elab_ctx.tcx;
         // Note: We skip a binder but rebind it just after.
@@ -226,12 +229,12 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
 
         // The predicate we're looking for is is `<T as Trait>::Type: OtherTrait`. We try to solve
         // `T as Trait` and add all the bounds on `Trait::Type` to our context.
-        let proof = self.resolve(&trait_ref);
+        let proof = self.resolve(state, &trait_ref);
         if matches!(proof.kind, TraitProofKind::Error(_)) {
             return;
         }
         let item_ref =
-            self.resolve_rust_item_reference(*def_id, args, AssocItemResolution::ImplItem);
+            self.resolve_rust_item_reference(state, *def_id, args, AssocItemResolution::ImplItem);
 
         // The bounds that hold on the associated type.
         let item_bounds = ItemPredicates::implied(self.elab_ctx, *def_id);
@@ -260,7 +263,11 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
 
     /// Resolve a local clause by looking it up in this set. If the predicate applies to an
     /// associated type, we add the relevant implied associated type bounds to the set as well.
-    fn resolve_local(&mut self, target: PolyTraitRef<'tcx>) -> Option<Candidate<'tcx>> {
+    fn resolve_local(
+        &mut self,
+        state: &Id::State<'tcx>,
+        target: PolyTraitRef<'tcx>,
+    ) -> Option<Candidate<'tcx>> {
         tracing::trace!("Looking for {target:?}");
 
         // Look up the predicate
@@ -270,7 +277,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         }
 
         // Add clauses related to associated type in the `Self` type of the predicate.
-        self.add_associated_type_refs(target.self_ty());
+        self.add_associated_type_refs(state, target.self_ty());
 
         let ret = self.candidates.get(&target).cloned();
         if ret.is_none() {
@@ -286,8 +293,12 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     }
 
     /// Resolve the given trait reference in the local context.
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn resolve(&mut self, tref: &PolyTraitRef<'tcx>) -> TraitProof<'tcx> {
+    #[tracing::instrument(level = "trace", skip(self, state))]
+    pub fn resolve(
+        &mut self,
+        state: &Id::State<'tcx>,
+        tref: &PolyTraitRef<'tcx>,
+    ) -> TraitProof<'tcx> {
         if let Some(trait_proof) = self.trait_proofs_cache.get(tref).copied() {
             return trait_proof;
         }
@@ -324,11 +335,12 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                 args: generics,
                 ..
             }) => TraitProofKind::Concrete(self.resolve_rust_item_reference(
+                state,
                 impl_def_id,
                 generics,
                 AssocItemResolution::ImplItem,
             )),
-            ImplSource::Param(_) => match self.resolve_local(erased_tref.upcast(tcx)) {
+            ImplSource::Param(_) => match self.resolve_local(state, erased_tref.upcast(tcx)) {
                 Some(candidate) => candidate.proof.kind.clone(),
                 None => {
                     let msg =
@@ -342,8 +354,11 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                 // If we wanted to not skip this binder, we'd have to instantiate the bound
                 // regions, solve, then wrap the result in a binder. And track higher-kinded
                 // clauses better all over.
-                let trait_proofs = self
-                    .resolve_item_implied_predicates(trait_def_id, erased_tref.skip_binder().args);
+                let trait_proofs = self.resolve_item_implied_predicates(
+                    state,
+                    trait_def_id,
+                    erased_tref.skip_binder().args,
+                );
                 let types = tcx
                     .associated_items(trait_def_id)
                     .in_definition_order()
@@ -366,6 +381,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                             return None;
                         }
                         let trait_proofs = self.resolve_item_implied_predicates(
+                            state,
                             assoc.def_id,
                             erased_tref.skip_binder().args,
                         );
@@ -408,7 +424,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                             if self.elab_ctx.bounds_options().add_destruct_bounds {
                                 // We've added `Destruct` impls on everything, we should be able to resolve
                                 // it.
-                                match self.resolve_local(erased_tref.upcast(tcx)) {
+                                match self.resolve_local(state, erased_tref.upcast(tcx)) {
                                     Some(candidate) => Either::Right(candidate.proof.kind.clone()),
                                     None => {
                                         let msg = format!(
@@ -458,27 +474,34 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     }
 
     /// Resolve the predicates required by the given item.
-    pub fn resolve_item_required_predicates<OutId: ItemId>(
+    pub fn resolve_item_required_predicates(
         &mut self,
-        def_id: OutId,
+        state: &Id::State<'tcx>,
+        def_id: Id,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<TraitProof<'tcx>> {
-        self.resolve_predicates(def_id.required_predicates(self.elab_ctx), generics)
+        self.resolve_predicates(state, def_id.required_predicates(state), generics)
     }
 
     /// Resolve the predicates implied by the given item.
     pub fn resolve_item_implied_predicates(
         &mut self,
+        state: &Id::State<'tcx>,
         def_id: DefId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<TraitProof<'tcx>> {
-        self.resolve_predicates(ItemPredicates::implied(self.elab_ctx, def_id), generics)
+        self.resolve_predicates(
+            state,
+            ItemPredicates::implied(self.elab_ctx, def_id),
+            generics,
+        )
     }
 
     /// Apply the given generics to the provided clauses and resolve the trait references in the
     /// current context.
     pub fn resolve_predicates(
         &mut self,
+        state: &Id::State<'tcx>,
         predicates: ItemPredicates<'tcx>,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<TraitProof<'tcx>> {
@@ -492,7 +515,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
                     .skip_normalization()
             })
             // Resolve
-            .map(|trait_ref| self.resolve(&trait_ref))
+            .map(|trait_ref| self.resolve(state, &trait_ref))
             .collect()
     }
 }

--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -4,7 +4,6 @@ use crate::*;
 use itertools::{Either, Itertools};
 use std::collections::{HashMap, hash_map::Entry};
 
-use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::traits::CodegenObligationError;
 use rustc_middle::ty::{self, *};
@@ -18,21 +17,19 @@ struct ItemClause<'tcx> {
 
 /// Returns the predicate to resolve as `Self`, if that makes sense in the current item.
 /// Currently this predicate is only used inside trait declarations and their asosciated types.
-fn initial_self_pred<'tcx>(
+fn initial_self_pred<'tcx, Id: ItemId>(
     tcx: TyCtxt<'tcx>,
-    def_id: rustc_span::def_id::DefId,
+    def_id: &Id,
 ) -> Option<PolyTraitRef<'tcx>> {
-    use DefKind::*;
-    let trait_def_id = match tcx.def_kind(def_id) {
-        Trait | TraitAlias => def_id,
-        // Associated types can refer to the implicit `Self` clause. For methods and associated
-        // consts we pass an explicit `Self: Trait` clause to make the corresponding item
-        // reuseable.
-        AssocTy => tcx.parent(def_id),
-        _ => return None,
-    };
-    let self_pred = self_predicate(tcx, trait_def_id).upcast(tcx);
-    Some(self_pred)
+    if let Some(parent) = def_id.parent_of_assoc(tcx) {
+        if def_id.takes_explicit_self_clause(tcx) {
+            None
+        } else {
+            parent.self_pred(tcx)
+        }
+    } else {
+        def_id.self_pred(tcx)
+    }
 }
 
 #[tracing::instrument(level = "trace", skip(elab_ctx))]
@@ -99,7 +96,7 @@ impl<'tcx> Candidate<'tcx> {
 
 /// Stores a set of predicates along with where they came from.
 #[derive(Clone)]
-pub struct PredicateSearcher<'tcx> {
+pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
     pub(crate) elab_ctx: ElaborationCtx<'tcx>,
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
@@ -109,19 +106,19 @@ pub struct PredicateSearcher<'tcx> {
     implicit_self_clause: bool,
     /// Cache the `ItemRef` translations. This is fast because `GenericArgsRef` is interned.
     pub(crate) item_refs_cache:
-        HashMap<(DefId, ty::GenericArgsRef<'tcx>, AssocItemResolution), ItemRef<'tcx>>,
+        HashMap<(Id, ty::GenericArgsRef<'tcx>, AssocItemResolution), ItemRef<'tcx, Id>>,
     /// Cache of trait refs to resolved trait proofs.
     trait_proofs_cache: HashMap<ty::PolyTraitRef<'tcx>, TraitProof<'tcx>>,
 }
 
-impl<'tcx> PredicateSearcher<'tcx> {
+impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// Initialize the elaborator with the predicates accessible within this item.
-    pub(crate) fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: DefId) -> Self {
+    pub(crate) fn new_for_owner(elab_ctx: ElaborationCtx<'tcx>, owner_id: Id) -> Self {
         let tcx = elab_ctx.tcx;
-        let initial_self_pred = initial_self_pred(tcx, owner_id);
+        let initial_self_pred = initial_self_pred(tcx, &owner_id);
         let mut out = Self {
             elab_ctx,
-            typing_env: TypingEnv::new(tcx.param_env(owner_id), TypingMode::PostAnalysis),
+            typing_env: TypingEnv::new(owner_id.param_env(tcx), TypingMode::PostAnalysis),
             candidates: Default::default(),
             implicit_self_clause: initial_self_pred.is_some(),
             item_refs_cache: Default::default(),
@@ -131,9 +128,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             id: ItemPredicateId::TraitSelf,
             clause,
         }));
-        out.insert_bound_predicates(
-            ItemPredicates::required_recursively(elab_ctx, owner_id).predicates,
-        );
+        out.insert_bound_predicates(owner_id.required_predicates(elab_ctx).predicates);
         out
     }
 
@@ -235,7 +230,8 @@ impl<'tcx> PredicateSearcher<'tcx> {
         if matches!(proof.kind, TraitProofKind::Error(_)) {
             return;
         }
-        let item_ref = self.resolve_item_reference(*def_id, args, AssocItemResolution::ImplItem);
+        let item_ref =
+            self.resolve_rust_item_reference(*def_id, args, AssocItemResolution::ImplItem);
 
         // The bounds that hold on the associated type.
         let item_bounds = ItemPredicates::implied(self.elab_ctx, *def_id);
@@ -327,7 +323,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
                 impl_def_id,
                 args: generics,
                 ..
-            }) => TraitProofKind::Concrete(self.resolve_item_reference(
+            }) => TraitProofKind::Concrete(self.resolve_rust_item_reference(
                 impl_def_id,
                 generics,
                 AssocItemResolution::ImplItem,
@@ -462,15 +458,12 @@ impl<'tcx> PredicateSearcher<'tcx> {
     }
 
     /// Resolve the predicates required by the given item.
-    pub fn resolve_item_required_predicates(
+    pub fn resolve_item_required_predicates<OutId: ItemId>(
         &mut self,
-        def_id: DefId,
+        def_id: OutId,
         generics: GenericArgsRef<'tcx>,
     ) -> Vec<TraitProof<'tcx>> {
-        self.resolve_predicates(
-            ItemPredicates::required_recursively(self.elab_ctx, def_id),
-            generics,
-        )
+        self.resolve_predicates(def_id.required_predicates(self.elab_ctx), generics)
     }
 
     /// Resolve the predicates implied by the given item.

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -4,8 +4,8 @@ use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::ty::{self, GenericArg, GenericArgsRef};
 
 use crate::{
-    ElaborationCtx, ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind, normalize,
-    self_predicate,
+    ElaborationCtx, ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind,
+    inherits_parent_clauses, normalize, self_predicate,
 };
 
 /// The identifier of an item; generalizes over rustc's `DefId` to allow for virtual items.
@@ -26,7 +26,8 @@ pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
     /// The clauses that can be assumed when inside this item.
     fn param_env<'tcx>(&self, state: &Self::State<'tcx>) -> ty::ParamEnv<'tcx>;
 
-    /// The set of predicates required to mention this item.
+    /// The set of predicates required to mention just this item (without the predicates for its
+    /// parents).
     fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx>;
 
     /// If this item is a trait, return its Self predicate.
@@ -35,6 +36,9 @@ pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
     /// If this item is typechecked together with its parent (e.g. inline consts and closures),
     /// return that parent.
     fn typeck_parent<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self>;
+
+    /// If this item inherits the clauses of its parent, return the parent.
+    fn parent_for_clauses<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self>;
 
     /// If this item is an associated item, return its parent.
     fn parent_of_assoc<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self>;
@@ -70,7 +74,7 @@ impl ItemId for DefId {
     }
 
     fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx> {
-        ItemPredicates::required_recursively(*state, *self)
+        ItemPredicates::required(*state, *self)
     }
 
     fn self_pred<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
@@ -90,6 +94,11 @@ impl ItemId for DefId {
     fn parent_of_assoc<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
         let tcx = state.tcx;
         tcx.def_kind(*self).is_assoc().then(|| tcx.parent(*self))
+    }
+
+    fn parent_for_clauses<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = state.tcx;
+        inherits_parent_clauses(tcx, *self).then(|| tcx.parent(*self))
     }
 
     fn takes_explicit_self_clause<'tcx>(&self, state: &Self::State<'tcx>) -> bool {
@@ -224,7 +233,8 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             let self_pred = ty::EarlyBinder::bind(self_pred)
                 .instantiate(tcx, generics)
                 .skip_norm_wip();
-            let num_trait_req_clauses = tr_def_id.required_predicates(state).len();
+            let num_trait_req_clauses =
+                ItemPredicates::required_recursively(self.elab_ctx, state, tr_def_id).len();
             Some((self.resolve(state, &self_pred), num_trait_req_clauses))
         } else {
             None
@@ -317,7 +327,7 @@ impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
 }
 
 impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
-    fn map_item_id<OtherId: ItemId>(
+    pub fn map_item_id<OtherId: ItemId>(
         &self,
         f: impl FnOnce(&Id) -> OtherId,
     ) -> ItemRef<'tcx, OtherId> {

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, hash::Hash, ops::Deref, sync::Arc};
 
 use rustc_hir::{def::DefKind, def_id::DefId};
-use rustc_middle::ty::{self, GenericArg, GenericArgsRef, TyCtxt};
+use rustc_middle::ty::{self, GenericArg, GenericArgsRef};
 
 use crate::{
     ElaborationCtx, ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind, normalize,
@@ -10,86 +10,98 @@ use crate::{
 
 /// The identifier of an item; generalizes over rustc's `DefId` to allow for virtual items.
 pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
+    /// State needed to query information about this item.
+    type State<'tcx>: ?Sized;
+
     /// An identifier that refers to a real Rust item.
-    fn from_rust_def_id(def_id: DefId) -> Self;
+    fn from_rust_def_id<'tcx>(state: &Self::State<'tcx>, def_id: DefId) -> Self;
 
     /// If this item corresponds to a real Rust item, return its DefId. Only used to avoid caching
     /// the same `ItemRef` as both `Id` and `DefId`.
-    fn to_rust_def_id(&self) -> Option<DefId>;
+    fn to_rust_def_id<'tcx>(&self, state: &Self::State<'tcx>) -> Option<DefId>;
 
     /// The generics of this item.
-    fn generics_of<'tcx>(&self, tcx: TyCtxt<'tcx>) -> &'tcx ty::Generics;
+    fn generics_of<'tcx>(&self, state: &Self::State<'tcx>) -> &'tcx ty::Generics;
 
     /// The clauses that can be assumed when inside this item.
-    fn param_env<'tcx>(&self, tcx: TyCtxt<'tcx>) -> ty::ParamEnv<'tcx>;
+    fn param_env<'tcx>(&self, state: &Self::State<'tcx>) -> ty::ParamEnv<'tcx>;
 
     /// The set of predicates required to mention this item.
-    fn required_predicates<'tcx>(&self, elab_ctx: ElaborationCtx<'tcx>) -> ItemPredicates<'tcx>;
+    fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx>;
 
     /// If this item is a trait, return its Self predicate.
-    fn self_pred<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ty::PolyTraitRef<'tcx>>;
+    fn self_pred<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>>;
 
     /// If this item is typechecked together with its parent (e.g. inline consts and closures),
     /// return that parent.
-    fn typeck_parent<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self>;
+    fn typeck_parent<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self>;
 
     /// If this item is an associated item, return its parent.
-    fn parent_of_assoc<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self>;
+    fn parent_of_assoc<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self>;
 
     /// Whether this item takes an explicit `Self: Trait` clause or whether it is allowed to refer
     /// to the ambiant one. Only relevant for associated items.
-    fn takes_explicit_self_clause(&self, tcx: TyCtxt<'_>) -> bool;
+    fn takes_explicit_self_clause<'tcx>(&self, state: &Self::State<'tcx>) -> bool;
 
     /// If this item is an associated item definition, and the given impl implements it, returns
     /// the implemented associated item.
-    fn find_in_impl<'tcx>(&self, tcx: TyCtxt<'tcx>, trait_impl: DefId) -> Option<Self>;
+    fn find_in_impl<'tcx>(&self, state: &Self::State<'tcx>, trait_impl: DefId) -> Option<Self>;
 }
 
 impl ItemId for DefId {
-    fn from_rust_def_id(def_id: DefId) -> Self {
+    type State<'tcx> = ElaborationCtx<'tcx>;
+
+    fn from_rust_def_id<'tcx>(_: &Self::State<'tcx>, def_id: DefId) -> Self {
         def_id
     }
 
-    fn to_rust_def_id(&self) -> Option<DefId> {
+    fn to_rust_def_id<'tcx>(&self, _: &Self::State<'tcx>) -> Option<DefId> {
         Some(*self)
     }
 
-    fn generics_of<'tcx>(&self, tcx: TyCtxt<'tcx>) -> &'tcx ty::Generics {
+    fn generics_of<'tcx>(&self, state: &Self::State<'tcx>) -> &'tcx ty::Generics {
+        let tcx = state.tcx;
         tcx.generics_of(*self)
     }
 
-    fn param_env<'tcx>(&self, tcx: TyCtxt<'tcx>) -> ty::ParamEnv<'tcx> {
+    fn param_env<'tcx>(&self, state: &Self::State<'tcx>) -> ty::ParamEnv<'tcx> {
+        let tcx = state.tcx;
         tcx.param_env(*self)
     }
 
-    fn required_predicates<'tcx>(&self, elab_ctx: ElaborationCtx<'tcx>) -> ItemPredicates<'tcx> {
-        ItemPredicates::required_recursively(elab_ctx, *self)
+    fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx> {
+        ItemPredicates::required_recursively(*state, *self)
     }
 
-    fn self_pred<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
+    fn self_pred<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
+        let tcx = state.tcx;
         match tcx.def_kind(*self) {
             DefKind::Trait | DefKind::TraitAlias => Some(self_predicate(tcx, *self)),
             _ => None,
         }
     }
 
-    fn typeck_parent<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self> {
+    fn typeck_parent<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = state.tcx;
         tcx.is_typeck_child(*self)
             .then(|| tcx.typeck_root_def_id(*self))
     }
 
-    fn parent_of_assoc<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self> {
+    fn parent_of_assoc<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = state.tcx;
         tcx.def_kind(*self).is_assoc().then(|| tcx.parent(*self))
     }
 
-    fn takes_explicit_self_clause(&self, tcx: TyCtxt<'_>) -> bool {
+    fn takes_explicit_self_clause<'tcx>(&self, state: &Self::State<'tcx>) -> bool {
+        let tcx = state.tcx;
         matches!(
             tcx.def_kind(*self),
             DefKind::AssocFn | DefKind::AssocConst { .. }
         )
     }
 
-    fn find_in_impl<'tcx>(&self, tcx: TyCtxt<'tcx>, trait_impl: DefId) -> Option<Self> {
+    fn find_in_impl<'tcx>(&self, state: &Self::State<'tcx>, trait_impl: DefId) -> Option<Self> {
+        let tcx = state.tcx;
         tcx.associated_items(trait_impl)
             .in_definition_order()
             .find(|item| item.trait_item_def_id() == Some(*self))
@@ -154,6 +166,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// `DefId` of the trait item definition: `core::convert::From::from`.
     pub fn resolve_item_reference(
         &mut self,
+        state: &Id::State<'tcx>,
         def_id: Id,
         generics: ty::GenericArgsRef<'tcx>,
         assoc_item_resolution: AssocItemResolution,
@@ -163,55 +176,56 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
             return entry.clone();
         }
         let item_ref =
-            self.resolve_item_reference_uncached(def_id, generics, assoc_item_resolution);
+            self.resolve_item_reference_uncached(state, def_id, generics, assoc_item_resolution);
         self.item_refs_cache.insert(key, item_ref.clone());
         item_ref
     }
 
     pub(crate) fn resolve_rust_item_reference(
         &mut self,
+        state: &Id::State<'tcx>,
         def_id: DefId,
         generics: ty::GenericArgsRef<'tcx>,
         assoc_item_resolution: AssocItemResolution,
     ) -> ItemRef<'tcx> {
-        let id = Id::from_rust_def_id(def_id);
-        let item_ref = self.resolve_item_reference(id, generics, assoc_item_resolution);
+        let id = Id::from_rust_def_id(state, def_id);
+        let item_ref = self.resolve_item_reference(state, id, generics, assoc_item_resolution);
         item_ref.map_item_id(|id| {
-            id.to_rust_def_id()
+            id.to_rust_def_id(state)
                 .expect("got a virtual DefId from resolving a real one")
         })
     }
 
-    fn resolve_item_reference_uncached<OutId: ItemId>(
+    fn resolve_item_reference_uncached(
         &mut self,
-        mut def_id: OutId,
+        state: &Id::State<'tcx>,
+        mut def_id: Id,
         generics: ty::GenericArgsRef<'tcx>,
         assoc_item_resolution: AssocItemResolution,
-    ) -> ItemRef<'tcx, OutId> {
+    ) -> ItemRef<'tcx, Id> {
         use rustc_infer::infer::canonical::ir::TypeVisitableExt;
-        let elab_ctx = self.elab_ctx;
         let tcx = self.elab_ctx.tcx;
         let typing_env = self.typing_env;
         // Normalize the generics.
         let mut generics = normalize(tcx, typing_env, ty::Unnormalized::new_wip(generics));
 
         // Rustc gives closures/inline consts extra generic for inference that we don't care about.
-        if let Some(parent) = def_id.typeck_parent(tcx) {
-            generics = generics.truncate_to(tcx, parent.generics_of(tcx));
+        if let Some(parent) = def_id.typeck_parent(state) {
+            generics = generics.truncate_to(tcx, parent.generics_of(state));
         }
 
         // If this is an associated item, resolve the trait reference.
         let mut trait_info = if assoc_item_resolution != AssocItemResolution::None
-            && let Some(tr_def_id) = def_id.parent_of_assoc(tcx)
-            && let Some(self_pred) = tr_def_id.self_pred(tcx)
+            && let Some(tr_def_id) = def_id.parent_of_assoc(state)
+            && let Some(self_pred) = tr_def_id.self_pred(state)
         {
             // Substitute to be in the context of the current item.
-            let generics = generics.truncate_to(tcx, tr_def_id.generics_of(tcx));
+            let generics = generics.truncate_to(tcx, tr_def_id.generics_of(state));
             let self_pred = ty::EarlyBinder::bind(self_pred)
                 .instantiate(tcx, generics)
                 .skip_norm_wip();
-            let num_trait_req_clauses = tr_def_id.required_predicates(elab_ctx).len();
-            Some((self.resolve(&self_pred), num_trait_req_clauses))
+            let num_trait_req_clauses = tr_def_id.required_predicates(state).len();
+            Some((self.resolve(state, &self_pred), num_trait_req_clauses))
         } else {
             None
         };
@@ -224,15 +238,15 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         {
             // If the item is implemented, point to it; otherwise the item has a default and we're
             // already pointing to it.
-            if let Some(implemented_item) = def_id.find_in_impl(tcx, impl_item_ref.def_id) {
+            if let Some(implemented_item) = def_id.find_in_impl(state, impl_item_ref.def_id) {
                 def_id = implemented_item;
                 generics = generics.rebase_onto(tcx, tinfo.pred.def_id(), impl_item_ref.generics());
             }
             trait_info = None;
         }
 
-        let trait_proofs = self.resolve_item_required_predicates(def_id.clone(), generics);
-        let needs_explicit_self_clause = def_id.takes_explicit_self_clause(tcx);
+        let trait_proofs = self.resolve_item_required_predicates(state, def_id.clone(), generics);
+        let needs_explicit_self_clause = def_id.takes_explicit_self_clause(state);
 
         let content = ItemRefContents {
             def_id,

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -1,23 +1,113 @@
-use std::{ops::Deref, sync::Arc};
+use std::{fmt::Debug, hash::Hash, ops::Deref, sync::Arc};
 
 use rustc_hir::{def::DefKind, def_id::DefId};
-use rustc_middle::ty::{self, GenericArg, GenericArgsRef};
+use rustc_middle::ty::{self, GenericArg, GenericArgsRef, TyCtxt};
 
 use crate::{
-    ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind, normalize, self_predicate,
+    ElaborationCtx, ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind, normalize,
+    self_predicate,
 };
+
+/// The identifier of an item; generalizes over rustc's `DefId` to allow for virtual items.
+pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
+    /// An identifier that refers to a real Rust item.
+    fn from_rust_def_id(def_id: DefId) -> Self;
+
+    /// If this item corresponds to a real Rust item, return its DefId. Only used to avoid caching
+    /// the same `ItemRef` as both `Id` and `DefId`.
+    fn to_rust_def_id(&self) -> Option<DefId>;
+
+    /// The generics of this item.
+    fn generics_of<'tcx>(&self, tcx: TyCtxt<'tcx>) -> &'tcx ty::Generics;
+
+    /// The clauses that can be assumed when inside this item.
+    fn param_env<'tcx>(&self, tcx: TyCtxt<'tcx>) -> ty::ParamEnv<'tcx>;
+
+    /// The set of predicates required to mention this item.
+    fn required_predicates<'tcx>(&self, elab_ctx: ElaborationCtx<'tcx>) -> ItemPredicates<'tcx>;
+
+    /// If this item is a trait, return its Self predicate.
+    fn self_pred<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ty::PolyTraitRef<'tcx>>;
+
+    /// If this item is typechecked together with its parent (e.g. inline consts and closures),
+    /// return that parent.
+    fn typeck_parent<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self>;
+
+    /// If this item is an associated item, return its parent.
+    fn parent_of_assoc<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self>;
+
+    /// Whether this item takes an explicit `Self: Trait` clause or whether it is allowed to refer
+    /// to the ambiant one. Only relevant for associated items.
+    fn takes_explicit_self_clause(&self, tcx: TyCtxt<'_>) -> bool;
+
+    /// If this item is an associated item definition, and the given impl implements it, returns
+    /// the implemented associated item.
+    fn find_in_impl<'tcx>(&self, tcx: TyCtxt<'tcx>, trait_impl: DefId) -> Option<Self>;
+}
+
+impl ItemId for DefId {
+    fn from_rust_def_id(def_id: DefId) -> Self {
+        def_id
+    }
+
+    fn to_rust_def_id(&self) -> Option<DefId> {
+        Some(*self)
+    }
+
+    fn generics_of<'tcx>(&self, tcx: TyCtxt<'tcx>) -> &'tcx ty::Generics {
+        tcx.generics_of(*self)
+    }
+
+    fn param_env<'tcx>(&self, tcx: TyCtxt<'tcx>) -> ty::ParamEnv<'tcx> {
+        tcx.param_env(*self)
+    }
+
+    fn required_predicates<'tcx>(&self, elab_ctx: ElaborationCtx<'tcx>) -> ItemPredicates<'tcx> {
+        ItemPredicates::required_recursively(elab_ctx, *self)
+    }
+
+    fn self_pred<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
+        match tcx.def_kind(*self) {
+            DefKind::Trait | DefKind::TraitAlias => Some(self_predicate(tcx, *self)),
+            _ => None,
+        }
+    }
+
+    fn typeck_parent<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self> {
+        tcx.is_typeck_child(*self)
+            .then(|| tcx.typeck_root_def_id(*self))
+    }
+
+    fn parent_of_assoc<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Self> {
+        tcx.def_kind(*self).is_assoc().then(|| tcx.parent(*self))
+    }
+
+    fn takes_explicit_self_clause(&self, tcx: TyCtxt<'_>) -> bool {
+        matches!(
+            tcx.def_kind(*self),
+            DefKind::AssocFn | DefKind::AssocConst { .. }
+        )
+    }
+
+    fn find_in_impl<'tcx>(&self, tcx: TyCtxt<'tcx>, trait_impl: DefId) -> Option<Self> {
+        tcx.associated_items(trait_impl)
+            .in_definition_order()
+            .find(|item| item.trait_item_def_id() == Some(*self))
+            .map(|item| item.def_id)
+    }
+}
 
 /// Reference to an item, with generics as well as trait proofs for the required predicates.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct ItemRef<'tcx> {
+pub struct ItemRef<'tcx, Id: ItemId = DefId> {
     // TODO: intern?
-    contents: Arc<ItemRefContents<'tcx>>,
+    contents: Arc<ItemRefContents<'tcx, Id>>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct ItemRefContents<'tcx> {
+pub struct ItemRefContents<'tcx, Id: ItemId = DefId> {
     /// The item being refered to.
-    pub def_id: DefId,
+    pub def_id: Id,
     /// The arguments provided to this item.
     pub generic_args: ty::GenericArgsRef<'tcx>,
     /// Witnesses of the trait clauses required by the item, e.g. `T: Sized` for `Option<T>`.
@@ -26,16 +116,16 @@ pub struct ItemRefContents<'tcx> {
     /// referring to, as well as the number of clauses required to mention the trait (cached for
     /// easy access).
     pub in_trait: Option<(TraitProof<'tcx>, usize)>,
-    /// Whether this item is an associated type.
-    pub is_assoc_ty: bool,
+    /// Whether this item is an associated item that takes an explicit `Self: Trait` clause.
+    pub needs_explicit_self_clause: bool,
     /// Whether this contains any reference to a type/lifetime/const parameter.
     pub has_param: bool,
     /// Whether this contains any reference to a type/const parameter.
     pub has_non_lt_param: bool,
 }
 
-impl<'tcx> ItemRefContents<'tcx> {
-    fn intern(self) -> ItemRef<'tcx> {
+impl<'tcx, Id: ItemId> ItemRefContents<'tcx, Id> {
+    fn intern(self) -> ItemRef<'tcx, Id> {
         ItemRef {
             contents: Arc::new(self),
         }
@@ -52,7 +142,7 @@ pub enum AssocItemResolution {
     ImplItem,
 }
 
-impl<'tcx> PredicateSearcher<'tcx> {
+impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
     /// Construct an `ItemRef` by filling in the trait proofs required to mention said item.
     ///
     /// If `resolve_assoc_item_trait_ref == true` and `(def_id, generics)` points to a trait
@@ -64,14 +154,40 @@ impl<'tcx> PredicateSearcher<'tcx> {
     /// `DefId` of the trait item definition: `core::convert::From::from`.
     pub fn resolve_item_reference(
         &mut self,
-        mut def_id: DefId,
+        def_id: Id,
+        generics: ty::GenericArgsRef<'tcx>,
+        assoc_item_resolution: AssocItemResolution,
+    ) -> ItemRef<'tcx, Id> {
+        let key = (def_id.clone(), generics, assoc_item_resolution);
+        if let Some(entry) = self.item_refs_cache.get(&key) {
+            return entry.clone();
+        }
+        let item_ref =
+            self.resolve_item_reference_uncached(def_id, generics, assoc_item_resolution);
+        self.item_refs_cache.insert(key, item_ref.clone());
+        item_ref
+    }
+
+    pub(crate) fn resolve_rust_item_reference(
+        &mut self,
+        def_id: DefId,
         generics: ty::GenericArgsRef<'tcx>,
         assoc_item_resolution: AssocItemResolution,
     ) -> ItemRef<'tcx> {
-        let key = (def_id, generics, assoc_item_resolution);
-        if let Some(item_ref) = self.item_refs_cache.get(&key).cloned() {
-            return item_ref;
-        }
+        let id = Id::from_rust_def_id(def_id);
+        let item_ref = self.resolve_item_reference(id, generics, assoc_item_resolution);
+        item_ref.map_item_id(|id| {
+            id.to_rust_def_id()
+                .expect("got a virtual DefId from resolving a real one")
+        })
+    }
+
+    fn resolve_item_reference_uncached<OutId: ItemId>(
+        &mut self,
+        mut def_id: OutId,
+        generics: ty::GenericArgsRef<'tcx>,
+        assoc_item_resolution: AssocItemResolution,
+    ) -> ItemRef<'tcx, OutId> {
         use rustc_infer::infer::canonical::ir::TypeVisitableExt;
         let elab_ctx = self.elab_ctx;
         let tcx = self.elab_ctx.tcx;
@@ -79,24 +195,22 @@ impl<'tcx> PredicateSearcher<'tcx> {
         // Normalize the generics.
         let mut generics = normalize(tcx, typing_env, ty::Unnormalized::new_wip(generics));
 
-        if tcx.is_typeck_child(def_id) {
-            // Rustc gives closures/inline consts extra generic for inference that we don't care about.
-            generics = generics.truncate_to(tcx, tcx.generics_of(tcx.typeck_root_def_id(def_id)));
+        // Rustc gives closures/inline consts extra generic for inference that we don't care about.
+        if let Some(parent) = def_id.typeck_parent(tcx) {
+            generics = generics.truncate_to(tcx, parent.generics_of(tcx));
         }
 
         // If this is an associated item, resolve the trait reference.
         let mut trait_info = if assoc_item_resolution != AssocItemResolution::None
-            && let Some(tr_def_id) = tcx.trait_of_assoc(def_id)
+            && let Some(tr_def_id) = def_id.parent_of_assoc(tcx)
+            && let Some(self_pred) = tr_def_id.self_pred(tcx)
         {
-            // The "self" predicate in the context of the trait.
-            let self_pred = self_predicate(tcx, tr_def_id);
             // Substitute to be in the context of the current item.
-            let generics = generics.truncate_to(tcx, tcx.generics_of(tr_def_id));
+            let generics = generics.truncate_to(tcx, tr_def_id.generics_of(tcx));
             let self_pred = ty::EarlyBinder::bind(self_pred)
                 .instantiate(tcx, generics)
                 .skip_norm_wip();
-            let num_trait_req_clauses =
-                ItemPredicates::required_recursively(elab_ctx, tr_def_id).len();
+            let num_trait_req_clauses = tr_def_id.required_predicates(elab_ctx).len();
             Some((self.resolve(&self_pred), num_trait_req_clauses))
         } else {
             None
@@ -108,47 +222,42 @@ impl<'tcx> PredicateSearcher<'tcx> {
             && let Some((tinfo, _)) = &trait_info
             && let TraitProofKind::Concrete(impl_item_ref) = &tinfo.kind
         {
-            let implemented_item = tcx
-                .associated_items(impl_item_ref.def_id)
-                .in_definition_order()
-                .find(|item| item.trait_item_def_id() == Some(def_id));
             // If the item is implemented, point to it; otherwise the item has a default and we're
             // already pointing to it.
-            if let Some(implemented_item) = implemented_item {
-                def_id = implemented_item.def_id;
+            if let Some(implemented_item) = def_id.find_in_impl(tcx, impl_item_ref.def_id) {
+                def_id = implemented_item;
                 generics = generics.rebase_onto(tcx, tinfo.pred.def_id(), impl_item_ref.generics());
             }
             trait_info = None;
         }
 
-        let trait_proofs = self.resolve_item_required_predicates(def_id, generics);
+        let trait_proofs = self.resolve_item_required_predicates(def_id.clone(), generics);
+        let needs_explicit_self_clause = def_id.takes_explicit_self_clause(tcx);
 
         let content = ItemRefContents {
             def_id,
             generic_args: generics,
             trait_proofs,
             in_trait: trait_info,
-            is_assoc_ty: matches!(tcx.def_kind(def_id), DefKind::AssocTy),
+            needs_explicit_self_clause,
             has_param: generics.has_param()
                 || generics.has_escaping_bound_vars()
                 || generics.has_free_regions(),
             has_non_lt_param: generics.has_param(),
         };
-        let item_ref = content.intern();
-        self.item_refs_cache.insert(key, item_ref.clone());
-        item_ref
+        content.intern()
     }
 }
 
-impl<'tcx> ItemRef<'tcx> {
+impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
     /// Construct an `ItemRef` for items that can't have generics (e.g. modules).
-    pub fn dummy_without_generics(def_id: DefId) -> ItemRef<'tcx> {
+    pub fn dummy_without_generics(def_id: Id) -> ItemRef<'tcx, Id> {
         let content = ItemRefContents {
             def_id,
             generic_args: Default::default(),
             trait_proofs: Default::default(),
             in_trait: Default::default(),
-            is_assoc_ty: false,
+            needs_explicit_self_clause: false,
             has_param: false,
             has_non_lt_param: false,
         };
@@ -180,7 +289,12 @@ impl<'tcx> ItemRef<'tcx> {
         let start = if let Some((_, num_trait_req_clauses)) = self.in_trait {
             // Assoc consts and methods get an extra `Self: Trait` clause as the first clause, we
             // skip that one too. Note: that clause is the same as `self.in_trait`.
-            num_trait_req_clauses + if self.is_assoc_ty { 0 } else { 1 }
+            num_trait_req_clauses
+                + if self.needs_explicit_self_clause {
+                    1
+                } else {
+                    0
+                }
         } else {
             0
         };
@@ -188,8 +302,26 @@ impl<'tcx> ItemRef<'tcx> {
     }
 }
 
-impl<'tcx> Deref for ItemRef<'tcx> {
-    type Target = ItemRefContents<'tcx>;
+impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
+    fn map_item_id<OtherId: ItemId>(
+        &self,
+        f: impl FnOnce(&Id) -> OtherId,
+    ) -> ItemRef<'tcx, OtherId> {
+        ItemRefContents {
+            def_id: f(&self.def_id),
+            generic_args: self.generic_args,
+            trait_proofs: self.trait_proofs.clone(),
+            in_trait: self.in_trait,
+            needs_explicit_self_clause: self.needs_explicit_self_clause,
+            has_param: self.has_param,
+            has_non_lt_param: self.has_non_lt_param,
+        }
+        .intern()
+    }
+}
+
+impl<'tcx, Id: ItemId> Deref for ItemRef<'tcx, Id> {
+    type Target = ItemRefContents<'tcx, Id>;
     fn deref(&self) -> &Self::Target {
         &self.contents
     }

--- a/charon/rustc_trait_elaboration/src/item_ref.rs
+++ b/charon/rustc_trait_elaboration/src/item_ref.rs
@@ -4,7 +4,7 @@ use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::ty::{self, GenericArg, GenericArgsRef};
 
 use crate::{
-    ElaborationCtx, ItemPredicates, PredicateSearcher, TraitProof, TraitProofKind,
+    ItemPredicates, PredicateDirection, PredicateSearcher, TraitProof, TraitProofKind,
     inherits_parent_clauses, normalize, self_predicate,
 };
 
@@ -16,22 +16,24 @@ pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
     /// An identifier that refers to a real Rust item.
     fn from_rust_def_id<'tcx>(state: &Self::State<'tcx>, def_id: DefId) -> Self;
 
-    /// If this item corresponds to a real Rust item, return its DefId. Only used to avoid caching
-    /// the same `ItemRef` as both `Id` and `DefId`.
-    fn to_rust_def_id<'tcx>(&self, state: &Self::State<'tcx>) -> Option<DefId>;
-
     /// The generics of this item.
     fn generics_of<'tcx>(&self, state: &Self::State<'tcx>) -> &'tcx ty::Generics;
 
     /// The clauses that can be assumed when inside this item.
     fn param_env<'tcx>(&self, state: &Self::State<'tcx>) -> ty::ParamEnv<'tcx>;
 
-    /// The set of predicates required to mention just this item (without the predicates for its
-    /// parents).
-    fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx>;
+    /// The predicates defined directly on this item.
+    fn predicates_defined_on<'tcx>(
+        &self,
+        state: &Self::State<'tcx>,
+        direction: PredicateDirection,
+    ) -> ItemPredicates<'tcx, Self>;
 
     /// If this item is a trait, return its Self predicate.
     fn self_pred<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>>;
+
+    /// The type of this item as an associated type projection, if it is a trait associated type.
+    fn as_identity_assoc_ty<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::Ty<'tcx>>;
 
     /// If this item is typechecked together with its parent (e.g. inline consts and closures),
     /// return that parent.
@@ -49,69 +51,69 @@ pub trait ItemId: Clone + Debug + Hash + PartialEq + Eq {
 
     /// If this item is an associated item definition, and the given impl implements it, returns
     /// the implemented associated item.
-    fn find_in_impl<'tcx>(&self, state: &Self::State<'tcx>, trait_impl: DefId) -> Option<Self>;
+    fn find_in_impl<'tcx>(&self, state: &Self::State<'tcx>, trait_impl: &Self) -> Option<Self>;
 }
 
 impl ItemId for DefId {
-    type State<'tcx> = ElaborationCtx<'tcx>;
+    type State<'tcx> = ty::TyCtxt<'tcx>;
 
     fn from_rust_def_id<'tcx>(_: &Self::State<'tcx>, def_id: DefId) -> Self {
         def_id
     }
 
-    fn to_rust_def_id<'tcx>(&self, _: &Self::State<'tcx>) -> Option<DefId> {
-        Some(*self)
-    }
-
-    fn generics_of<'tcx>(&self, state: &Self::State<'tcx>) -> &'tcx ty::Generics {
-        let tcx = state.tcx;
+    fn generics_of<'tcx>(&self, tcx: &Self::State<'tcx>) -> &'tcx ty::Generics {
         tcx.generics_of(*self)
     }
 
-    fn param_env<'tcx>(&self, state: &Self::State<'tcx>) -> ty::ParamEnv<'tcx> {
-        let tcx = state.tcx;
+    fn param_env<'tcx>(&self, tcx: &Self::State<'tcx>) -> ty::ParamEnv<'tcx> {
         tcx.param_env(*self)
     }
 
-    fn required_predicates<'tcx>(&self, state: &Self::State<'tcx>) -> ItemPredicates<'tcx> {
-        ItemPredicates::required(*state, *self)
+    fn predicates_defined_on<'tcx>(
+        &self,
+        tcx: &Self::State<'tcx>,
+        direction: PredicateDirection,
+    ) -> ItemPredicates<'tcx, Self> {
+        ItemPredicates::defined_on(*tcx, tcx, *self, direction)
     }
 
-    fn self_pred<'tcx>(&self, state: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
-        let tcx = state.tcx;
+    fn self_pred<'tcx>(&self, tcx: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
         match tcx.def_kind(*self) {
-            DefKind::Trait | DefKind::TraitAlias => Some(self_predicate(tcx, *self)),
+            DefKind::Trait | DefKind::TraitAlias => Some(self_predicate(*tcx, *self)),
             _ => None,
         }
     }
 
-    fn typeck_parent<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
-        let tcx = state.tcx;
+    fn as_identity_assoc_ty<'tcx>(&self, tcx: &Self::State<'tcx>) -> Option<ty::Ty<'tcx>> {
+        (matches!(tcx.def_kind(*self), DefKind::AssocTy)
+            && matches!(tcx.def_kind(tcx.parent(*self)), DefKind::Trait))
+        .then(|| {
+            ty::Ty::new_projection(*tcx, *self, ty::GenericArgs::identity_for_item(*tcx, *self))
+        })
+    }
+
+    fn typeck_parent<'tcx>(&self, tcx: &Self::State<'tcx>) -> Option<Self> {
         tcx.is_typeck_child(*self)
             .then(|| tcx.typeck_root_def_id(*self))
     }
 
-    fn parent_of_assoc<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
-        let tcx = state.tcx;
+    fn parent_of_assoc<'tcx>(&self, tcx: &Self::State<'tcx>) -> Option<Self> {
         tcx.def_kind(*self).is_assoc().then(|| tcx.parent(*self))
     }
 
-    fn parent_for_clauses<'tcx>(&self, state: &Self::State<'tcx>) -> Option<Self> {
-        let tcx = state.tcx;
-        inherits_parent_clauses(tcx, *self).then(|| tcx.parent(*self))
+    fn parent_for_clauses<'tcx>(&self, tcx: &Self::State<'tcx>) -> Option<Self> {
+        inherits_parent_clauses(*tcx, *self).then(|| tcx.parent(*self))
     }
 
-    fn takes_explicit_self_clause<'tcx>(&self, state: &Self::State<'tcx>) -> bool {
-        let tcx = state.tcx;
+    fn takes_explicit_self_clause<'tcx>(&self, tcx: &Self::State<'tcx>) -> bool {
         matches!(
             tcx.def_kind(*self),
             DefKind::AssocFn | DefKind::AssocConst { .. }
         )
     }
 
-    fn find_in_impl<'tcx>(&self, state: &Self::State<'tcx>, trait_impl: DefId) -> Option<Self> {
-        let tcx = state.tcx;
-        tcx.associated_items(trait_impl)
+    fn find_in_impl<'tcx>(&self, tcx: &Self::State<'tcx>, trait_impl: &Self) -> Option<Self> {
+        tcx.associated_items(*trait_impl)
             .in_definition_order()
             .find(|item| item.trait_item_def_id() == Some(*self))
             .map(|item| item.def_id)
@@ -132,11 +134,11 @@ pub struct ItemRefContents<'tcx, Id: ItemId = DefId> {
     /// The arguments provided to this item.
     pub generic_args: ty::GenericArgsRef<'tcx>,
     /// Witnesses of the trait clauses required by the item, e.g. `T: Sized` for `Option<T>`.
-    pub trait_proofs: Vec<TraitProof<'tcx>>,
+    pub trait_proofs: Vec<TraitProof<'tcx, Id>>,
     /// If we're referring to a trait associated item, this gives the trait clause/impl we're
     /// referring to, as well as the number of clauses required to mention the trait (cached for
     /// easy access).
-    pub in_trait: Option<(TraitProof<'tcx>, usize)>,
+    pub in_trait: Option<(TraitProof<'tcx, Id>, usize)>,
     /// Whether this item is an associated item that takes an explicit `Self: Trait` clause.
     pub needs_explicit_self_clause: bool,
     /// Whether this contains any reference to a type/lifetime/const parameter.
@@ -190,21 +192,6 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         item_ref
     }
 
-    pub(crate) fn resolve_rust_item_reference(
-        &mut self,
-        state: &Id::State<'tcx>,
-        def_id: DefId,
-        generics: ty::GenericArgsRef<'tcx>,
-        assoc_item_resolution: AssocItemResolution,
-    ) -> ItemRef<'tcx> {
-        let id = Id::from_rust_def_id(state, def_id);
-        let item_ref = self.resolve_item_reference(state, id, generics, assoc_item_resolution);
-        item_ref.map_item_id(|id| {
-            id.to_rust_def_id(state)
-                .expect("got a virtual DefId from resolving a real one")
-        })
-    }
-
     fn resolve_item_reference_uncached(
         &mut self,
         state: &Id::State<'tcx>,
@@ -248,7 +235,7 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         {
             // If the item is implemented, point to it; otherwise the item has a default and we're
             // already pointing to it.
-            if let Some(implemented_item) = def_id.find_in_impl(state, impl_item_ref.def_id) {
+            if let Some(implemented_item) = def_id.find_in_impl(state, &impl_item_ref.def_id) {
                 def_id = implemented_item;
                 generics = generics.rebase_onto(tcx, tinfo.pred.def_id(), impl_item_ref.generics());
             }
@@ -293,7 +280,7 @@ impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
         self.generic_args
     }
     /// The trait proofs passed to the item.
-    pub fn trait_proofs(&self) -> &[TraitProof<'tcx>] {
+    pub fn trait_proofs(&self) -> &[TraitProof<'tcx, Id>] {
         &self.trait_proofs
     }
     /// The generics passed to the item, except for trait associated items these are only the
@@ -309,7 +296,7 @@ impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
     }
     /// The trait proofs passed to the item, except for trait associated items these are only the
     /// proofs of the method/type/const itself.
-    pub fn assoc_trait_proofs(&self) -> &[TraitProof<'tcx>] {
+    pub fn assoc_trait_proofs(&self) -> &[TraitProof<'tcx, Id>] {
         let start = if let Some((_, num_trait_req_clauses)) = self.in_trait {
             // Assoc consts and methods get an extra `Self: Trait` clause as the first clause, we
             // skip that one too. Note: that clause is the same as `self.in_trait`.
@@ -323,24 +310,6 @@ impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
             0
         };
         &self.trait_proofs[start..]
-    }
-}
-
-impl<'tcx, Id: ItemId> ItemRef<'tcx, Id> {
-    pub fn map_item_id<OtherId: ItemId>(
-        &self,
-        f: impl FnOnce(&Id) -> OtherId,
-    ) -> ItemRef<'tcx, OtherId> {
-        ItemRefContents {
-            def_id: f(&self.def_id),
-            generic_args: self.generic_args,
-            trait_proofs: self.trait_proofs.clone(),
-            in_trait: self.in_trait,
-            needs_explicit_self_clause: self.needs_explicit_self_clause,
-            has_param: self.has_param,
-            has_non_lt_param: self.has_non_lt_param,
-        }
-        .intern()
     }
 }
 

--- a/charon/rustc_trait_elaboration/src/lib.rs
+++ b/charon/rustc_trait_elaboration/src/lib.rs
@@ -65,9 +65,9 @@ pub enum BuiltinTraitData<'tcx> {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum ImpliedPredicate<'tcx> {
+pub enum ImpliedPredicate<'tcx, Id: ItemId = DefId> {
     AssocItem {
-        item: ItemRef<'tcx>,
+        item: ItemRef<'tcx, Id>,
         /// The index of this predicate among the trait predicates returned by `ItemPredicates::Implied`.
         index: usize,
     },
@@ -78,11 +78,11 @@ pub enum ImpliedPredicate<'tcx> {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum TraitProofKind<'tcx> {
+pub enum TraitProofKind<'tcx, Id: ItemId = DefId> {
     /// A concrete `impl Trait for Type {}` item.
-    Concrete(ItemRef<'tcx>),
+    Concrete(ItemRef<'tcx, Id>),
     /// A context-bound clause like `where T: Trait`.
-    LocalBound(ItemPredicateId),
+    LocalBound(ItemPredicateId<Id>),
     /// The automatic clause `Self: Trait` present inside a `impl Trait for Type {}` item.
     SelfProof,
     /// `dyn Trait` is a wrapped value with a virtual table for trait
@@ -101,40 +101,48 @@ pub enum TraitProofKind<'tcx> {
         /// The trait proofs required to satisfy the implied predicates on the trait declaration.
         /// E.g. since `FnMut: FnOnce`, a built-in `T: FnMut` impl would have a proof for
         /// `T: FnOnce`.
-        proofs: Vec<TraitProof<'tcx>>,
+        proofs: Vec<TraitProof<'tcx, Id>>,
         /// The values of the associated types for this trait.
-        types: Vec<(DefId, ty::Ty<'tcx>, Vec<TraitProof<'tcx>>)>,
+        types: Vec<(DefId, ty::Ty<'tcx>, Vec<TraitProof<'tcx, Id>>)>,
     },
     /// A predicate implied by `base` by following `path`.
     Derived {
-        base: TraitProof<'tcx>,
-        path: ImpliedPredicate<'tcx>,
+        base: TraitProof<'tcx, Id>,
+        path: ImpliedPredicate<'tcx, Id>,
     },
     /// An error happened while elaborating traits.
     Error(String),
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct TraitProofContents<'tcx> {
+pub struct TraitProofContents<'tcx, Id: ItemId = DefId> {
     /// The trait predicate this is a proof for.
     pub pred: ty::PolyTraitRef<'tcx>,
     /// The proof.
-    pub kind: TraitProofKind<'tcx>,
+    pub kind: TraitProofKind<'tcx, Id>,
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct TraitProof<'tcx> {
-    contents: Interned<'tcx, TraitProofContents<'tcx>>,
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub struct TraitProof<'tcx, Id: ItemId = DefId> {
+    contents: Interned<'tcx, TraitProofContents<'tcx, Id>>,
 }
 
-impl<'tcx> TraitProof<'tcx> {
-    pub fn contents(&self) -> &TraitProofContents<'tcx> {
+impl<'tcx, Id: ItemId> TraitProof<'tcx, Id> {
+    pub fn contents(&self) -> &TraitProofContents<'tcx, Id> {
         &self.contents
     }
 }
 
-impl<'tcx> Deref for TraitProof<'tcx> {
-    type Target = TraitProofContents<'tcx>;
+impl<'tcx, Id: ItemId> Copy for TraitProof<'tcx, Id> {}
+
+impl<'tcx, Id: ItemId> Clone for TraitProof<'tcx, Id> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'tcx, Id: ItemId> Deref for TraitProof<'tcx, Id> {
+    type Target = TraitProofContents<'tcx, Id>;
     fn deref(&self) -> &Self::Target {
         &self.contents
     }

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -233,7 +233,7 @@ impl<'tcx> ItemPredicates<'tcx> {
             // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
             // Associated types get to use the implicit `Self: Trait` clause instead.
             if let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
-                && def_id.takes_explicit_self_clause(tcx)
+                && def_id.takes_explicit_self_clause(&elab_ctx)
             {
                 let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
                 predicates.predicates.insert(

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -205,7 +205,10 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// ```
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic.
-    pub fn required(elab_ctx: ElaborationCtx<'tcx>, def_id: DefId) -> ItemPredicates<'tcx> {
+    pub fn required<Id: ItemId>(
+        elab_ctx: ElaborationCtx<'tcx, Id>,
+        def_id: DefId,
+    ) -> ItemPredicates<'tcx> {
         elab_ctx.cached_required_predicates(def_id, || {
             use DefKind::*;
             let tcx = elab_ctx.tcx;
@@ -233,7 +236,7 @@ impl<'tcx> ItemPredicates<'tcx> {
             // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
             // Associated types get to use the implicit `Self: Trait` clause instead.
             if let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
-                && def_id.takes_explicit_self_clause(&elab_ctx)
+                && matches!(def_kind, AssocFn | AssocConst { .. })
             {
                 let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
                 predicates.predicates.insert(
@@ -264,12 +267,12 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// }
     /// ```
     pub fn required_recursively(
-        elab_ctx: ElaborationCtx<'tcx>,
+        elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
         def_id: rustc_span::def_id::DefId,
     ) -> ItemPredicates<'tcx> {
         elab_ctx.cached_required_recursively_predicates(def_id, || {
-            fn acc_predicates<'tcx>(
-                elab_ctx: ElaborationCtx<'tcx>,
+            fn acc_predicates<'tcx, Id: ItemId>(
+                elab_ctx: ElaborationCtx<'tcx, Id>,
                 def_id: rustc_span::def_id::DefId,
                 predicates: &mut ItemPredicates<'tcx>,
                 is_parent: bool,
@@ -309,7 +312,10 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// ```
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic and associated type.
-    pub fn implied(elab_ctx: ElaborationCtx<'tcx>, def_id: DefId) -> ItemPredicates<'tcx> {
+    pub fn implied(
+        elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
+        def_id: DefId,
+    ) -> ItemPredicates<'tcx> {
         elab_ctx.cached_implied_predicates(def_id, || {
             use DefKind::*;
             let tcx = elab_ctx.tcx;

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -46,16 +46,22 @@ pub struct BoundsOptions {
     pub remove_traits: HashSet<DefId>,
 }
 
-/// Uniquely identifies a predicate.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum ItemPredicateId {
+pub enum PredicateDirection {
+    Required,
+    Implied,
+}
+
+/// Uniquely identifies a predicate.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum ItemPredicateId<Id = DefId> {
     /// A predicate that counts as "input" for an item, e.g. `where` clauses on a function or impl.
     /// Numbered in some arbitrary but consistent order.
-    Required(DefId, u32),
+    Required(Id, u32),
     /// A predicate that counts as "output" of an item, e.g. supertrait clauses in a trait. Note
     /// that we count `where` clauses on a trait as implied.
     /// Numbered in some arbitrary but consistent order.
-    Implied(DefId, u32),
+    Implied(Id, u32),
     /// Predicate inside a non-item binder, e.g. within a `dyn Trait`.
     /// Numbered in some arbitrary but consistent order.
     Unmapped(u32),
@@ -63,14 +69,13 @@ pub enum ItemPredicateId {
     TraitSelf,
 }
 
-impl ItemPredicateId {
-    fn new(def_id: DefId, required: bool, next_id: &mut usize) -> Self {
+impl<Id> ItemPredicateId<Id> {
+    fn new(def_id: Id, direction: PredicateDirection, next_id: &mut usize) -> Self {
         let i = *next_id as u32;
         *next_id += 1;
-        if required {
-            ItemPredicateId::Required(def_id, i)
-        } else {
-            ItemPredicateId::Implied(def_id, i)
+        match direction {
+            PredicateDirection::Required => ItemPredicateId::Required(def_id, i),
+            PredicateDirection::Implied => ItemPredicateId::Implied(def_id, i),
         }
     }
     fn new_unmapped(next_id: &mut usize) -> Self {
@@ -80,37 +85,47 @@ impl ItemPredicateId {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct ItemPredicate<'tcx> {
-    pub id: ItemPredicateId,
+#[derive(Debug, Clone)]
+pub struct ItemPredicate<'tcx, Id = DefId> {
+    pub id: ItemPredicateId<Id>,
     pub clause: Clause<'tcx>,
     pub span: Span,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ItemPredicates<'tcx> {
-    required: bool,
+#[derive(Debug, Clone)]
+pub struct ItemPredicates<'tcx, Id = DefId> {
+    direction: PredicateDirection,
     next_id: usize,
-    pub predicates: Vec<ItemPredicate<'tcx>>,
+    pub predicates: Vec<ItemPredicate<'tcx, Id>>,
 }
 
-impl<'tcx> ItemPredicates<'tcx> {
-    fn new(
-        def_id: DefId,
-        required: bool,
+impl<'tcx, Id> Default for ItemPredicates<'tcx, Id> {
+    fn default() -> Self {
+        Self {
+            direction: PredicateDirection::Implied,
+            next_id: 0,
+            predicates: Vec::new(),
+        }
+    }
+}
+
+impl<'tcx, Id: ItemId> ItemPredicates<'tcx, Id> {
+    pub fn new(
+        def_id: Id,
+        direction: PredicateDirection,
         predicates: impl IntoIterator<Item = (Clause<'tcx>, Span)>,
     ) -> Self {
         let mut next_id = 0;
         let predicates = predicates
             .into_iter()
             .map(|(clause, span)| {
-                let id = ItemPredicateId::new(def_id, required, &mut next_id);
+                let id = ItemPredicateId::new(def_id.clone(), direction, &mut next_id);
                 ItemPredicate { id, clause, span }
             })
             .collect_vec();
         Self {
             next_id,
-            required,
+            direction,
             predicates,
         }
     }
@@ -125,18 +140,18 @@ impl<'tcx> ItemPredicates<'tcx> {
             .collect_vec();
         Self {
             next_id,
-            required: true,
+            direction: PredicateDirection::Required,
             predicates,
         }
     }
 
     fn add_synthetic_predicates(
         &mut self,
-        def_id: DefId,
+        def_id: Id,
         predicates: impl IntoIterator<Item = Clause<'tcx>>,
     ) {
         self.predicates.extend(predicates.into_iter().map(|clause| {
-            let id = ItemPredicateId::new(def_id, self.required, &mut self.next_id);
+            let id = ItemPredicateId::new(def_id.clone(), self.direction, &mut self.next_id);
             ItemPredicate {
                 id,
                 clause,
@@ -145,17 +160,13 @@ impl<'tcx> ItemPredicates<'tcx> {
         }));
     }
     /// Add `T: Destruct` bounds for every generic parameter of the given item.
-    fn add_destruct_bounds(&mut self, tcx: TyCtxt<'tcx>, def_id: DefId) {
-        let def_kind = tcx.def_kind(def_id);
-        if matches!(def_kind, DefKind::Closure | DefKind::InlineConst) {
-            // Closures and inline consts have fictitious weird type parameters in their `own_args`
-            // that we don't want to add `Destruct` bounds for.
-            return;
-        }
-        // Add a `T: Destruct` bound for every generic.
+    fn add_destruct_bounds(&mut self, tcx: TyCtxt<'tcx>, state: &Id::State<'tcx>, def_id: Id)
+    where
+        Id: ItemId,
+    {
         let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
-        let extra_bounds = tcx
-            .generics_of(def_id)
+        let extra_bounds = def_id
+            .generics_of(state)
             .own_params
             .iter()
             .filter(|param| matches!(param.kind, GenericParamDefKind::Type { .. }))
@@ -180,20 +191,69 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// Returns a list of type predicates for the definition with id `def_id`, including inferred
     /// lifetime constraints. This is the basic list of predicates we use for essentially all
     /// items.
-    fn defined_on(tcx: TyCtxt<'_>, def_id: DefId, required: bool) -> ItemPredicates<'_> {
-        let predicates = tcx
-            .explicit_predicates_of(def_id)
-            .predicates
-            .iter()
-            .copied()
-            .chain(
-                tcx.inferred_outlives_of(def_id)
-                    .iter()
-                    .copied()
-                    .map(|(clause, span)| (clause.upcast(tcx), span)),
-            );
-        ItemPredicates::new(def_id, required, predicates)
+    pub fn defined_on(
+        tcx: TyCtxt<'tcx>,
+        state: &Id::State<'tcx>,
+        def_id: DefId,
+        direction: PredicateDirection,
+    ) -> Self {
+        use DefKind::*;
+        let id = Id::from_rust_def_id(state, def_id);
+        let explicit_predicates_of = || {
+            let predicates = tcx
+                .explicit_predicates_of(def_id)
+                .predicates
+                .iter()
+                .copied()
+                .chain(
+                    tcx.inferred_outlives_of(def_id)
+                        .iter()
+                        .copied()
+                        .map(|(clause, span)| (clause.upcast(tcx), span)),
+                );
+            ItemPredicates::new(id.clone(), direction, predicates)
+        };
+
+        match tcx.def_kind(def_id) {
+            AssocConst { .. }
+            | AssocFn
+            | AssocTy
+            | Const { .. }
+            | Enum
+            | Fn
+            | ForeignTy
+            | Impl { .. }
+            | OpaqueTy
+            | Static { .. }
+            | Struct
+            | TyAlias
+            | Union
+                if direction == PredicateDirection::Required =>
+            {
+                explicit_predicates_of()
+            }
+            // We consider all predicates on traits to be outputs
+            Trait | TraitAlias if direction == PredicateDirection::Implied => {
+                explicit_predicates_of()
+            }
+            AssocTy
+                if direction == PredicateDirection::Implied
+                    && matches!(tcx.def_kind(tcx.parent(def_id)), DefKind::Trait) =>
+            {
+                ItemPredicates::new(
+                    id,
+                    PredicateDirection::Implied,
+                    tcx.explicit_item_bounds(def_id)
+                        .skip_binder()
+                        .iter()
+                        .copied(),
+                )
+            }
+            // `explicit_predicates_of` ICEs on other def kinds.
+            _ => Default::default(),
+        }
     }
+
     /// The predicates that must hold to mention this item (ignoring its parents). E.g.
     ///
     /// ```ignore
@@ -205,53 +265,38 @@ impl<'tcx> ItemPredicates<'tcx> {
     /// ```
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic.
-    pub fn required<Id: ItemId>(
+    pub fn required(
         elab_ctx: ElaborationCtx<'tcx, Id>,
-        def_id: DefId,
-    ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_required_predicates(def_id, || {
-            use DefKind::*;
-            let tcx = elab_ctx.tcx;
+        state: &Id::State<'tcx>,
+        def_id: Id,
+    ) -> Self {
+        elab_ctx.cached_required_predicates(def_id.clone(), || {
             let options = elab_ctx.bounds_options();
-            let def_kind = tcx.def_kind(def_id);
-            let mut predicates = match def_kind {
-                AssocConst { .. }
-                | AssocFn
-                | AssocTy
-                | Const { .. }
-                | Enum
-                | Fn
-                | ForeignTy
-                | Impl { .. }
-                | OpaqueTy
-                | Static { .. }
-                | Struct
-                | TyAlias
-                | Union => Self::defined_on(tcx, def_id, true),
-                // We consider all predicates on traits to be outputs
-                Trait | TraitAlias => Default::default(),
-                // `predicates_defined_on` ICEs on other def kinds.
-                _ => Default::default(),
-            };
+            let mut predicates = def_id.predicates_defined_on(state, PredicateDirection::Required);
             // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
             // Associated types get to use the implicit `Self: Trait` clause instead.
-            if let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
-                && matches!(def_kind, AssocFn | AssocConst { .. })
+            if def_id.takes_explicit_self_clause(state)
+                && let Some(parent) = def_id.parent_of_assoc(state)
+                && let Some(self_clause) = parent.self_pred(state)
             {
-                let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
                 predicates.predicates.insert(
                     0,
                     ItemPredicate {
                         id: ItemPredicateId::TraitSelf,
-                        clause: self_clause,
+                        clause: self_clause.upcast(elab_ctx.tcx),
                         span: DUMMY_SP,
                     },
                 );
             }
-            if options.add_destruct_bounds && !matches!(def_kind, Trait | TraitAlias) {
-                // Add a `T: Destruct` bound for every generic. For traits we consider these predicates
-                // implied instead of required.
-                predicates.add_destruct_bounds(tcx, def_id);
+            let is_trait = def_id.self_pred(state).is_some();
+            // Add a `T: Destruct` bound for every generic. For traits we consider these predicates
+            // implied instead of required.
+            if options.add_destruct_bounds && !is_trait {
+                // Closures and inline consts have fictitious weird type parameters in their
+                // `own_args` that we don't want to add `Destruct` bounds for.
+                if def_id.typeck_parent(state).is_none() {
+                    predicates.add_destruct_bounds(elab_ctx.tcx, state, def_id.clone());
+                }
             }
             predicates.filter_traits(options);
             predicates
@@ -266,22 +311,23 @@ impl<'tcx> ItemPredicates<'tcx> {
     ///     type Type<T: Clone>;
     /// }
     /// ```
-    pub fn required_recursively<Id: ItemId>(
+    pub fn required_recursively(
         elab_ctx: ElaborationCtx<'tcx, Id>,
         state: &Id::State<'tcx>,
         def_id: Id,
-    ) -> ItemPredicates<'tcx> {
+    ) -> Self {
         elab_ctx.cached_required_recursively_predicates(def_id.clone(), || {
             fn acc_predicates<'tcx, Id: ItemId>(
+                elab_ctx: ElaborationCtx<'tcx, Id>,
                 state: &Id::State<'tcx>,
                 def_id: Id,
-                predicates: &mut ItemPredicates<'tcx>,
+                predicates: &mut ItemPredicates<'tcx, Id>,
                 is_parent: bool,
             ) {
                 if let Some(parent) = def_id.parent_for_clauses(state) {
-                    acc_predicates(state, parent, predicates, true);
+                    acc_predicates(elab_ctx, state, parent, predicates, true);
                 }
-                let required = def_id.required_predicates(state);
+                let required = ItemPredicates::required(elab_ctx, state, def_id);
                 predicates.predicates.extend(required.iter());
                 if !is_parent {
                     // Use the next_id that corresponds to the current item.
@@ -290,14 +336,15 @@ impl<'tcx> ItemPredicates<'tcx> {
             }
 
             let mut predicates = Self {
-                required: true,
+                direction: PredicateDirection::Required,
                 next_id: 0,
                 predicates: vec![],
             };
-            acc_predicates(state, def_id, &mut predicates, false);
+            acc_predicates(elab_ctx, state, def_id, &mut predicates, false);
             predicates
         })
     }
+
     /// The predicates that can be deduced from the presence of this item in a signature. We only
     /// consider predicates implied by traits here, not implied bounds such as `&'a T` implying `T:
     /// 'a`. E.g.
@@ -312,83 +359,61 @@ impl<'tcx> ItemPredicates<'tcx> {
     ///
     /// If `add_drop` is true, we add a `T: Drop` bound for every type generic and associated type.
     pub fn implied(
-        elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
-        def_id: DefId,
-    ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_implied_predicates(def_id, || {
-            use DefKind::*;
+        elab_ctx: ElaborationCtx<'tcx, Id>,
+        state: &Id::State<'tcx>,
+        def_id: Id,
+    ) -> Self {
+        elab_ctx.cached_implied_predicates(def_id.clone(), || {
             let tcx = elab_ctx.tcx;
             let options = elab_ctx.bounds_options();
-            let parent = tcx.opt_parent(def_id);
-            let mut predicates = match tcx.def_kind(def_id) {
-                // We consider all predicates on traits to be outputs
-                Trait | TraitAlias => {
-                    let mut predicates = Self::defined_on(tcx, def_id, false);
-                    if options.add_destruct_bounds {
-                        // Add a `T: Drop` bound for every generic, unless the current trait is `Drop` itself, or a
-                        // built-in marker trait that we know doesn't need the bound.
-                        if !matches!(
-                            tcx.as_lang_item(def_id),
-                            Some(
-                                LangItem::Destruct
-                                    | LangItem::Sized
-                                    | LangItem::MetaSized
-                                    | LangItem::PointeeSized
-                                    | LangItem::DiscriminantKind
-                                    | LangItem::PointeeTrait
-                                    | LangItem::Tuple
-                            )
-                        ) {
-                            predicates.add_destruct_bounds(tcx, def_id);
-                        }
+            let mut predicates = def_id.predicates_defined_on(state, PredicateDirection::Implied);
+            if options.add_destruct_bounds {
+                if let Some(pred) = def_id.self_pred(state) {
+                    // Add a `T: Drop` bound for every generic, unless the current trait is `Drop` itself, or a
+                    // built-in marker trait that we know doesn't need the bound.
+                    if !matches!(
+                        tcx.as_lang_item(pred.def_id()),
+                        Some(
+                            LangItem::Destruct
+                                | LangItem::Sized
+                                | LangItem::MetaSized
+                                | LangItem::PointeeSized
+                                | LangItem::DiscriminantKind
+                                | LangItem::PointeeTrait
+                                | LangItem::Tuple
+                        )
+                    ) {
+                        predicates.add_destruct_bounds(tcx, state, def_id.clone());
                     }
-                    predicates
-                }
-                AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
-                    // `skip_binder` is for the GAT `EarlyBinder`
-                    let mut predicates = ItemPredicates::new(
-                        def_id,
-                        false,
-                        tcx.explicit_item_bounds(def_id)
-                            .skip_binder()
-                            .iter()
-                            .copied(),
-                    );
-                    if options.add_destruct_bounds {
-                        // Add a `Drop` bound to the assoc item.
-                        let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
-                        let ty = Ty::new_projection(
-                            tcx,
-                            def_id,
-                            GenericArgs::identity_for_item(tcx, def_id),
-                        );
-                        let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
-                        predicates.add_synthetic_predicates(def_id, [tref.upcast(tcx)]);
-                    }
-                    predicates
-                }
-                _ => ItemPredicates::default(),
-            };
+                } else if let Some(ty) = def_id.as_identity_assoc_ty(state) {
+                    // Add a `Destruct` bound to the associated type itself.
+                    let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
+                    let tref = Binder::dummy(TraitRef::new(tcx, destruct_trait, [ty]));
+                    predicates.add_synthetic_predicates(def_id.clone(), [tref.upcast(tcx)]);
+                };
+            }
             predicates.filter_traits(options);
             predicates
         })
     }
+}
 
+impl<'tcx, Id: Clone> ItemPredicates<'tcx, Id> {
     pub fn len(&self) -> usize {
         self.predicates.len()
     }
-    pub fn iter(&self) -> impl Iterator<Item = ItemPredicate<'tcx>> {
-        self.predicates.iter().copied()
+    pub fn iter(&self) -> impl Iterator<Item = ItemPredicate<'tcx, Id>> + '_ {
+        self.predicates.iter().cloned()
     }
     pub fn iter_trait_clauses(
         &self,
-    ) -> impl Iterator<Item = (ItemPredicateId, PolyTraitRef<'tcx>)> {
+    ) -> impl Iterator<Item = (ItemPredicateId<Id>, PolyTraitRef<'tcx>)> + '_ {
         self.iter().filter_map(|pred| {
             let tref = pred.clause.as_trait_clause()?.to_poly_trait_ref();
             Some((pred.id, tref))
         })
     }
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ItemPredicate<'tcx>> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ItemPredicate<'tcx, Id>> {
         self.predicates.iter_mut()
     }
 

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -35,7 +35,7 @@ use rustc_middle::ty::{self, *};
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span};
 
-use crate::{ElaborationCtx, ToPolyTraitRef};
+use crate::{ElaborationCtx, ItemId, ToPolyTraitRef};
 
 #[derive(Debug, Default, Clone)]
 pub struct BoundsOptions {
@@ -232,8 +232,8 @@ impl<'tcx> ItemPredicates<'tcx> {
             };
             // For methods and assoc consts in trait definitions, we add an explicit `Self: Trait` clause.
             // Associated types get to use the implicit `Self: Trait` clause instead.
-            if !matches!(def_kind, AssocTy)
-                && let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
+            if let Some(trait_def_id) = tcx.trait_of_assoc(def_id)
+                && def_id.takes_explicit_self_clause(tcx)
             {
                 let self_clause = self_predicate(tcx, trait_def_id).upcast(tcx);
                 predicates.predicates.insert(

--- a/charon/rustc_trait_elaboration/src/predicates.rs
+++ b/charon/rustc_trait_elaboration/src/predicates.rs
@@ -266,23 +266,22 @@ impl<'tcx> ItemPredicates<'tcx> {
     ///     type Type<T: Clone>;
     /// }
     /// ```
-    pub fn required_recursively(
-        elab_ctx: ElaborationCtx<'tcx, impl ItemId>,
-        def_id: rustc_span::def_id::DefId,
+    pub fn required_recursively<Id: ItemId>(
+        elab_ctx: ElaborationCtx<'tcx, Id>,
+        state: &Id::State<'tcx>,
+        def_id: Id,
     ) -> ItemPredicates<'tcx> {
-        elab_ctx.cached_required_recursively_predicates(def_id, || {
+        elab_ctx.cached_required_recursively_predicates(def_id.clone(), || {
             fn acc_predicates<'tcx, Id: ItemId>(
-                elab_ctx: ElaborationCtx<'tcx, Id>,
-                def_id: rustc_span::def_id::DefId,
+                state: &Id::State<'tcx>,
+                def_id: Id,
                 predicates: &mut ItemPredicates<'tcx>,
                 is_parent: bool,
             ) {
-                let tcx = elab_ctx.tcx;
-                if inherits_parent_clauses(tcx, def_id) {
-                    let parent = tcx.parent(def_id);
-                    acc_predicates(elab_ctx, parent, predicates, true);
+                if let Some(parent) = def_id.parent_for_clauses(state) {
+                    acc_predicates(state, parent, predicates, true);
                 }
-                let required = ItemPredicates::required(elab_ctx, def_id);
+                let required = def_id.required_predicates(state);
                 predicates.predicates.extend(required.iter());
                 if !is_parent {
                     // Use the next_id that corresponds to the current item.
@@ -295,7 +294,7 @@ impl<'tcx> ItemPredicates<'tcx> {
                 next_id: 0,
                 predicates: vec![],
             };
-            acc_predicates(elab_ctx, def_id, &mut predicates, false);
+            acc_predicates(state, def_id, &mut predicates, false);
             predicates
         })
     }
@@ -410,7 +409,7 @@ pub fn self_predicate<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> PolyTraitRef<'t
     Binder::dummy(TraitRef::identity(tcx, def_id))
 }
 
-fn inherits_parent_clauses<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
+pub fn inherits_parent_clauses<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
     use DefKind::*;
     matches!(
         tcx.def_kind(def_id),

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -11,7 +11,7 @@ use rustc_interface::Config;
 use rustc_interface::interface::Compiler;
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
-use rustc_session::config::{OutputType, OutputTypes};
+use rustc_session::config::OutputTypes;
 use rustc_span::ErrorGuaranteed;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, fmt};
@@ -53,12 +53,10 @@ fn set_parallel_frontend(config: &mut Config) {
     }
 }
 
-/// Don't even try to codegen. This avoids errors due to checking if the output filename is
-/// available (despite the fact that we won't emit it because we stop compilation early).
-fn set_no_codegen(config: &mut Config) {
+/// Don't even try to codegen or emit rustc artifacts.
+fn suppress_codegen_outputs(config: &mut Config) {
     config.opts.unstable_opts.no_codegen = true;
-    // Only emit metadata.
-    config.opts.output_types = OutputTypes::new(&[(OutputType::Metadata, None)]);
+    config.opts.output_types = OutputTypes::new(&[]);
 }
 
 // We use a static to be able to pass data to `override_queries`.
@@ -75,7 +73,12 @@ fn skip_borrowck_if_set(providers: &mut Providers) {
     }
 }
 
-fn setup_compiler(config: &mut Config, options: &CliOpts, do_translate: bool) {
+fn setup_compiler(
+    config: &mut Config,
+    options: &CliOpts,
+    do_translate: bool,
+    emit_artifacts: bool,
+) {
     if do_translate {
         if options.skip_borrowck {
             // We use a static to be able to pass data to `override_queries`.
@@ -94,7 +97,9 @@ fn setup_compiler(config: &mut Config, options: &CliOpts, do_translate: bool) {
             // };
         });
 
-        set_no_codegen(config);
+        if !emit_artifacts {
+            suppress_codegen_outputs(config);
+        }
         set_parallel_frontend(config);
     }
     set_mir_options(config);
@@ -135,6 +140,14 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
     // Retreive the command-line arguments pased to `charon_driver`. The first arg is the path to
     // the current executable, we skip it.
     let mut compiler_args: Vec<String> = env::args().skip(1).collect();
+    // We use `RUSTC_WORKSPACE_WRAPPER` to break cargo's caching; that value ends up as our first
+    // argument.
+    if compiler_args
+        .first()
+        .is_some_and(|arg| arg.starts_with("charon-dont-cache-this-"))
+    {
+        compiler_args.remove(0);
+    }
     trace!(
         "charon-driver called with args: {}",
         compiler_args.iter().format(" ")
@@ -167,7 +180,7 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
 
         // Retrieve the Charon options by deserializing them from the environment variable
         // (cargo-charon serialized the arguments and stored them in a specific environment
-        // variable before calling cargo with RUSTC_WRAPPER=charon-driver).
+        // variable before calling cargo with `RUSTC_WRAPPER=charon-driver`).
         let mut options: options::CliOpts = match env::var(options::CHARON_ARGS) {
             Ok(opts) => serde_json::from_str(opts.as_str()).unwrap(),
             Err(_) => {
@@ -192,6 +205,7 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
         // Call the Rust compiler with our custom callback.
         let mut callback = CharonCallbacks {
             options: &options,
+            emit_artifacts: env::var("CHARON_USING_CARGO").is_ok(),
             error_ctx: Some(error_ctx),
             transform_ctx: None,
         };
@@ -206,6 +220,9 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
 /// The callbacks for Charon
 pub struct CharonCallbacks<'a> {
     options: &'a CliOpts,
+    /// Whether rustc should emit the artifacts requested by its command line. This is needed under
+    /// cargo so later crate invocations can consume earlier selected crates.
+    emit_artifacts: bool,
     /// Context for errors; `take()`n by translation.
     error_ctx: Option<ErrorCtx>,
     /// This is to be filled during the extraction; it contains the translated crate. `None` at the
@@ -214,7 +231,7 @@ pub struct CharonCallbacks<'a> {
 }
 impl<'a> Callbacks for CharonCallbacks<'a> {
     fn config(&mut self, config: &mut Config) {
-        setup_compiler(config, self.options, true);
+        setup_compiler(config, self.options, true, self.emit_artifacts);
     }
 
     /// The MIR is modified in place: borrow-checking requires the "promoted" MIR, which causes the
@@ -240,10 +257,6 @@ impl<'a> Callbacks for CharonCallbacks<'a> {
 
         Compilation::Continue
     }
-    fn after_analysis<'tcx>(&mut self, _: &Compiler, _: TyCtxt<'tcx>) -> Compilation {
-        // Don't continue to codegen etc.
-        Compilation::Stop
-    }
 }
 
 /// Dummy callbacks used to run the compiler normally when we shouldn't be analyzing the crate.
@@ -251,7 +264,7 @@ pub struct RunCompilerNormallyCallbacks;
 
 impl Callbacks for RunCompilerNormallyCallbacks {
     fn config(&mut self, config: &mut Config) {
-        setup_compiler(config, &Default::default(), false);
+        setup_compiler(config, &Default::default(), false, true);
     }
 }
 

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -306,7 +306,10 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
     fn with_cache<T>(&self, f: impl FnOnce(&mut ItemCache<'tcx>) -> T) -> T {
         self.with_item_cache(&self.owner(), f)
     }
-    fn with_predicate_searcher<T>(&self, f: impl FnOnce(&mut PredicateSearcher<'tcx>) -> T) -> T {
+    fn with_predicate_searcher<T>(
+        &self,
+        f: impl FnOnce(&mut PredicateSearcher<'tcx>, &ElaborationCtx<'tcx>) -> T,
+    ) -> T {
         let s = self;
         let base = s.base();
         let owner = s.owner();
@@ -324,11 +327,11 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
                         predicate_searcher.insert_bound_predicates(predicates.iter());
                         predicate_searcher
                     });
-                f(predicate_searcher)
+                f(predicate_searcher, &base.elab_ctx)
             })
         } else {
             let mut predicate_searcher = base.elab_ctx.predicate_searcher_for(s.owner_id());
-            f(&mut predicate_searcher)
+            f(&mut predicate_searcher, &base.elab_ctx)
         }
     }
 }

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -94,10 +94,8 @@ mod types {
         pub def_ids: HashMap<RDefId, DefId>,
         /// Map that recovers rustc args for a given `ItemRef`.
         pub reverse_item_refs_map: HashMap<ItemRef, ty::GenericArgsRef<'tcx>>,
-        /// We create some artificial items; their def_ids are stored here. See the
-        /// `synthetic_items` module.
-        pub synthetic_def_ids: HashMap<SyntheticItem, RDefId>,
-        pub reverse_synthetic_map: HashMap<RDefId, SyntheticItem>,
+        /// Data for synthetic items. See the `synthetic_items` module.
+        pub synthetic_item_data: HashMap<SyntheticItem, SyntheticItemData<'tcx>>,
         /// Cached names and disambiguators for crate names.
         pub disambiguated_crate_names: Option<FxHashMap<CrateNum, (Symbol, u32)>>,
     }

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -166,8 +166,6 @@ mod types {
         pub trait_proofs: HashMap<ty::PolyTraitRef<'tcx>, crate::hax::traits::TraitProof>,
         /// Generics for this item, if it is virtual.
         pub virtual_generics: Option<&'tcx ty::Generics>,
-        /// Predicate searcher for this item, if it is virtual.
-        pub virtual_predicate_searcher: Option<PredicateSearcher<'tcx>>,
     }
 
     #[derive(Clone)]
@@ -176,7 +174,7 @@ mod types {
         pub local_ctx: Rc<RefCell<LocalContextS>>,
         pub opt_def_id: Option<rustc_hir::def_id::DefId>,
         pub cache: Rc<RefCell<GlobalCache<'tcx>>>,
-        pub elab_ctx: crate::hax::traits::ElaborationCtx<'tcx>,
+        pub elab_ctx: crate::hax::traits::ElaborationCtx<'tcx, DefId>,
         pub tcx: ty::TyCtxt<'tcx>,
     }
 
@@ -250,6 +248,15 @@ pub trait BaseState<'tcx>: HasBase<'tcx> + Clone {
         let owner = &owner_id.sinto(self);
         Self::with_hax_owner(self, owner)
     }
+
+    /// State with only access to the global state.
+    fn base_state(&self) -> StateWithBase<'tcx> {
+        State {
+            base: self.base(),
+            owner: (),
+            binder: (),
+        }
+    }
 }
 impl<'tcx, T: HasBase<'tcx> + Clone> BaseState<'tcx> for T {}
 
@@ -308,33 +315,14 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
     }
     fn with_predicate_searcher<T>(
         &self,
-        f: impl FnOnce(&mut PredicateSearcher<'tcx>, &ElaborationCtx<'tcx>) -> T,
+        f: impl FnOnce(&mut PredicateSearcher<'tcx>, &StateWithBase<'tcx>) -> T,
     ) -> T {
         let s = self;
         let base = s.base();
         let owner = s.owner();
-        if let DefIdBase::ImplAssocItem(id) = owner.base {
-            let param_env = owner.param_env(s);
-            let predicates = owner.required_predicates(s);
-            s.with_cache(|cache| {
-                let predicate_searcher =
-                    cache.virtual_predicate_searcher.get_or_insert_with(|| {
-                        let mut predicate_searcher = base
-                            .elab_ctx
-                            .predicate_searcher_for(&base.elab_ctx, id.trait_impl_id)
-                            .clone();
-                        predicate_searcher.set_param_env(param_env);
-                        predicate_searcher.insert_bound_predicates(predicates.iter());
-                        predicate_searcher
-                    });
-                f(predicate_searcher, &base.elab_ctx)
-            })
-        } else {
-            let mut predicate_searcher = base
-                .elab_ctx
-                .predicate_searcher_for(&base.elab_ctx, s.owner_id());
-            f(&mut predicate_searcher, &base.elab_ctx)
-        }
+        let base_state = s.base_state();
+        let mut predicate_searcher = base.elab_ctx.predicate_searcher_for(&base_state, owner);
+        f(&mut predicate_searcher, &base_state)
     }
 }
 impl<'tcx, S: UnderOwnerState<'tcx>> WithItemCacheExt<'tcx> for S {}

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -262,9 +262,6 @@ impl<'tcx, T: HasBase<'tcx> + Clone> BaseState<'tcx> for T {}
 
 /// State of anything below an `owner`.
 pub trait UnderOwnerState<'tcx>: BaseState<'tcx> + HasOwner {
-    fn owner_id(&self) -> RDefId {
-        self.owner().as_real_promoted_or_synthetic()
-    }
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.owner().param_env(self)
     }

--- a/charon/src/bin/charon-driver/hax/state.rs
+++ b/charon/src/bin/charon-driver/hax/state.rs
@@ -321,7 +321,7 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
                     cache.virtual_predicate_searcher.get_or_insert_with(|| {
                         let mut predicate_searcher = base
                             .elab_ctx
-                            .predicate_searcher_for(id.trait_impl_id)
+                            .predicate_searcher_for(&base.elab_ctx, id.trait_impl_id)
                             .clone();
                         predicate_searcher.set_param_env(param_env);
                         predicate_searcher.insert_bound_predicates(predicates.iter());
@@ -330,7 +330,9 @@ pub trait WithItemCacheExt<'tcx>: UnderOwnerState<'tcx> {
                 f(predicate_searcher, &base.elab_ctx)
             })
         } else {
-            let mut predicate_searcher = base.elab_ctx.predicate_searcher_for(s.owner_id());
+            let mut predicate_searcher = base
+                .elab_ctx
+                .predicate_searcher_for(&base.elab_ctx, s.owner_id());
             f(&mut predicate_searcher, &base.elab_ctx)
         }
     }

--- a/charon/src/bin/charon-driver/hax/traits.rs
+++ b/charon/src/bin/charon-driver/hax/traits.rs
@@ -4,7 +4,8 @@ use rustc_span::def_id::DefId as RDefId;
 pub use rustc_trait_elaboration as elaboration;
 pub use rustc_trait_elaboration::{
     AssocItemResolution, ElaborationCtx, ItemId, ItemPredicate, ItemPredicateId, ItemPredicates,
-    ToPolyTraitRef, erase_and_norm, erase_free_regions, normalize, self_predicate,
+    PredicateDirection, ToPolyTraitRef, erase_and_norm, erase_free_regions, normalize,
+    self_predicate,
 };
 
 use crate::hax::prelude::*;
@@ -13,7 +14,7 @@ use charon_lib::ast::HashConsed;
 pub type PredicateSearcher<'tcx> = elaboration::PredicateSearcher<'tcx, DefId>;
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::ImpliedPredicate<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::ImpliedPredicate<'tcx, DefId>, state: S as s)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TraitProofImpliedPredicate {
     AssocItem {
@@ -37,7 +38,7 @@ pub enum TraitProofImpliedPredicate {
 /// The source of a particular trait implementation. Most often this is either `Concrete` for a
 /// concrete `impl Trait for Type {}` item, or `LocalBound` for a context-bound `where T: Trait`.
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::TraitProofKind<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::TraitProofKind<'tcx, DefId>, state: S as s)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TraitProofKind {
     /// A concrete `impl Trait for Type {}` item.
@@ -116,7 +117,7 @@ pub enum DestructData {
 pub type TraitProof = HashConsed<TraitProofContents>;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::TraitProofContents<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::TraitProofContents<'tcx, DefId>, state: S as s)]
 pub struct TraitProofContents {
     /// The trait predicate this is an impl for.
     pub pred: Binder<TraitRef>,
@@ -124,7 +125,7 @@ pub struct TraitProofContents {
     pub kind: TraitProofKind,
 }
 
-impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, TraitProof> for elaboration::TraitProof<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, TraitProof> for elaboration::TraitProof<'tcx, DefId> {
     fn sinto(&self, s: &S) -> TraitProof {
         HashConsed::new(self.contents().sinto(s))
     }
@@ -197,7 +198,7 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<TraitProof> {
-    let predicates = ItemPredicates::implied(s.base().elab_ctx, def_id);
+    let predicates = ItemPredicates::implied(s.base().elab_ctx, &s.base_state(), def_id.sinto(s));
     solve_item_traits_inner(s, generics, predicates)
 }
 
@@ -206,7 +207,7 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
 fn solve_item_traits_inner<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     generics: ty::GenericArgsRef<'tcx>,
-    predicates: ItemPredicates<'tcx>,
+    predicates: ItemPredicates<'tcx, DefId>,
 ) -> Vec<TraitProof> {
     let tcx = s.base().tcx;
     let typing_env = s.typing_env();

--- a/charon/src/bin/charon-driver/hax/traits.rs
+++ b/charon/src/bin/charon-driver/hax/traits.rs
@@ -170,7 +170,9 @@ pub fn solve_trait<'tcx, S: UnderOwnerState<'tcx>>(
     if let Some(trait_proof) = s.with_cache(|cache| cache.trait_proofs.get(&trait_ref).cloned()) {
         return trait_proof;
     }
-    let trait_proof = s.with_predicate_searcher(|pred_searcher| pred_searcher.resolve(&trait_ref));
+    let trait_proof = s.with_predicate_searcher(|pred_searcher, elab_ctx| {
+        pred_searcher.resolve(elab_ctx, &trait_ref)
+    });
     let trait_proof: TraitProof = trait_proof.sinto(s);
     s.with_cache(|cache| cache.trait_proofs.insert(trait_ref, trait_proof.clone()));
     trait_proof

--- a/charon/src/bin/charon-driver/hax/traits.rs
+++ b/charon/src/bin/charon-driver/hax/traits.rs
@@ -3,13 +3,14 @@ use rustc_span::def_id::DefId as RDefId;
 
 pub use rustc_trait_elaboration as elaboration;
 pub use rustc_trait_elaboration::{
-    AssocItemResolution, ElaborationCtx, ItemPredicate, ItemPredicateId, ItemPredicates,
-    PredicateSearcher, ToPolyTraitRef, erase_and_norm, erase_free_regions, normalize,
-    self_predicate,
+    AssocItemResolution, ElaborationCtx, ItemId, ItemPredicate, ItemPredicateId, ItemPredicates,
+    ToPolyTraitRef, erase_and_norm, erase_free_regions, normalize, self_predicate,
 };
 
 use crate::hax::prelude::*;
 use charon_lib::ast::HashConsed;
+
+pub type PredicateSearcher<'tcx> = elaboration::PredicateSearcher<'tcx, DefId>;
 
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: elaboration::ImpliedPredicate<'tcx>, state: S as s)]

--- a/charon/src/bin/charon-driver/hax/types/def_id.rs
+++ b/charon/src/bin/charon-driver/hax/types/def_id.rs
@@ -297,18 +297,6 @@ impl DefId {
             _ => None,
         }
     }
-    /// The def_id of this item, or its parent if this is a promoted constant, or a made-up `DefId`
-    /// for synthetic items.
-    pub fn as_real_promoted_or_synthetic(&self) -> RDefId {
-        match self.base {
-            DefIdBase::Real(did) | DefIdBase::Promoted(did, ..) | DefIdBase::Synthetic(.., did) => {
-                did
-            }
-            DefIdBase::ImplAssocItem(_) => {
-                panic!("expected real, promoted, or synthetic def id, got {self:?}")
-            }
-        }
-    }
     pub fn promoted_id(&self) -> Option<PromotedId> {
         match self.base {
             DefIdBase::Promoted(_, promoted) => Some(promoted),
@@ -329,10 +317,9 @@ impl DefId {
 
     pub fn is_local(&self) -> bool {
         match self.base {
-            DefIdBase::Real(did) | DefIdBase::Promoted(did, ..) | DefIdBase::Synthetic(.., did) => {
-                did.is_local()
-            }
+            DefIdBase::Real(did) | DefIdBase::Promoted(did, ..) => did.is_local(),
             DefIdBase::ImplAssocItem(id) => id.trait_impl_id.is_local(),
+            DefIdBase::Synthetic(..) => false,
         }
     }
     pub fn is_typeck_child<'tcx>(&self, s: &impl BaseState<'tcx>) -> bool {
@@ -762,7 +749,7 @@ impl<'s, S: BaseState<'s>> SInto<S, DefId> for RDefId {
 #[args(<'ctx, S: UnderOwnerState<'ctx>>, from: rustc_hir::definitions::DefPathData, state: S as s)]
 pub enum DefPathItem {
     CrateRoot {
-        #[value(s.base().tcx.crate_name(s.owner_id().krate).sinto(s))]
+        #[value(s.owner().crate_name(s))]
         name: Symbol,
     },
     Impl,

--- a/charon/src/bin/charon-driver/hax/types/def_id.rs
+++ b/charon/src/bin/charon-driver/hax/types/def_id.rs
@@ -13,7 +13,6 @@ use charon_lib::ast::HashConsed;
 use itertools::Itertools;
 pub use rustc_middle::mir::Promoted as PromotedId;
 use rustc_span::DUMMY_SP;
-use rustc_trait_elaboration::inherits_parent_clauses;
 use {rustc_hir as hir, rustc_hir::def_id::DefId as RDefId, rustc_middle::ty};
 
 sinto_reexport!(hir::Safety);
@@ -101,10 +100,8 @@ pub enum DefIdBase {
     /// declared method generics to implemented method generics.
     ImplAssocItem(VirtualImplAssocItem),
     /// A completely fictitious item, we use this for arrays, slices and tuples to make
-    /// monomorphization and other shenanigans easier. The contained DefId is created using
-    /// `create_def`.
-    /// FIXME: remove that DefId, it causes ICEs if we try to go to codegen/rlib generation.
-    Synthetic(SyntheticItem, RDefId),
+    /// monomorphization and other shenanigans easier.
+    Synthetic(SyntheticItem),
 }
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
@@ -186,10 +183,6 @@ impl rustc_trait_elaboration::ItemId for DefId {
         def_id.sinto(s)
     }
 
-    fn to_rust_def_id<'tcx>(&self, _s: &Self::State<'tcx>) -> Option<RDefId> {
-        self.as_real_def_id()
-    }
-
     fn generics_of<'tcx>(&self, s: &Self::State<'tcx>) -> &'tcx ty::Generics {
         DefId::generics_of(self, s)
     }
@@ -198,18 +191,38 @@ impl rustc_trait_elaboration::ItemId for DefId {
         DefId::param_env(self, s)
     }
 
-    fn required_predicates<'tcx>(&self, s: &Self::State<'tcx>) -> ItemPredicates<'tcx> {
-        DefId::required_predicates(self, s)
+    fn predicates_defined_on<'tcx>(
+        &self,
+        s: &Self::State<'tcx>,
+        direction: PredicateDirection,
+    ) -> ItemPredicates<'tcx, Self> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id) => ItemPredicates::defined_on(tcx, s, def_id, direction),
+            DefIdBase::ImplAssocItem(id) => {
+                let item_args = id.identity_args_for_item_decl(s);
+                ItemPredicates::defined_on(tcx, s, id.item_decl_id, direction)
+                    .instantiate(tcx, item_args)
+            }
+            DefIdBase::Synthetic(synthetic) => {
+                synthetic.predicates_defined_on(s, self.clone(), direction)
+            }
+            DefIdBase::Promoted(..) => ItemPredicates::new_unmapped(DUMMY_SP, []),
+        }
     }
 
     fn self_pred<'tcx>(&self, s: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id)
-                if matches!(self.kind, DefKind::Trait | DefKind::TraitAlias) =>
-            {
-                Some(self_predicate(tcx, def_id))
-            }
+            DefIdBase::Real(def_id) => def_id.self_pred(&tcx),
+            _ => None,
+        }
+    }
+
+    fn as_identity_assoc_ty<'tcx>(&self, s: &Self::State<'tcx>) -> Option<ty::Ty<'tcx>> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id) => def_id.as_identity_assoc_ty(&tcx),
             _ => None,
         }
     }
@@ -217,9 +230,7 @@ impl rustc_trait_elaboration::ItemId for DefId {
     fn typeck_parent<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id) => tcx
-                .is_typeck_child(def_id)
-                .then(|| tcx.typeck_root_def_id(def_id).sinto(s)),
+            DefIdBase::Real(def_id) => def_id.typeck_parent(&tcx).map(|def_id| def_id.sinto(s)),
             DefIdBase::Promoted(def_id, ..) => Some(tcx.typeck_root_def_id(def_id).sinto(s)),
             DefIdBase::ImplAssocItem(..) | DefIdBase::Synthetic(..) => None,
         }
@@ -228,15 +239,8 @@ impl rustc_trait_elaboration::ItemId for DefId {
     fn parent_of_assoc<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id)
-                if matches!(
-                    self.kind,
-                    DefKind::AssocTy | DefKind::AssocFn | DefKind::AssocConst { .. }
-                ) =>
-            {
-                Some(tcx.parent(def_id).sinto(s))
-            }
-            DefIdBase::ImplAssocItem(id) => Some(tcx.parent(id.item_decl_id).sinto(s)),
+            DefIdBase::Real(def_id) => def_id.parent_of_assoc(&tcx).map(|def_id| def_id.sinto(s)),
+            DefIdBase::ImplAssocItem(id) => Some(id.trait_impl_id.sinto(s)),
             _ => None,
         }
     }
@@ -244,9 +248,9 @@ impl rustc_trait_elaboration::ItemId for DefId {
     fn parent_for_clauses<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id) => {
-                inherits_parent_clauses(tcx, def_id).then(|| self.parent(s).unwrap())
-            }
+            DefIdBase::Real(def_id) => def_id
+                .parent_for_clauses(&tcx)
+                .map(|def_id| def_id.sinto(s)),
             DefIdBase::ImplAssocItem(id) => Some(id.trait_impl_id.sinto(s)),
             DefIdBase::Promoted(def_id, _) => Some(def_id.sinto(s)),
             DefIdBase::Synthetic(..) => None,
@@ -256,22 +260,21 @@ impl rustc_trait_elaboration::ItemId for DefId {
     fn takes_explicit_self_clause<'tcx>(&self, s: &Self::State<'tcx>) -> bool {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Promoted(def_id, ..) => matches!(
-                tcx.def_kind(def_id),
-                hir::def::DefKind::AssocFn | hir::def::DefKind::AssocConst { .. }
-            ),
-            _ => matches!(self.kind, DefKind::AssocFn | DefKind::AssocConst { .. }),
+            DefIdBase::Real(def_id) | DefIdBase::Promoted(def_id, ..) => {
+                def_id.takes_explicit_self_clause(&tcx)
+            }
+            DefIdBase::ImplAssocItem(id) => id.item_decl_id.takes_explicit_self_clause(&tcx),
+            DefIdBase::Synthetic(..) => false,
         }
     }
 
-    fn find_in_impl<'tcx>(&self, s: &Self::State<'tcx>, trait_impl: RDefId) -> Option<Self> {
+    fn find_in_impl<'tcx>(&self, s: &Self::State<'tcx>, trait_impl: &Self) -> Option<Self> {
         let tcx = s.base().tcx;
+        let trait_impl = trait_impl.as_real_def_id()?;
         match self.base {
-            DefIdBase::Real(def_id) => tcx
-                .associated_items(trait_impl)
-                .in_definition_order()
-                .find(|item| item.trait_item_def_id() == Some(def_id))
-                .map(|item| item.def_id.sinto(s)),
+            DefIdBase::Real(def_id) => def_id
+                .find_in_impl(&tcx, &trait_impl)
+                .map(|def_id| def_id.sinto(s)),
             _ => None,
         }
     }
@@ -303,14 +306,10 @@ impl DefId {
             _ => None,
         }
     }
-    /// Returns the [`SyntheticItem`] encoded by a [rustc `DefId`](RDefId), if
-    /// any.
-    ///
-    /// Note that this method relies on rustc indexes, which are session
-    /// specific. See [`Self`] documentation.
+    /// Returns the [`SyntheticItem`] encoded by this hax [`DefId`], if any.
     pub fn as_synthetic<'tcx>(&self, _s: &impl BaseState<'tcx>) -> Option<SyntheticItem> {
         match self.base {
-            DefIdBase::Synthetic(v, _) => Some(v),
+            DefIdBase::Synthetic(v) => Some(v),
             _ => None,
         }
     }
@@ -330,10 +329,7 @@ impl DefId {
     }
 
     fn make<'tcx, S: BaseState<'tcx>>(s: &S, def_id: RDefId) -> Self {
-        let base = match s.with_global_cache(|c| c.reverse_synthetic_map.get(&def_id).copied()) {
-            None => DefIdBase::Real(def_id),
-            Some(synthetic) => return Self::make_synthetic(s, synthetic, def_id),
-        };
+        let base = DefIdBase::Real(def_id);
         let tcx = s.base().tcx;
         let contents = DefIdContents {
             base,
@@ -342,13 +338,9 @@ impl DefId {
         contents.make_def_id(s)
     }
 
-    pub fn make_synthetic<'tcx, S: BaseState<'tcx>>(
-        s: &S,
-        synthetic: SyntheticItem,
-        def_id: RDefId,
-    ) -> Self {
+    pub fn make_synthetic<'tcx, S: BaseState<'tcx>>(s: &S, synthetic: SyntheticItem) -> Self {
         let contents = DefIdContents {
-            base: DefIdBase::Synthetic(synthetic, def_id),
+            base: DefIdBase::Synthetic(synthetic),
             kind: DefKind::Struct,
         };
         contents.make_def_id(s)
@@ -459,7 +451,7 @@ impl DefId {
                     .map(|x| x.sinto(s))
                     .unwrap()
             }
-            DefIdBase::Synthetic(synthetic, ..) => DisambiguatedDefPathItem {
+            DefIdBase::Synthetic(synthetic) => DisambiguatedDefPathItem {
                 disambiguator: 0,
                 data: DefPathItem::TypeNs(Symbol::intern(&synthetic.name())),
             },
@@ -486,15 +478,16 @@ impl DefId {
             | DefIdBase::ImplAssocItem(VirtualImplAssocItem {
                 item_decl_id: def_id,
                 ..
-            })
-            | DefIdBase::Synthetic(.., def_id) => can_have_generics(tcx, def_id),
+            }) => can_have_generics(tcx, def_id),
+            DefIdBase::Synthetic(synthetic) => synthetic.can_have_generics(s),
         }
     }
 
     pub fn generics_of<'tcx>(&self, s: &impl BaseState<'tcx>) -> &'tcx ty::Generics {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id) | DefIdBase::Synthetic(.., def_id) => tcx.generics_of(def_id),
+            DefIdBase::Real(def_id) => tcx.generics_of(def_id),
+            DefIdBase::Synthetic(synthetic) => synthetic.generics_of(s),
             DefIdBase::Promoted(def_id, ..) => s.with_item_cache(self, |cache| {
                 if let Some(generics) = cache.virtual_generics {
                     return generics;
@@ -550,15 +543,14 @@ impl DefId {
     pub fn identity_args<'tcx>(&self, s: &impl BaseState<'tcx>) -> ty::GenericArgsRef<'tcx> {
         let tcx = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id)
-            | DefIdBase::Promoted(def_id, ..)
-            | DefIdBase::Synthetic(.., def_id) => {
+            DefIdBase::Real(def_id) | DefIdBase::Promoted(def_id, ..) => {
                 if can_have_generics(tcx, def_id) {
                     ty::GenericArgs::identity_for_item(tcx, def_id)
                 } else {
                     ty::GenericArgsRef::default()
                 }
             }
+            DefIdBase::Synthetic(synthetic) => synthetic.identity_args(s),
             DefIdBase::ImplAssocItem(_) => panic!(
                 "virtual trait impl associated items do not have a \
                 sensible `identity_args`. consider `identity_args_for_item_decl`"
@@ -578,15 +570,14 @@ impl DefId {
                     .map(|(predicate, _)| predicate.skip_normalization());
                 param_env_from_clauses(tcx, impl_predicates.chain(item_predicates))
             }
-            DefIdBase::Real(def_id)
-            | DefIdBase::Promoted(def_id, ..)
-            | DefIdBase::Synthetic(.., def_id) => {
+            DefIdBase::Real(def_id) | DefIdBase::Promoted(def_id, ..) => {
                 if can_have_generics(tcx, def_id) {
                     tcx.param_env(def_id)
                 } else {
                     ty::ParamEnv::empty()
                 }
             }
+            DefIdBase::Synthetic(synthetic) => synthetic.param_env(s),
         }
     }
 
@@ -594,32 +585,19 @@ impl DefId {
         ty::TypingEnv::new(self.param_env(s), ty::TypingMode::PostAnalysis)
     }
 
-    pub fn required_predicates<'tcx, S: BaseState<'tcx>>(&self, s: &S) -> ItemPredicates<'tcx> {
-        match self.base {
-            DefIdBase::ImplAssocItem(id) => {
-                let tcx = s.base().tcx;
-                let item_args = id.identity_args_for_item_decl(s);
-                let mut predicates = ItemPredicates::required(s.base().elab_ctx, id.item_decl_id);
-                if matches!(self.kind, DefKind::AssocFn) {
-                    predicates
-                        .predicates
-                        .retain(|predicate| !matches!(predicate.id, ItemPredicateId::TraitSelf));
-                }
-                predicates.instantiate(tcx, item_args)
-            }
-            DefIdBase::Real(def_id) | DefIdBase::Synthetic(.., def_id) => {
-                ItemPredicates::required(s.base().elab_ctx, def_id)
-            }
-            DefIdBase::Promoted(..) => ItemPredicates::new_unmapped(DUMMY_SP, []),
-        }
+    pub fn required_predicates<'tcx, S: BaseState<'tcx>>(
+        &self,
+        s: &S,
+    ) -> ItemPredicates<'tcx, Self> {
+        let state = s.base_state();
+        ItemPredicates::required(s.base().elab_ctx, &state, self.clone())
     }
 
     pub fn type_of<'tcx, S: BaseState<'tcx>>(&self, s: &S) -> ty::EarlyBinder<'tcx, ty::Ty<'tcx>> {
         let tcx: ty::TyCtxt<'tcx> = s.base().tcx;
         match self.base {
-            DefIdBase::Real(def_id)
-            | DefIdBase::Promoted(def_id, ..)
-            | DefIdBase::Synthetic(.., def_id) => tcx.type_of(def_id),
+            DefIdBase::Real(def_id) | DefIdBase::Promoted(def_id, ..) => tcx.type_of(def_id),
+            DefIdBase::Synthetic(synthetic) => synthetic.type_of(s),
             DefIdBase::ImplAssocItem(id) => tcx.type_of(id.item_decl_id),
         }
     }
@@ -705,7 +683,7 @@ impl std::fmt::Debug for DefId {
             DefIdBase::Promoted(def_id, promoted) => {
                 write!(f, "{def_id:?}::promoted#{}", promoted.as_u32())
             }
-            DefIdBase::Synthetic(item, _) => write!(f, "{}", item.name()),
+            DefIdBase::Synthetic(item) => write!(f, "{}", item.name()),
             DefIdBase::ImplAssocItem(id) => {
                 write!(f, "{:?}::{:?}", id.trait_impl_id, id.item_decl_id)
             }
@@ -740,6 +718,12 @@ impl<'s, S: BaseState<'s>> SInto<S, DefId> for RDefId {
             cache.def_ids.insert(*self, def_id.clone());
         });
         def_id
+    }
+}
+
+impl<S> SInto<S, DefId> for DefId {
+    fn sinto(&self, _s: &S) -> DefId {
+        self.clone()
     }
 }
 

--- a/charon/src/bin/charon-driver/hax/types/def_id.rs
+++ b/charon/src/bin/charon-driver/hax/types/def_id.rs
@@ -13,6 +13,7 @@ use charon_lib::ast::HashConsed;
 use itertools::Itertools;
 pub use rustc_middle::mir::Promoted as PromotedId;
 use rustc_span::DUMMY_SP;
+use rustc_trait_elaboration::inherits_parent_clauses;
 use {rustc_hir as hir, rustc_hir::def_id::DefId as RDefId, rustc_middle::ty};
 
 sinto_reexport!(hir::Safety);
@@ -175,6 +176,104 @@ impl DefIdContents {
     pub fn make_def_id<'tcx, S: BaseState<'tcx>>(self, _s: &S) -> DefId {
         let contents = HashConsed::new(self);
         DefId { contents }
+    }
+}
+
+impl rustc_trait_elaboration::ItemId for DefId {
+    type State<'tcx> = StateWithBase<'tcx>;
+
+    fn from_rust_def_id<'tcx>(s: &Self::State<'tcx>, def_id: RDefId) -> Self {
+        def_id.sinto(s)
+    }
+
+    fn to_rust_def_id<'tcx>(&self, _s: &Self::State<'tcx>) -> Option<RDefId> {
+        self.as_real_def_id()
+    }
+
+    fn generics_of<'tcx>(&self, s: &Self::State<'tcx>) -> &'tcx ty::Generics {
+        DefId::generics_of(self, s)
+    }
+
+    fn param_env<'tcx>(&self, s: &Self::State<'tcx>) -> ty::ParamEnv<'tcx> {
+        DefId::param_env(self, s)
+    }
+
+    fn required_predicates<'tcx>(&self, s: &Self::State<'tcx>) -> ItemPredicates<'tcx> {
+        DefId::required_predicates(self, s)
+    }
+
+    fn self_pred<'tcx>(&self, s: &Self::State<'tcx>) -> Option<ty::PolyTraitRef<'tcx>> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id)
+                if matches!(self.kind, DefKind::Trait | DefKind::TraitAlias) =>
+            {
+                Some(self_predicate(tcx, def_id))
+            }
+            _ => None,
+        }
+    }
+
+    fn typeck_parent<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id) => tcx
+                .is_typeck_child(def_id)
+                .then(|| tcx.typeck_root_def_id(def_id).sinto(s)),
+            DefIdBase::Promoted(def_id, ..) => Some(tcx.typeck_root_def_id(def_id).sinto(s)),
+            DefIdBase::ImplAssocItem(..) | DefIdBase::Synthetic(..) => None,
+        }
+    }
+
+    fn parent_of_assoc<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id)
+                if matches!(
+                    self.kind,
+                    DefKind::AssocTy | DefKind::AssocFn | DefKind::AssocConst { .. }
+                ) =>
+            {
+                Some(tcx.parent(def_id).sinto(s))
+            }
+            DefIdBase::ImplAssocItem(id) => Some(tcx.parent(id.item_decl_id).sinto(s)),
+            _ => None,
+        }
+    }
+
+    fn parent_for_clauses<'tcx>(&self, s: &Self::State<'tcx>) -> Option<Self> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id) => {
+                inherits_parent_clauses(tcx, def_id).then(|| self.parent(s).unwrap())
+            }
+            DefIdBase::ImplAssocItem(id) => Some(id.trait_impl_id.sinto(s)),
+            DefIdBase::Promoted(def_id, _) => Some(def_id.sinto(s)),
+            DefIdBase::Synthetic(..) => None,
+        }
+    }
+
+    fn takes_explicit_self_clause<'tcx>(&self, s: &Self::State<'tcx>) -> bool {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Promoted(def_id, ..) => matches!(
+                tcx.def_kind(def_id),
+                hir::def::DefKind::AssocFn | hir::def::DefKind::AssocConst { .. }
+            ),
+            _ => matches!(self.kind, DefKind::AssocFn | DefKind::AssocConst { .. }),
+        }
+    }
+
+    fn find_in_impl<'tcx>(&self, s: &Self::State<'tcx>, trait_impl: RDefId) -> Option<Self> {
+        let tcx = s.base().tcx;
+        match self.base {
+            DefIdBase::Real(def_id) => tcx
+                .associated_items(trait_impl)
+                .in_definition_order()
+                .find(|item| item.trait_item_def_id() == Some(def_id))
+                .map(|item| item.def_id.sinto(s)),
+            _ => None,
+        }
     }
 }
 

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -55,7 +55,7 @@ where
     let diagnostic_item;
     let kind;
     match def_id.base {
-        DefIdBase::Synthetic(item, ..) => {
+        DefIdBase::Synthetic(item) => {
             let adt_kind = match item {
                 SyntheticItem::Array => AdtKind::Array,
                 SyntheticItem::Slice => AdtKind::Slice,
@@ -1358,9 +1358,10 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     args: Option<ty::GenericArgsRef<'tcx>>,
 ) -> GenericPredicates {
     let tcx = s.base().tcx;
-    let def_id = s.owner().as_real_def_id().unwrap();
+    let owner = s.owner();
     let typing_env = s.typing_env();
-    let mut implied_predicates = ItemPredicates::implied(s.base().elab_ctx, def_id);
+    let mut implied_predicates =
+        ItemPredicates::implied(s.base().elab_ctx, &s.base_state(), owner.clone());
     if args.is_some() {
         for pred in implied_predicates.iter_mut() {
             pred.clause = substitute(tcx, typing_env, args, pred.clause);

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -486,7 +486,7 @@ fn gen_vtable_sig<'tcx>(
     s: &impl UnderOwnerState<'tcx>,
     args: Option<ty::GenericArgsRef<'tcx>>,
 ) -> Option<PolyFnSig> {
-    let method_def_id = s.owner_id();
+    let method_def_id = s.owner().as_real_def_id().unwrap();
     let tcx = s.base().tcx;
     let assoc_item = tcx.associated_item(method_def_id);
     let container_id = assoc_item.container_id(tcx);
@@ -1238,8 +1238,9 @@ fn get_self_predicate<'tcx, S: UnderOwnerState<'tcx>>(
 ) -> TraitPredicate {
     use ty::Upcast;
     let tcx = s.base().tcx;
+    let def_id = s.owner().as_real_def_id().unwrap();
     let typing_env = s.typing_env();
-    let pred: ty::TraitPredicate = crate::hax::traits::self_predicate(tcx, s.owner_id())
+    let pred: ty::TraitPredicate = self_predicate(tcx, def_id)
         .no_bound_vars()
         .unwrap()
         .upcast(tcx);
@@ -1357,7 +1358,7 @@ fn get_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     args: Option<ty::GenericArgsRef<'tcx>>,
 ) -> GenericPredicates {
     let tcx = s.base().tcx;
-    let def_id = s.owner_id();
+    let def_id = s.owner().as_real_def_id().unwrap();
     let typing_env = s.typing_env();
     let mut implied_predicates = ItemPredicates::implied(s.base().elab_ctx, def_id);
     if args.is_some() {

--- a/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
@@ -156,8 +156,8 @@ impl ItemRef {
             AssocItemResolution::None
         };
         let def_id = hax_def_id.as_real_promoted_or_synthetic();
-        let item_ref = s.with_predicate_searcher(|pred_searcher| {
-            pred_searcher.resolve_item_reference(def_id, generics, assoc_item_resolution)
+        let item_ref = s.with_predicate_searcher(|pred_searcher, elab_ctx| {
+            pred_searcher.resolve_item_reference(elab_ctx, def_id, generics, assoc_item_resolution)
         });
 
         let def_id = if is_real_def_id {

--- a/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
@@ -70,12 +70,6 @@ pub struct ItemRefContents {
     pub has_non_lt_param: bool,
 }
 
-impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ItemRef> for rustc_trait_elaboration::ItemRef<'tcx> {
-    fn sinto(&self, s: &S) -> ItemRef {
-        self.map_item_id(|def_id| def_id.sinto(s)).sinto(s)
-    }
-}
-
 impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ItemRef>
     for rustc_trait_elaboration::ItemRef<'tcx, DefId>
 {

--- a/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/item_ref.rs
@@ -42,11 +42,11 @@ pub struct ItemRef {
 
 /// Contents of `ItemRef`.
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_trait_elaboration::ItemRef<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_trait_elaboration::ItemRef<'tcx, DefId>, state: S as s)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ItemRefContents {
     /// The item being refered to.
-    #[value(self.def_id.sinto(s))]
+    #[value(self.def_id.clone())]
     pub def_id: DefId,
     /// The generics passed to the item. If `in_trait` is `Some`, these are only the generics of
     /// the method/type/const itself; generics for the traits are available in
@@ -71,6 +71,14 @@ pub struct ItemRefContents {
 }
 
 impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ItemRef> for rustc_trait_elaboration::ItemRef<'tcx> {
+    fn sinto(&self, s: &S) -> ItemRef {
+        self.map_item_id(|def_id| def_id.sinto(s)).sinto(s)
+    }
+}
+
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ItemRef>
+    for rustc_trait_elaboration::ItemRef<'tcx, DefId>
+{
     fn sinto(&self, s: &S) -> ItemRef {
         let content: ItemRefContents = self.sinto(s);
         let item = content.intern(s);
@@ -155,25 +163,16 @@ impl ItemRef {
         } else {
             AssocItemResolution::None
         };
-        let def_id = hax_def_id.as_real_promoted_or_synthetic();
-        let item_ref = s.with_predicate_searcher(|pred_searcher, elab_ctx| {
-            pred_searcher.resolve_item_reference(elab_ctx, def_id, generics, assoc_item_resolution)
+        let item_ref = s.with_predicate_searcher(|pred_searcher, state| {
+            pred_searcher.resolve_item_reference(
+                state,
+                hax_def_id.clone(),
+                generics,
+                assoc_item_resolution,
+            )
         });
 
-        let def_id = if is_real_def_id {
-            // This can have changed if the item was normalized to a direct referent to an impl
-            // item.
-            item_ref.def_id.sinto(s)
-        } else {
-            // If the original `DefId` was not real, make sure we keep that around.
-            assert_eq!(item_ref.def_id, def_id);
-            hax_def_id
-        };
-        let content = ItemRefContents {
-            def_id,
-            ..item_ref.sinto(s)
-        };
-
+        let content: ItemRefContents = item_ref.sinto(s);
         let item = content.intern(s);
         s.with_cache(|cache| {
             cache.item_refs.insert(key, item.clone());

--- a/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
@@ -1,7 +1,9 @@
 use crate::hax::prelude::*;
+use crate::translate::resolve_path::def_path_def_ids;
+use charon_lib::name_matcher::NamePattern;
 
+use itertools::Itertools;
 use {
-    rustc_hir::definitions::PerParentDisambiguatorState,
     rustc_middle::ty,
     rustc_span::{DUMMY_SP, Symbol},
     rustc_type_ir::Upcast,
@@ -27,6 +29,43 @@ pub struct SyntheticItemData<'tcx> {
     generics: &'tcx ty::Generics,
     clauses: &'tcx [ty::Clause<'tcx>],
     param_env: ty::ParamEnv<'tcx>,
+}
+
+/// This is a pretty criminal hack: I want to generate `ty::Generics` for my fake items. This
+/// requires `DefId`s for the generic parameters. rustc has an affordance for creating new `DefId`s
+/// (`tcx.create_def()`) but I could not figure out a way to use it that didn't end up ICEing
+/// during metadata encoding. So instead I'm reusing the `DefId`s of the generic parameters of the
+/// `core::array::repeat` function because that function had the right kind of generics.
+#[derive(Clone, Copy)]
+struct GenericParamDefIds {
+    ty: RDefId,
+    ct: RDefId,
+}
+
+impl GenericParamDefIds {
+    fn construct<'tcx>(s: &impl BaseState<'tcx>) -> Self {
+        let tcx = s.base().tcx;
+        let pat = NamePattern::parse("core::array::repeat").unwrap();
+        let repeat = def_path_def_ids(s, &pat, true)
+            .unwrap_or_else(|err| panic!("could not resolve `core::array::repeat`: {err}"))
+            .into_iter()
+            .exactly_one()
+            .unwrap();
+        let generics = tcx.generics_of(repeat);
+        let ty = generics
+            .own_params
+            .iter()
+            .find(|param| matches!(param.kind, ty::GenericParamDefKind::Type { .. }))
+            .unwrap_or_else(|| panic!("`core::array::repeat` has no type parameter"))
+            .def_id;
+        let ct = generics
+            .own_params
+            .iter()
+            .find(|param| matches!(param.kind, ty::GenericParamDefKind::Const { .. }))
+            .unwrap_or_else(|| panic!("`core::array::repeat` has no const parameter"))
+            .def_id;
+        GenericParamDefIds { ty, ct }
+    }
 }
 
 impl SyntheticItem {
@@ -100,7 +139,11 @@ impl SyntheticItem {
     }
 
     fn data<'tcx>(&self, s: &impl BaseState<'tcx>) -> SyntheticItemData<'tcx> {
-        s.with_global_cache(|c| c.synthetic_data(s, *self))
+        if let Some(data) = s.with_global_cache(|c| c.synthetic_item_data.get(self).copied()) {
+            return data;
+        }
+        let borrowed_param_def_ids = GenericParamDefIds::construct(s);
+        s.with_global_cache(|c| c.synthetic_data(s, *self, borrowed_param_def_ids))
     }
 }
 
@@ -109,12 +152,12 @@ impl<'tcx> GlobalCache<'tcx> {
         &mut self,
         s: &impl BaseState<'tcx>,
         item: SyntheticItem,
+        borrowed_param_def_ids: GenericParamDefIds,
     ) -> SyntheticItemData<'tcx> {
         if let Some(data) = self.synthetic_item_data.get(&item) {
             return *data;
         }
         let tcx = s.base().tcx;
-        let mut disambiguator_state = PerParentDisambiguatorState::default();
         let mut generics = ty::Generics {
             parent: None,
             parent_count: 0,
@@ -123,25 +166,17 @@ impl<'tcx> GlobalCache<'tcx> {
             has_self: false,
             has_late_bound_regions: None,
         };
-        // The synthetic item itself is hax-only. We still create rustc defs for its generic
+        // The synthetic item itself is hax-only. We still need rustc defs for its generic
         // parameters because rustc generic params carry a `DefId`, and const params need a
-        // `type_of` entry.
-        let mut mk_param = |name: &str, def_kind, kind| {
+        // `type_of` entry. We do a little compiler crime to get such `DefId`s, see
+        // `GenericParamDefIds`.
+        let mut mk_param = |name: &str, kind: ty::GenericParamDefKind| {
             let name = Symbol::intern(name);
-            let def_name = Symbol::intern(&format!("{}::{name}", item.name()));
-            let param_feed = tcx.create_def(
-                rustc_span::def_id::CRATE_DEF_ID,
-                Some(def_name),
-                def_kind,
-                None,
-                &mut disambiguator_state,
-            );
-            // Avoid ICEs
-            param_feed.def_span(DUMMY_SP);
-            param_feed.feed_hir();
-            param_feed.visibility(ty::Visibility::Public);
-
-            let param_def_id = param_feed.def_id().into();
+            let param_def_id = match kind {
+                ty::GenericParamDefKind::Type { .. } => borrowed_param_def_ids.ty,
+                ty::GenericParamDefKind::Const { .. } => borrowed_param_def_ids.ct,
+                ty::GenericParamDefKind::Lifetime => unreachable!(),
+            };
             let index = generics.own_params.len() as u32;
             let param_def = ty::GenericParamDef {
                 name,
@@ -153,27 +188,21 @@ impl<'tcx> GlobalCache<'tcx> {
             let arg = tcx.mk_param_from_def(&param_def);
             generics.own_params.push(param_def);
             generics.param_def_id_to_index.insert(param_def_id, index);
-            (arg, param_feed)
+            arg
         };
 
         let mut clauses = vec![];
         let sized_trait = tcx.lang_items().sized_trait().unwrap();
         match item {
             SyntheticItem::Array => {
-                let (t_arg, _) = mk_param(
+                let t_arg = mk_param(
                     "T",
-                    rustc_hir::def::DefKind::TyParam,
                     ty::GenericParamDefKind::Type {
                         has_default: false,
                         synthetic: false,
                     },
                 );
-                let (n_arg, n_feed) = mk_param(
-                    "N",
-                    rustc_hir::def::DefKind::ConstParam,
-                    ty::GenericParamDefKind::Const { has_default: false },
-                );
-                n_feed.type_of(ty::EarlyBinder::bind(tcx.types.usize));
+                let n_arg = mk_param("N", ty::GenericParamDefKind::Const { has_default: false });
 
                 let item_ty = t_arg.as_type().unwrap();
                 let len = n_arg.as_const().unwrap();
@@ -184,9 +213,8 @@ impl<'tcx> GlobalCache<'tcx> {
                 clauses.push(len_is_usize.upcast(tcx));
             }
             SyntheticItem::Slice => {
-                let (t_arg, _) = mk_param(
+                let t_arg = mk_param(
                     "T",
-                    rustc_hir::def::DefKind::TyParam,
                     ty::GenericParamDefKind::Type {
                         has_default: false,
                         synthetic: false,
@@ -205,9 +233,8 @@ impl<'tcx> GlobalCache<'tcx> {
                     } else {
                         format!("T{i}")
                     };
-                    let (arg, _) = mk_param(
+                    let arg = mk_param(
                         &name,
-                        rustc_hir::def::DefKind::TyParam,
                         ty::GenericParamDefKind::Type {
                             has_default: false,
                             synthetic: false,

--- a/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
@@ -3,7 +3,7 @@ use crate::hax::prelude::*;
 use {
     rustc_hir::definitions::PerParentDisambiguatorState,
     rustc_middle::ty,
-    rustc_span::{DUMMY_SP, Symbol, def_id::DefId as RDefId},
+    rustc_span::{DUMMY_SP, Symbol},
     rustc_type_ir::Upcast,
 };
 
@@ -22,6 +22,13 @@ pub enum SyntheticItem {
     Tuple(usize),
 }
 
+#[derive(Clone, Copy)]
+pub struct SyntheticItemData<'tcx> {
+    generics: &'tcx ty::Generics,
+    clauses: &'tcx [ty::Clause<'tcx>],
+    param_env: ty::ParamEnv<'tcx>,
+}
+
 impl SyntheticItem {
     pub fn name(&self) -> String {
         match self {
@@ -30,34 +37,84 @@ impl SyntheticItem {
             SyntheticItem::Tuple(n) => format!("<tuple_{n}>"),
         }
     }
+
+    pub fn can_have_generics<'tcx>(&self, s: &impl BaseState<'tcx>) -> bool {
+        !self.generics_of(s).own_params.is_empty()
+    }
+
+    pub fn generics_of<'tcx>(&self, s: &impl BaseState<'tcx>) -> &'tcx ty::Generics {
+        self.data(s).generics
+    }
+
+    pub fn identity_args<'tcx>(&self, s: &impl BaseState<'tcx>) -> ty::GenericArgsRef<'tcx> {
+        let tcx = s.base().tcx;
+        tcx.mk_args_from_iter(
+            self.generics_of(s)
+                .own_params
+                .iter()
+                .map(|param| tcx.mk_param_from_def(param)),
+        )
+    }
+
+    pub fn param_env<'tcx>(&self, s: &impl BaseState<'tcx>) -> ty::ParamEnv<'tcx> {
+        self.data(s).param_env
+    }
+
+    pub fn predicates_defined_on<'tcx>(
+        &self,
+        s: &impl BaseState<'tcx>,
+        def_id: DefId,
+        direction: PredicateDirection,
+    ) -> ItemPredicates<'tcx, DefId> {
+        ItemPredicates::new(
+            def_id,
+            direction,
+            self.data(s)
+                .clauses
+                .iter()
+                .copied()
+                .map(|clause| (clause, DUMMY_SP)),
+        )
+    }
+
+    pub fn type_of<'tcx>(&self, s: &impl BaseState<'tcx>) -> ty::EarlyBinder<'tcx, ty::Ty<'tcx>> {
+        let tcx = s.base().tcx;
+        let args = self.identity_args(s);
+        let type_of = match self {
+            SyntheticItem::Array => {
+                let item_ty = args[0].as_type().unwrap();
+                let len = args[1].as_const().unwrap();
+                ty::Ty::new_array_with_const_len(tcx, item_ty, len)
+            }
+            SyntheticItem::Slice => {
+                let item_ty = args[0].as_type().unwrap();
+                ty::Ty::new_slice(tcx, item_ty)
+            }
+            SyntheticItem::Tuple(_) => {
+                let tys = args.iter().map(|arg| arg.as_type().unwrap());
+                let tys = tcx.arena.alloc_from_iter(tys);
+                ty::Ty::new_tup(tcx, tys)
+            }
+        };
+        ty::EarlyBinder::bind(type_of)
+    }
+
+    fn data<'tcx>(&self, s: &impl BaseState<'tcx>) -> SyntheticItemData<'tcx> {
+        s.with_global_cache(|c| c.synthetic_data(s, *self))
+    }
 }
 
 impl<'tcx> GlobalCache<'tcx> {
-    pub fn get_synthetic_def_id(
+    fn synthetic_data(
         &mut self,
         s: &impl BaseState<'tcx>,
         item: SyntheticItem,
-    ) -> RDefId {
-        if let Some(def_id) = self.synthetic_def_ids.get(&item) {
-            return *def_id;
+    ) -> SyntheticItemData<'tcx> {
+        if let Some(data) = self.synthetic_item_data.get(&item) {
+            return *data;
         }
         let tcx = s.base().tcx;
         let mut disambiguator_state = PerParentDisambiguatorState::default();
-        let name = &item.name();
-        // Create a fake item, to which we'll assign generics and a param_env, which we can
-        // then use to generate the `FullDefKind` we want.
-        let feed = tcx.create_def(
-            rustc_span::def_id::CRATE_DEF_ID,
-            Some(Symbol::intern(name)),
-            rustc_hir::def::DefKind::Struct,
-            None,
-            &mut disambiguator_state,
-        );
-        let def_id = feed.def_id().to_def_id();
-        // Insert the def_ids early so we record them even if we panic later in this function.
-        self.reverse_synthetic_map.insert(def_id, item);
-        self.synthetic_def_ids.insert(item, def_id);
-
         let mut generics = ty::Generics {
             parent: None,
             parent_count: 0,
@@ -66,16 +123,24 @@ impl<'tcx> GlobalCache<'tcx> {
             has_self: false,
             has_late_bound_regions: None,
         };
+        // The synthetic item itself is hax-only. We still create rustc defs for its generic
+        // parameters because rustc generic params carry a `DefId`, and const params need a
+        // `type_of` entry.
         let mut mk_param = |name: &str, def_kind, kind| {
             let name = Symbol::intern(name);
+            let def_name = Symbol::intern(&format!("{}::{name}", item.name()));
             let param_feed = tcx.create_def(
-                feed.def_id(),
-                Some(name),
+                rustc_span::def_id::CRATE_DEF_ID,
+                Some(def_name),
                 def_kind,
                 None,
                 &mut disambiguator_state,
             );
-            param_feed.feed_hir(); // Avoid panics on `local_def_id_to_hir_id`.
+            // Avoid ICEs
+            param_feed.def_span(DUMMY_SP);
+            param_feed.feed_hir();
+            param_feed.visibility(ty::Visibility::Public);
+
             let param_def_id = param_feed.def_id().into();
             let index = generics.own_params.len() as u32;
             let param_def = ty::GenericParamDef {
@@ -112,8 +177,6 @@ impl<'tcx> GlobalCache<'tcx> {
 
                 let item_ty = t_arg.as_type().unwrap();
                 let len = n_arg.as_const().unwrap();
-                let type_of = ty::Ty::new_array_with_const_len(tcx, item_ty, len);
-                feed.type_of(ty::EarlyBinder::bind(type_of));
 
                 let ty_is_sized = ty::TraitRef::new(tcx, sized_trait, [item_ty]);
                 clauses.push(ty_is_sized.upcast(tcx));
@@ -131,8 +194,6 @@ impl<'tcx> GlobalCache<'tcx> {
                 );
 
                 let item_ty = t_arg.as_type().unwrap();
-                let type_of = ty::Ty::new_slice(tcx, item_ty);
-                feed.type_of(ty::EarlyBinder::bind(type_of));
 
                 let ty_is_sized = ty::TraitRef::new(tcx, sized_trait, [item_ty]);
                 clauses.push(ty_is_sized.upcast(tcx));
@@ -156,9 +217,6 @@ impl<'tcx> GlobalCache<'tcx> {
                 });
                 let tys = tcx.arena.alloc_from_iter(tys);
 
-                let type_of = ty::Ty::new_tup(tcx, tys);
-                feed.type_of(ty::EarlyBinder::bind(type_of));
-
                 // All types except the last one are sized.
                 for ty in tys.iter().rev().skip(1).rev() {
                     let arg: ty::GenericArg = (*ty).into();
@@ -168,19 +226,14 @@ impl<'tcx> GlobalCache<'tcx> {
             }
         }
 
-        feed.generics_of(generics);
-        feed.explicit_predicates_of(ty::GenericPredicates {
-            parent: None,
-            predicates: tcx
-                .arena
-                .alloc_from_iter(clauses.iter().map(|cl| (*cl, DUMMY_SP))),
-        });
-        feed.param_env(ty::ParamEnv::new(
-            tcx.mk_clauses_from_iter(clauses.into_iter()),
-        ));
-        feed.feed_hir();
-
-        def_id
+        let clauses = tcx.arena.alloc_from_iter(clauses);
+        let data = SyntheticItemData {
+            generics: Box::leak(Box::new(generics)),
+            clauses,
+            param_env: ty::ParamEnv::new(tcx.mk_clauses_from_iter(clauses.iter().copied())),
+        };
+        self.synthetic_item_data.insert(item, data);
+        data
     }
 }
 
@@ -190,8 +243,7 @@ impl ItemRef {
         synthetic: SyntheticItem,
         generics: ty::GenericArgsRef<'tcx>,
     ) -> ItemRef {
-        let def_id = s.with_global_cache(|c| c.get_synthetic_def_id(s, synthetic));
-        let hax_def_id = DefId::make_synthetic(s, synthetic, def_id);
+        let hax_def_id = DefId::make_synthetic(s, synthetic);
         ItemRef::translate_from_hax_def_id(s, hax_def_id, generics)
     }
 }

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -866,7 +866,7 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
                         let trait_proof = {
                             let poly_trait_ref = proj.rebind(alias_ty.trait_ref(tcx));
                             predicate_searcher
-                                .resolve(&s.base().elab_ctx, &poly_trait_ref)
+                                .resolve(&s.base_state(), &poly_trait_ref)
                                 .sinto(s)
                         };
                         let Term::Ty(ty) = proj.skip_binder().term.sinto(s) else {
@@ -1048,7 +1048,7 @@ pub fn compute_unsizing_metadata<'tcx, S: UnderOwnerState<'tcx>>(
                         .expect("expected a trait predicate in dyn upcast target");
                     ty::Binder::dummy(ty::TraitRef::new(tcx, def_id, [fresh_ty]))
                 };
-                searcher.resolve(&s.base().elab_ctx, &to_pred).sinto(s)
+                searcher.resolve(&s.base_state(), &to_pred).sinto(s)
             });
             UnsizingMetadata::NestedVTable(trait_proof)
         }

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -811,12 +811,12 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
 ) -> DynBinder<R> {
     fn searcher_for_traits<'tcx, S: UnderOwnerState<'tcx>>(
         s: &S,
-        preds: &ItemPredicates<'tcx>,
+        preds: &ItemPredicates<'tcx, DefId>,
     ) -> PredicateSearcher<'tcx> {
         let tcx = s.base().tcx;
         // Populate a predicate searcher that knows about the `dyn` clauses.
         let mut predicate_searcher = s.with_predicate_searcher(|ps, _| ps.clone());
-        predicate_searcher.insert_bound_predicates(preds.iter());
+        predicate_searcher.insert_bound_predicates(&s.base_state(), preds.iter());
         predicate_searcher.set_param_env(param_env_from_clauses(
             tcx,
             s.param_env()
@@ -842,7 +842,7 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
 
     // Set the new type as the `Self` parameter of our predicates.
     let predicates = epreds.iter().map(|epred| epred.with_self_ty(tcx, new_ty));
-    let predicates: ItemPredicates<'_> = ItemPredicates::new_unmapped(span, predicates);
+    let predicates: ItemPredicates<'_, DefId> = ItemPredicates::new_unmapped(span, predicates);
 
     // Populate a predicate searcher that knows about the `dyn` clauses.
     let mut predicate_searcher = searcher_for_traits(s, &predicates);
@@ -1310,7 +1310,7 @@ impl<T> Binder<T> {
 
 /// Uniquely identifies a predicate.
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicateId, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicateId<DefId>, state: S as s)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum GenericPredicateId {
     /// A predicate that counts as "input" for an item, e.g. `where` clauses on a function or impl.
@@ -1328,7 +1328,7 @@ pub enum GenericPredicateId {
 }
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicate<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicate<'tcx, DefId>, state: S as s)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct GenericPredicate {
     pub id: GenericPredicateId,
@@ -1338,7 +1338,7 @@ pub struct GenericPredicate {
 
 /// Reflects [`ty::GenericPredicates`]
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicates<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: traits::ItemPredicates<'tcx, DefId>, state: S as s)]
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct GenericPredicates {
     pub predicates: Vec<GenericPredicate>,

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -815,7 +815,7 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
     ) -> PredicateSearcher<'tcx> {
         let tcx = s.base().tcx;
         // Populate a predicate searcher that knows about the `dyn` clauses.
-        let mut predicate_searcher = s.with_predicate_searcher(|ps| ps.clone());
+        let mut predicate_searcher = s.with_predicate_searcher(|ps, _| ps.clone());
         predicate_searcher.insert_bound_predicates(preds.iter());
         predicate_searcher.set_param_env(param_env_from_clauses(
             tcx,
@@ -865,7 +865,9 @@ fn resolve_for_dyn<'tcx, S: UnderOwnerState<'tcx>, R>(
                         let alias_ty = &proj.skip_binder().projection_term.expect_ty(tcx);
                         let trait_proof = {
                             let poly_trait_ref = proj.rebind(alias_ty.trait_ref(tcx));
-                            predicate_searcher.resolve(&poly_trait_ref).sinto(s)
+                            predicate_searcher
+                                .resolve(&s.base().elab_ctx, &poly_trait_ref)
+                                .sinto(s)
                         };
                         let Term::Ty(ty) = proj.skip_binder().term.sinto(s) else {
                             unreachable!()
@@ -1046,7 +1048,7 @@ pub fn compute_unsizing_metadata<'tcx, S: UnderOwnerState<'tcx>>(
                         .expect("expected a trait predicate in dyn upcast target");
                     ty::Binder::dummy(ty::TraitRef::new(tcx, def_id, [fresh_ty]))
                 };
-                searcher.resolve(&to_pred).sinto(s)
+                searcher.resolve(&s.base().elab_ctx, &to_pred).sinto(s)
             });
             UnsizingMetadata::NestedVTable(trait_proof)
         }

--- a/charon/src/bin/charon/main.rs
+++ b/charon/src/bin/charon/main.rs
@@ -201,6 +201,8 @@ fn translate_with_cargo(
     options.validate()?;
     let mut cmd = toolchain::in_toolchain("cargo")?;
     cmd.env("RUSTC_WRAPPER", toolchain::driver_path());
+    // We pass a random value to prevent cargo from considering a charon run cacheable.
+    cmd.env("RUSTC_WORKSPACE_WRAPPER", fresh_fingerprint());
     cmd.env("CHARON_USING_CARGO", "1");
     cmd.env_remove("CARGO_PRIMARY_PACKAGE");
     cmd.env(CHARON_ARGS, serde_json::to_string(&options).unwrap());
@@ -249,6 +251,14 @@ fn get_rustc_version() -> anyhow::Result<rustc_version::VersionMeta> {
         panic!("failed to determine underlying rustc version of Charon:\\n{err:?}",)
     });
     Ok(rustc_version)
+}
+
+/// A sufficiently unique string used to force cargo to re-run charon each time we call it.
+fn fresh_fingerprint() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("charon-dont-cache-this-{}-{nanos}", std::process::id())
 }
 
 fn ensure_rustup() {

--- a/charon/tests/cargo.rs
+++ b/charon/tests/cargo.rs
@@ -155,7 +155,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             root.join("issue-396-lib-bin"),
             &[],
             &[],
-            Failure,
+            Success,
         ),
         mktest(
             "issue-412-dup-deps",

--- a/charon/tests/cargo/error-dependencies/src/main.rs
+++ b/charon/tests/cargo/error-dependencies/src/main.rs
@@ -1,7 +1,6 @@
 //! This crate tests the error messages that indicates why we attempt to translate a given
 //! definition. We try some fun mutual dependencies to test the output, in particular the
 //! multi-file output.
-#![feature(pattern)]
 #![feature(register_tool)]
 #![register_tool(charon)]
 

--- a/charon/tests/cargo/issue-396-lib-bin.out
+++ b/charon/tests/cargo/issue-396-lib-bin.out
@@ -1,8 +1,168 @@
-error: extern location for issue_396_lib_bin does not exist
- --> src/main.rs:2:20
-  |
-2 |     println!("{}", issue_396_lib_bin::hello());
-  |                    ^^^^^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Code failed to compile
-error: could not compile `issue-396-lib-bin` (bin "issue-396-lib-bin") due to 1 previous error
+// Full name: issue_396_lib_bin::hello
+pub fn hello() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 42u32
+    return
+}
+
+
+
+# Final LLBC before serialization:
+
+// Full name: core::fmt::Error
+pub struct Error {}
+
+// Full name: core::fmt::Formatter
+#[lang_item("Formatter")]
+pub opaque type Formatter<mut 'a>
+where
+    RegionOutlives0: 'a: 'a,
+
+// Full name: core::fmt::Arguments
+#[lang_item("format_arguments")]
+pub opaque type Arguments<'a>
+
+// Full name: core::fmt::rt::Argument
+#[lang_item("format_argument")]
+pub opaque type Argument<'a>
+
+// Full name: core::fmt::{Arguments<'a>}::new
+pub unsafe fn new<'a, const N : usize, const M : usize>(_1: &'a [u8; N], _2: &'a [Argument<'a>; M]) -> Arguments<'a>
+= <opaque>
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[lang_item("sized")]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::result::Result
+#[lang_item("Result")]
+pub enum Result<T, E>
+where
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+{
+  Ok(T),
+  Err(E),
+}
+
+// Full name: core::fmt::Display
+#[lang_item("Display")]
+pub trait Display<Self>
+{
+    fn fmt<'_0_1, '_1_1, '_2_1> = core::fmt::Display::fmt<'_0_1, '_1_1, '_2_1, Self>[Self]
+    vtable: core::fmt::Display::{vtable}
+}
+
+pub fn core::fmt::Display::fmt<'_0, '_1, '_2, Self>(_1: &'_0 Self, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
+where
+    TraitClause0: (Self: Display),
+= <opaque>
+
+// Full name: core::fmt::num::imp::{impl Display for u32}::fmt
+pub fn impl_Display_for_u32::fmt<'_0, '_1, '_2>(_1: &'_0 u32, _2: &'_1 mut Formatter<'_2>) -> Result<(), Error>[{built_in impl Sized for ()}, {built_in impl Sized for Error}]
+= <opaque>
+
+// Full name: core::fmt::num::imp::{impl Display for u32}
+impl "impl_Display_for_u32" Display for u32 {
+    fn fmt<'_0_1, '_1_1, '_2_1> = impl_Display_for_u32::fmt<'_0_1, '_1_1, '_2_1>
+    vtable: impl_Display_for_u32::{vtable}
+}
+
+// Full name: core::fmt::rt::{Argument<'_0>}::new_display
+pub fn new_display<'_0, '_1, T>(_1: &'_1 T) -> Argument<'_1>
+where
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Display),
+= <opaque>
+
+// Full name: std::io::stdio::_print
+pub fn _print<'_0>(_1: Arguments<'_0>)
+= <opaque>
+
+// Full name: issue_396_lib_bin#1::hello
+pub fn hello() -> u32
+{
+    let _0: u32; // return
+
+    _0 = const 42u32
+    return
+}
+
+// Full name: issue_396_lib_bin::main
+fn main()
+{
+    let _0: (); // return
+    let _1: (); // anonymous local
+    let _2: Arguments<'1>; // anonymous local
+    let args_3: (&'4 u32,); // local
+    let _4: &'5 u32; // anonymous local
+    let _5: u32; // anonymous local
+    let args_6: [Argument<'8>; 1usize]; // local
+    let _7: Argument<'9>; // anonymous local
+    let _8: &'10 u32; // anonymous local
+    let _9: &'12 [u8; 4usize]; // anonymous local
+    let _10: &'13 [u8; 4usize]; // anonymous local
+    let _11: &'16 [Argument<'17>; 1usize]; // anonymous local
+    let _12: &'18 [Argument<'19>; 1usize]; // anonymous local
+    let _13: [u8; 4usize]; // anonymous local
+    let _14: &'25 [u8; 4usize]; // anonymous local
+
+    _0 = ()
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(args_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = hello()
+    _4 = &_5
+    args_3 = (move _4,)
+    storage_dead(_4)
+    storage_live(args_6)
+    storage_live(_7)
+    storage_live(_8)
+    _8 = &(*args_3.0)
+    _7 = new_display<'21, '23, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
+    storage_dead(_8)
+    args_6 = [move _7]
+    storage_dead(_7)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_13)
+    _13 = [const 192u8, const 1u8, const 10u8, const 0u8]
+    storage_live(_14)
+    _14 = &_13
+    _10 = move _14
+    _9 = &(*_10)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &args_6
+    _11 = &(*_12)
+    _2 = new<'27, 4usize, 1usize>(move _9, move _11)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_dead(_10)
+    storage_dead(_9)
+    _1 = _print<'29>(move _2)
+    storage_dead(_2)
+    storage_dead(args_6)
+    storage_dead(_5)
+    storage_dead(args_3)
+    storage_dead(_1)
+    _0 = ()
+    return
+}
+
+
+

--- a/charon/tests/ui/assert-kinds-reconstruct-fallible.rs
+++ b/charon/tests/ui/assert-kinds-reconstruct-fallible.rs
@@ -2,6 +2,8 @@
 //@ charon-args=--ullbc --print-ullbc
 //@ charon-args=--reconstruct-fallible-operations
 
+#![allow(unconditional_panic)]
+
 fn main() {
     let _ = [1, 2, 3][0];
     let _ = 5 * 10;

--- a/charon/tests/ui/assert-kinds.rs
+++ b/charon/tests/ui/assert-kinds.rs
@@ -2,6 +2,8 @@
 //@ charon-args=--ullbc --print-ullbc
 // see "assert-kinds-reconstruct-fallible" for the version with --reconstruct-fallible-operations
 
+#![allow(unconditional_panic)]
+
 fn main() {
     let _ = [1, 2, 3][0];
     let _ = 5 * 10;

--- a/charon/tests/ui/closure-as-fn.rs
+++ b/charon/tests/ui/closure-as-fn.rs
@@ -1,3 +1,5 @@
+#![allow(unconditional_panic)]
+
 fn main() {
     let f: fn() = || {
         let _ = 1 / 0;

--- a/charon/tests/ui/drop_after_overflow.rs
+++ b/charon/tests/ui/drop_after_overflow.rs
@@ -1,6 +1,8 @@
 //@ no-default-options
 //@ charon-args=--ullbc --print-ullbc
 
+#![allow(arithmetic_overflow)]
+
 struct Foo {}
 
 impl Drop for Foo {

--- a/charon/tests/ui/simple/array_index.rs
+++ b/charon/tests/ui/simple/array_index.rs
@@ -1,3 +1,5 @@
+#![allow(unconditional_panic)]
+
 pub fn first(s: [u32; 0]) -> u32 {
     s[0]
 }

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -83,16 +83,6 @@ where
     TraitClause0: (Self: FnOnce<Args>),
 = <opaque>
 
-// Full name: test_crate::Thing
-trait Thing<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Self::Item: Sized)
-    type Item
-    fn foo = foo<Self>[Self]
-    non-dyn-compatible
-}
-
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 {
@@ -107,6 +97,16 @@ unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}
 impl<A> "impl_Destruct_for_tuple" Destruct for (A,) {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::Thing
+trait Thing<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Item: Sized)
+    type Item
+    fn foo = foo<Self>[Self]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -93,18 +93,6 @@ pub enum AssertKind {
   Match,
 }
 
-// Full name: test_crate::LendingIterator
-pub trait LendingIterator<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    type Item<'a>
-    where
-        TypeOutlives0: Self: 'a,
-        proof ImpliedClause0: (Self::Item<'a>: Sized);
-    fn next<'a> = test_crate::LendingIterator::next<'a, Self>[Self]
-    non-dyn-compatible
-}
-
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 {
@@ -119,6 +107,18 @@ unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 // Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}
 impl<A> "impl_Destruct_for_tuple" Destruct for (A,) {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::LendingIterator
+pub trait LendingIterator<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    type Item<'a>
+    where
+        TypeOutlives0: Self: 'a,
+        proof ImpliedClause0: (Self::Item<'a>: Sized);
+    fn next<'a> = test_crate::LendingIterator::next<'a, Self>[Self]
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -114,15 +114,6 @@ where
 #[lang_item("String")]
 pub opaque type String
 
-// Full name: test_crate::BoolTrait
-pub trait BoolTrait<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    fn get_bool<'_0_1> = test_crate::BoolTrait::get_bool<'_0_1, Self>[Self]
-    fn ret_true<'_0_1> = test_crate::BoolTrait::ret_true<'_0_1, Self>[Self]
-    vtable: test_crate::BoolTrait::{vtable}
-}
-
 // Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A, B>(_1: &'_0 mut (A, B))
 where
@@ -144,6 +135,15 @@ where
 {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A, B>[TraitClause0]
     non-dyn-compatible
+}
+
+// Full name: test_crate::BoolTrait
+pub trait BoolTrait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    fn get_bool<'_0_1> = test_crate::BoolTrait::get_bool<'_0_1, Self>[Self]
+    fn ret_true<'_0_1> = test_crate::BoolTrait::ret_true<'_0_1, Self>[Self]
+    vtable: test_crate::BoolTrait::{vtable}
 }
 
 pub fn test_crate::BoolTrait::get_bool<'_0, Self>(_1: &'_0 Self) -> bool


### PR DESCRIPTION
This required a big rework + a hack to avoid using `create_def` which caused ICEs whenever we let Charon progress to metadata encoding and codegen. I've since figured out how to use it properly, but too late x)

Fixes https://github.com/AeneasVerif/charon/issues/396 and hopefully fixes https://github.com/AeneasVerif/charon/issues/212 too.