### PR TITLE
Fix/miri sysroot portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       #- uses: cachix/install-nix-action@v22
       - uses: actions/checkout@v4
       - run: nix build -L .#charon
+      - run: nix build -L .#charon-portable
       - run: nix build -L .#charon-ml
       - run: nix flake check -L
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,19 +21,40 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
+        inherit (pkgs) lib stdenv makeWrapper bintools;
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
         ocamlformat = pkgs.ocamlPackages.ocamlformat_0_27_0;
 
         fullMirSysroots = pkgs.callPackage ./nix/full-mir-sysroots.nix { inherit rustToolchain; };
-        charon = pkgs.callPackage ./nix/charon.nix {
-          inherit craneLib rustToolchain;
-          miriSysroots = fullMirSysroots;
-        };
+        charon = pkgs.runCommand "charon"
+          {
+            nativeBuildInputs = [ makeWrapper ]
+              # For `install_name_tool`.
+              ++ lib.optionals stdenv.isDarwin [ bintools ];
+            passthru = charon-unwrapped.passthru;
+          }
+          (''
+            cp -r ${charon-unwrapped} $out
+            chmod -R u+w $out
+
+            # Make sure the toolchain is in $PATH so that `cargo` can work
+            # properly. On mac we also have to tell `charon-driver` where to
+            # find the rustc_driver dynamic library; this is done automatically
+            # on linux.
+            wrapProgram $out/bin/charon \
+              --set CHARON_TOOLCHAIN_IS_IN_PATH 1 \
+              --set CHARON_MIRI_SYSROOTS "${fullMirSysroots}" \
+              --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ rustToolchain ]}" \
+              --prefix PATH : "${lib.makeBinPath [ rustToolchain ]}"
+          ''
+          + (lib.optionalString stdenv.isDarwin ''
+            # Ensures `charon-driver` finds the dylibs correctly.
+            install_name_tool -add_rpath "${rustToolchain}/lib" "$out/bin/charon-driver"
+          ''));
         charon-unwrapped = pkgs.callPackage ./nix/charon.nix {
-          inherit craneLib rustToolchain;
-          enableWrapping = false;
+          inherit craneLib;
           miriSysroots = fullMirSysroots;
         };
         charon-portable = pkgs.runCommand "charon-portable" { } ''

--- a/flake.nix
+++ b/flake.nix
@@ -57,19 +57,18 @@
             # Ensures `charon-driver` finds the dylibs correctly.
             install_name_tool -add_rpath "${rustToolchain}/lib" "$out/bin/charon-driver"
           ''));
-        charon-portable = pkgs.runCommand "charon-portable" { } ''
+        charon-portable = pkgs.runCommand "charon-portable" { } (''
           mkdir -p $out/bin
           cp ${charon-unwrapped}/bin/charon $out/bin/charon
           cp ${charon-unwrapped}/bin/charon-driver $out/bin/charon-driver
-
-          if [[ "${pkgs.stdenv.hostPlatform.system}" == *"linux"* ]]; then
-            for f in $out/bin/*; do
-              chmod +w $f
-              ${pkgs.patchelf}/bin/patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 $f || true
-              ${pkgs.patchelf}/bin/patchelf --remove-rpath $f || true
-            done
-          fi
-        '';
+        ''
+        + (lib.optionalString stdenv.isLinux ''
+          for f in $out/bin/*; do
+            chmod +w $f
+            ${pkgs.patchelf}/bin/patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 $f || true
+            ${pkgs.patchelf}/bin/patchelf --remove-rpath $f || true
+          done
+        ''));
         charon-ml = pkgs.callPackage ./nix/charon-ml.nix { inherit charon; };
 
         # Check rust files are correctly formatted.

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,11 @@
           inherit craneLib rustToolchain;
           miriSysroots = fullMirSysroots;
         };
-        charon-unwrapped = pkgs.callPackage ./nix/charon.nix { inherit craneLib rustToolchain; enableWrapping = false; };
+        charon-unwrapped = pkgs.callPackage ./nix/charon.nix {
+          inherit craneLib rustToolchain;
+          enableWrapping = false;
+          miriSysroots = fullMirSysroots;
+        };
         charon-portable = pkgs.runCommand "charon-portable" { } ''
           mkdir -p $out/bin
           cp ${charon-unwrapped}/bin/charon $out/bin/charon

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
         ocamlformat = pkgs.ocamlPackages.ocamlformat_0_27_0;
 
         fullMirSysroots = pkgs.callPackage ./nix/full-mir-sysroots.nix { inherit rustToolchain; };
+        charon-unwrapped = pkgs.callPackage ./nix/charon.nix {
+          inherit craneLib;
+          miriSysroots = fullMirSysroots;
+        };
         charon = pkgs.runCommand "charon"
           {
             nativeBuildInputs = [ makeWrapper ]
@@ -53,10 +57,6 @@
             # Ensures `charon-driver` finds the dylibs correctly.
             install_name_tool -add_rpath "${rustToolchain}/lib" "$out/bin/charon-driver"
           ''));
-        charon-unwrapped = pkgs.callPackage ./nix/charon.nix {
-          inherit craneLib;
-          miriSysroots = fullMirSysroots;
-        };
         charon-portable = pkgs.runCommand "charon-portable" { } ''
           mkdir -p $out/bin
           cp ${charon-unwrapped}/bin/charon $out/bin/charon

--- a/nix/charon.nix
+++ b/nix/charon.nix
@@ -1,12 +1,7 @@
-{ bintools
-, cargoLock ? ../charon/Cargo.lock
+{ cargoLock ? ../charon/Cargo.lock
 , craneLib
 , lib
-, makeWrapper
 , miriSysroots ? null
-, rustToolchain
-, stdenv
-, enableWrapping ? true
 , zlib
 }:
 
@@ -34,30 +29,10 @@ craneLib.buildPackage (
   craneArgs
     // rec {
     buildInputs = [
-      makeWrapper
       zlib
     ];
-    # For `install_name_tool`.
-    nativeBuildInputs = lib.optionals (stdenv.isDarwin) [ bintools ];
     # It's important to pass the same `RUSTFLAGS` to dependencies otherwise we'll have to rebuild them.
     cargoArtifacts = craneLib.buildDepsOnly craneArgs;
-    # Make sure the toolchain is in $PATH so that `cargo` can work
-    # properly. On mac we also have to tell `charon-driver` where to find
-    # the rustc_driver dynamic library; this is done automatically on
-    # linux.
-    postFixup = lib.optionalString enableWrapping (
-      ''
-        wrapProgram $out/bin/charon \
-          --set CHARON_TOOLCHAIN_IS_IN_PATH 1 \
-          ${lib.optionalString (miriSysroots != null) ''--set CHARON_MIRI_SYSROOTS "${miriSysroots}" \''}
-          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ rustToolchain ]}" \
-          --prefix PATH : "${lib.makeBinPath [ rustToolchain ]}"
-      ''
-      + (lib.optionalString stdenv.isDarwin ''
-        # Ensures `charon-driver` finds the dylibs correctly.
-        install_name_tool -add_rpath "${rustToolchain}/lib" "$out/bin/charon-driver"
-      '')
-    );
     checkPhaseCargoCommand = ''
       ${lib.optionalString (miriSysroots != null) ''export CHARON_MIRI_SYSROOTS="${miriSysroots}"''}
       CHARON_TOOLCHAIN_IS_IN_PATH=1 IN_CI=1 cargo test --profile release --locked

--- a/nix/full-mir-sysroots.nix
+++ b/nix/full-mir-sysroots.nix
@@ -16,15 +16,17 @@ runCommand "charon-full-mir-sysroots"
   nativeBuildInputs = [ rustToolchain ];
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "sha256-Ha3594AoFhsQWieAa+XdklLV4eBnoL2b4XmfAw2zEBY=";
+  outputHash = "sha256-sbmBXFEOx2v3gIg+yRYpijd2MBouoeD9oFyfEDFGjcs=";
   # Rust metadata records rust-src paths from rustToolchain; charon supplies that toolchain
   # separately.
   unsafeDiscardReferences.out = true;
 }
   ''
-    export HOME="/build/home"
-    export CARGO_HOME="/build/cargo"
-    export TMPDIR="/build/tmp"
+    builddir=/tmp/charon-full-mir-sysroots-build
+    rm -rf "$builddir"
+    export HOME="$builddir/home"
+    export CARGO_HOME="$builddir/cargo"
+    export TMPDIR="$builddir/tmp"
     export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
     unset CHARON_ARGS CHARON_USING_CARGO RUSTC_WORKSPACE_WRAPPER RUSTC_WRAPPER
     mkdir -p "$HOME" "$CARGO_HOME" "$TMPDIR"
@@ -40,4 +42,6 @@ runCommand "charon-full-mir-sysroots"
     # Remove some non-reproducible outputs we don't need
     find "$out" -name '*.d' -delete
     find "$out" -name '*custom_local_sysroot-*' -delete
+
+    rm -rf "$builddir"
   ''

--- a/nix/full-mir-sysroots.nix
+++ b/nix/full-mir-sysroots.nix
@@ -23,7 +23,6 @@ runCommand "charon-full-mir-sysroots"
 }
   ''
     builddir=/tmp/charon-full-mir-sysroots-build
-    rm -rf "$builddir"
     export HOME="$builddir/home"
     export CARGO_HOME="$builddir/cargo"
     export TMPDIR="$builddir/tmp"


### PR DESCRIPTION
This PR fixes two different issues affecting aeneas nix builds:

## Missing `/build` directory on github runners

The `full-mir-sysroot.nix` build script introduced by https://github.com/AeneasVerif/charon/pull/1278 uses `/build` which exists on self-hosted runners but not on github runners which results in failing [builds](https://github.com/AeneasVerif/aeneas/actions/runs/28148842408/job/83361757659) for aeneas.
This PR changes this nix script to use a temporary directory instead.

## `charon-unwrapped` missing `miriSysroots`

Also following https://github.com/AeneasVerif/charon/pull/1278, charon needs the `CHARON_MIRI_SYSROOTS` which is correctly passed to the `charon` nix package, but not to `charon-unwrapped`. This one affects [linux-x86_64 aeneas builds](https://github.com/AeneasVerif/aeneas/actions/runs/28148842408/job/83361757660) which avoid the previous one because they run on self-hosted runners.
This PR fixes that, and also adds a CI job that build `charon-unwrapped` to avoid future regressions for this package.
