### PR TITLE
Fix `reconstruct_fallible_operations`

### DIFF
--- a/charon/src/transform/resugar/reconstruct_fallible_operations.rs
+++ b/charon/src/transform/resugar/reconstruct_fallible_operations.rs
@@ -152,6 +152,12 @@ fn remove_dynamic_checks(
     locals: &mut Locals,
     statements: &mut [Statement],
 ) {
+    // Whether this local was used in another block
+    let used_outside_block = |local: LocalId| {
+        uses.iter_enumerated()
+            .any(|(bid, used)| bid != block_id && used.contains(&local))
+    };
+
     // We return the statements we want to keep, which must be a prefix of `block.statements`.
     let statements_to_keep = match statements {
         // Bounds checks for slices. They look like:
@@ -463,7 +469,7 @@ fn remove_dynamic_checks(
         // ```
         // We replace that with:
         // ```text
-        // z := x + y;
+        // z := x panic.+ y;
         // ```
         //
         // But sometimes, because of constant promotion, we end up with a lone checked operation
@@ -482,7 +488,9 @@ fn remove_dynamic_checks(
                 ..
             },
             rest @ ..,
-        ] if let Some(tuple_local_id) = tuple.as_local() => {
+        ] if let Some(tuple_local_id) = tuple.as_local()
+            && !used_outside_block(tuple_local_id) =>
+        {
             // Check if the result boolean is used in any other way than just getting the integer
             // result.
             let mut uses_of_tuple = 0;
@@ -580,9 +588,7 @@ fn remove_dynamic_checks(
         if let StatementKind::Assign(place, _) = &statements[i].kind
             && let Some(local) = place.as_local()
             && let mut statements_to_keep = statements[removed_len..].as_ref().iter()
-            && let mut other_blocks = uses.iter_enumerated().filter(|(bid, _)| *bid != block_id)
-            && (other_blocks.any(|(_, used)| used.contains(&local))
-                || statements_to_keep.any(|st| uses_local(st, local)))
+            && (used_outside_block(local) || statements_to_keep.any(|st| uses_local(st, local)))
         {
             continue;
         };

--- a/charon/tests/ui/regressions/reconstruct-fallible.out
+++ b/charon/tests/ui/regressions/reconstruct-fallible.out
@@ -47,14 +47,14 @@ fn sink_bool(_x_1: bool)
 fn must_preserve_tuple()
 {
     let _0: (); // return
-    let z_1: usize; // local
+    let z_1: (usize, bool); // local
     let _2: (); // anonymous local
     let _3: (); // anonymous local
     let _4: (usize, bool); // anonymous local
 
     _0 = ()
     storage_live(z_1)
-    z_1 = const 0usize wrap.+ const 0usize
+    z_1 = const 0usize checked.+ const 0usize
     storage_live(_2)
     _2 = other()
     storage_dead(_2)
@@ -73,14 +73,14 @@ fn must_preserve_tuple()
 fn can_erase_check()
 {
     let _0: (); // return
-    let z_1: usize; // local
+    let z_1: (usize, bool); // local
     let _2: (); // anonymous local
     let _3: (); // anonymous local
     let _4: usize; // anonymous local
 
     _0 = ()
     storage_live(z_1)
-    z_1 = const 0usize wrap.+ const 0usize
+    z_1 = const 0usize checked.+ const 0usize
     storage_live(_2)
     _2 = other()
     storage_dead(_2)
@@ -99,14 +99,14 @@ fn can_erase_check()
 fn must_preserve_overflow_flag()
 {
     let _0: (); // return
-    let z_1: usize; // local
+    let z_1: (usize, bool); // local
     let _2: (); // anonymous local
     let _3: (); // anonymous local
     let _4: bool; // anonymous local
 
     _0 = ()
     storage_live(z_1)
-    z_1 = const 0usize wrap.+ const 0usize
+    z_1 = const 0usize checked.+ const 0usize
     storage_live(_2)
     _2 = other()
     storage_dead(_2)
@@ -125,7 +125,7 @@ fn must_preserve_overflow_flag()
 fn mixed_field0_and_cross_block_tuple()
 {
     let _0: (); // return
-    let z_1: usize; // local
+    let z_1: (usize, bool); // local
     let _2: (); // anonymous local
     let _3: usize; // anonymous local
     let _4: (); // anonymous local
@@ -134,10 +134,10 @@ fn mixed_field0_and_cross_block_tuple()
 
     _0 = ()
     storage_live(z_1)
-    z_1 = const 0usize wrap.+ const 0usize
+    z_1 = const 0usize checked.+ const 0usize
     storage_live(_2)
     storage_live(_3)
-    _3 = copy z_1
+    _3 = copy z_1.0
     _2 = sink_int(move _3)
     storage_dead(_3)
     storage_dead(_2)
@@ -159,7 +159,7 @@ fn mixed_field0_and_cross_block_tuple()
 fn can_erase_check_multi_block()
 {
     let _0: (); // return
-    let z_1: usize; // local
+    let z_1: (usize, bool); // local
     let _2: (); // anonymous local
     let _3: (); // anonymous local
     let _4: usize; // anonymous local
@@ -169,7 +169,7 @@ fn can_erase_check_multi_block()
 
     _0 = ()
     storage_live(z_1)
-    z_1 = const 0usize wrap.+ const 0usize
+    z_1 = const 0usize checked.+ const 0usize
     storage_live(_2)
     _2 = other()
     storage_dead(_2)

--- a/charon/tests/ui/regressions/reconstruct-fallible.out
+++ b/charon/tests/ui/regressions/reconstruct-fallible.out
@@ -1,0 +1,197 @@
+# Final LLBC before serialization:
+
+// Full name: test_crate::other
+fn other()
+{
+    let _0: (); // return
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::sink_tuple
+fn sink_tuple(_x_1: (usize, bool))
+{
+    let _0: (); // return
+    let _x_1: (usize, bool); // arg #1
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::sink_int
+fn sink_int(_x_1: usize)
+{
+    let _0: (); // return
+    let _x_1: usize; // arg #1
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::sink_bool
+fn sink_bool(_x_1: bool)
+{
+    let _0: (); // return
+    let _x_1: bool; // arg #1
+
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::must_preserve_tuple
+fn must_preserve_tuple()
+{
+    let _0: (); // return
+    let z_1: usize; // local
+    let _2: (); // anonymous local
+    let _3: (); // anonymous local
+    let _4: (usize, bool); // anonymous local
+
+    _0 = ()
+    storage_live(z_1)
+    z_1 = const 0usize wrap.+ const 0usize
+    storage_live(_2)
+    _2 = other()
+    storage_dead(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy z_1
+    _3 = sink_tuple(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = ()
+    storage_dead(z_1)
+    return
+}
+
+// Full name: test_crate::can_erase_check
+fn can_erase_check()
+{
+    let _0: (); // return
+    let z_1: usize; // local
+    let _2: (); // anonymous local
+    let _3: (); // anonymous local
+    let _4: usize; // anonymous local
+
+    _0 = ()
+    storage_live(z_1)
+    z_1 = const 0usize wrap.+ const 0usize
+    storage_live(_2)
+    _2 = other()
+    storage_dead(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy z_1.0
+    _3 = sink_int(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = ()
+    storage_dead(z_1)
+    return
+}
+
+// Full name: test_crate::must_preserve_overflow_flag
+fn must_preserve_overflow_flag()
+{
+    let _0: (); // return
+    let z_1: usize; // local
+    let _2: (); // anonymous local
+    let _3: (); // anonymous local
+    let _4: bool; // anonymous local
+
+    _0 = ()
+    storage_live(z_1)
+    z_1 = const 0usize wrap.+ const 0usize
+    storage_live(_2)
+    _2 = other()
+    storage_dead(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy z_1.1
+    _3 = sink_bool(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = ()
+    storage_dead(z_1)
+    return
+}
+
+// Full name: test_crate::mixed_field0_and_cross_block_tuple
+fn mixed_field0_and_cross_block_tuple()
+{
+    let _0: (); // return
+    let z_1: usize; // local
+    let _2: (); // anonymous local
+    let _3: usize; // anonymous local
+    let _4: (); // anonymous local
+    let _5: (); // anonymous local
+    let _6: (usize, bool); // anonymous local
+
+    _0 = ()
+    storage_live(z_1)
+    z_1 = const 0usize wrap.+ const 0usize
+    storage_live(_2)
+    storage_live(_3)
+    _3 = copy z_1
+    _2 = sink_int(move _3)
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_live(_4)
+    _4 = other()
+    storage_dead(_4)
+    storage_live(_5)
+    storage_live(_6)
+    _6 = copy z_1
+    _5 = sink_tuple(move _6)
+    storage_dead(_6)
+    storage_dead(_5)
+    _0 = ()
+    storage_dead(z_1)
+    return
+}
+
+// Full name: test_crate::can_erase_check_multi_block
+fn can_erase_check_multi_block()
+{
+    let _0: (); // return
+    let z_1: usize; // local
+    let _2: (); // anonymous local
+    let _3: (); // anonymous local
+    let _4: usize; // anonymous local
+    let _5: (); // anonymous local
+    let _6: (); // anonymous local
+    let _7: usize; // anonymous local
+
+    _0 = ()
+    storage_live(z_1)
+    z_1 = const 0usize wrap.+ const 0usize
+    storage_live(_2)
+    _2 = other()
+    storage_dead(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy z_1.0
+    _3 = sink_int(move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_live(_5)
+    _5 = other()
+    storage_dead(_5)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = copy z_1.0
+    _6 = sink_int(move _7)
+    storage_dead(_7)
+    storage_dead(_6)
+    _0 = ()
+    storage_dead(z_1)
+    return
+}
+
+
+

--- a/charon/tests/ui/regressions/reconstruct-fallible.rs
+++ b/charon/tests/ui/regressions/reconstruct-fallible.rs
@@ -1,0 +1,41 @@
+//@ charon-args=--sysroot default --monomorphize --mir elaborated
+
+#![feature(core_intrinsics)]
+
+fn other() {}
+fn sink_tuple(_x: (usize, bool)) {}
+fn sink_int(_x: usize) {}
+fn sink_bool(_x: bool) {}
+
+fn must_preserve_tuple() {
+    let z = std::intrinsics::add_with_overflow(0usize, 0usize);
+    other();
+    sink_tuple(z);
+}
+
+fn can_erase_check() {
+    let z = std::intrinsics::add_with_overflow(0usize, 0usize);
+    other();
+    sink_int(z.0);
+}
+
+fn must_preserve_overflow_flag() {
+    let z = std::intrinsics::add_with_overflow(0usize, 0usize);
+    other();
+    sink_bool(z.1);
+}
+
+fn mixed_field0_and_cross_block_tuple() {
+    let z = std::intrinsics::add_with_overflow(0usize, 0usize);
+    sink_int(z.0);
+    other();
+    sink_tuple(z);
+}
+
+fn can_erase_check_multi_block() {
+    let z = std::intrinsics::add_with_overflow(0usize, 0usize);
+    other();
+    sink_int(z.0);
+    other();
+    sink_int(z.0);
+}

--- a/charon/tests/ui/regressions/reconstruct-fallible.rs
+++ b/charon/tests/ui/regressions/reconstruct-fallible.rs
@@ -1,5 +1,6 @@
 //@ charon-args=--sysroot default --monomorphize --mir elaborated
-
+// Check that the reconstruct_fallible_operations pass correctly handles check_add usage
+// that spans multiple basic blocks.
 #![feature(core_intrinsics)]
 
 fn other() {}


### PR DESCRIPTION
The reconstruct_fallible_operations pass didn't look outside its block for uses, which led to code that wouldn't type check (either with `.0` access to an integer variable, or with `int -> (int, bool)` assignments.

The fix i did was to expand the transformation to work across blocks, but another solution would be to simply not do the pass if we know the local is used outside the block, since it's questionable whether it makes sense to do this pass when the user explicitly calls `add_with_overflow`

Either solutions are fine with me I just want well-typed code :D 