### PR TITLE
Promote shifts across blocks in reconstruct_fallible_operations

### DIFF
--- a/charon/src/transform/resugar/reconstruct_fallible_operations.rs
+++ b/charon/src/transform/resugar/reconstruct_fallible_operations.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 
 use derive_generic_visitor::*;
 
+use crate::ast::ullbc_ast_utils::StmtLoc;
 use crate::ast::*;
 use crate::ids::IndexVec;
 use crate::transform::TransformCtx;
@@ -143,6 +144,24 @@ fn equiv_op(op_l: &Operand, op_r: &Operand) -> bool {
     }
 }
 
+/// A shift overflow check whose shift operation is not in the same block: rustc evaluates the
+/// shift operands (which is when it emits the overflow check) before computing the destination
+/// place, so when that computation involves a function call (e.g. `out[i] = x >> y` through an
+/// overloaded `IndexMut`), the check ends up separated from the shift by the call terminator.
+/// See issue #1041. These asserts are only ever emitted by the compiler, so instead of following
+/// the control flow we record the check and find the matching shift over the whole body in
+/// [resolve_pending_shift_check].
+struct PendingShiftCheck {
+    /// The block containing the check.
+    block: BlockId,
+    /// The checked shift amount; used to find the shift.
+    amount: Operand,
+    /// The comparison result asserted by the check. Identifies the check's statements to remove.
+    cond_local: LocalId,
+    /// The `y as uN` cast temporary, when the amount is cast before the comparison; also removed.
+    cast_local: Option<LocalId>,
+}
+
 /// Rustc inserts dynamic checks during MIR lowering. They all end in an `Assert` statement (and
 /// this is the only use of this statement).
 fn remove_dynamic_checks(
@@ -151,6 +170,7 @@ fn remove_dynamic_checks(
     block_id: BlockId,
     locals: &mut Locals,
     statements: &mut [Statement],
+    pending_shift_checks: &mut Vec<PendingShiftCheck>,
 ) {
     // Whether this local was used in another block
     let used_outside_block = |local: LocalId| {
@@ -393,6 +413,16 @@ fn remove_dynamic_checks(
             if found {
                 rest
             } else {
+                // The shift is not in this block; it may live in a later one (see
+                // [PendingShiftCheck]). Record it and resolve it over the whole body afterwards.
+                if let Some(cond_local) = has_overflow.as_local() {
+                    pending_shift_checks.push(PendingShiftCheck {
+                        block: block_id,
+                        amount: y_op.clone(),
+                        cond_local,
+                        cast_local: Some(cast_local),
+                    });
+                }
                 return;
             }
         }
@@ -425,7 +455,7 @@ fn remove_dynamic_checks(
                                 cond: Operand::Move(cond),
                                 expected: true,
                                 check_kind:
-                                    Some(
+                                    check_kind @ Some(
                                         BuiltinAssertKind::Overflow(..)
                                         | BuiltinAssertKind::BoundsCheck { .. },
                                     ),
@@ -456,6 +486,18 @@ fn remove_dynamic_checks(
             if found {
                 rest
             } else {
+                // The shift may be in a later block (see [PendingShiftCheck]). This only applies
+                // to overflow checks: a bounds check never guards a shift.
+                if matches!(check_kind, Some(BuiltinAssertKind::Overflow(..)))
+                    && let Some(cond_local) = has_overflow.as_local()
+                {
+                    pending_shift_checks.push(PendingShiftCheck {
+                        block: block_id,
+                        amount: y_op.clone(),
+                        cond_local,
+                        cast_local: None,
+                    });
+                }
                 return;
             }
         }
@@ -596,6 +638,100 @@ fn remove_dynamic_checks(
     }
 }
 
+/// Resolve a [PendingShiftCheck] whose shift landed in a different block. We remove the check and
+/// compute the shift early, promoted to panic-on-overflow, into a fresh local placed where the
+/// check used to be; the fresh local then carries the result to the original destination.
+///
+/// This is correct because rustc has already evaluated both shift operands by the time control
+/// reaches the check: the only effects of the shift are that evaluation and the panic-on-overflow,
+/// and the overflow check already performs both at that point. Storing the result in a fresh local
+/// lets us keep the write to the (not-yet-computed) destination place at the original shift site.
+fn resolve_pending_shift_check(body: &mut ExprBody, check: PendingShiftCheck) {
+    let PendingShiftCheck {
+        block,
+        amount,
+        cond_local,
+        cast_local,
+    } = check;
+
+    // Locate the assert we will repurpose to hold the early, promoted shift. Pairing it with the
+    // shift below (via `zip`) means we bail before mutating anything if either is unexpectedly
+    // absent, so the shift is never rewired to a fresh local we never assigned.
+    let assert_pos = body.body[block].statements.iter().position(|stmt| {
+        matches!(
+            &stmt.kind,
+            StatementKind::Assert {
+                assert: Assert {
+                    cond: Operand::Move(cond),
+                    ..
+                },
+                ..
+            } if cond.as_local() == Some(cond_local)
+        )
+    });
+
+    // rustc only emits these asserts for its own shifts, so we don't follow the control flow: we
+    // look for the (still-wrapping) shift by its amount anywhere in the body.
+    let Some(((shift_loc, dest, lhs, rhs, panic_binop, ty), assert_pos)) = body
+        .body
+        .iter_enumerated()
+        .find_map(|(sb, block_data)| {
+            block_data
+                .statements
+                .iter()
+                .enumerate()
+                .find_map(|(i, stmt)| {
+                    if let StatementKind::Assign(dest, Rvalue::BinaryOp(binop, lhs, rhs)) =
+                        &stmt.kind
+                        && matches!(
+                            binop,
+                            BinOp::Shl(OverflowMode::Wrap) | BinOp::Shr(OverflowMode::Wrap)
+                        )
+                        && equiv_op(rhs, &amount)
+                    {
+                        Some((
+                            StmtLoc::new(sb, i),
+                            dest.clone(),
+                            lhs.clone(),
+                            rhs.clone(),
+                            binop.with_overflow(OverflowMode::Panic),
+                            dest.ty.clone(),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+        })
+        .zip(assert_pos)
+    else {
+        return;
+    };
+
+    // Every mutation below now happens together, so the fresh local is always assigned and used.
+    let fresh = body.locals.new_var(None, ty);
+
+    // Drop the check's comparison and optional cast; they are dead once the assert is gone.
+    body.body[block].statements.iter_mut().for_each(|stmt| {
+        let is_check_temp = if let StatementKind::Assign(place, _) = &stmt.kind {
+            let local = place.as_local();
+            local == Some(cond_local) || cast_local.is_some_and(|c| local == Some(c))
+        } else {
+            false
+        };
+        if is_check_temp {
+            stmt.kind = StatementKind::Nop;
+        }
+    });
+
+    // Compute the shift early, promoted to panic-on-overflow, where the check used to be.
+    body[StmtLoc::new(block, assert_pos)].kind =
+        StatementKind::Assign(fresh.clone(), Rvalue::BinaryOp(panic_binop, lhs, rhs));
+
+    // Forward the result at the original shift site.
+    body[shift_loc].kind =
+        StatementKind::Assign(dest, Rvalue::Use(Operand::Move(fresh), WithRetag::No));
+}
+
 pub struct Transform;
 impl UllbcPass for Transform {
     fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
@@ -604,9 +740,14 @@ impl UllbcPass for Transform {
 
     fn transform_body(&self, ctx: &mut TransformCtx, b: &mut ExprBody) {
         let local_uses: LocalUses = compute_uses(b);
+        let mut pending_shift_checks = Vec::new();
         b.transform_sequences_fwd(|id, locals, seq| {
-            remove_dynamic_checks(ctx, &local_uses, id, locals, seq);
+            remove_dynamic_checks(ctx, &local_uses, id, locals, seq, &mut pending_shift_checks);
             Vec::new()
         });
+        // Resolve the checks whose shift lives in a later block (see [PendingShiftCheck]).
+        pending_shift_checks
+            .into_iter()
+            .for_each(|check| resolve_pending_shift_check(b, check));
     }
 }

--- a/charon/tests/ui/issue-1041-shift-through-index-mut.out
+++ b/charon/tests/ui/issue-1041-shift-through-index-mut.out
@@ -110,45 +110,39 @@ pub fn shr_into_index<'_0>(x: u64, out: &'_0 mut Wrap)
     let x: u64; // arg #1
     let out: &'1 mut Wrap; // arg #2
     let _3: u64; // anonymous local
-    let _4: u32; // anonymous local
-    let _5: bool; // anonymous local
-    let _6: &'3 mut u64; // anonymous local
-    let _7: &'4 mut Wrap; // anonymous local
+    let _4: &'3 mut u64; // anonymous local
+    let _5: &'4 mut Wrap; // anonymous local
+    let _6: u64; // anonymous local
 
     bb0: {
+        storage_live(_6);
         storage_live(_0);
-        storage_live(_4);
-        storage_live(_5);
         _0 = ();
         storage_live(_3);
         _3 = copy x;
-        _4 = cast<i32, u32>(const 20i32);
-        _5 = move _4 < const 64u32;
-        assert(move _5 == true) (overflow) else panic;
-        storage_live(_6);
-        storage_live(_7);
-        _7 = &mut (*out);
-        _6 = index_mut<'6>(move _7, const 0usize) -> bb2 (unwind: bb1);
+        _6 = move _3 panic.>> const 20i32;
+        storage_live(_4);
+        storage_live(_5);
+        _5 = &mut (*out);
+        _4 = index_mut<'6>(move _5, const 0usize) -> bb2 (unwind: bb1);
     }
 
     bb1: {
-        storage_dead(_5);
-        storage_dead(_4);
         storage_dead(out);
         storage_dead(x);
+        storage_dead(_6);
         unwind_continue;
     }
 
     bb2: {
-        storage_dead(_7);
-        (*_6) = move _3 wrap.>> const 20i32;
-        storage_dead(_3);
-        storage_dead(_6);
-        _0 = ();
         storage_dead(_5);
+        (*_4) = move _6;
+        storage_dead(_3);
         storage_dead(_4);
+        _0 = ();
         storage_dead(out);
         storage_dead(x);
+        storage_dead(_6);
         return;
     }
 }
@@ -162,45 +156,44 @@ pub fn shl_into_index_by_var<'_0>(x: u64, n: u32, out: &'_0 mut Wrap)
     let out: &'1 mut Wrap; // arg #3
     let _4: u64; // anonymous local
     let _5: u32; // anonymous local
-    let _6: bool; // anonymous local
-    let _7: &'3 mut u64; // anonymous local
-    let _8: &'4 mut Wrap; // anonymous local
+    let _6: &'3 mut u64; // anonymous local
+    let _7: &'4 mut Wrap; // anonymous local
+    let _8: u64; // anonymous local
 
     bb0: {
+        storage_live(_8);
         storage_live(_0);
-        storage_live(_6);
         _0 = ();
         storage_live(_4);
         _4 = copy x;
         storage_live(_5);
         _5 = copy n;
-        _6 = copy _5 < const 64u32;
-        assert(move _6 == true) (overflow) else panic;
+        _8 = move _4 panic.<< move _5;
+        storage_live(_6);
         storage_live(_7);
-        storage_live(_8);
-        _8 = &mut (*out);
-        _7 = index_mut<'6>(move _8, const 1usize) -> bb2 (unwind: bb1);
+        _7 = &mut (*out);
+        _6 = index_mut<'6>(move _7, const 1usize) -> bb2 (unwind: bb1);
     }
 
     bb1: {
-        storage_dead(_6);
         storage_dead(out);
         storage_dead(n);
         storage_dead(x);
+        storage_dead(_8);
         unwind_continue;
     }
 
     bb2: {
-        storage_dead(_8);
-        (*_7) = move _4 wrap.<< move _5;
+        storage_dead(_7);
+        (*_6) = move _8;
         storage_dead(_5);
         storage_dead(_4);
-        storage_dead(_7);
-        _0 = ();
         storage_dead(_6);
+        _0 = ();
         storage_dead(out);
         storage_dead(n);
         storage_dead(x);
+        storage_dead(_8);
         return;
     }
 }

--- a/charon/tests/ui/issue-1041-shift-through-index-mut.out
+++ b/charon/tests/ui/issue-1041-shift-through-index-mut.out
@@ -1,0 +1,209 @@
+# Final ULLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[lang_item("meta_sized")]
+pub trait MetaSized<Self>
+
+// Full name: core::ops::index::Index
+#[lang_item("index")]
+pub trait Index<Self, Idx>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Idx: MetaSized)
+    proof ImpliedClause2: (Self::Output: MetaSized)
+    type Output
+    fn index<'_0_1>;
+    vtable: core::ops::index::Index::{vtable}<Idx, Self::Output>
+}
+
+// Full name: core::ops::index::IndexMut
+#[lang_item("index_mut")]
+pub trait IndexMut<Self, Idx>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Index<Idx>)
+    proof ImpliedClause2: (Idx: MetaSized)
+    fn index_mut<'_0_1>;
+    vtable: core::ops::index::IndexMut::{vtable}<Idx, Self::ImpliedClause1::Output>
+}
+
+// Full name: test_crate::Wrap
+pub struct Wrap {
+  [u64; 2usize],
+}
+
+// Full name: test_crate::{impl Index<usize> for Wrap}::index
+pub fn index<'_0>(self: &'_0 Wrap, i: usize) -> &'_0 u64
+{
+    let _0: &'1 u64; // return
+    let self: &'3 Wrap; // arg #1
+    let i: usize; // arg #2
+    let _3: &'4 u64; // anonymous local
+    let _4: usize; // anonymous local
+
+    bb0: {
+        storage_live(_0);
+        storage_live(_3);
+        storage_live(_4);
+        _4 = copy i;
+        _3 = &((*self)).0[copy _4];
+        _0 = &(*_3);
+        storage_dead(_4);
+        storage_dead(_3);
+        storage_dead(i);
+        storage_dead(self);
+        return;
+    }
+}
+
+// Full name: test_crate::{impl Index<usize> for Wrap}
+impl "impl_Index_usize_for_Wrap" Index<usize> for Wrap {
+    proof ImpliedClause0: (Wrap: MetaSized) = {built_in impl MetaSized for Wrap}
+    proof ImpliedClause1: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    proof ImpliedClause2: (u64: MetaSized) = {built_in impl MetaSized for u64}
+    type Output = u64
+    fn index<'_0_1> = index<'_0_1>
+    vtable: impl_Index_usize_for_Wrap::{vtable}
+}
+
+// Full name: test_crate::{impl IndexMut<usize> for Wrap}::index_mut
+pub fn index_mut<'_0>(self: &'_0 mut Wrap, i: usize) -> &'_0 mut u64
+{
+    let _0: &'1 mut u64; // return
+    let self: &'3 mut Wrap; // arg #1
+    let i: usize; // arg #2
+    let _3: &'4 mut u64; // anonymous local
+    let _4: &'5 mut u64; // anonymous local
+    let _5: usize; // anonymous local
+
+    bb0: {
+        storage_live(_0);
+        storage_live(_3);
+        storage_live(_4);
+        storage_live(_5);
+        _5 = copy i;
+        _4 = &mut ((*self)).0[copy _5];
+        _3 = &mut (*_4);
+        _0 = &mut (*_3);
+        storage_dead(_5);
+        storage_dead(_4);
+        storage_dead(_3);
+        storage_dead(i);
+        storage_dead(self);
+        return;
+    }
+}
+
+// Full name: test_crate::{impl IndexMut<usize> for Wrap}
+impl "impl_IndexMut_usize_for_Wrap" IndexMut<usize> for Wrap {
+    proof ImpliedClause0: (Wrap: MetaSized) = {built_in impl MetaSized for Wrap}
+    proof ImpliedClause1: (Wrap: Index<usize>) = impl_Index_usize_for_Wrap
+    proof ImpliedClause2: (usize: MetaSized) = {built_in impl MetaSized for usize}
+    fn index_mut<'_0_1> = index_mut<'_0_1>
+    vtable: impl_IndexMut_usize_for_Wrap::{vtable}
+}
+
+// Full name: test_crate::shr_into_index
+pub fn shr_into_index<'_0>(x: u64, out: &'_0 mut Wrap)
+{
+    let _0: (); // return
+    let x: u64; // arg #1
+    let out: &'1 mut Wrap; // arg #2
+    let _3: u64; // anonymous local
+    let _4: u32; // anonymous local
+    let _5: bool; // anonymous local
+    let _6: &'3 mut u64; // anonymous local
+    let _7: &'4 mut Wrap; // anonymous local
+
+    bb0: {
+        storage_live(_0);
+        storage_live(_4);
+        storage_live(_5);
+        _0 = ();
+        storage_live(_3);
+        _3 = copy x;
+        _4 = cast<i32, u32>(const 20i32);
+        _5 = move _4 < const 64u32;
+        assert(move _5 == true) (overflow) else panic;
+        storage_live(_6);
+        storage_live(_7);
+        _7 = &mut (*out);
+        _6 = index_mut<'6>(move _7, const 0usize) -> bb2 (unwind: bb1);
+    }
+
+    bb1: {
+        storage_dead(_5);
+        storage_dead(_4);
+        storage_dead(out);
+        storage_dead(x);
+        unwind_continue;
+    }
+
+    bb2: {
+        storage_dead(_7);
+        (*_6) = move _3 wrap.>> const 20i32;
+        storage_dead(_3);
+        storage_dead(_6);
+        _0 = ();
+        storage_dead(_5);
+        storage_dead(_4);
+        storage_dead(out);
+        storage_dead(x);
+        return;
+    }
+}
+
+// Full name: test_crate::shl_into_index_by_var
+pub fn shl_into_index_by_var<'_0>(x: u64, n: u32, out: &'_0 mut Wrap)
+{
+    let _0: (); // return
+    let x: u64; // arg #1
+    let n: u32; // arg #2
+    let out: &'1 mut Wrap; // arg #3
+    let _4: u64; // anonymous local
+    let _5: u32; // anonymous local
+    let _6: bool; // anonymous local
+    let _7: &'3 mut u64; // anonymous local
+    let _8: &'4 mut Wrap; // anonymous local
+
+    bb0: {
+        storage_live(_0);
+        storage_live(_6);
+        _0 = ();
+        storage_live(_4);
+        _4 = copy x;
+        storage_live(_5);
+        _5 = copy n;
+        _6 = copy _5 < const 64u32;
+        assert(move _6 == true) (overflow) else panic;
+        storage_live(_7);
+        storage_live(_8);
+        _8 = &mut (*out);
+        _7 = index_mut<'6>(move _8, const 1usize) -> bb2 (unwind: bb1);
+    }
+
+    bb1: {
+        storage_dead(_6);
+        storage_dead(out);
+        storage_dead(n);
+        storage_dead(x);
+        unwind_continue;
+    }
+
+    bb2: {
+        storage_dead(_8);
+        (*_7) = move _4 wrap.<< move _5;
+        storage_dead(_5);
+        storage_dead(_4);
+        storage_dead(_7);
+        _0 = ();
+        storage_dead(_6);
+        storage_dead(out);
+        storage_dead(n);
+        storage_dead(x);
+        return;
+    }
+}
+
+
+

--- a/charon/tests/ui/issue-1041-shift-through-index-mut.rs
+++ b/charon/tests/ui/issue-1041-shift-through-index-mut.rs
@@ -1,0 +1,30 @@
+//@ no-default-options
+//@ charon-args=--ullbc --print-ullbc
+//@ charon-args=--reconstruct-fallible-operations
+//! Regression test for issue #1041: rustc evaluates the shift operands (and emits the overflow
+//! check) before computing the destination place, so when that computation involves a call (here
+//! the overloaded `index_mut`), the shift ends up in the block the call returns to. The check
+//! must still be reconstructed into a panic-on-overflow shift.
+use std::ops::IndexMut;
+
+pub struct Wrap(pub [u64; 2]);
+
+impl std::ops::Index<usize> for Wrap {
+    type Output = u64;
+    fn index(&self, i: usize) -> &u64 {
+        &self.0[i]
+    }
+}
+impl IndexMut<usize> for Wrap {
+    fn index_mut(&mut self, i: usize) -> &mut u64 {
+        &mut self.0[i]
+    }
+}
+
+pub fn shr_into_index(x: u64, out: &mut Wrap) {
+    out[0] = x >> 20;
+}
+
+pub fn shl_into_index_by_var(x: u64, n: u32, out: &mut Wrap) {
+    out[1] = x << n;
+}


### PR DESCRIPTION
Fixes #1041.

Rustc evaluates a shift's operands, and emits its overflow check, before computing the destination place.  When that computation needs a call, as with the overloaded `index_mut` in the issue, the call ends the block and the shift lands in the block the call returns to.  `reconstruct_fallible_operations` only matches within one block, so it never pairs the check with the shift and the shift stays wrapping.

We now record these checks during the per-block pass and resolve them afterwards over the whole body.  For each one we find the wrapping shift by its amount, drop the check, and compute the shift early into a fresh local where the check used to be, promoted to panic on overflow.  A move then carries the result to the destination back at the original site.

Doing the computation there is sound.  By the time control reaches the check, rustc has already evaluated both operands, and the check itself already reads them and panics on overflow, so the early assignment introduces no new effect and the panic stays in its original position before the call.

The new UI test covers the issue's example and a variable shift amount, which now reconstruct to `panic.>>` and `panic.<<`.  The rest of the suite is unchanged and there is no AST change, so charon-ml is unaffected.