### PR TITLE
Add `reconstruct_ptr_null_checks` pass

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.214"
+let supported_charon_version = "0.1.215"

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -177,6 +177,10 @@ and cli_options = {
           information. *)
   reconstruct_asserts : bool;
       (** Replace [if x { panic() }] with [assert(x)]. *)
+  reconstruct_null_checks : bool;
+      (** Replace the [transmute::<*T, usize>(p)] that rustc emits when lowering
+          pointer null-checks (e.g. [<*const T>::is_null]) with a comparison
+          against the null pointer. *)
   unbind_item_vars : bool;
       (** Use [DeBruijnVar::Free] for the variables bound in item signatures,
           instead of [DeBruijnVar::Bound] everywhere. This simplifies the

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2057,6 +2057,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("unsized_strings", unsized_strings);
           ("reconstruct_fallible_operations", reconstruct_fallible_operations);
           ("reconstruct_asserts", reconstruct_asserts);
+          ("reconstruct_null_checks", reconstruct_null_checks);
           ("unbind_item_vars", unbind_item_vars);
           ("print_original_ullbc", print_original_ullbc);
           ("print_ullbc", print_ullbc);
@@ -2121,6 +2122,9 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           bool_of_json ctx reconstruct_fallible_operations
         in
         let* reconstruct_asserts = bool_of_json ctx reconstruct_asserts in
+        let* reconstruct_null_checks =
+          bool_of_json ctx reconstruct_null_checks
+        in
         let* unbind_item_vars = bool_of_json ctx unbind_item_vars in
         let* print_original_ullbc = bool_of_json ctx print_original_ullbc in
         let* print_ullbc = bool_of_json ctx print_ullbc in
@@ -2174,6 +2178,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              unsized_strings;
              reconstruct_fallible_operations;
              reconstruct_asserts;
+             reconstruct_null_checks;
              unbind_item_vars;
              print_original_ullbc;
              print_ullbc;

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1816,6 +1816,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* unsized_strings = bool_of_postcard ctx st in
      let* reconstruct_fallible_operations = bool_of_postcard ctx st in
      let* reconstruct_asserts = bool_of_postcard ctx st in
+     let* reconstruct_null_checks = bool_of_postcard ctx st in
      let* unbind_item_vars = bool_of_postcard ctx st in
      let* print_original_ullbc = bool_of_postcard ctx st in
      let* print_ullbc = bool_of_postcard ctx st in
@@ -1867,6 +1868,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           unsized_strings;
           reconstruct_fallible_operations;
           reconstruct_asserts;
+          reconstruct_null_checks;
           unbind_item_vars;
           print_original_ullbc;
           print_ullbc;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.214"
+version = "0.1.215"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "adt-into",
-    "macros",
-    "rustc_trait_elaboration",
-]
+members = ["adt-into", "macros", "rustc_trait_elaboration"]
 
 [workspace.package]
 authors = [
@@ -25,7 +21,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.214"
+version = "0.1.215"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -109,8 +105,14 @@ take_mut = "0.2.2"
 tar = { version = "0.4.42", optional = true }
 tempfile = "3"
 toml = { version = "0.8", features = ["parse"] }
-tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "fmt", ] }
-tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [ "time", ] } # Fork with improved formating and timing info.
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "std",
+    "fmt",
+] }
+tracing-tree = { git = "https://github.com/Nadrieril/tracing-tree", features = [
+    "time",
+] } # Fork with improved formating and timing info.
 tracing.workspace = true
 ustr = { version = "1.1.0", features = ["serde"] }
 wait-timeout = { version = "0.2.0", optional = true }

--- a/charon/src/ast/expressions_utils.rs
+++ b/charon/src/ast/expressions_utils.rs
@@ -117,6 +117,21 @@ impl Operand {
             Operand::Const(constant_expr) => &constant_expr.ty,
         }
     }
+
+    pub fn is_zero_constant(&self) -> bool {
+        matches!(
+            self,
+            Operand::Const(c) if matches!(&c.kind, ConstantExprKind::Literal(lit) if lit.is_zero())
+        )
+    }
+
+    /// If this operand is a copy/move of an unprojected local, return that local. Otherwise, return `None`.
+    pub fn as_local(&self) -> Option<LocalId> {
+        match self {
+            Operand::Copy(p) | Operand::Move(p) => p.as_local(),
+            Operand::Const(_) => None,
+        }
+    }
 }
 
 impl Rvalue {

--- a/charon/src/ast/values_utils.rs
+++ b/charon/src/ast/values_utils.rs
@@ -46,6 +46,10 @@ impl Literal {
             _ => None,
         }
     }
+
+    pub fn is_zero(&self) -> bool {
+        matches!(self, Literal::Scalar(scalar) if scalar.to_bits() == 0)
+    }
 }
 
 impl ScalarValue {

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -233,6 +233,11 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub reconstruct_asserts: bool,
+    /// Replace the `transmute::<*T, usize>(p)` that rustc emits when lowering pointer null-checks
+    /// (e.g. `<*const T>::is_null`) with a comparison against the null pointer.
+    #[clap(long)]
+    #[serde(default)]
+    pub reconstruct_null_checks: bool,
     /// Use `DeBruijnVar::Free` for the variables bound in item signatures, instead of
     /// `DeBruijnVar::Bound` everywhere. This simplifies the management of generics for projects
     /// that don't intend to manipulate them too much.
@@ -620,6 +625,9 @@ pub struct TranslateOptions {
     pub reconstruct_fallible_operations: bool,
     /// Replace `if x { panic() }` with `assert(x)`.
     pub reconstruct_asserts: bool,
+    /// Replace the `transmute::<*T, usize>(p)` that rustc emits for pointer null-checks with a
+    /// comparison against the null pointer.
+    pub reconstruct_null_checks: bool,
     // Use `DeBruijnVar::Free` for the variables bound in item signatures.
     pub unbind_item_vars: bool,
     /// List of patterns to assign a given opacity to. Same as the corresponding `TranslateOptions`
@@ -772,6 +780,7 @@ impl TranslateOptions {
             unsized_strings: options.unsized_strings,
             reconstruct_fallible_operations: options.reconstruct_fallible_operations,
             reconstruct_asserts: options.reconstruct_asserts,
+            reconstruct_null_checks: options.reconstruct_null_checks,
             lift_associated_types,
             unbind_item_vars: options.unbind_item_vars,
             translate_all_methods: options.translate_all_methods,

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -38,6 +38,7 @@ pub mod resugar {
     pub mod reconstruct_fallible_operations;
     pub mod reconstruct_intrinsics;
     pub mod reconstruct_matches;
+    pub mod reconstruct_ptr_null_checks;
     pub mod reconstruct_vec_boxes;
 }
 
@@ -161,6 +162,9 @@ pub fn run_transformation_passes(options: &CliOpts, ctx: &mut TransformCtx) {
         CowBox::Borrowed(&resugar::reconstruct_intrinsics::Transform),
         // Reconstruct the asserts
         CowBox::Borrowed(&resugar::reconstruct_asserts::Transform),
+        // # Micro pass: when a pointer is transmuted only to check if it is null, replace the
+        // transmutation with a comparison against the null pointer.
+        CowBox::Borrowed(&resugar::reconstruct_ptr_null_checks::Transform),
         // Desugar the constants to other values/operands as much as possible.
         CowBox::Borrowed(&simplify_output::simplify_constants::Transform),
         // Introduce intermediate assignments in preparation of the [`index_to_function_calls`]

--- a/charon/src/transform/resugar/reconstruct_ptr_null_checks.rs
+++ b/charon/src/transform/resugar/reconstruct_ptr_null_checks.rs
@@ -1,0 +1,189 @@
+//! # Micro-pass: reconstruct pointer null-checks.
+//!
+//! When rustc lowers a pointer null-check (e.g. `<*const T>::is_null`), it reinterprets the
+//! pointer's bits as an integer and tests that integer against `0`. Depending on the MIR level, the
+//! test takes one of two shapes:
+//! ```text
+//! // optimized MIR: the comparison is a `switch` terminator
+//! _23 := transmute<*mut u8, usize>(copy raw_ptr_6);
+//! switch copy _23 -> [0: bb20, otherwise: bb21]
+//!
+//! // built MIR: the comparison is a `== 0` / `!= 0` statement
+//! _3 := transmute<*const u8, usize>(copy _2);
+//! _0 := move _3 == const 0usize;
+//! ```
+//!
+//! Some tools would like to avoid reasoning about the pointer-to-integer transmutation. Instead we
+//! compare the pointer against the null pointer (a no-provenance pointer with address `0`), so
+//! that the comparison stays in the pointer world:
+//! ```text
+//! _tmp := copy raw_ptr_6 != const (no-provenance 0);
+//! _23 := cast<bool, usize>(move _tmp);
+//! switch copy _23 -> [0: bb20, otherwise: bb21]
+//! ```
+//! The new value assigned to `_23` is `0` if and only if the pointer is null, exactly like the
+//! transmuted address it replaces, so the null-check itself is left untouched. The only
+//! information lost is the address of a non-null pointer (the value becomes `1`), which is sound
+//! because that value feeds nothing but the null-check.
+//!
+//! The transformation is only fired when:
+//! - we transmute a *sized* (thin) pointer to `usize`/`isize`;
+//! - the result feeds either a switch with a single `0` case and an otherwise branch, or a
+//!   `== 0` / `!= 0` comparison against the null address;
+//! - the transmuted value is used nowhere else (necessary for soundness)
+
+use derive_generic_visitor::Visitor;
+use std::ops::ControlFlow::{self, Continue};
+
+use crate::ids::IndexVec;
+use crate::transform::TransformCtx;
+use crate::transform::ctx::UllbcPass;
+use crate::ullbc_ast::*;
+
+/// Count how many times each local appears in the body, ignoring `StorageLive`/`StorageDead`
+/// statements (which mention a local but don't actually use its value).
+#[derive(Visitor)]
+struct LocalUsageCounter {
+    counts: IndexVec<LocalId, usize>,
+}
+
+impl VisitBody for LocalUsageCounter {
+    fn enter_local_id(&mut self, lid: &LocalId) {
+        self.counts[*lid] += 1;
+    }
+    fn visit_ullbc_statement(&mut self, st: &Statement) -> ControlFlow<Self::Break> {
+        match &st.kind {
+            StatementKind::StorageLive(_) | StatementKind::StorageDead(_) => Continue(()),
+            _ => self.visit_inner(st),
+        }
+    }
+}
+
+fn count_local_usages(b: &ExprBody) -> IndexVec<LocalId, usize> {
+    let mut visitor = LocalUsageCounter {
+        counts: b.locals.locals.map_ref(|_| 0),
+    };
+    let _ = b.body.drive_body(&mut visitor);
+    visitor.counts
+}
+
+/// Whether `local`'s non-defining use is a pointer null-check, i.e. either:
+/// - a `switch local -> [0: _, otherwise: _]` terminator (the shape rustc emits in *optimized*
+///   MIR), or
+/// - a `_ = (local == 0)` / `_ = (local != 0)` comparison statement (the shape rustc emits in
+///   *built* MIR, where `<*const T>::is_null` is `transmute::<*T, usize>(p) == 0`).
+///
+/// The caller guarantees `local` is used exactly twice, so whichever use we find here is its unique
+/// non-defining use.
+fn feeds_null_check(block: &BlockData, local: LocalId) -> bool {
+    // The result feeds a `switch [0, otherwise]` terminator.
+    if let TerminatorKind::Switch {
+        discr,
+        targets: SwitchTargets::SwitchInt(_, cases, _),
+    } = &block.terminator.kind
+        && let [(case, _)] = cases.as_slice()
+        && case.is_zero()
+        && discr.as_local() == Some(local)
+    {
+        return true;
+    }
+    // The result feeds a `== 0` / `!= 0` comparison against the null address.
+    block.statements.iter().any(|st| {
+        matches!(
+            &st.kind,
+            StatementKind::Assign(_, Rvalue::BinaryOp(BinOp::Eq | BinOp::Ne, lhs, rhs))
+                if (lhs.as_local() == Some(local) && rhs.is_zero_constant())
+                    || (rhs.as_local() == Some(local) && lhs.is_zero_constant())
+        )
+    })
+}
+
+/// If `st` is a `transmute` of a sized (thin) pointer into a `usize`/`isize` whose result is used
+/// exactly twice and whose unique other use is a null-check (a `switch [0, _]` or a `== 0` /
+/// `!= 0` within `block`), return the assigned place, the pointer type, the target integer type
+/// and the transmuted operand.
+fn match_transmuted_null_check<'a>(
+    ctx: &TransformCtx,
+    usages: &IndexVec<LocalId, usize>,
+    block: &'a BlockData,
+    st: &'a Statement,
+) -> Option<(&'a Place, &'a Ty, LiteralTy, &'a Operand)> {
+    let StatementKind::Assign(
+        place,
+        Rvalue::UnaryOp(UnOp::Cast(CastKind::Transmute(src_ty, tgt_ty)), op),
+    ) = &st.kind
+    else {
+        return None;
+    };
+    let result = place.as_local()?;
+    let TyKind::Literal(
+        tgt_lit_ty @ (LiteralTy::UInt(UIntTy::Usize) | LiteralTy::Int(IntTy::Isize)),
+    ) = tgt_ty.kind()
+    else {
+        return None;
+    };
+    if usages[result] != 2 {
+        return None;
+    }
+    let (TyKind::RawPtr(pointee, _) | TyKind::Ref(_, pointee, _)) = src_ty.kind() else {
+        return None;
+    };
+    if !matches!(pointee.get_ptr_metadata(&ctx.translated), PtrMetadata::None) {
+        return None;
+    }
+    if !feeds_null_check(block, result) {
+        return None;
+    }
+    Some((place, src_ty, *tgt_lit_ty, op))
+}
+
+pub struct Transform;
+
+impl UllbcPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        options.reconstruct_null_checks
+    }
+
+    fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
+        let usages = count_local_usages(b);
+
+        let locals = &mut b.locals;
+        for block in b.body.iter_mut() {
+            let mut idx = 0;
+            while idx < block.statements.len() {
+                let Some((dest, src_ty, tgt_lit_ty, operand)) =
+                    match_transmuted_null_check(ctx, &usages, block, &block.statements[idx])
+                        .map(|(place, ty, lit, op)| (place.clone(), ty.clone(), lit, op.clone()))
+                else {
+                    idx += 1;
+                    continue;
+                };
+                let span = block.statements[idx].span;
+
+                // `(p != null) as usize` is `0` exactly when `transmute::<_, usize>(p)` is, so the
+                // downstream null-check is left untouched.
+                let tmp = locals.new_var(None, Ty::mk_bool());
+                let tmp_local = tmp.as_local().unwrap();
+                let null_ptr = Operand::Const(Box::new(ConstantExpr {
+                    kind: ConstantExprKind::PtrNoProvenance(0),
+                    ty: src_ty,
+                }));
+                let is_not_null = Rvalue::BinaryOp(BinOp::Ne, operand, null_ptr);
+                let cast = Rvalue::UnaryOp(
+                    UnOp::Cast(CastKind::Scalar(LiteralTy::Bool, tgt_lit_ty)),
+                    Operand::Move(tmp.clone()),
+                );
+                let new_statements = [
+                    StatementKind::StorageLive(tmp_local),
+                    StatementKind::Assign(tmp, is_not_null),
+                    StatementKind::Assign(dest, cast),
+                    StatementKind::StorageDead(tmp_local),
+                ]
+                .map(|kind| Statement::new(span, kind));
+                let num_new = new_statements.len();
+                block.statements.splice(idx..=idx, new_statements);
+                idx += num_new;
+            }
+        }
+    }
+}

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -135,6 +135,9 @@ Options:
       --reconstruct-asserts
           Replace `if x { panic() }` with `assert(x)`
 
+      --reconstruct-null-checks
+          Replace the `transmute::<*T, usize>(p)` that rustc emits when lowering pointer null-checks (e.g. `<*const T>::is_null`) with a comparison against the null pointer
+
       --unbind-item-vars
           Use `DeBruijnVar::Free` for the variables bound in item signatures, instead of `DeBruijnVar::Bound` everywhere. This simplifies the management of generics for projects that don't intend to manipulate them too much
 

--- a/charon/tests/ui/ptr-null-checks.out
+++ b/charon/tests/ui/ptr-null-checks.out
@@ -1,0 +1,109 @@
+# Final LLBC before serialization:
+
+// Full name: core::num::{usize}::wrapping_add
+pub fn wrapping_add(_1: usize, _2: usize) -> usize
+= <opaque>
+
+// Full name: test_crate::check_raw
+pub fn check_raw(p_1: *mut u8) -> u32
+{
+    let _0: u32; // return
+    let p_1: *mut u8; // arg #1
+    let x_2: usize; // local
+    let _3: *mut u8; // anonymous local
+    let _4: bool; // anonymous local
+    let _5: *mut u8; // anonymous local
+
+    storage_live(x_2)
+    storage_live(_3)
+    _3 = copy p_1
+    storage_live(_4)
+    storage_live(_5)
+    _5 = cast<usize, *mut u8>(const 0usize)
+    _4 = move _3 != move _5
+    x_2 = cast<bool, usize>(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    switch copy x_2 {
+        0usize => {
+            _0 = const 1u32
+        },
+        _ => {
+            _0 = const 2u32
+        },
+    }
+    storage_dead(x_2)
+    return
+}
+
+// Full name: test_crate::check_ref
+pub fn check_ref<'_0>(p_1: &'_0 u8) -> u32
+{
+    let _0: u32; // return
+    let p_1: &'1 u8; // arg #1
+    let x_2: isize; // local
+    let _3: &'2 u8; // anonymous local
+    let _4: bool; // anonymous local
+    let _5: &'2 u8; // anonymous local
+
+    storage_live(x_2)
+    storage_live(_3)
+    _3 = copy p_1
+    storage_live(_4)
+    storage_live(_5)
+    _5 = cast<usize, &'2 u8>(const 0usize)
+    _4 = move _3 != move _5
+    x_2 = cast<bool, isize>(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    switch copy x_2 {
+        0isize => {
+            _0 = const 1u32
+        },
+        _ => {
+            _0 = const 2u32
+        },
+    }
+    storage_dead(x_2)
+    return
+}
+
+// Full name: test_crate::other_use
+pub fn other_use(p_1: *mut u8) -> usize
+{
+    let _0: usize; // return
+    let p_1: *mut u8; // arg #1
+    let x_2: usize; // local
+    let _3: *mut u8; // anonymous local
+    let y_4: usize; // local
+    let _5: usize; // anonymous local
+    let _6: usize; // anonymous local
+
+    storage_live(x_2)
+    storage_live(_3)
+    _3 = copy p_1
+    x_2 = transmute<*mut u8, usize>(move _3)
+    storage_dead(_3)
+    storage_live(y_4)
+    switch copy x_2 {
+        0usize => {
+            y_4 = const 1usize
+        },
+        _ => {
+            y_4 = const 2usize
+        },
+    }
+    storage_live(_5)
+    _5 = copy x_2
+    storage_live(_6)
+    _6 = copy y_4
+    _0 = wrapping_add(move _5, move _6)
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_dead(y_4)
+    storage_dead(x_2)
+    return
+}
+
+
+

--- a/charon/tests/ui/ptr-null-checks.rs
+++ b/charon/tests/ui/ptr-null-checks.rs
@@ -1,0 +1,34 @@
+//@ charon-args=--mir optimized --reconstruct-null-checks
+//! Tests for the `reconstruct_ptr_null_checks` micro-pass, which rewrites a
+//! `transmute::<*T, usize>(p)` that feeds a `switch [0, otherwise]` (the shape rustc emits when
+//! lowering pointer null-checks) into a comparison against the null pointer.
+
+// Should be rewritten: a thin pointer is transmuted to `usize`, switched against `0`, and the
+// resulting value is used nowhere else.
+pub fn check_raw(p: *mut u8) -> u32 {
+    let x: usize = unsafe { core::mem::transmute(p) };
+    match x {
+        0 => 1,
+        _ => 2,
+    }
+}
+
+// Same, but through a shared reference and to `isize`.
+pub fn check_ref(p: &u8) -> u32 {
+    let x: isize = unsafe { core::mem::transmute(p) };
+    match x {
+        0 => 1,
+        _ => 2,
+    }
+}
+
+// Should NOT be rewritten: the transmuted value `x` is used after the switch, so replacing it with
+// the address-erasing null-check would change the observable result.
+pub fn other_use(p: *mut u8) -> usize {
+    let x: usize = unsafe { core::mem::transmute(p) };
+    let y = match x {
+        0 => 1usize,
+        _ => 2,
+    };
+    x.wrapping_add(y)
+}


### PR DESCRIPTION
In Soteria, reasoning about pointer-to-integer cast is expensive. It requires instantiating a fresh variable and adding a bunch of constraints on it that need to be checked.
After a bit of investigation, I realised that a *lot* of these casts are just there to check if a pointer is null. It's done by transmuting to an integer and checking if it's 0. Checking for null pointers in Soteria directly is cheap though, so we'd rather do that.

This PR addresses this need by reconstructing the following pattern into a builtin:
```rs
_x := transmute<*const _, usize>(_y);
switch _x [0usize -> .., _ -> ]
```
or 
```rs
_x := transmute<*const _, usize>(_y);
_z := _x == 0 // or _x != 0
```

The first pattern occurs in optimsied MIR and the second in unoptimised MIR. We unfortunately have to deal with both since a lot of these patterns happen in the stdlib that we obtain as already optimised.

We replace this with:
```rs
_tmp := copy _y != (no-provenance 0);
_x := cast<bool, usize>(move _tmp);
switch _x ....
```