### PR TITLE
Remove the `Serialize` derive on `Layout`

### DIFF
--- a/charon/src/ast/types.rs
+++ b/charon/src/ast/types.rs
@@ -567,19 +567,7 @@ pub enum Discriminator {
 /// Does not include information about niches.
 /// If the type does not have a fully known layout (e.g. it is ?Sized)
 /// some of the layout parts are not available.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-)]
-#[serde_state(stateless)]
+#[derive(Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut)]
 pub struct Layout {
     /// The size of the type in bytes.
     #[drive(skip)]
@@ -589,6 +577,7 @@ pub struct Layout {
     pub align: Option<ByteCount>,
     /// Decision tree that determines the active variant by reading memory. Only `Some` for enums.
     #[drive(skip)]
+    #[serde_state(stateless)]
     pub discriminator: Option<Discriminator>,
     /// Whether the type is uninhabited, i.e. has any valid value at all.
     /// Note that uninhabited types can have arbitrary layouts: `(u32, !)` has space for the `u32`
@@ -598,6 +587,7 @@ pub struct Layout {
     /// Map from `VariantId` to the corresponding field layouts. Some variants don't have a
     /// meaningful layout due to being uninhabited (though an uninhabited variant may have a
     /// layout). Structs and unions are modeled as having exactly one variant.
+    #[serde_state(stateless)]
     pub variant_layouts: IndexVec<VariantId, Option<VariantLayout>>,
     /// The representation options of this type declaration as annotated by the user.
     #[drive(skip)]

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use serde_state::WithState;
 use std::path::PathBuf;
 
 use charon_lib::ast::*;
@@ -234,7 +235,7 @@ fn type_layout() -> anyhow::Result<()> {
         }
     }
 
-    let layouts: SeqHashMap<String, Option<Layout>> = crate_data
+    let layouts: SeqHashMap<String, Option<_>> = crate_data
         .type_decls
         .iter()
         .filter_map(|tdecl| {
@@ -242,7 +243,9 @@ fn type_layout() -> anyhow::Result<()> {
                 return None;
             }
             let name = repr_name(&crate_data, &tdecl.item_meta.name);
-            Some((name, tdecl.layout.get(&the_target).cloned()))
+            let opt_layout = tdecl.layout.get(&the_target).cloned();
+            let serializable = opt_layout.map(|l| WithState::new(l, &()));
+            Some((name, serializable))
         })
         .collect();
     let layouts_str = serde_json::to_string_pretty(&layouts)?;


### PR DESCRIPTION
In preparation for work where `Layout` would store types that need real state.

cc @firefighterduck 