### PR TITLE
Avoid copyleft in deps

### DIFF
--- a/charon-ml/src/Logging.ml
+++ b/charon-ml/src/Logging.ml
@@ -1,163 +1,54 @@
-module H = Easy_logging.Handlers
-module L = Easy_logging.Logging
+(** The main source *)
+let main_log = Logs.Src.create "charon" ~doc:"Charon"
 
-let _ = L.make_logger "MainLogger" Debug [ Cli Debug ]
+(** Source for LlbcOfJson *)
+let llbc_of_json_logger =
+  Logs.Src.create "charon.llbc_of_json" ~doc:"Deserialization of LLBC files"
 
-(** The main logger *)
-let main_log = L.get_logger "MainLogger"
+(** Source for NameMatcher *)
+let name_matcher_logger =
+  Logs.Src.create "charon.name_matcher"
+    ~doc:"Matching of names against patterns"
 
-(** Below, we create subgloggers for various submodules, so that we can
-    precisely toggle logging on/off, depending on which information we need *)
-
-(** Logger for LlbcOfJson *)
-let llbc_of_json_logger = L.get_logger "MainLogger.LlbcOfJson"
-
-(** Terminal colors - TODO: comes from easy_logging (did not manage to reuse the
-    module directly) *)
-type color =
-  | Default
-  | Black
-  | Red
-  | Green
-  | Yellow
-  | Blue
-  | Magenta
-  | Cyan
-  | Gray
-  | White
-  | LRed
-  | LGreen
-  | LYellow
-  | LBlue
-  | LMagenta
-  | LCyan
-  | LGray
-
-(** Terminal styles - TODO: comes from easy_logging (did not manage to reuse the
-    module directly) *)
-type format = Bold | Underline | Invert | Fg of color | Bg of color
-
-(** TODO: comes from easy_logging (did not manage to reuse the module directly)
-*)
-let to_fg_code c =
-  match c with
-  | Default -> 39
-  | Black -> 30
-  | Red -> 31
-  | Green -> 32
-  | Yellow -> 33
-  | Blue -> 34
-  | Magenta -> 35
-  | Cyan -> 36
-  | Gray -> 90
-  | White -> 97
-  | LRed -> 91
-  | LGreen -> 92
-  | LYellow -> 93
-  | LBlue -> 94
-  | LMagenta -> 95
-  | LCyan -> 96
-  | LGray -> 37
-
-(** TODO: comes from easy_logging (did not manage to reuse the module directly)
-*)
-let to_bg_code c =
-  match c with
-  | Default -> 49
-  | Black -> 40
-  | Red -> 41
-  | Green -> 42
-  | Yellow -> 43
-  | Blue -> 44
-  | Magenta -> 45
-  | Cyan -> 46
-  | Gray -> 100
-  | White -> 107
-  | LRed -> 101
-  | LGreen -> 102
-  | LYellow -> 103
-  | LBlue -> 104
-  | LMagenta -> 105
-  | LCyan -> 106
-  | LGray -> 47
-
-(** TODO: comes from easy_logging (did not manage to reuse the module directly)
-*)
-let style_to_codes s =
-  match s with
-  | Bold -> (1, 21)
-  | Underline -> (4, 24)
-  | Invert -> (7, 27)
-  | Fg c -> (to_fg_code c, to_fg_code Default)
-  | Bg c -> (to_bg_code c, to_bg_code Default)
-
-(** TODO: comes from easy_logging (did not manage to reuse the module directly)
-    I made a minor modifications, though. *)
-let level_to_color (lvl : L.level) =
-  match lvl with
-  | L.Flash -> LMagenta
-  | Error -> LRed
-  | Warning -> LYellow
-  | Info -> LGreen
-  | Trace -> Cyan
-  | Debug -> LBlue
-  | NoLevel -> Default
-
-(** [format styles str] formats [str] to the given [styles] - TODO: comes from
-    {{:http://ocamlverse.net/content/documentation_guidelines.html}[easy_logging]}
-    (did not manage to reuse the module directly) *)
-let rec format styles str =
-  match styles with
-  | (_ as s) :: styles' ->
-      let set, reset = style_to_codes s in
-      Printf.sprintf "\027[%dm%s\027[%dm" set (format styles' str) reset
-  | [] -> str
-
-(** TODO: comes from
-    {{:http://ocamlverse.net/content/documentation_guidelines.html}[easy_logging]}
-    (did not manage to reuse the module directly) *)
-let format_tags (tags : string list) =
-  match tags with
-  | [] -> ""
-  | _ ->
-      let elems_str = String.concat " | " tags in
-      "[" ^ elems_str ^ "] "
-
-(* Reimplementing this to make minor modifications *)
-let show_level (lvl : L.level) =
-  match lvl with
-  | Debug -> "Debug"
-  | Trace -> "Trace"
-  | Info -> "Info"
-  | Warning -> "Warn"
-  | Error -> "Error"
-  | Flash -> "Flash"
-  | NoLevel -> "NoLevel"
-
-(* Change the formatters *)
-let main_logger_handler =
-  (* TODO: comes from easy_logging *)
-  let formatter (item : L.log_item) : string =
-    let item_level_fmt =
-      format [ Fg (level_to_color item.level) ] (show_level item.level)
-    and item_msg_fmt =
-      match item.level with
-      | Flash -> format [ Fg Black; Bg LMagenta ] item.msg
-      | _ -> item.msg
-    in
-
-    Format.pp_set_max_indent Format.str_formatter 200;
-    Format.sprintf "@[[%-15s] %s%s@]" item_level_fmt (format_tags item.tags)
-      item_msg_fmt
+(** The ANSI escape sequence which sets the foreground color used to display a
+    given level. *)
+let level_color (lvl : Logs.level) : string =
+  let code =
+    match lvl with
+    | App -> 95 (* light magenta *)
+    | Error -> 91 (* light red *)
+    | Warning -> 93 (* light yellow *)
+    | Info -> 92 (* light green *)
+    | Debug -> 94 (* light blue *)
   in
-  (* There should be exactly one handler *)
-  let handlers = main_log#get_handlers in
-  List.iter (fun h -> H.set_formatter h formatter) handlers;
-  match handlers with
-  | [ handler ] -> handler
-  | _ -> raise (Failure "Unexpected")
+  Printf.sprintf "\027[%dm" code
 
-(*
- * Subloggers
- *)
-let name_matcher_logger = L.get_logger "NameMatcher"
+(** The ANSI escape sequence which resets the foreground color *)
+let color_reset = "\027[39m"
+
+let show_level : Logs.level -> string = function
+  | App -> "Flash"
+  | Error -> "Error"
+  | Warning -> "Warn"
+  | Info -> "Info"
+  | Debug -> "Debug"
+
+(** A reporter which prints the messages on [ppf], prefixed with their level and
+    the name of their source. *)
+let reporter (ppf : Format.formatter) : Logs.reporter =
+  let report src lvl ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    msgf @@ fun ?header:_ ?tags:_ fmt ->
+    Format.pp_set_max_indent ppf 200;
+    Format.kfprintf k ppf
+      ("@[[%s%-5s%s] [%s] @[" ^^ fmt ^^ "@]@]@.")
+      (level_color lvl) (show_level lvl) color_reset (Logs.Src.name src)
+  in
+  { Logs.report }
+
+let () =
+  Logs.set_reporter (reporter Format.std_formatter);
+  Logs.set_level ~all:true (Some Logs.Info)

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -38,8 +38,7 @@ include Name_matcher_parser.Ast
 include Name_matcher_parser.Interface
 module T = Types
 module E = Expressions
-
-let log = Logging.name_matcher_logger
+module Log = (val Logs.src_log Logging.name_matcher_logger : Logs.LOG)
 
 (*
  * Convert patterns to strings
@@ -505,10 +504,8 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
         "match_name_with_generics: attempt to match empty names and patterns"
       (* We shouldn't get there: the names/patterns should be non empty *)
   | [ PIdent (pid, pd, pg) ], [ PeIdent (id, d) ] ->
-      log#ldebug
-        (lazy
-          ("match_name_with_generics: last ident:" ^ "\n- pid: " ^ pid
-         ^ "\n- id: " ^ id));
+      Log.debug (fun m ->
+          m "match_name_with_generics: last ident:\n- pid: %s\n- id: %s" pid id);
       (* We reached the end: match the generics.
          We have to generate an empty map. *)
       pid = id
@@ -699,13 +696,11 @@ and match_trait_type (ctx : ctx) (c : match_config) (m : maps) (pid : pattern)
 
 and match_generic_args (ctx : ctx) (c : match_config) (m : maps)
     (pgenerics : generic_args) (generics : T.generic_args) : bool =
-  log#ldebug
-    (lazy
-      (let fmt_env = ctx_to_fmt_env ctx in
-       "match_generic_args: " ^ "\n- pgenerics: "
-       ^ generic_args_to_string { tgt = TkPattern } pgenerics
-       ^ "\n- generics: "
-       ^ Print.generic_args_to_string fmt_env generics));
+  Log.debug (fun m ->
+      let fmt_env = ctx_to_fmt_env ctx in
+      m "match_generic_args:\n- pgenerics: %s\n- generics: %s"
+        (generic_args_to_string { tgt = TkPattern } pgenerics)
+        (Print.generic_args_to_string fmt_env generics));
   let merged_generics =
     List.concat
       [
@@ -720,11 +715,10 @@ and match_generic_args (ctx : ctx) (c : match_config) (m : maps)
 
 and match_generic_arg (ctx : ctx) (c : match_config) (m : maps)
     (pg : generic_arg) (g : mexpr) : bool =
-  log#ldebug
-    (lazy
-      ("match_generic_arg: " ^ "\n- pg: "
-      ^ generic_arg_to_string { tgt = TkPattern } pg
-      ^ "\n- g: " ^ show_mexpr g));
+  Log.debug (fun m ->
+      m "match_generic_arg:\n- pg: %s\n- g: %a"
+        (generic_arg_to_string { tgt = TkPattern } pg)
+        pp_mexpr g);
   match (pg, g) with
   | GRegion pr, MRegion r -> match_region c m pr r
   | GExpr e, MTy ty -> match_expr_with_ty ctx c m e ty
@@ -1237,13 +1231,12 @@ let fn_ptr_to_pattern (ctx : ctx) (c : to_pat_config)
           func.generics
   in
   (* Sanity check *)
-  log#ldebug
-    (lazy
-      (let fmt_env = ctx_to_fmt_env ctx in
-       "fn_ptr_to_pattern:" ^ "\n- fn_ptr: "
-       ^ Print.fn_ptr_to_string fmt_env func
-       ^ "\n- pattern: "
-       ^ pattern_to_string { tgt = TkPattern } pat));
+  Log.debug (fun m ->
+      let fmt_env = ctx_to_fmt_env ctx in
+      m "fn_ptr_to_pattern:\n- fn_ptr: %a\n- pattern: %s"
+        (PrintFmt.pp_fn_ptr fmt_env)
+        func
+        (pattern_to_string { tgt = TkPattern } pat));
   assert (
     c.tgt = TkName
     || match_fn_ptr ctx

--- a/charon-ml/src/dune
+++ b/charon-ml/src/dune
@@ -5,7 +5,7 @@
  (public_name charon) ;; The name as revealed to the projects importing this library
  (preprocess
   (pps ppx_deriving.show ppx_deriving.ord ppx_deriving.eq visitors.ppx))
- (libraries yojson zarith easy_logging name_matcher_parser unionFind))
+ (libraries yojson zarith logs name_matcher_parser unionFind))
 
 (documentation
  (package charon))

--- a/charon-ml/tests/Test_Deserialize.ml
+++ b/charon-ml/tests/Test_Deserialize.ml
@@ -1,8 +1,6 @@
 open Charon
 open Logging
-module EL = Easy_logging.Logging
-
-let log = main_log
+module Log = (val Logs.src_log main_log : Logs.LOG)
 
 (** [dir_is_empty dir] is true, if [dir] contains no files except * "." and ".."
 *)
@@ -126,11 +124,9 @@ let test_cross_format_errors json postcard =
   | Error e ->
       assert_contains ~msg:"Wrong error for Postcard fed to JSON"
         ~sub:"looks like Postcard" e);
-  log#linfo
-    (lazy
-      (Printf.sprintf
-         "Cross-format error tests passed for JSON file %s and Postcard file %s"
-         json postcard))
+  Log.info (fun m ->
+      m "Cross-format error tests passed for JSON file %s and Postcard file %s"
+        json postcard)
 
 (* Run the tests *)
 let run_tests (folder : string) : unit =
@@ -157,32 +153,33 @@ let run_tests (folder : string) : unit =
   let () =
     List.iter
       (fun file ->
-        log#ldebug (lazy ("Deserializing JSON file: " ^ file));
+        Log.debug (fun m -> m "Deserializing JSON file: %s" file);
         (* Load the module *)
         let start_time = Unix.gettimeofday () in
         match OfJson.crate_of_json_file file with
         | Error s ->
-            log#error "Error when deserializing file %s: %s\n" file s;
+            Log.err (fun m -> m "Error when deserializing file %s: %s" file s);
             exit 1
         | Ok _ ->
             json_time := !json_time +. (Unix.gettimeofday () -. start_time);
-            log#linfo (lazy ("Deserialized: " ^ file)))
+            Log.info (fun m -> m "Deserialized: %s" file))
       json_files
   in
   let () =
     List.iter
       (fun file ->
-        log#ldebug (lazy ("Deserializing postcard file: " ^ file));
+        Log.debug (fun m -> m "Deserializing postcard file: %s" file);
         (* Load the module *)
         let start_time = Unix.gettimeofday () in
         match OfPostcard.crate_of_postcard_file file with
         | Error s ->
-            log#error "Error when deserializing postcard file %s: %s\n" file s;
+            Log.err (fun m ->
+                m "Error when deserializing postcard file %s: %s" file s);
             exit 1
         | Ok m ->
             postcard_time :=
               !postcard_time +. (Unix.gettimeofday () -. start_time);
-            log#linfo (lazy ("Deserialized postcard: " ^ file));
+            Log.info (fun m -> m "Deserialized postcard: %s" file);
             let printed = Print.crate_to_string m in
             assert_pretty_matches_rust file printed)
       postcard_files
@@ -194,14 +191,13 @@ let run_tests (folder : string) : unit =
   in
   let avg_json_time = avg_of json_time json_files in
   let avg_postcard_time = avg_of postcard_time postcard_files in
-  log#linfo
-    (lazy
-      (Printf.sprintf
-         "Average deserialization time: JSON: %f seconds, Postcard: %f seconds \
-          (%f times faster)"
-         avg_json_time avg_postcard_time
-         (if avg_postcard_time > 0.0 then avg_json_time /. avg_postcard_time
-          else 0.0)));
+  Log.info (fun m ->
+      m
+        "Average deserialization time: JSON: %f seconds, Postcard: %f seconds \
+         (%f times faster)"
+        avg_json_time avg_postcard_time
+        (if avg_postcard_time > 0.0 then avg_json_time /. avg_postcard_time
+         else 0.0));
 
   (* for each JSON and Postcard file pair, check the size of the file and print the ratio *)
   let ratios = ref [] in
@@ -233,17 +229,15 @@ let run_tests (folder : string) : unit =
         let mid = List.length sorted_ratios / 2 in
         (List.nth sorted_ratios mid +. List.nth sorted_ratios (mid - 1)) /. 2.0
     in
-    log#linfo
-      (lazy
-        (Printf.sprintf
-           "Size ratio (JSON/Postcard): min: %f, max: %f, avg: %f, med: %f"
-           min_ratio max_ratio avg_ratio med_ratio));
+    Log.info (fun m ->
+        m "Size ratio (JSON/Postcard): min: %f, max: %f, avg: %f, med: %f"
+          min_ratio max_ratio avg_ratio med_ratio);
 
     match (json_files, postcard_files) with
     | json :: _, postcard :: _ -> test_cross_format_errors json postcard
     | _ ->
-        log#linfo
-          (lazy "No JSON or Postcard files found, skipping cross-format tests.");
+        Log.info (fun m ->
+            m "No JSON or Postcard files found, skipping cross-format tests.");
 
         (* Done *)
         ()

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -4,8 +4,7 @@ open Charon.Meta
 open Charon.GAstUtils
 open Logging
 open NameMatcher
-
-let log = main_log
+module Log = (val Logs.src_log main_log : Logs.LOG)
 
 let parse_tests () =
   let patterns : string list =
@@ -194,25 +193,28 @@ module PatternTest = struct
         try fn_ptr_to_pattern env.ctx env.to_pat_config decl.generics fn_ptr
         with _ -> [ PIdent ("ERROR", 0, []) ]
       in
-      log#error "Pattern %s failed to match function %s (in `%s`)\n"
-        (pattern_to_string env.print_config (Option.get test.pattern))
-        (pattern_to_string env.print_config fn_ptr)
-        env.file_name;
+      Log.err (fun m ->
+          m "Pattern %s failed to match function %s (in `%s`)"
+            (pattern_to_string env.print_config (Option.get test.pattern))
+            (pattern_to_string env.print_config fn_ptr)
+            env.file_name);
       false)
     else if (not test.success) && match_success then (
-      log#error "Pattern %s matches function %s but shouldn't\n"
-        (pattern_to_string env.print_config (Option.get test.pattern))
-        (Print.name_to_string env.fmt_env decl.item_meta.name);
+      Log.err (fun m ->
+          m "Pattern %s matches function %s but shouldn't"
+            (pattern_to_string env.print_config (Option.get test.pattern))
+            (Print.name_to_string env.fmt_env decl.item_meta.name));
       false)
     else if test.success && not pattern_to_name_success then (
       let pattern, name = Option.get pattern_name in
-      log#error
-        "Pattern '%s' converted to name is '%s' but is expected to be '%s' (in \
-         %s)\n"
-        (pattern_to_string env.print_config pattern)
-        name
-        (Option.get test.pattern_to_name)
-        env.file_name;
+      Log.err (fun m ->
+          m
+            "Pattern '%s' converted to name is '%s' but is expected to be '%s' \
+             (in %s)"
+            (pattern_to_string env.print_config pattern)
+            name
+            (Option.get test.pattern_to_name)
+            env.file_name);
       false)
     else true
 end
@@ -223,11 +225,11 @@ end
    annotations are available. *)
 let annotated_rust_tests test_file =
   (* We read the llbc file generated from the annotated rust file. *)
-  log#ldebug (lazy ("Deserializing LLBC file: " ^ test_file));
+  Log.debug (fun m -> m "Deserializing LLBC file: %s" test_file);
   let (crate : crate) =
     match OfJson.crate_of_json_file test_file with
     | Error s ->
-        log#error "Error when deserializing file %s: %s\n" test_file s;
+        Log.err (fun m -> m "Error when deserializing file %s: %s" test_file s);
         exit 1
     | Ok crate -> crate
   in
@@ -253,7 +255,8 @@ let annotated_rust_tests test_file =
       crate.fun_decls
   in
 
-  if all_pass then log#linfo (lazy "Name matcher tests: success") else exit 1
+  if all_pass then Log.info (fun m -> m "Name matcher tests: success")
+  else exit 1
 
 let run_tests test_file =
   parse_tests ();

--- a/charon-ml/tests/Tests.ml
+++ b/charon-ml/tests/Tests.ml
@@ -1,16 +1,13 @@
-open Charon
-open Logging
-module EL = Easy_logging.Logging
-
 (* Set the log level - we use the environment variable "CHARON_LOG" *)
-let log = main_log
-
 let () =
   Printexc.record_backtrace true;
-  try
-    let _ = Unix.getenv "CHARON_LOG" in
-    log#set_level EL.Debug
-  with Not_found -> log#set_level EL.Info
+  let level =
+    try
+      let _ = Unix.getenv "CHARON_LOG" in
+      Logs.Debug
+    with Not_found -> Logs.Info
+  in
+  Logs.Src.set_level Charon.Logging.main_log (Some level)
 
 let llbc_dir =
   try Unix.getenv "CHARON_TESTS_DIR" with Not_found -> "../../charon/tests/ui"

--- a/charon-ml/tests/dune
+++ b/charon-ml/tests/dune
@@ -4,4 +4,4 @@
  (modules Tests Test_Deserialize Test_NameMatcher)
  (deps
   (glob_files_rec ../../charon/tests/ui/*))
- (libraries charon str))
+ (libraries charon re str unix))

--- a/charon.opam
+++ b/charon.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/AeneasVerif/charon"
 bug-reports: "https://github.com/AeneasVerif/charon/issues"
 depends: [
   "dune" {>= "3.7"}
-  "easy_logging"
+  "logs"
   "ppx_deriving"
   "unionFind"
   "visitors"

--- a/charon.opam
+++ b/charon.opam
@@ -25,6 +25,7 @@ depends: [
   "yojson"
   "zarith"
   "name_matcher_parser"
+  "re" {with-test}
   "ocamlformat" {with-test}
   "odoc" {with-doc}
 ]

--- a/charon.opam
+++ b/charon.opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "ppx_deriving"
   "unionFind"
-  "visitors"
+  "visitors" {>= "20260520"}
   "yojson"
   "zarith"
   "name_matcher_parser"

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -259,7 +259,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "colored",
  "convert_case",
  "crates_io_api",
  "derive_generic_visitor",
@@ -375,16 +374,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "convert_case"

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -115,12 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,15 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
-name = "brownstone"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,7 +264,6 @@ dependencies = [
  "log",
  "macros",
  "nom",
- "nom-supreme",
  "num-bigint",
  "paste",
  "petgraph",
@@ -1198,12 +1182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "index_vec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,12 +1287,6 @@ dependencies = [
  "quote 1.0.40",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "joinery"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -1470,19 +1442,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom-supreme"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
-dependencies = [
- "brownstone",
- "indent_write",
- "joinery",
- "memchr",
- "nom",
 ]
 
 [[package]]

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -74,7 +74,6 @@ anstream = "0.6.18"
 anyhow = "1.0.81"
 assert_cmd = "2.0"
 clap = { version = "4.0", features = ["derive", "env"] }
-colored = "2.0.4"
 convert_case = "0.6.0"
 crates_io_api = { version = "0.11.0", optional = true }
 derive_generic_visitor = "1.1.0"

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -90,7 +90,6 @@ itertools.workspace = true
 lazy_static = "1.4.0"
 log = "0.4.17"
 nom = "7.1.3"
-nom-supreme = "0.8.0"
 num-bigint = "0.4.6"
 paste = "1.0.11"
 petgraph = "0.8.0"

--- a/charon/src/logger.rs
+++ b/charon/src/logger.rs
@@ -25,6 +25,16 @@ pub fn initialize_logger() {
         .init();
 }
 
+#[macro_export]
+macro_rules! ansi_color {
+    (red) => {
+        "\x1b[31m"
+    };
+    (yellow) => {
+        "\x1b[33m"
+    };
+}
+
 /// This macro computes the name of the function in which it is called and the line number.
 /// We adapted it from:
 /// <https://stackoverflow.com/questions/38088067/equivalent-of-func-or-function-in-rust>
@@ -47,9 +57,8 @@ macro_rules! code_location {
 
         use std::io::IsTerminal;
         if std::io::stderr().is_terminal() {
-            use colored::Colorize;
-            name = name.$color().to_string();
-            location = location.dimmed().to_string();
+            name = format!("{}{name}\x1b[39m", $crate::ansi_color!($color));
+            location = format!("\x1b[2m{location}\x1b[22m");
         }
         format!("in {name} at {location}")
     }};

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -39,7 +39,7 @@ pub enum PatTy {
 }
 
 impl Pattern {
-    pub fn parse(i: &str) -> Result<Self, nom_supreme::error::ErrorTree<String>> {
+    pub fn parse(i: &str) -> Result<Self, nom::error::Error<String>> {
         use std::str::FromStr;
         Self::from_str(i)
     }

--- a/charon/src/name_matcher/parser.rs
+++ b/charon/src/name_matcher/parser.rs
@@ -2,23 +2,22 @@ use std::{fmt, str::FromStr};
 
 use itertools::Itertools;
 use nom::{
-    Parser,
+    Finish, Parser,
     bytes::complete::{tag, take_while},
     character::complete::{multispace0, multispace1},
-    combinator::{map_res, success},
-    error::ParseError,
+    combinator::{all_consuming, cut, map_res, opt, success},
+    error::{Error, ParseError},
     multi::separated_list0,
-    sequence::{delimited, preceded},
+    sequence::{delimited, preceded, terminated},
 };
-use nom_supreme::{ParserExt, error::ErrorTree};
 
 use super::{PatElem, PatTy, Pattern};
 use crate::ast::RefKind;
 
-type ParseResult<'a, T> = nom::IResult<&'a str, T, ErrorTree<&'a str>>;
+type ParseResult<'a, T> = nom::IResult<&'a str, T, Error<&'a str>>;
 
 /// Extra methods on parsers.
-trait ParserExtExt<I, O, E>: Parser<I, O, E> + Sized
+trait ParserExt<I, O, E>: Parser<I, O, E> + Sized
 where
     I: Clone,
     E: ParseError<I>,
@@ -27,10 +26,25 @@ where
     where
         F: Parser<I, O2, E>,
     {
-        self.terminated(suffix)
+        terminated(self, suffix)
+    }
+
+    fn precedes<F, O2>(self, next: F) -> impl Parser<I, O2, E>
+    where
+        F: Parser<I, O2, E>,
+    {
+        preceded(self, next)
+    }
+
+    fn opt(self) -> impl Parser<I, Option<O>, E> {
+        opt(self)
+    }
+
+    fn cut(self) -> impl Parser<I, O, E> {
+        cut(self)
     }
 }
-impl<I, O, E, P> ParserExtExt<I, O, E> for P
+impl<I, O, E, P> ParserExt<I, O, E> for P
 where
     I: Clone,
     E: ParseError<I>,
@@ -40,15 +54,18 @@ where
 
 /// The entry point for this module: parses a string into a `Pattern`.
 impl FromStr for Pattern {
-    type Err = ErrorTree<String>;
+    type Err = Error<String>;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_pattern_complete(s)
     }
 }
 
-fn parse_pattern_complete(i: &str) -> Result<Pattern, ErrorTree<String>> {
-    nom_supreme::final_parser::final_parser(parse_pattern)(i)
-        .map_err(|e: ErrorTree<_>| e.map_locations(|s: &str| s.to_string()))
+fn parse_pattern_complete(i: &str) -> Result<Pattern, Error<String>> {
+    all_consuming(parse_pattern)
+        .parse(i)
+        .finish()
+        .map(|(_, pattern)| pattern)
+        .map_err(|e| Error::new(e.input.to_string(), e.code))
 }
 
 fn parse_pattern(i: &str) -> ParseResult<'_, Pattern> {

--- a/charon/tests/ui/filtering/start_from_errors.out
+++ b/charon/tests/ui/filtering/start_from_errors.out
@@ -1,4 +1,4 @@
-error: failed to parse pattern `std::iter:once` (expected eof at :once)
+error: failed to parse pattern `std::iter:once` (error Eof at: :once)
 
 error: failed to resolve item path `start_from_errors::module1`: path `start_from_errors` does not correspond to any item; did you mean `crate::start_from_errors`?
 

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (description
   "\n   This library allows for manipulation of LLBC, the language output by\n   Charon. Charon acts as an interface between the rustc compiler and program\n   verification projects.  Its purpose is to process Rust .rs files and convert\n   them into files easy to handle by program verifiers.")
  (depends
-  easy_logging
+  logs
   ppx_deriving
   unionFind
   visitors

--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   logs
   ppx_deriving
   unionFind
-  visitors
+  (visitors (>= 20260520))
   yojson
   zarith
   name_matcher_parser
@@ -52,5 +52,5 @@
   (menhir :build)
   menhirLib
   ppx_deriving
-  visitors
+  (visitors (>= 20260520))
   zarith))

--- a/dune-project
+++ b/dune-project
@@ -41,6 +41,7 @@
   yojson
   zarith
   name_matcher_parser
+  (re :with-test)
   (ocamlformat :with-test)))
 
 (package

--- a/flake.lock
+++ b/flake.lock
@@ -65,12 +65,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762111121,
-        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
-        "type": "github"
+        "lastModified": 1785692966,
+        "narHash": "sha256-1+YGJM7PLfvTsbUxDHKj0NcuEXYFHfZBDuajujCcVmY=",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1046609.643809054d65/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,9 @@
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-        ocamlformat = pkgs.ocamlPackages.ocamlformat_0_27_0;
+
+        # nixpkgs marks ocamlformat broken for OCaml 5.4, so build it with 5.3 instead
+        ocamlformat = pkgs.ocaml-ng.ocamlPackages_5_3.ocamlformat_0_27_0;
 
         # Glibc version that the Linux release binaries are lowered to after building
         # to ensure compatibility with older Linux systems
@@ -117,7 +119,19 @@
             exit 1
           fi
         '');
-        charon-ml = pkgs.callPackage ./nix/charon-ml.nix { inherit charon; };
+        ocamlPackages = pkgs.ocamlPackages.overrideScope (_: prev: {
+          visitors = (prev.visitors.override { version = "20260520"; }).overrideAttrs (_: {
+            src = pkgs.fetchFromGitLab {
+              owner = "fpottier";
+              repo = "visitors";
+              tag = "20260520";
+              domain = "gitlab.inria.fr";
+              hash = "sha256-QR/kxwojyFOFLeu1JKjBfgmq2xaGZHq8hB1YwVpRVYI=";
+            };
+          });
+        });
+
+        charon-ml = pkgs.callPackage ./nix/charon-ml.nix { inherit charon ocamlPackages; };
 
         # Check rust files are correctly formatted.
         charon-check-fmt = charon.passthru.check-fmt;

--- a/name_matcher_parser.opam
+++ b/name_matcher_parser.opam
@@ -15,7 +15,7 @@ depends: [
   "menhir" {build}
   "menhirLib"
   "ppx_deriving"
-  "visitors"
+  "visitors" {>= "20260520"}
   "zarith"
   "odoc" {with-doc}
 ]

--- a/nix/charon-ml.nix
+++ b/nix/charon-ml.nix
@@ -1,24 +1,11 @@
 { lib
 , charon
-, fetchFromGitHub
 , ocaml-ng
 , ocamlPackages
 , runCommand
 , stdenv
 }:
 let
-  easy_logging = ocamlPackages.buildDunePackage rec {
-    pname = "easy_logging";
-    version = "0.8.2";
-    src = fetchFromGitHub {
-      owner = "sapristi";
-      repo = "easy_logging";
-      rev = "v${version}";
-      sha256 = "sha256-Xy6Rfef7r2K8DTok7AYa/9m3ZEV07LlUeMQSRayLBco=";
-    };
-    buildInputs = [ ocamlPackages.calendar ];
-  };
-
   # We need both `charon-ml` and the `dune-project` file.
   src = lib.cleanSourceWith {
     src = ./..;
@@ -53,7 +40,7 @@ let
     buildInputs = [
       ocamlPackages.dune_3
       ocamlPackages.ocaml
-      ocamlPackages.ocamlformat_0_27_0
+      ocaml-ng.ocamlPackages_5_3.ocamlformat_0_27_0
     ];
     buildPhase = ''
       if ! dune build @fmt; then
@@ -78,7 +65,6 @@ let
         logs
         zarith
         yojson
-        calendar
         charon-name_matcher_parser
         unionFind
         ocaml-ng.ocamlPackages_4_14.ppx_tools # to view the output of visitor derivation

--- a/nix/charon-ml.nix
+++ b/nix/charon-ml.nix
@@ -75,7 +75,7 @@ let
         core
         ppx_deriving
         visitors
-        easy_logging
+        logs
         zarith
         yojson
         calendar

--- a/nix/charon-ml.nix
+++ b/nix/charon-ml.nix
@@ -96,6 +96,7 @@ let
 
       passthru = { inherit charon-ml-tests charon-ml-check-fmt; };
     } // lib.optionalAttrs doCheck {
+      checkInputs = [ ocamlPackages.re ]; # Used by the tests only.
       CHARON_TESTS_DIR = "${charon}/tests-llbc"; # Tell the tests where to find the llbc files.
       CHARON_BIN = "${charon}/bin/charon";
     });


### PR DESCRIPTION
Remove copyleft (LGPL/GPL) dependencies, to allow using Charon (ML) in private code. 

### OCaml

- Remove `easy_logging` (MPL-2.0), use `logs` instead (ISC)
  
  Note the testing code used `re`, which was imported via `easy_logging`, we now declare it explicitly.

- Use a `visitors` version that's at least 20260520, which is LGPL-2.1-only WITH **OCaml-LGPL-linking-exception**, allowing its use when distributing binaries.

Had to override `visitors` in the nix file bc it's not in nixpkgs yet, and `ocamlformat` was broken too so had to use it from a separate build.

### Rust

The dependencies were very minor and could just be re-implemented 

- Removed `colored` (MPL-2.0)
- Removed `nom-supreme` (MPL-2.0)


ci: use https://github.com/AeneasVerif/aeneas/pull/1246
ci: use https://github.com/AeneasVerif/eurydice/pull/436