### PR TITLE
ci: build release for older glibc versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,13 +93,6 @@ jobs:
           rm -f "../${{ matrix.artifact_name }}.tar.gz"
           tar -czf "../${{ matrix.artifact_name }}.tar.gz" -- *
 
-      # On Linux, check that the release binaries are compatible with older glibc versions
-      - name: Check glibc version
-        if: ${{ startsWith(matrix.artifact_name, 'charon-linux') }}
-        run: |
-          set -eo pipefail
-          nix build -L .#charon-release-glibc-check
-
       # Verify the binary is functional and still links to `rustc_driver.so` on Linux.
       - name: Smoke Test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,13 @@ jobs:
           rm -f "../${{ matrix.artifact_name }}.tar.gz"
           tar -czf "../${{ matrix.artifact_name }}.tar.gz" -- *
 
+      # On Linux, check that the release binaries are compatible with older glibc versions
+      - name: Check glibc version
+        if: ${{ startsWith(matrix.artifact_name, 'charon-linux') }}
+        run: |
+          set -eo pipefail
+          nix build -L .#charon-release-glibc-check
+
       # Verify the binary is functional and still links to `rustc_driver.so` on Linux.
       - name: Smoke Test
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,11 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
         ocamlformat = pkgs.ocamlPackages.ocamlformat_0_27_0;
 
+        # Glibc version that the Linux release binaries are lowered to after building
+        # to ensure compatibility with older Linux systems
+        releaseGlibcVersion = "2.35";
+        polyfill-glibc = pkgs.callPackage ./nix/polyfill-glibc.nix { };
+
         fullMirSysroots = pkgs.callPackage ./nix/full-mir-sysroots.nix { inherit rustToolchain; };
         charon-unwrapped = pkgs.callPackage ./nix/charon.nix {
           inherit craneLib;
@@ -74,12 +79,40 @@
             ${pkgs.patchelf}/bin/patchelf --remove-rpath $f || true
           done
         ''));
-        charon-release = pkgs.runCommand "charon-release" { } ''
+        charon-release = pkgs.runCommand "charon-release" { } (''
           mkdir $out
           cd $out
           cp ${charon-portable}/bin/charon ${charon-portable}/bin/charon-driver .
           cp ${./charon/rust-toolchain} rust-toolchain
-        '';
+        ''
+        # Lower the glibc version the binaries require, so the release runs on
+        # any host with glibc >= ${releaseGlibcVersion} regardless of the
+        # (newer) glibc it was built against.
+        + lib.optionalString stdenv.isLinux ''
+          chmod +w charon charon-driver
+          for f in charon charon-driver; do
+            ${polyfill-glibc}/bin/polyfill-glibc \
+              --clear-symbol-version=pidfd_getpid,pidfd_spawnp \
+              --target-glibc=${releaseGlibcVersion} "$f"
+          done
+        '');
+        # Sanity-check that the release binaries don't require a glibc newer
+        # than `releaseGlibcVersion`. No-op on non-Linux.
+        charon-release-glibc-check = pkgs.runCommand "charon-release-glibc-check"
+          {
+            nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.binutils ];
+          }
+          ((lib.optionalString stdenv.isLinux ''
+            max="$(objdump -T ${charon-release}/charon ${charon-release}/charon-driver \
+              | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+            echo "Highest required glibc symbol version: ''${max:-none}"
+            if [ -n "$max" ] && [ "$(printf '%s\n${releaseGlibcVersion}\n' "$max" | sort -V | tail -1)" != "${releaseGlibcVersion}" ]; then
+              echo "ERROR: charon-release-glibc-check failed. Release binaries require glibc $max > ${releaseGlibcVersion}." >&2
+              exit 1
+            fi
+          '') + ''
+            touch $out
+          '');
         charon-ml = pkgs.callPackage ./nix/charon-ml.nix { inherit charon; };
 
         # Check rust files are correctly formatted.
@@ -142,7 +175,7 @@
       in
       {
         packages = {
-          inherit charon charon-unwrapped charon-portable charon-release charon-ml rustToolchain;
+          inherit charon charon-unwrapped charon-portable charon-release charon-release-glibc-check charon-ml polyfill-glibc rustToolchain;
           charon-full-mir-sysroots = fullMirSysroots;
           inherit (rustc-tests) rustc-tests;
           default = charon;

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,12 @@
         # Lower the glibc version the binaries require, so the release runs on
         # any host with glibc >= ${releaseGlibcVersion} regardless of the
         # (newer) glibc it was built against.
+        #
+        # We need to use `--clear-symbol-version` for `pidfd_getpid` and `pidfd_spawnp` because
+        # `polyfill-glibc` has no polyfill for them and refuses to process the binary when they
+        # carry a symbol version above ${releaseGlibcVersion}. Glibc versions before 2.39 did not
+        # have these symbols at all, but Rust only imports them weakly and will fall back to a
+        # different mechanism when these symbols are not available.
         + lib.optionalString stdenv.isLinux ''
           chmod +w charon charon-driver
           for f in charon charon-driver; do

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,11 @@
             ${pkgs.patchelf}/bin/patchelf --remove-rpath $f || true
           done
         ''));
-        charon-release = pkgs.runCommand "charon-release" { } (''
+        charon-release = pkgs.runCommand "charon-release"
+          {
+            nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.binutils ];
+          }
+          (''
           mkdir $out
           cd $out
           cp ${charon-portable}/bin/charon ${charon-portable}/bin/charon-driver .
@@ -101,24 +105,17 @@
               --clear-symbol-version=pidfd_getpid,pidfd_spawnp \
               --target-glibc=${releaseGlibcVersion} "$f"
           done
+
+          # Sanity-check that the release binaries don't require a glibc newer
+          # than `releaseGlibcVersion`.
+          max="$(objdump -T charon charon-driver \
+            | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+          echo "Highest required glibc symbol version: ''${max:-none}"
+          if [ -n "$max" ] && [ "$(printf '%s\n${releaseGlibcVersion}\n' "$max" | sort -V | tail -1)" != "${releaseGlibcVersion}" ]; then
+            echo "ERROR: charon-release requires glibc $max > ${releaseGlibcVersion}." >&2
+            exit 1
+          fi
         '');
-        # Sanity-check that the release binaries don't require a glibc newer
-        # than `releaseGlibcVersion`. No-op on non-Linux.
-        charon-release-glibc-check = pkgs.runCommand "charon-release-glibc-check"
-          {
-            nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.binutils ];
-          }
-          ((lib.optionalString stdenv.isLinux ''
-            max="$(objdump -T ${charon-release}/charon ${charon-release}/charon-driver \
-              | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1)"
-            echo "Highest required glibc symbol version: ''${max:-none}"
-            if [ -n "$max" ] && [ "$(printf '%s\n${releaseGlibcVersion}\n' "$max" | sort -V | tail -1)" != "${releaseGlibcVersion}" ]; then
-              echo "ERROR: charon-release-glibc-check failed. Release binaries require glibc $max > ${releaseGlibcVersion}." >&2
-              exit 1
-            fi
-          '') + ''
-            touch $out
-          '');
         charon-ml = pkgs.callPackage ./nix/charon-ml.nix { inherit charon; };
 
         # Check rust files are correctly formatted.
@@ -181,7 +178,7 @@
       in
       {
         packages = {
-          inherit charon charon-unwrapped charon-portable charon-release charon-release-glibc-check charon-ml polyfill-glibc rustToolchain;
+          inherit charon charon-unwrapped charon-portable charon-release charon-ml polyfill-glibc rustToolchain;
           charon-full-mir-sysroots = fullMirSysroots;
           inherit (rustc-tests) rustc-tests;
           default = charon;

--- a/nix/polyfill-glibc.nix
+++ b/nix/polyfill-glibc.nix
@@ -1,0 +1,31 @@
+# polyfill-glibc (https://github.com/corsix/polyfill-glibc): a post-processing
+# tool that rewrites an ELF's glibc symbol-version requirements down to a chosen
+# version, so a binary built against a newer glibc runs on older ones.
+# Not (yet) packaged in nixpkgs, hence this small derivation.
+{ stdenv, fetchFromGitHub, ninja }:
+
+stdenv.mkDerivation {
+  pname = "polyfill-glibc";
+  version = "0-unstable-2024-10-30";
+
+  src = fetchFromGitHub {
+    owner = "corsix";
+    repo = "polyfill-glibc";
+    rev = "dd59051faaa10ee63c1b96f1b47bf9fcd3770ee2";
+    hash = "sha256-Qkzy33dIGnv9BOmRwql+LpYaEukZZIADSux09Fz3h7E=";
+  };
+
+  nativeBuildInputs = [ ninja ];
+
+  buildPhase = ''
+    runHook preBuild
+    ninja polyfill-glibc
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 polyfill-glibc $out/bin/polyfill-glibc
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
This PR uses polyfill-glibc to make the charon binaries compatible with older glibc versions.

Disclaimer: Mostly coded by Claude. I am not a Nix expert.