### PR TITLE
ci: change heartbeat delay

### DIFF
--- a/.github/workflows/select-runner.yml
+++ b/.github/workflows/select-runner.yml
@@ -25,7 +25,7 @@ jobs:
 
           self_hosted='["self-hosted","linux","nix"]'
           github_hosted='["ubuntu-latest"]'
-          max_age_seconds=$((3 * 60 * 60))
+          max_age_seconds=$((10 * 60 * 60))
 
           query_error="$(mktemp)"
           if default_branch=$(gh api "repos/${GITHUB_REPOSITORY}" --jq .default_branch 2>"$query_error"); then


### PR DESCRIPTION
GitHub Action's cron jobs are highly unreliable: I've seen a 5h delay between jobs meant to run every 2 hours...