### PR TITLE
Add `--sysroot=miri` option

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.213"
+let supported_charon_version = "0.1.214"

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -82,6 +82,10 @@ and cli_options = {
           compiler once for each target and aggregate the results, which is
           useful if the code includes [#[cfg(..)]] filters. Warning: this is an
           initial implementation which is extremely slow. *)
+  sysroot : string option;
+      (** Sysroot to use for rustc invocations. Use [miri] to ask Charon to
+          prepare a per-target sysroot with full MIR for standard library items.
+      *)
   monomorphize : bool;
       (** Monomorphize the items encountered when possible. Generic items found
           in the crate are skipped. To only translate a particular call graph,

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2031,6 +2031,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("mir", mir);
           ("rustc_args", rustc_args);
           ("targets", targets);
+          ("sysroot", sysroot);
           ("monomorphize", monomorphize);
           ("monomorphize_mut", monomorphize_mut);
           ("start_from", start_from);
@@ -2078,6 +2079,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* mir = option_of_json mir_level_of_json ctx mir in
         let* rustc_args = list_of_json string_of_json ctx rustc_args in
         let* targets = list_of_json string_of_json ctx targets in
+        let* sysroot = option_of_json string_of_json ctx sysroot in
         let* monomorphize = bool_of_json ctx monomorphize in
         let* monomorphize_mut =
           option_of_json monomorphize_mut_of_json ctx monomorphize_mut
@@ -2146,6 +2148,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              mir;
              rustc_args;
              targets;
+             sysroot;
              monomorphize;
              monomorphize_mut;
              start_from;

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1788,6 +1788,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* mir = option_of_postcard mir_level_of_postcard ctx st in
      let* rustc_args = list_of_postcard string_of_postcard ctx st in
      let* targets = list_of_postcard string_of_postcard ctx st in
+     let* sysroot = option_of_postcard string_of_postcard ctx st in
      let* monomorphize = bool_of_postcard ctx st in
      let* monomorphize_mut =
        option_of_postcard monomorphize_mut_of_postcard ctx st
@@ -1840,6 +1841,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           mir;
           rustc_args;
           targets;
+          sysroot;
           monomorphize;
           monomorphize_mut;
           start_from;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.213"
+version = "0.1.214"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.213"
+version = "0.1.214"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -13,6 +13,8 @@ use rustc_middle::ty::{InstanceKind, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_session::config::{OutputType, OutputTypes};
 use rustc_span::ErrorGuaranteed;
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, fmt};
 
@@ -53,12 +55,6 @@ fn set_parallel_frontend(config: &mut Config) {
     }
 }
 
-/// Don't emit rustc artifacts.
-fn suppress_codegen_outputs(config: &mut Config) {
-    config.opts.unstable_opts.no_codegen = true;
-    config.opts.output_types = OutputTypes::new(&[(OutputType::Object, None)]);
-}
-
 // We use a static to be able to pass data to `override_queries`.
 static SKIP_BORROWCK: AtomicBool = AtomicBool::new(false);
 fn set_skip_borrowck() {
@@ -78,6 +74,7 @@ fn setup_compiler(
     options: &CliOpts,
     do_translate: bool,
     emit_artifacts: bool,
+    codegen: bool,
 ) {
     if do_translate {
         if options.skip_borrowck {
@@ -97,8 +94,9 @@ fn setup_compiler(
             // };
         });
 
+        config.opts.unstable_opts.no_codegen = !codegen;
         if !emit_artifacts {
-            suppress_codegen_outputs(config);
+            config.opts.output_types = OutputTypes::new(&[(OutputType::Object, None)]);
         }
         set_parallel_frontend(config);
     }
@@ -145,6 +143,59 @@ fn check_late_rustc_errors(tcx: TyCtxt<'_>) {
     }
 }
 
+/// `cargo miri setup` sets up a sysroot containing a standard library built with
+/// `-Zalways-encode-mir`.
+fn setup_miri_sysroot(target: &str) -> Option<PathBuf> {
+    if let Some(root) = env::var_os("CHARON_MIRI_SYSROOTS")
+        && let sysroot = PathBuf::from(root)
+        && sysroot.join("lib").join("rustlib").join(target).is_dir()
+    {
+        return Some(sysroot);
+    }
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("miri")
+        .arg("setup")
+        .arg(format!("--target={target}"))
+        .arg("--print-sysroot")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("RUSTC_WRAPPER");
+
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to run `cargo miri setup` for target `{target}`; \
+                falling back to rustc's default sysroot: {err}"
+            );
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!(
+            "warning: `cargo miri setup` failed for target `{target}`; \
+            falling back to rustc's default sysroot: {}",
+            stderr.trim()
+        );
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sysroot = stdout.lines().map(str::trim).find(|line| !line.is_empty());
+    match sysroot {
+        Some(sysroot) => Some(PathBuf::from(sysroot)),
+        None => {
+            eprintln!(
+                "warning: `cargo miri setup --print-sysroot` printed no sysroot for target \
+                `{target}`; falling back to rustc's default sysroot"
+            );
+            None
+        }
+    }
+}
+
 /// Run the rustc driver with our custom hooks. Returns `None` if the crate was not compiled with
 /// charon (e.g. because it was a dependency). Otherwise returns the translated crate, ready for
 /// post-processing transformations.
@@ -171,6 +222,10 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
     // whether the crate was specifically selected or is a dependency.
     let is_workspace_dependency =
         env::var("CHARON_USING_CARGO").is_ok() && env::var("CARGO_PRIMARY_PACKAGE").is_err();
+    // Let rustc emit artifacts (metadata, binaries) normally if invoked by `cargo`.
+    let emit_artifacts = env::var("CHARON_USING_CARGO").is_ok();
+    // Let rustc emit codegen artifacts, more specifically.
+    let mut codegen = emit_artifacts;
     // Determines if we are being invoked to build a crate for the "target" architecture, in
     // contrast to the "host" architecture. Host crates are for build scripts and proc macros and
     // still need to be built like normal; target crates need to be processed by Charon.
@@ -178,9 +233,45 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
     // Currently, we detect this by checking for "--target=", which is never set for host crates.
     // This matches what Miri does, which hopefully makes it reliable enough. This relies on us
     // always invoking cargo itself with `--target`, which `charon` ensures.
-    let is_target = arg_value(&compiler_args, "--target").is_some();
+    let target = arg_value(&compiler_args, "--target");
     // Whether this is the crate we want to translate.
-    let is_selected_crate = !is_workspace_dependency && is_target;
+    let is_selected_crate = !is_workspace_dependency && target.is_some();
+
+    let mut error_ctx = ErrorCtx::new();
+
+    // Retrieve the Charon options by deserializing them from the environment variable
+    // (cargo-charon serialized the arguments and stored them in a specific environment
+    // variable before calling cargo with `RUSTC_WRAPPER=charon-driver`).
+    let mut options = match env::var(options::CHARON_ARGS)
+        .ok()
+        .map(|opts| serde_json::from_str::<options::CliOpts>(&opts).unwrap())
+    {
+        Some(options) => options,
+        None if !is_selected_crate => Default::default(),
+        None => {
+            register_error!(
+                error_ctx,
+                no_crate,
+                "environment variable `CHARON_ARGS` not set; \
+                don't call `charon-driver` directly, call `charon rustc` instead"
+            );
+            return Err(CharonFailure::CharonError(1));
+        }
+    };
+
+    if let Some(target) = target
+        && let Some(sysroot) = options.sysroot.as_ref()
+    {
+        if sysroot == "miri" {
+            if let Some(sysroot) = setup_miri_sysroot(target) {
+                compiler_args.push(format!("--sysroot={}", sysroot.display()));
+                // The Miri sysroot doesn't support codegen.
+                codegen = false;
+            }
+        } else {
+            compiler_args.push(format!("--sysroot={sysroot}"));
+        }
+    }
 
     let output = if !is_selected_crate {
         trace!("Skipping charon; running compiler normally instead.");
@@ -188,23 +279,6 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
         run_compiler_with_callbacks(compiler_args, &mut RunCompilerNormallyCallbacks)?;
         None
     } else {
-        let mut error_ctx = ErrorCtx::new();
-
-        // Retrieve the Charon options by deserializing them from the environment variable
-        // (cargo-charon serialized the arguments and stored them in a specific environment
-        // variable before calling cargo with `RUSTC_WRAPPER=charon-driver`).
-        let mut options: options::CliOpts = match env::var(options::CHARON_ARGS) {
-            Ok(opts) => serde_json::from_str(opts.as_str()).unwrap(),
-            Err(_) => {
-                register_error!(
-                    error_ctx,
-                    no_crate,
-                    "environment variable `CHARON_ARGS` not set; \
-                    don't call `charon-driver` directly, call `charon rustc` instead"
-                );
-                return Err(CharonFailure::CharonError(1));
-            }
-        };
         options.apply_preset();
 
         error_ctx.continue_on_failure = !options.abort_on_error;
@@ -217,7 +291,8 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
         // Call the Rust compiler with our custom callback.
         let mut callback = CharonCallbacks {
             options: &options,
-            emit_artifacts: env::var("CHARON_USING_CARGO").is_ok(),
+            emit_artifacts,
+            codegen,
             error_ctx: Some(error_ctx),
             transform_ctx: None,
         };
@@ -232,9 +307,11 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
 /// The callbacks for Charon
 pub struct CharonCallbacks<'a> {
     options: &'a CliOpts,
-    /// Whether rustc should emit the artifacts requested by its command line. This is needed under
-    /// cargo so later crate invocations can consume earlier selected crates.
+    /// Whether rustc should emit the artifacts (metadata, binaries) it normally would. This is
+    /// needed under cargo so later crate invocations can consume earlier selected crates.
     emit_artifacts: bool,
+    /// Whether to let rustc run codegen as it normally would.
+    codegen: bool,
     /// Context for errors; `take()`n by translation.
     error_ctx: Option<ErrorCtx>,
     /// This is to be filled during the extraction; it contains the translated crate. `None` at the
@@ -243,7 +320,13 @@ pub struct CharonCallbacks<'a> {
 }
 impl<'a> Callbacks for CharonCallbacks<'a> {
     fn config(&mut self, config: &mut Config) {
-        setup_compiler(config, self.options, true, self.emit_artifacts);
+        setup_compiler(
+            config,
+            self.options,
+            true,
+            self.emit_artifacts,
+            self.codegen,
+        );
     }
 
     /// The MIR is modified in place: borrow-checking requires the "promoted" MIR, which causes the
@@ -282,7 +365,7 @@ pub struct RunCompilerNormallyCallbacks;
 
 impl Callbacks for RunCompilerNormallyCallbacks {
     fn config(&mut self, config: &mut Config) {
-        setup_compiler(config, &Default::default(), false, true);
+        setup_compiler(config, &Default::default(), false, true, true);
     }
 }
 

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -61,6 +61,11 @@ pub struct CliOpts {
     #[clap(long, value_delimiter = ',')]
     #[serde(default)]
     pub targets: Vec<String>,
+    /// Sysroot to use for rustc invocations. Use `miri` to ask Charon to prepare a per-target
+    /// sysroot with full MIR for standard library items.
+    #[clap(long)]
+    #[serde(default)]
+    pub sysroot: Option<String>,
 
     /// Monomorphize the items encountered when possible. Generic items found in the crate are
     /// skipped. To only translate a particular call graph, use `--start-from`. Note: this doesn't

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -33,6 +33,9 @@ Options:
       --targets <TARGETS>
           A list of target architectures to translate for. Charon will run the compiler once for each target and aggregate the results, which is useful if the code includes `#[cfg(..)]` filters. Warning: this is an initial implementation which is extremely slow
 
+      --sysroot <SYSROOT>
+          Sysroot to use for rustc invocations. Use `miri` to ask Charon to prepare a per-target sysroot with full MIR for standard library items
+
       --monomorphize
           Monomorphize the items encountered when possible. Generic items found in the crate are skipped. To only translate a particular call graph, use `--start-from`. Note: this doesn't currently support `dyn Trait`
           

--- a/charon/tests/ui/multi-target/sysroot.out
+++ b/charon/tests/ui/multi-target/sysroot.out
@@ -1,0 +1,6 @@
+pub opaque type core::ascii::EscapeDefault
+
+pub fn core::ascii::escape_default(_1: u8) -> core::ascii::EscapeDefault
+= <missing>
+
+

--- a/charon/tests/ui/multi-target/sysroot.out
+++ b/charon/tests/ui/multi-target/sysroot.out
@@ -1,6 +1,19 @@
 pub opaque type core::ascii::EscapeDefault
 
-pub fn core::ascii::escape_default(_1: u8) -> core::ascii::EscapeDefault
-= <missing>
+fn core::ascii::{core::ascii::EscapeDefault}::new(_1: u8) -> core::ascii::EscapeDefault
+= <opaque>
+
+pub fn core::ascii::escape_default(c_1: u8) -> core::ascii::EscapeDefault
+{
+    let _0: core::ascii::EscapeDefault; // return
+    let c_1: u8; // arg #1
+    let _2: u8; // anonymous local
+
+    storage_live(_2)
+    _2 = copy c_1
+    _0 = core::ascii::{core::ascii::EscapeDefault}::new(move _2)
+    storage_dead(_2)
+    return
+}
 
 

--- a/charon/tests/ui/multi-target/sysroot.rs
+++ b/charon/tests/ui/multi-target/sysroot.rs
@@ -1,3 +1,4 @@
 //@ charon-args=--start-from=core::ascii::escape_default --include=core::ascii::escape_default
 //@ charon-args=--targets=x86_64-unknown-linux-gnu,x86_64-pc-windows-msvc,aarch64-apple-darwin,i686-unknown-linux-gnu
+//@ charon-args=--sysroot=miri
 // This tests that we use a sysroot that has full MIR: that function has no MIR in the default sysroot.

--- a/charon/tests/ui/multi-target/sysroot.rs
+++ b/charon/tests/ui/multi-target/sysroot.rs
@@ -1,0 +1,3 @@
+//@ charon-args=--start-from=core::ascii::escape_default --include=core::ascii::escape_default
+//@ charon-args=--targets=x86_64-unknown-linux-gnu,x86_64-pc-windows-msvc,aarch64-apple-darwin,i686-unknown-linux-gnu
+// This tests that we use a sysroot that has full MIR: that function has no MIR in the default sysroot.

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,11 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
         ocamlformat = pkgs.ocamlPackages.ocamlformat_0_27_0;
 
-        charon = pkgs.callPackage ./nix/charon.nix { inherit craneLib rustToolchain; };
+        fullMirSysroots = pkgs.callPackage ./nix/full-mir-sysroots.nix { inherit rustToolchain; };
+        charon = pkgs.callPackage ./nix/charon.nix {
+          inherit craneLib rustToolchain;
+          miriSysroots = fullMirSysroots;
+        };
         charon-unwrapped = pkgs.callPackage ./nix/charon.nix { inherit craneLib rustToolchain; enableWrapping = false; };
         charon-portable = pkgs.runCommand "charon-portable" { } ''
           mkdir -p $out/bin
@@ -104,6 +108,7 @@
       {
         packages = {
           inherit charon charon-unwrapped charon-portable charon-ml rustToolchain;
+          charon-full-mir-sysroots = fullMirSysroots;
           inherit (rustc-tests) rustc-tests;
           default = charon;
         };

--- a/nix/charon.nix
+++ b/nix/charon.nix
@@ -3,6 +3,7 @@
 , craneLib
 , lib
 , makeWrapper
+, miriSysroots ? null
 , rustToolchain
 , stdenv
 , enableWrapping ? true
@@ -48,6 +49,7 @@ craneLib.buildPackage (
       ''
         wrapProgram $out/bin/charon \
           --set CHARON_TOOLCHAIN_IS_IN_PATH 1 \
+          ${lib.optionalString (miriSysroots != null) ''--set CHARON_MIRI_SYSROOTS "${miriSysroots}" \''}
           --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ rustToolchain ]}" \
           --prefix PATH : "${lib.makeBinPath [ rustToolchain ]}"
       ''
@@ -57,6 +59,7 @@ craneLib.buildPackage (
       '')
     );
     checkPhaseCargoCommand = ''
+      ${lib.optionalString (miriSysroots != null) ''export CHARON_MIRI_SYSROOTS="${miriSysroots}"''}
       CHARON_TOOLCHAIN_IS_IN_PATH=1 IN_CI=1 cargo test --profile release --locked
       # We also re-generate the ocaml files.
       mkdir src/bin/generate-ml/generated

--- a/nix/full-mir-sysroots.nix
+++ b/nix/full-mir-sysroots.nix
@@ -1,0 +1,43 @@
+{ lib
+, cacert
+, runCommand
+, rustToolchain
+}:
+
+let
+  toolchain = builtins.fromTOML (builtins.readFile ../charon/rust-toolchain);
+  targets = toolchain.toolchain.targets or [ ];
+in
+
+# This has a few hacks to make the output reproducible
+runCommand "charon-full-mir-sysroots"
+{
+  __structuredAttrs = true;
+  nativeBuildInputs = [ rustToolchain ];
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "sha256-Ha3594AoFhsQWieAa+XdklLV4eBnoL2b4XmfAw2zEBY=";
+  # Rust metadata records rust-src paths from rustToolchain; charon supplies that toolchain
+  # separately.
+  unsafeDiscardReferences.out = true;
+}
+  ''
+    export HOME="/build/home"
+    export CARGO_HOME="/build/cargo"
+    export TMPDIR="/build/tmp"
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+    unset CHARON_ARGS CHARON_USING_CARGO RUSTC_WORKSPACE_WRAPPER RUSTC_WRAPPER
+    mkdir -p "$HOME" "$CARGO_HOME" "$TMPDIR"
+
+    sysroot=
+    # This relies on the fact that miri uses the same directory for all sysroots.
+    for target in ${lib.escapeShellArgs targets}; do
+      sysroot="$(cargo miri setup --target="$target" --print-sysroot)"
+    done
+
+    mkdir -p "$out"
+    cp -a "$sysroot/." "$out/"
+    # Remove some non-reproducible outputs we don't need
+    find "$out" -name '*.d' -delete
+    find "$out" -name '*custom_local_sysroot-*' -delete
+  ''


### PR DESCRIPTION
This adds the option for running Charon with a full-MIR sysroot. Didn't enable it by default because this made all the `--extract-opaque-bodies` test die x)

cc https://github.com/AeneasVerif/charon/issues/865