### PR TITLE
Fix `ConstantExprKind::PtrNoProvenance`

### DIFF
--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -658,7 +658,7 @@ pub enum ConstantExprKind {
     ///
     /// We eliminate this case in a micro-pass.
     #[drive(skip)]
-    PtrNoProvenance(u128),
+    PtrNoProvenance(#[serde(with = "crate::ast::values_utils::scalar_value_ser_de")] u128),
     /// Raw memory value obtained from constant evaluation. Used when a more structured
     /// representation isn't possible (e.g. for unions) or just isn't implemented yet.
     #[drive(skip)]

--- a/charon/src/ast/values_utils.rs
+++ b/charon/src/ast/values_utils.rs
@@ -257,6 +257,20 @@ pub(crate) mod scalar_value_ser_de {
         serializer.serialize_str(&val.to_string())
     }
 
+    /// Stateful variant for types that derive `SerializeState`: the state is irrelevant for a
+    /// scalar, so we delegate to the stateless [`serialize`].
+    pub fn serialize_state<S, State: ?Sized, V>(
+        val: &V,
+        _state: &State,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+        V: ToString,
+    {
+        serialize(val, serializer)
+    }
+
     pub fn deserialize<'de, D, V>(deserializer: D) -> Result<V, D::Error>
     where
         D: Deserializer<'de>,
@@ -282,6 +296,19 @@ pub(crate) mod scalar_value_ser_de {
             }
         }
         deserializer.deserialize_str(Visitor { _val: PhantomData })
+    }
+
+    /// Stateful variant for types that derive `DeserializeState`: the state is irrelevant for a
+    /// scalar, so we delegate to the stateless [`deserialize`].
+    pub fn deserialize_state<'de, D, State: ?Sized, V>(
+        _state: &State,
+        deserializer: D,
+    ) -> Result<V, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: FromStr,
+    {
+        deserialize(deserializer)
     }
 }
 

--- a/charon/src/bin/charon-driver/hax/constant_utils.rs
+++ b/charon/src/bin/charon-driver/hax/constant_utils.rs
@@ -70,13 +70,6 @@ pub enum ConstantExprKind {
         mutability: Mutability,
         arg: ConstantExpr,
     },
-    /// A cast `<source> as <type>`, `<type>` is stored as the type of
-    /// the current constant expression. Currently, this is only used
-    /// to represent `lit as *mut T` or `lit as *const T`, where `lit`
-    /// is a `usize` literal.
-    Cast {
-        source: ConstantExpr,
-    },
     ConstRef {
         id: ParamConst,
     },

--- a/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
+++ b/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
@@ -222,14 +222,8 @@ pub(crate) fn valtree_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
             }
         }
         (ty::ValTreeKind::Leaf(x), ty::RawPtr(_, _)) => {
-            use rustc_type_ir::inherent::Ty;
             let raw_address = x.to_bits_unchecked();
-            let uint_ty = UintTy::Usize;
-            let usize_ty = rustc_middle::ty::Ty::new_usize(s.base().tcx).sinto(s);
-            let lit = ConstantLiteral::Int(ConstantInt::Uint(raw_address, uint_ty));
-            ConstantExprKind::Cast {
-                source: ConstantExprKind::Literal(lit).decorate(usize_ty, span.sinto(s)),
-            }
+            ConstantExprKind::Literal(ConstantLiteral::PtrNoProvenance(raw_address))
         }
         (ty::ValTreeKind::Leaf(x), _) => {
             ConstantExprKind::Literal(scalar_int_to_constant_literal(s, *x, ty))

--- a/charon/src/bin/charon-driver/translate/translate_constants.rs
+++ b/charon/src/bin/charon-driver/translate/translate_constants.rs
@@ -150,14 +150,6 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 };
                 ConstantExprKind::Ref(Box::new(val), metadata)
             }
-            hax::ConstantExprKind::Cast { .. } => {
-                register_error!(
-                    self,
-                    span,
-                    "Unsupported constant: `ConstantExprKind::Cast {{..}}`",
-                );
-                ConstantExprKind::Opaque("`ConstantExprKind::Cast {{..}}`".into())
-            }
             hax::ConstantExprKind::RawBorrow { mutability, arg } => {
                 let arg = self.translate_constant_expr(span, arg)?;
                 let rk = RefKind::mutable(mutability.is_mut());

--- a/charon/tests/ui/consts/pointer-cast-const-pattern.out
+++ b/charon/tests/ui/consts/pointer-cast-const-pattern.out
@@ -1,7 +1,41 @@
-error: Unsupported constant: `ConstantExprKind::Cast {..}`
- --> tests/ui/consts/pointer-cast-const-pattern.rs:9:9
-  |
-9 |         DISGUISED_INT => {}
-  |         ^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: test_crate::DISGUISED_INT
+fn DISGUISED_INT() -> *const ()
+{
+    let _0: *const (); // return
+    let _1: *const (); // anonymous local
+
+    storage_live(_1)
+    _1 = cast<i32, *const ()>(const 42i32)
+    _0 = copy _1
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::DISGUISED_INT
+const DISGUISED_INT: *const () = DISGUISED_INT()
+
+// Full name: test_crate::pointer_pattern
+pub fn pointer_pattern()
+{
+    let _0: (); // return
+    let _1: *const (); // anonymous local
+    let _2: bool; // anonymous local
+
+    storage_live(_2)
+    _0 = ()
+    storage_live(_1)
+    _1 = cast<usize, *const ()>(const 43usize)
+    _2 = const no-provenance 42 == copy _1
+    if move _2 {
+        _0 = const ()
+    } else {
+        _0 = const ()
+    }
+    storage_dead(_1)
+    return
+}
+
+
+

--- a/charon/tests/ui/consts/pointer-cast-const-pattern.rs
+++ b/charon/tests/ui/consts/pointer-cast-const-pattern.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ no-default-options
 //@ charon-args=--raw-consts
 

--- a/charon/tests/ui/pointers-in-consts-no-warns.out
+++ b/charon/tests/ui/pointers-in-consts-no-warns.out
@@ -22,12 +22,15 @@ pub fn bar()
     let _0: (); // return
     let _1: *const (); // anonymous local
     let _2: bool; // anonymous local
+    let _3: *const (); // anonymous local
 
     storage_live(_2)
     _0 = ()
     storage_live(_1)
     _1 = cast<usize, *const ()>(const 43usize)
-    _2 = const Opaque(`ConstantExprKind::Cast {{..}}`) == copy _1
+    storage_live(_3)
+    _3 = cast<usize, *const ()>(const 42usize)
+    _2 = move _3 == copy _1
     if move _2 {
         _0 = ()
     } else {

--- a/charon/tests/ui/pointers-in-consts.out
+++ b/charon/tests/ui/pointers-in-consts.out
@@ -1,7 +1,44 @@
-error: Unsupported constant: `ConstantExprKind::Cast {..}`
- --> tests/ui/pointers-in-consts.rs:6:9
-  |
-6 |         DISGUISED_INT => {}
-  |         ^^^^^^^^^^^^^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: test_crate::DISGUISED_INT
+fn DISGUISED_INT() -> *const ()
+{
+    let _0: *const (); // return
+    let _1: *const (); // anonymous local
+
+    storage_live(_1)
+    _1 = cast<i32, *const ()>(const 42i32)
+    _0 = copy _1
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::DISGUISED_INT
+const DISGUISED_INT: *const () = DISGUISED_INT()
+
+// Full name: test_crate::bar
+pub fn bar()
+{
+    let _0: (); // return
+    let _1: *const (); // anonymous local
+    let _2: bool; // anonymous local
+    let _3: *const (); // anonymous local
+
+    storage_live(_2)
+    _0 = ()
+    storage_live(_1)
+    _1 = cast<usize, *const ()>(const 43usize)
+    storage_live(_3)
+    _3 = cast<usize, *const ()>(const 42usize)
+    _2 = move _3 == copy _1
+    if move _2 {
+        _0 = ()
+    } else {
+        _0 = ()
+    }
+    storage_dead(_1)
+    return
+}
+
+
+

--- a/charon/tests/ui/pointers-in-consts.rs
+++ b/charon/tests/ui/pointers-in-consts.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 const DISGUISED_INT: *const () = 42 as _;
 
 pub fn bar() {


### PR DESCRIPTION
- Start using the variant in hax, and remove the now useless `hax::ConstantExprKind::Cast`
- Fix a bug with the serialization of `ConstantExprKind::PtrNoProvenance`; we weren't wrapping the `u128` correctly, so it was being serialized wrong, causing issues on the OCaml side.