### PR TITLE
Nicer char pretty-printing

### DIFF
--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -101,12 +101,25 @@ let uchar_to_utf8 (c : Uchar.t) : string =
       | 2 -> cont (i lsr 6)
       | _ -> cont i)
 
+(* Mirror Rust's `char::escape_debug` *)
+let escape_char_debug (c : Uchar.t) : string =
+  let i = Uchar.to_int c in
+  match i with
+  | 0x09 -> "\\t"
+  | 0x0a -> "\\n"
+  | 0x0d -> "\\r"
+  | 0x5c -> "\\\\"
+  | 0x27 -> "\\'"
+  | 0x22 -> "\\\""
+  | _ when i >= 0x20 && i <= 0x7e -> uchar_to_utf8 c
+  | _ -> Printf.sprintf "\\u{%x}" i
+
 let pp_literal (fmt : Format.formatter) (lit : literal) : unit =
   match lit with
   | VScalar sv -> pp_scalar_value fmt sv
   | VFloat fv -> pp_float_value fmt fv
   | VBool b -> pp_string fmt (Bool.to_string b)
-  | VChar c -> pp_string fmt (uchar_to_utf8 c)
+  | VChar c -> Format.fprintf fmt "'%s'" (escape_char_debug c)
   | VStr s -> Format.fprintf fmt "\"%s\"" (escape_string s)
   | VByteStr bs ->
       Format.fprintf fmt "[%a]"

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1119,7 +1119,7 @@ impl Display for Literal {
             Literal::Scalar(v) => write!(f, "{v}"),
             Literal::Float(v) => write!(f, "{v}"),
             Literal::Bool(v) => write!(f, "{v}"),
-            Literal::Char(v) => write!(f, "{v}"),
+            Literal::Char(v) => write!(f, "'{}'", v.escape_debug()),
             Literal::Str(v) => write!(f, "\"{}\"", v.replace("\\", "\\\\").replace("\n", "\\n")),
             Literal::ByteStr(v) => write!(f, "{v:?}"),
         }

--- a/charon/tests/ui/max_char.out
+++ b/charon/tests/ui/max_char.out
@@ -5,7 +5,7 @@ pub fn MAX() -> char
 {
     let _0: char; // return
 
-    _0 = const 􏿿
+    _0 = const '\u{10ffff}'
     return
 }
 

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -226,7 +226,7 @@ fn main()
     storage_live(_28)
     storage_live(_29)
     storage_live(_30)
-    _30 = const x
+    _30 = const 'x'
     _29 = &_30
     _28 = move _29
     storage_dead(_20)

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -539,7 +539,7 @@ pub fn test_char() -> char
 {
     let _0: char; // return
 
-    _0 = const a
+    _0 = const 'a'
     return
 }
 

--- a/charon/tests/ui/simple/match-on-char.out
+++ b/charon/tests/ui/simple/match-on-char.out
@@ -8,9 +8,9 @@ fn main()
 
     _0 = ()
     storage_live(_1)
-    _1 = const x
+    _1 = const 'x'
     switch copy _1 {
-        a => {
+        'a' => {
             _0 = ()
         },
         _ => {


### PR DESCRIPTION
We used to print chars as literally their value, which is hard to parse for non-ascii characters and quite unclear (e.g. `const X` could refer to the character `'X'`, or to the global `X`)

changed it so characters are printed like they would be written in Rust