### PR TITLE
Give a robust order to monomorphized declarations

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.219"
+let supported_charon_version = "0.1.220"

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -216,6 +216,8 @@ and cli_options = {
   no_serialize : bool;  (** Don't serialize the final (U)LLBC to a file. *)
   no_typecheck : bool;  (** Skip the typecheck passes. *)
   no_normalize : bool;  (** Don't normalize associated types. *)
+  no_reorder_decls : bool;
+      (** Don't compute a stable order for declarations. *)
   abort_on_error : bool;
       (** Panic on the first error. This is useful for debugging. *)
   error_on_warnings : bool;  (** Consider any warnings to be errors. *)
@@ -377,6 +379,6 @@ and translated_crate = {
           be removed from the crate, but we keep them around to be able to tell
           method implementations apart.
 
-          Always [Some] after translation. *)
+          [Some] after translation unless [--no-reorder-decls] is passed. *)
 }
 [@@deriving show]

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2071,6 +2071,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("no_serialize", no_serialize);
           ("no_typecheck", no_typecheck);
           ("no_normalize", no_normalize);
+          ("no_reorder_decls", no_reorder_decls);
           ("abort_on_error", abort_on_error);
           ("error_on_warnings", error_on_warnings);
           ("preset", preset);
@@ -2141,6 +2142,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
         let* no_serialize = bool_of_json ctx no_serialize in
         let* no_typecheck = bool_of_json ctx no_typecheck in
         let* no_normalize = bool_of_json ctx no_normalize in
+        let* no_reorder_decls = bool_of_json ctx no_reorder_decls in
         let* abort_on_error = bool_of_json ctx abort_on_error in
         let* error_on_warnings = bool_of_json ctx error_on_warnings in
         let* preset = option_of_json preset_of_json ctx preset in
@@ -2192,6 +2194,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              no_serialize;
              no_typecheck;
              no_normalize;
+             no_reorder_decls;
              abort_on_error;
              error_on_warnings;
              preset;

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1831,6 +1831,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* no_serialize = bool_of_postcard ctx st in
      let* no_typecheck = bool_of_postcard ctx st in
      let* no_normalize = bool_of_postcard ctx st in
+     let* no_reorder_decls = bool_of_postcard ctx st in
      let* abort_on_error = bool_of_postcard ctx st in
      let* error_on_warnings = bool_of_postcard ctx st in
      let* preset = option_of_postcard preset_of_postcard ctx st in
@@ -1882,6 +1883,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           no_serialize;
           no_typecheck;
           no_normalize;
+          no_reorder_decls;
           abort_on_error;
           error_on_warnings;
           preset;

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.219"
+version = "0.1.220"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.219"
+version = "0.1.220"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/Makefile
+++ b/charon/Makefile
@@ -10,8 +10,7 @@ format:
 	cargo fmt
 
 .PHONY: test
-test:
-	$(MAKE) test
+test: test-noclippy
 	$(MAKE) clippy
 
 .PHONY: test-noclippy

--- a/charon/src/ast/expressions.rs
+++ b/charon/src/ast/expressions.rs
@@ -250,6 +250,8 @@ pub enum CastKind {
     Debug,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Clone,
     EnumIsA,
     VariantName,
@@ -375,6 +377,8 @@ pub enum Operand {
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     EnumIsA,
     EnumAsGetters,
@@ -416,6 +420,8 @@ impl From<BuiltinFunId> for FunId {
     Copy,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     EnumIsA,
     EnumAsGetters,
@@ -457,7 +463,20 @@ pub enum BuiltinFunId {
 }
 
 /// One of 8 built-in indexing operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Drive,
+    DriveMut,
+)]
 pub struct BuiltinIndexOp {
     /// Whether this is a slice or array.
     #[drive(skip)]
@@ -485,6 +504,8 @@ pub struct MaybeBuiltinFunDeclRef {
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     EnumAsGetters,
     SerializeState,
     DeserializeState,
@@ -511,7 +532,19 @@ impl From<FunDeclId> for FnPtrKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, Hash)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct FnPtr {
     pub kind: Box<FnPtrKind>,
     pub generics: BoxedArgs,
@@ -523,7 +556,19 @@ impl From<FunDeclRef> for FnPtr {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, Hash)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("Prov"))]
 pub enum Provenance {
     Global(GlobalDeclRef),
@@ -533,7 +578,19 @@ pub enum Provenance {
 
 /// A byte, in the MiniRust sense: it can either be uninitialized, a concrete u8 value,
 /// or part of a pointer with provenance (e.g. to a global or a function)
-#[derive(Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, Hash)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub enum Byte {
     /// An uninitialized byte
     Uninit,
@@ -575,9 +632,11 @@ pub enum Byte {
 /// reading the constant `a.b` is translated to `{ _1 = const a; _2 = (_1.0) }`.
 #[derive(
     Debug,
-    Hash,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
+    Hash,
     Clone,
     VariantName,
     EnumIsA,
@@ -666,7 +725,19 @@ pub enum ConstantExprKind {
     Opaque(String),
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct ConstantExpr {
     pub kind: ConstantExprKind,

--- a/charon/src/ast/gast.rs
+++ b/charon/src/ast/gast.rs
@@ -230,7 +230,19 @@ pub struct FunDecl {
 }
 
 /// Reference to a function declaration.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct FunDeclRef {
     pub id: FunDeclId,
     /// Generic arguments passed to the function.
@@ -272,7 +284,19 @@ pub struct GlobalDecl {
 }
 
 /// Reference to a global declaration.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct GlobalDeclRef {
     pub id: GlobalDeclId,
     pub generics: BoxedArgs,
@@ -438,7 +462,19 @@ pub struct TraitImpl {
 }
 
 /// The value of a trait associated type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TraitAssocTyImpl {
     pub value: Ty,
     /// This matches the corresponding vector in `TraitAssocTy`. In the same way, this is empty

--- a/charon/src/ast/hash_cons.rs
+++ b/charon/src/ast/hash_cons.rs
@@ -27,6 +27,18 @@ impl<T> HashConsed<T> {
     }
 }
 
+impl<T: PartialOrd> PartialOrd for HashConsed<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.inner().partial_cmp(other.inner())
+    }
+}
+
+impl<T: Ord> Ord for HashConsed<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner().cmp(other.inner())
+    }
+}
+
 pub trait HashConsable: Hash + PartialEq + Eq + Clone + Mappable {}
 impl<T> HashConsable for T where T: Hash + PartialEq + Eq + Clone + Mappable {}
 

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -290,7 +290,7 @@ pub struct TranslatedCrate {
     /// referred to by reachable items so could in principle be removed from the crate, but we keep
     /// them around to be able to tell method implementations apart.
     ///
-    /// Always `Some` after translation.
+    /// `Some` after translation unless `--no-reorder-decls` is passed.
     #[drive(skip)]
     #[serde_state(stateless)]
     pub ordered_decls: Option<DeclarationsGroups>,

--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -47,11 +47,13 @@ pub enum Region {
 #[derive(
     Debug,
     Clone,
-    SerializeState,
-    DeserializeState,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
+    SerializeState,
+    DeserializeState,
     EnumIsA,
     EnumAsGetters,
     Drive,
@@ -149,7 +151,19 @@ pub enum TraitRefKind {
 
 /// Describes a built-in impl. Mostly lists the implemented trait, sometimes with more details
 /// about the contents of the implementation.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("Builtin"))]
 pub enum BuiltinImplData {
     /// Auto traits (defined with `auto trait ...`, also `Unpin`).
@@ -194,11 +208,35 @@ pub enum BuiltinImplData {
 /// A reference to a trait.
 ///
 /// This type is hash-consed, `TraitRefContents` contains the actual data.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct TraitRef(pub HashConsed<TraitRefContents>);
 
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TraitRefContents {
     pub kind: TraitRefKind,
     /// Not necessary, but useful
@@ -213,7 +251,19 @@ pub struct TraitRefContents {
 /// ```
 ///
 /// The substitution is: `[String, bool]`.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TraitDeclRef {
     pub id: TraitDeclId,
     pub generics: BoxedArgs,
@@ -223,14 +273,38 @@ pub struct TraitDeclRef {
 pub type PolyTraitDeclRef = RegionBinder<TraitDeclRef>;
 
 /// A reference to a tait impl, using the provided arguments.
-#[derive(Debug, Clone, SerializeState, DeserializeState, PartialEq, Eq, Hash, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TraitImplRef {
     pub id: TraitImplId,
     pub generics: BoxedArgs,
 }
 
 /// .0 outlives .1
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct OutlivesPred<T, U>(pub T, pub U);
 
 pub type RegionOutlives = OutlivesPred<Region, Region>;
@@ -243,7 +317,19 @@ pub type TypeOutlives = OutlivesPred<Ty, Region>;
 /// T : Foo<S = String>
 ///         ^^^^^^^^^^
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TraitTypeConstraint {
     pub trait_ref: TraitRef,
     pub type_id: AssocTypeId,
@@ -251,7 +337,9 @@ pub struct TraitTypeConstraint {
 }
 
 /// A set of generic arguments.
-#[derive(Clone, Eq, PartialEq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Clone, PartialEq, Eq, PartialOrd, Ord, Hash, SerializeState, DeserializeState, Drive, DriveMut,
+)]
 pub struct GenericArgs {
     pub regions: IndexVec<RegionId, Region>,
     pub types: IndexVec<TypeVarId, Ty>,
@@ -263,7 +351,19 @@ pub type BoxedArgs = Box<GenericArgs>;
 
 /// A value of type `T` bound by regions. We should use `binder` instead but this causes name clash
 /// issues in the derived ocaml visitors.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct RegionBinder<T> {
     #[cfg_attr(feature = "charon_on_charon", charon::rename("binder_regions"))]
     #[serde_state(stateless)]
@@ -274,7 +374,19 @@ pub struct RegionBinder<T> {
     pub skip_binder: T,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("BK"))]
 pub enum BinderKind {
     /// The parameters of a generic associated type.
@@ -293,7 +405,19 @@ pub enum BinderKind {
 /// A value of type `T` bound by generic parameters. Used in any context where we're adding generic
 /// parameters that aren't on the top-level item, e.g. `for<'a>` clauses (uses `RegionBinder` for
 /// now), trait methods, GATs (TODO).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct Binder<T> {
     #[cfg_attr(feature = "charon_on_charon", charon::rename("binder_params"))]
     pub params: GenericParams,
@@ -308,7 +432,17 @@ pub struct Binder<T> {
 
 /// Generic parameters for a declaration, including predicates.
 #[derive(
-    Default, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
 )]
 pub struct GenericParams {
     #[serde_state(stateless)]
@@ -327,7 +461,19 @@ pub struct GenericParams {
 }
 
 /// Where a given predicate came from.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub enum PredicateOrigin {
     // Note: we use this for globals too, but that's only available with an unstable feature.
     // ```
@@ -462,7 +608,19 @@ pub struct Layout {
 /// The metadata stored in a pointer. That's the information stored in pointers alongside
 /// their address. It's empty for `Sized` types, and interesting for unsized
 /// aka dynamically-sized types.
-#[derive(Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[serde_state(default_state = ())]
 pub enum PtrMetadata {
     /// Types that need no metadata, namely `T: Sized` types.
@@ -790,7 +948,19 @@ pub enum TypeId {
 }
 
 /// Reference to a type declaration or builtin type.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct TypeDeclRef {
     pub id: TypeId,
     pub generics: BoxedArgs,
@@ -832,7 +1002,19 @@ pub enum LiteralTy {
 ///
 /// Warning: the `DriveMut` impls of `Ty` needs to clone and re-hash the modified type to maintain
 /// the hash-consing invariant. This is expensive, avoid visiting types mutably when not needed.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 #[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Ty(pub HashConsed<TyKind>);
 
@@ -841,6 +1023,8 @@ pub struct Ty(pub HashConsed<TyKind>);
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     VariantName,
     EnumIsA,
@@ -997,7 +1181,9 @@ impl ClosureKind {
 }
 
 /// Additional information for closures.
-#[derive(Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, SerializeState, DeserializeState, Drive, DriveMut,
+)]
 pub struct ClosureInfo {
     #[serde_state(stateless)]
     pub kind: ClosureKind,
@@ -1012,7 +1198,19 @@ pub struct ClosureInfo {
 }
 
 /// A function signature.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct FunSig {
     /// Is the function unsafe or not
     #[drive(skip)]
@@ -1032,6 +1230,8 @@ pub struct FunSig {
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     VariantName,
     EnumIsA,
@@ -1064,7 +1264,19 @@ impl Abi {
 }
 
 /// The contents of a `dyn Trait` type.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct DynPredicate {
     /// This binder binds a single type `T`, which is considered existentially quantified. The
     /// predicates in the binder apply to `T` and represent the `dyn Trait` constraints.
@@ -1081,6 +1293,8 @@ pub struct DynPredicate {
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     VariantName,
     EnumIsA,

--- a/charon/src/ast/types/vars.rs
+++ b/charon/src/ast/types/vars.rs
@@ -101,7 +101,9 @@ generate_index_type!(TraitClauseId, "TraitClause");
 generate_index_type!(TraitTypeConstraintId, "TraitTypeConstraint");
 
 /// A type variable in a signature or binder.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Drive, DriveMut)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Drive, DriveMut,
+)]
 pub struct TypeParam {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: TypeVarId,
@@ -128,7 +130,19 @@ pub struct RegionParam {
 }
 
 /// A const generic variable in a signature or binder.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState, Drive, DriveMut)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+)]
 pub struct ConstGenericParam {
     /// Index identifying the variable among other variables bound at the same level.
     pub index: ConstGenericVarId,
@@ -159,6 +173,18 @@ impl PartialEq for TraitParam {
     fn eq(&self, other: &Self) -> bool {
         // Skip `span` and `origin`
         self.clause_id == other.clause_id && self.trait_ == other.trait_
+    }
+}
+
+impl PartialOrd for TraitParam {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TraitParam {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.clause_id, &self.trait_).cmp(&(&other.clause_id, &other.trait_))
     }
 }
 

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -301,6 +301,10 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub no_normalize: bool,
+    /// Don't compute a stable order for declarations.
+    #[clap(long)]
+    #[serde(default)]
+    pub no_reorder_decls: bool,
     /// Panic on the first error. This is useful for debugging.
     #[clap(long)]
     #[serde(default)]
@@ -446,6 +450,7 @@ impl CliOpts {
                     self.ullbc = true;
                     self.no_typecheck = true;
                     self.no_normalize = true;
+                    self.no_reorder_decls = true;
                     self.hide_marker_traits = true;
                     self.raw_consts = true;
                 }
@@ -482,6 +487,7 @@ impl CliOpts {
                     self.mir = Some(MirLevel::Elaborated);
                     self.monomorphize = true;
                     self.no_normalize = true;
+                    self.no_reorder_decls = true;
                     self.precise_drops = true;
                     self.consts = Some(ConstHandling::Values);
                     self.ullbc = true;
@@ -665,6 +671,8 @@ pub struct TranslateOptions {
     pub no_typecheck: bool,
     /// Don't normalize associated types.
     pub no_normalize: bool,
+    /// Don't reorder declarations and compute recursive declaration groups.
+    pub no_reorder_decls: bool,
     /// Transform Drop to Call drop_glue
     pub desugar_drops: bool,
     /// Add `Destruct` bounds to all generic params.
@@ -814,6 +822,7 @@ impl TranslateOptions {
             duplicate_defaulted_methods: options.duplicate_defaulted_methods,
             no_typecheck: options.no_typecheck,
             no_normalize: options.no_normalize,
+            no_reorder_decls: options.no_reorder_decls,
             desugar_drops: options.desugar_drops,
             add_destruct_bounds: options.precise_drops,
         }

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -7,6 +7,7 @@
 //! to be explicit about mutual recursion. This should come useful for translation to any other
 //! language with these properties.
 use crate::common::*;
+use crate::options::TranslateOptions;
 use crate::transform::TransformCtx;
 use crate::ullbc_ast::*;
 use derive_generic_visitor::*;
@@ -475,6 +476,10 @@ fn compute_reordered_decls(ctx: &mut TransformCtx) -> DeclarationsGroups {
 
 pub struct Transform;
 impl TransformPass for Transform {
+    fn should_run(&self, options: &TranslateOptions) -> bool {
+        !options.no_reorder_decls
+    }
+
     fn transform_ctx(&self, ctx: &mut TransformCtx) {
         let reordered_decls = compute_reordered_decls(ctx);
         ctx.translated.ordered_decls = Some(reordered_decls);

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -426,7 +426,13 @@ fn compute_reordered_decls(ctx: &mut TransformCtx) -> DeclarationsGroups {
         let item_meta = item.item_meta();
         let span = item_meta.span.data;
         let file_name_order = sorted_file_ids.get(span.file_id);
-        (item_meta.is_local, file_name_order, span.beg, item.id())
+        (
+            item_meta.is_local,
+            file_name_order,
+            span.beg,
+            item_meta.name.mono_args().cloned(),
+            item.id(),
+        )
     };
     // We record for each item the order in which we're sorting it, to make `sort_by` cheap.
     let item_sorted_index: HashMap<ItemId, usize> = ctx

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -183,6 +183,9 @@ Options:
       --no-normalize
           Don't normalize associated types
 
+      --no-reorder-decls
+          Don't compute a stable order for declarations
+
       --abort-on-error
           Panic on the first error. This is useful for debugging
 

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -71,22 +71,22 @@ fn foo::<u8><'a>(x: &'a u8)
     return
 }
 
-// Full name: test_crate::foo::<char>
-fn foo::<char><'a>(x: &'a char)
+// Full name: test_crate::foo::<u32>
+fn foo::<u32><'a>(x: &'a u32)
 {
     let _0: (); // return
-    let x: &'1 char; // arg #1
+    let x: &'1 u32; // arg #1
 
     _0 = ()
     _0 = ()
     return
 }
 
-// Full name: test_crate::foo::<u32>
-fn foo::<u32><'a>(x: &'a u32)
+// Full name: test_crate::foo::<char>
+fn foo::<char><'a>(x: &'a char)
 {
     let _0: (); // return
-    let x: &'1 u32; // arg #1
+    let x: &'1 char; // arg #1
 
     _0 = ()
     _0 = ()

--- a/charon/tests/ui/monomorphization/global_with_generics.out
+++ b/charon/tests/ui/monomorphization/global_with_generics.out
@@ -1,13 +1,13 @@
 # Final LLBC before serialization:
 
-// Full name: test_crate::Foo::<bool>
-struct Foo::<bool> {
-  value: bool,
-}
-
 // Full name: test_crate::Foo::<i32>
 struct Foo::<i32> {
   value: i32,
+}
+
+// Full name: test_crate::Foo::<bool>
+struct Foo::<bool> {
+  value: bool,
 }
 
 // Full name: test_crate::FooInt

--- a/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
+++ b/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
@@ -19,13 +19,6 @@ opaque type {vtable}
 #[lang_item("meta_sized")]
 pub trait MetaSized<Self>
 
-// Full name: core::option::Option::<&'_ [u64]>
-#[lang_item("Option")]
-pub enum Option::<&'_ [u64]> {
-  None,
-  Some(&'_ [u64]),
-}
-
 // Full name: core::option::Option
 #[lang_item("Option")]
 pub enum Option<T>
@@ -34,6 +27,13 @@ where
 {
   None,
   Some(T),
+}
+
+// Full name: core::option::Option::<&'_ [u64]>
+#[lang_item("Option")]
+pub enum Option::<&'_ [u64]> {
+  None,
+  Some(&'_ [u64]),
 }
 
 // Full name: test_crate::MyConfig


### PR DESCRIPTION
The `ordered_decls` list is robustly ordered for poly declarations, but for mono ones it would still depend on incidental details of translation. This fixes that by sorting the monomorphized types. Order may still change if we change the representation of types significantly, but that seems less common.