### PR TITLE
Translate closure method implementations in mono mode

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -558,10 +558,6 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
         let mut timpl = self.translate_virtual_trait_impl(def_id, item_meta, vimpl)?;
 
-        if self.monomorphize() {
-            return Ok(timpl);
-        }
-
         // Construct the `call_*` method reference.
         let trait_decl_id = timpl.impl_trait.id;
         let trait_method_id = self.translate_trait_method_id(trait_decl_id, &vimpl.methods[0])?;
@@ -580,6 +576,9 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 fn_decl_ref,
             )
         };
+        if self.monomorphize() {
+            return Ok(timpl);
+        }
         timpl
             .methods
             .set_slot_extend(trait_method_id, call_fn_binder);

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -245,5 +245,84 @@ impl<'_0, '_1> "impl_Destruct_for_closure" Destruct for closure<'_0, '_1> {
     non-dyn-compatible
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}::call_once
+fn call_once<'_0, '_1>(_1: closure<'_0, '_1>, _2: (u8, u8)) -> u8
+{
+    let _0: u8; // return
+    let _1: closure<'_0, '_1>; // arg #1
+    let _2: (u8, u8); // arg #2
+    let _3: &'1 mut closure<'_0, '_1>; // anonymous local
+
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = impl_FnMut_tuple_for_closure<'_0, '_1>::call_mut<'6>(move _3, move _2)
+    drop[drop_glue<'_0, '_1, '16>] _1
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}::call
+fn call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, tupled_args: (u8, u8)) -> u8
+{
+    let _0: u8; // return
+    let _1: &'1 closure<'_0, '_1>; // arg #1
+    let tupled_args: (u8, u8); // arg #2
+    let x: u8; // local
+    let y: u8; // local
+    let _5: u8; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+    let _8: u8; // anonymous local
+    let _9: u8; // anonymous local
+    let _10: u8; // anonymous local
+    let _11: u8; // anonymous local
+    let _12: u8; // anonymous local
+    let _13: u8; // anonymous local
+
+    storage_live(x)
+    storage_live(y)
+    storage_live(_9)
+    storage_live(_11)
+    storage_live(_13)
+    x = move tupled_args.0
+    y = move tupled_args.1
+    storage_live(_5)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = copy (*((*_1)).0)
+    storage_live(_8)
+    _8 = copy x
+    _9 = copy _7 panic.+ copy _8
+    _6 = move _9
+    storage_dead(_8)
+    storage_dead(_7)
+    storage_live(_10)
+    _10 = copy y
+    _11 = copy _6 panic.+ copy _10
+    _5 = move _11
+    storage_dead(_10)
+    storage_dead(_6)
+    storage_live(_12)
+    _12 = copy (*((*_1)).1)
+    _13 = copy _5 panic.+ copy _12
+    _0 = move _13
+    storage_dead(_12)
+    storage_dead(_5)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut
+fn call_mut<'_0, '_1, '_2>(state: &'_2 mut closure<'_0, '_1>, args: (u8, u8)) -> u8
+{
+    let _0: u8; // return
+    let state: &'_2 mut closure<'_0, '_1>; // arg #1
+    let args: (u8, u8); // arg #2
+    let _3: &'0 closure<'_0, '_1>; // anonymous local
+
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call<'_0, '_1, '2>(move _3, move args)
+    return
+}
+
 
 

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -30,6 +30,14 @@ pub trait Tuple<Self>
     non-dyn-compatible
 }
 
+// Full name: test_crate::NotCopy
+struct NotCopy {}
+
+// Full name: core::mem::drop::<NotCopy>
+#[lang_item("mem_drop")]
+pub fn drop::<NotCopy>(_1: NotCopy)
+= <opaque>
+
 opaque type core::ops::function::FnOnce::{vtable}
 
 // Full name: core::ops::function::FnOnce
@@ -41,9 +49,6 @@ pub trait FnOnce<Self, Args>
     proof ImpliedClause2: (Args: Tuple)
     vtable: core::ops::function::FnOnce::{vtable}
 }
-
-// Full name: test_crate::NotCopy
-struct NotCopy {}
 
 // Full name: test_crate::main::closure
 struct closure {
@@ -113,6 +118,35 @@ fn main()
 impl "impl_Destruct_for_closure" Destruct for closure {
     fn drop_glue<'_0_1> = drop_glue<'_0_1>
     non-dyn-compatible
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}::call_once
+fn call_once(_1: closure, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: closure; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: (); // anonymous local
+    let _5: NotCopy; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+
+    storage_live(x)
+    storage_live(_7)
+    x = move tupled_args.0
+    storage_live(_4)
+    storage_live(_5)
+    _5 = move (_1).0
+    _4 = drop::<NotCopy>(move _5)
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    _6 = copy x
+    _7 = copy _6 panic.+ const 1u8
+    _0 = move _7
+    storage_dead(_6)
+    return
 }
 
 

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -30,6 +30,14 @@ pub trait Tuple<Self>
     non-dyn-compatible
 }
 
+// Full name: test_crate::Thing
+struct Thing {}
+
+// Full name: core::mem::drop::<Thing>
+#[lang_item("mem_drop")]
+pub fn drop::<Thing>(_1: Thing)
+= <opaque>
+
 opaque type core::ops::function::Fn::{vtable}
 
 opaque type core::ops::function::FnOnce::{vtable}
@@ -67,9 +75,6 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
 }
-
-// Full name: test_crate::Thing
-struct Thing {}
 
 struct test_crate::main::closure<'_0> {
   &'_0 u8,
@@ -281,16 +286,143 @@ impl<'_0> Destruct for test_crate::main::closure<'_0> {
     non-dyn-compatible
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once
+fn {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once<'_0>(_1: test_crate::main::closure<'_0>, _2: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: test_crate::main::closure<'_0>; // arg #1
+    let _2: (u8,); // arg #2
+    let _3: &'1 mut test_crate::main::closure<'_0>; // anonymous local
+
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>::call_mut<'4>(move _3, move _2)
+    drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '10>] _1
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}::call
+fn call<'_0, '_1>(_1: &'_1 test_crate::main::closure<'_0>, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: &'1 test_crate::main::closure<'_0>; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: u8; // anonymous local
+    let _5: u8; // anonymous local
+    let _6: u8; // anonymous local
+
+    storage_live(x)
+    storage_live(_6)
+    x = move tupled_args.0
+    storage_live(_4)
+    _4 = copy x
+    storage_live(_5)
+    _5 = copy (*((*_1)).0)
+    _6 = copy _4 panic.+ copy _5
+    _0 = move _6
+    storage_dead(_5)
+    storage_dead(_4)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::call_mut
+fn {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::closure<'_0>, args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let state: &'_1 mut test_crate::main::closure<'_0>; // arg #1
+    let args: (u8,); // arg #2
+    let _3: &'0 test_crate::main::closure<'_0>; // anonymous local
+
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call<'_0, '2>(move _3, move args)
+    return
+}
+
 // Full name: test_crate::main::closure#1::{impl Destruct for test_crate::main::closure#1<'_0>}
 impl<'_0> Destruct for test_crate::main::closure#1<'_0> {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'_0, '_0_1>
     non-dyn-compatible
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::call_once
+fn {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::call_once<'_0>(_1: test_crate::main::closure#1<'_0>, _2: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: test_crate::main::closure#1<'_0>; // arg #1
+    let _2: (u8,); // arg #2
+    let _3: &'1 mut test_crate::main::closure#1<'_0>; // anonymous local
+
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>::call_mut<'4>(move _3, move _2)
+    drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'_0, '10>] _1
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut
+fn {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::main::closure#1<'_0>, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: &'1 mut test_crate::main::closure#1<'_0>; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: u8; // anonymous local
+    let _5: u8; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+
+    storage_live(x)
+    storage_live(_4)
+    storage_live(_7)
+    x = move tupled_args.0
+    _4 = copy (*((*_1)).0) panic.+ const 1u8
+    (*((*_1)).0) = move _4
+    storage_live(_5)
+    _5 = copy x
+    storage_live(_6)
+    _6 = copy (*((*_1)).0)
+    _7 = copy _5 panic.+ copy _6
+    _0 = move _7
+    storage_dead(_6)
+    storage_dead(_5)
+    return
+}
+
 // Full name: test_crate::main::closure#2::{impl Destruct for test_crate::main::closure#2}
 impl Destruct for test_crate::main::closure#2 {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#2}::drop_glue<'_0_1>
     non-dyn-compatible
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once
+fn {impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once(_1: test_crate::main::closure#2, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: test_crate::main::closure#2; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: (); // anonymous local
+    let _5: Thing; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+
+    storage_live(x)
+    storage_live(_7)
+    x = move tupled_args.0
+    storage_live(_4)
+    storage_live(_5)
+    _5 = move (_1).0
+    _4 = drop::<Thing>(move _5)
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    _6 = copy x
+    _7 = copy _6 panic.+ const 1u8
+    _0 = move _7
+    storage_dead(_6)
+    return
 }
 
 

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -179,6 +179,36 @@ impl Destruct for closure::<()> {
     non-dyn-compatible
 }
 
+// Full name: test_crate::foo::{const}::{impl Fn<((),)> for closure::<()>}::call::<()>
+fn call::<()><'_0>(_1: &'_0 closure::<()>, tupled_args: ((),))
+{
+    let _0: (); // return
+    let _1: &'1 closure::<()>; // arg #1
+    let tupled_args: ((),); // arg #2
+    let x: (); // local
+
+    storage_live(x)
+    _0 = ()
+    x = move tupled_args.0
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}::call_mut::<()>
+fn call_mut::<()><'_0>(state: &'_0 mut closure::<()>, args: ((),))
+{
+    let _0: (); // return
+    let state: &'_0 mut closure::<()>; // arg #1
+    let args: ((),); // arg #2
+    let _3: &'0 closure::<()>; // anonymous local
+
+    _0 = ()
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call::<()><'2>(move _3, move args)
+    return
+}
+
 // Full name: test_crate::main
 pub fn main()
 {


### PR DESCRIPTION
Mono mode doesn't translate trait methods yet, but we can still translate their implementations.